### PR TITLE
feat(editor): frontmatter support with sidebar properties panel

### DIFF
--- a/src/components/Backlinks/BacklinksPanel.svelte
+++ b/src/components/Backlinks/BacklinksPanel.svelte
@@ -2,7 +2,6 @@
   import { backlinksStore } from "../../store/backlinksStore";
   import { tabStore } from "../../store/tabStore";
   import BacklinkRow from "./BacklinkRow.svelte";
-  import { X } from "lucide-svelte";
   import { vaultStore } from "../../store/vaultStore";
 
   function handleBacklinkClick(relPath: string): void {
@@ -11,22 +10,11 @@
     const absPath = `${vault}/${relPath}`;
     tabStore.openTab(absPath);
   }
-  function handleClose(): void {
-    backlinksStore.setOpen(false);
-  }
 </script>
 
 <div class="vc-backlinks-panel" role="complementary" aria-label="Backlinks">
   <div class="vc-backlinks-header">
     <span class="vc-backlinks-label">Backlinks</span>
-    <button
-      class="vc-backlinks-close"
-      on:click={handleClose}
-      aria-label="Backlinks-Panel schließen"
-      type="button"
-    >
-      <X size={16} />
-    </button>
   </div>
   <div class="vc-backlinks-body">
     {#if $backlinksStore.loading}
@@ -58,7 +46,6 @@
   .vc-backlinks-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     padding: 16px;
     border-bottom: 1px solid var(--color-border);
   }
@@ -68,19 +55,6 @@
     color: var(--color-text-muted);
     text-transform: none;
   }
-  .vc-backlinks-close {
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    color: var(--color-text-muted);
-    border-radius: 4px;
-  }
-  .vc-backlinks-close:hover { background: var(--color-accent-bg); }
   .vc-backlinks-body {
     flex: 1;
     overflow-y: auto;

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -7,6 +7,7 @@
   import type { Tab } from "../../store/tabStore";
   import { vaultStore } from "../../store/vaultStore";
   import { editorStore } from "../../store/editorStore";
+  import { activeViewStore } from "../../store/activeViewStore";
   import { readFile, writeFile, mergeExternalChange, getResolvedLinks, createFile, getFileHash } from "../../ipc/commands";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
@@ -280,10 +281,29 @@
             activeView.state.doc.toString(),
             activeTab.lastSaved ? String(activeTab.lastSaved) : null
           );
+          if (activePane === paneId) {
+            activeViewStore.setActive(activeView);
+          }
         }
+      } else if (activePane === paneId) {
+        activeViewStore.setActive(null);
       }
       prevActiveTabId = newActiveId;
     }
+  });
+
+  // Also publish the active view whenever the active pane itself switches.
+  // The block above only fires on tab-id changes within this pane — moving
+  // focus between panes wouldn't otherwise update the sidebar's source view.
+  $effect(() => {
+    if (activePane !== paneId) return;
+    const id = paneActiveTabId;
+    if (!id) {
+      activeViewStore.setActive(null);
+      return;
+    }
+    const view = viewMap.get(id);
+    if (view) activeViewStore.setActive(view);
   });
 
   /**
@@ -421,6 +441,9 @@
     // Sync editorStore if this is the active tab
     if (tab.id === paneActiveTabId) {
       editorStore.syncFromTab(tab.filePath, content, null);
+      if (activePane === paneId) {
+        activeViewStore.setActive(view);
+      }
     }
   }
 

--- a/src/components/Editor/__tests__/frontmatter.test.ts
+++ b/src/components/Editor/__tests__/frontmatter.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { detectFrontmatter } from "../frontmatterPlugin";
+
+describe("detectFrontmatter", () => {
+  it("detects a frontmatter block at the start of the document", () => {
+    const doc = "---\ntitle: Hello\ntags: [a, b]\n---\n# Body\n";
+    const region = detectFrontmatter(doc);
+    expect(region).not.toBeNull();
+    expect(region!.from).toBe(0);
+    expect(doc.slice(region!.from, region!.to)).toBe("---\ntitle: Hello\ntags: [a, b]\n---\n");
+    expect(region!.body).toBe("title: Hello\ntags: [a, b]");
+  });
+
+  it("returns null when the document has no frontmatter", () => {
+    expect(detectFrontmatter("# Just a note\n\nBody.")).toBeNull();
+  });
+
+  it("ignores `---` that is not at the very start of the document", () => {
+    const doc = "# Heading\n\n---\nnot: frontmatter\n---\n";
+    expect(detectFrontmatter(doc)).toBeNull();
+  });
+
+  it("ignores a leading blank line before `---`", () => {
+    const doc = "\n---\nkey: value\n---\n";
+    expect(detectFrontmatter(doc)).toBeNull();
+  });
+
+  it("detects frontmatter with CRLF line endings", () => {
+    const doc = "---\r\ntitle: X\r\n---\r\nBody";
+    const region = detectFrontmatter(doc);
+    expect(region).not.toBeNull();
+    expect(region!.body).toBe("title: X");
+  });
+
+  it("detects frontmatter even when it is the entire document (no trailing newline)", () => {
+    const doc = "---\ntitle: X\n---";
+    const region = detectFrontmatter(doc);
+    expect(region).not.toBeNull();
+    expect(region!.to).toBe(doc.length);
+  });
+
+  it("detects an empty frontmatter block", () => {
+    const doc = "---\n\n---\nBody";
+    const region = detectFrontmatter(doc);
+    expect(region).not.toBeNull();
+    expect(region!.body).toBe("");
+  });
+
+  it("only captures the first frontmatter block, not a later `---` pair", () => {
+    const doc = "---\nfoo: 1\n---\ntext\n---\nbar: 2\n---\n";
+    const region = detectFrontmatter(doc);
+    expect(region).not.toBeNull();
+    expect(region!.body).toBe("foo: 1");
+  });
+});

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -26,6 +26,12 @@ import { autoSaveExtension } from "./autoSave";
 import { flashField } from "./flashHighlight";
 import { wikiLinkPlugin } from "./wikiLink";
 import { livePreviewPlugin } from "./livePreview";
+import { frontmatterPlugin } from "./frontmatterPlugin";
+import { activeViewStore } from "../../store/activeViewStore";
+
+const docVersionBumpListener = EditorView.updateListener.of((update) => {
+  if (update.docChanged) activeViewStore.bumpDocVersion();
+});
 
 export function buildExtensions(onSave: (text: string) => void): Extension[] {
   return [
@@ -56,5 +62,7 @@ export function buildExtensions(onSave: (text: string) => void): Extension[] {
     flashField,
     wikiLinkPlugin,
     livePreviewPlugin,
+    frontmatterPlugin,
+    docVersionBumpListener,
   ];
 }

--- a/src/components/Editor/frontmatterPlugin.ts
+++ b/src/components/Editor/frontmatterPlugin.ts
@@ -1,0 +1,73 @@
+import { Decoration, EditorView, WidgetType } from "@codemirror/view";
+import type { DecorationSet } from "@codemirror/view";
+import { StateField } from "@codemirror/state";
+import type { EditorState, Extension } from "@codemirror/state";
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/;
+
+export interface FrontmatterRegion {
+  from: number;
+  to: number;
+  body: string;
+}
+
+export function detectFrontmatter(docText: string): FrontmatterRegion | null {
+  const match = FRONTMATTER_RE.exec(docText);
+  if (!match) return null;
+  return { from: 0, to: match[0].length, body: match[1] ?? "" };
+}
+
+// Empty block widget. The frontmatter region is fully hidden — properties
+// are edited in the RightSidebar's Properties panel, not inline. Block
+// replace decorations are atomic, so the cursor can never enter the region.
+class EmptyBlockWidget extends WidgetType {
+  eq(_other: EmptyBlockWidget): boolean {
+    return true;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement("div");
+    el.className = "cm-frontmatter-hidden";
+    el.setAttribute("aria-hidden", "true");
+    return el;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+const HIDDEN_WIDGET = new EmptyBlockWidget();
+
+function buildDecorations(state: EditorState): DecorationSet {
+  const region = detectFrontmatter(state.doc.toString());
+  if (!region) return Decoration.none;
+
+  return Decoration.set([
+    Decoration.replace({
+      widget: HIDDEN_WIDGET,
+      block: true,
+    }).range(region.from, region.to),
+  ]);
+}
+
+// Block-level replace decorations MUST be provided through the
+// EditorView.decorations facet (via a StateField), not through
+// ViewPlugin's `decorations` option — the latter silently ignores
+// block decorations.
+const frontmatterField = StateField.define<DecorationSet>({
+  create(state) {
+    return buildDecorations(state);
+  },
+  update(value, tr) {
+    if (tr.docChanged) {
+      return buildDecorations(tr.state);
+    }
+    return value;
+  },
+  provide(f) {
+    return EditorView.decorations.from(f);
+  },
+});
+
+export const frontmatterPlugin: Extension = frontmatterField;

--- a/src/components/Editor/livePreview.ts
+++ b/src/components/Editor/livePreview.ts
@@ -1,6 +1,7 @@
 import { ViewPlugin, Decoration, type EditorView, type DecorationSet, type ViewUpdate } from "@codemirror/view";
 import { RangeSetBuilder } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
+import { detectFrontmatter } from "./frontmatterPlugin";
 
 const HIDE = Decoration.replace({});
 
@@ -17,6 +18,12 @@ function buildDecorations(view: EditorView): DecorationSet {
   const cursorLine = view.state.doc.lineAt(head).number;
   const doc = view.state.doc;
 
+  // Lezer parses `title: X\n---` as a setext H2, so the closing fence of a
+  // YAML frontmatter block gets tagged as `HeaderMark`. Skip hiding inside
+  // the frontmatter region — otherwise the closing `---` vanishes whenever
+  // the cursor sits on a different line.
+  const frontmatter = detectFrontmatter(doc.toString());
+
   syntaxTree(view.state).iterate({
     from: view.viewport.from,
     to: view.viewport.to,
@@ -24,6 +31,9 @@ function buildDecorations(view: EditorView): DecorationSet {
       const name = node.name;
 
       if (name === "HeaderMark") {
+        if (frontmatter && node.from >= frontmatter.from && node.to <= frontmatter.to) {
+          return;
+        }
         const nodeLine = doc.lineAt(node.from).number;
         if (cursorLine !== nodeLine) {
           let from = node.from;

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -109,4 +109,9 @@ export const markdownTheme = EditorView.theme({
     padding: "8px 12px",
     borderRadius: "4px",
   },
+  // Frontmatter is fully hidden in the editor — the block-replace widget
+  // collapses to zero height so there is no visible gap at the top.
+  ".cm-frontmatter-hidden": {
+    display: "none",
+  },
 });

--- a/src/components/Layout/RightSidebar.svelte
+++ b/src/components/Layout/RightSidebar.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
   import BacklinksPanel from "../Backlinks/BacklinksPanel.svelte";
+  import PropertiesPanel from "../Properties/PropertiesPanel.svelte";
 </script>
 <div class="vc-right-sidebar">
-  <BacklinksPanel />
+  <PropertiesPanel />
+  <div class="vc-right-sidebar-backlinks">
+    <BacklinksPanel />
+  </div>
 </div>
 <style>
   .vc-right-sidebar {
     height: 100%;
     overflow: hidden;
     background: var(--color-bg);
+    display: flex;
+    flex-direction: column;
+  }
+  .vc-right-sidebar-backlinks {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
   }
 </style>

--- a/src/components/Properties/PropertiesPanel.svelte
+++ b/src/components/Properties/PropertiesPanel.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { Plus, X } from "lucide-svelte";
+  import { activeViewStore } from "../../store/activeViewStore";
+  import {
+    parseFrontmatter,
+    computeFrontmatterEdit,
+    type Property,
+  } from "../../lib/frontmatterIO";
+
+  // `version` is a direct dependency of `parsed` so edits to the doc via
+  // anywhere (this panel included) re-derive the property list.
+  let view = $derived($activeViewStore.view);
+  let version = $derived($activeViewStore.docVersion);
+
+  let parsed = $derived.by(() => {
+    // touch version so $derived tracks it even if view is unchanged
+    void version;
+    if (!view) return { properties: [] as Property[] };
+    return parseFrontmatter(view.state.doc.toString());
+  });
+
+  function commit(next: Property[]): void {
+    if (!view) return;
+    const edit = computeFrontmatterEdit(view.state.doc.toString(), next);
+    view.dispatch({
+      changes: { from: edit.from, to: edit.to, insert: edit.insert },
+    });
+  }
+
+  function updateRow(index: number, patch: Partial<Property>): void {
+    const next = parsed.properties.map((p, i) => (i === index ? { ...p, ...patch } : p));
+    commit(next);
+  }
+
+  function deleteRow(index: number): void {
+    const next = parsed.properties.filter((_, i) => i !== index);
+    commit(next);
+  }
+
+  function addRow(): void {
+    const existing = parsed.properties;
+    let base = "property";
+    let candidate = base;
+    let n = 1;
+    const keys = new Set(existing.map((p) => p.key));
+    while (keys.has(candidate)) {
+      n += 1;
+      candidate = `${base}${n}`;
+    }
+    commit([...existing, { key: candidate, value: "" }]);
+  }
+</script>
+
+<div class="vc-props-panel" role="complementary" aria-label="Properties">
+  <div class="vc-props-header">
+    <span class="vc-props-label">Properties</span>
+    <button
+      type="button"
+      class="vc-props-add"
+      onclick={addRow}
+      disabled={!view}
+      aria-label="Eigenschaft hinzufügen"
+      title="Eigenschaft hinzufügen"
+    >
+      <Plus size={14} />
+    </button>
+  </div>
+
+  <div class="vc-props-body">
+    {#if !view}
+      <div class="vc-props-empty">Keine Datei geöffnet.</div>
+    {:else if parsed.properties.length === 0}
+      <div class="vc-props-empty">
+        Keine Eigenschaften. Klicke <span class="vc-props-inline-plus">+</span>, um eine hinzuzufügen.
+      </div>
+    {:else}
+      <div class="vc-props-list">
+        {#each parsed.properties as prop, index (index)}
+          <div class="vc-props-row">
+            <input
+              type="text"
+              class="vc-props-key"
+              value={prop.key}
+              onchange={(e) => updateRow(index, { key: e.currentTarget.value })}
+              aria-label="Schlüssel"
+              spellcheck="false"
+            />
+            <input
+              type="text"
+              class="vc-props-value"
+              value={prop.value}
+              onchange={(e) => updateRow(index, { value: e.currentTarget.value })}
+              aria-label="Wert"
+              spellcheck="false"
+            />
+            <button
+              type="button"
+              class="vc-props-del"
+              onclick={() => deleteRow(index)}
+              aria-label="Eigenschaft löschen"
+              title="Löschen"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .vc-props-panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg);
+  }
+  .vc-props-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .vc-props-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: none;
+  }
+  .vc-props-add {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: 4px;
+  }
+  .vc-props-add:hover:not(:disabled) { background: var(--color-accent-bg); color: var(--color-accent); }
+  .vc-props-add:disabled { opacity: 0.4; cursor: not-allowed; }
+  .vc-props-body {
+    padding: 12px 16px;
+  }
+  .vc-props-empty {
+    font-size: 13px;
+    color: var(--color-text-muted);
+    padding: 4px 0 8px 0;
+  }
+  .vc-props-inline-plus {
+    font-family: var(--vc-font-mono);
+    font-size: 12px;
+    padding: 0 4px;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+  }
+  .vc-props-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .vc-props-row {
+    display: grid;
+    grid-template-columns: 32% 1fr 20px;
+    gap: 4px;
+    align-items: center;
+  }
+  .vc-props-key,
+  .vc-props-value {
+    height: 24px;
+    font-size: 13px;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 0 6px;
+    box-sizing: border-box;
+    outline: none;
+    min-width: 0;
+  }
+  .vc-props-key { font-family: var(--vc-font-mono); color: var(--color-text-muted); }
+  .vc-props-key:focus,
+  .vc-props-value:focus {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 2px var(--color-accent-bg);
+  }
+  .vc-props-del {
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: 3px;
+  }
+  .vc-props-del:hover { background: var(--color-accent-bg); color: var(--color-error); }
+</style>

--- a/src/lib/__tests__/frontmatterIO.test.ts
+++ b/src/lib/__tests__/frontmatterIO.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFrontmatter,
+  serializeBody,
+  serializeBlock,
+  computeFrontmatterEdit,
+} from "../frontmatterIO";
+
+describe("parseFrontmatter", () => {
+  it("returns empty properties when the doc has no frontmatter", () => {
+    const res = parseFrontmatter("# Just a heading\n");
+    expect(res.region).toBeNull();
+    expect(res.properties).toEqual([]);
+  });
+
+  it("parses flat key/value pairs", () => {
+    const doc = "---\ntitle: Hello\nstatus: draft\n---\nBody";
+    const res = parseFrontmatter(doc);
+    expect(res.region).toEqual({ from: 0, to: 35 });
+    expect(res.properties).toEqual([
+      { key: "title", value: "Hello" },
+      { key: "status", value: "draft" },
+    ]);
+  });
+
+  it("keeps array-ish values as raw strings", () => {
+    const res = parseFrontmatter("---\ntags: [a, b]\n---\n");
+    expect(res.properties).toEqual([{ key: "tags", value: "[a, b]" }]);
+  });
+
+  it("ignores lines that don't look like key: value", () => {
+    const res = parseFrontmatter("---\ntitle: X\n# not a key\nfoo: bar\n---\n");
+    expect(res.properties).toEqual([
+      { key: "title", value: "X" },
+      { key: "foo", value: "bar" },
+    ]);
+  });
+
+  it("handles empty frontmatter", () => {
+    const res = parseFrontmatter("---\n\n---\n");
+    expect(res.region).not.toBeNull();
+    expect(res.properties).toEqual([]);
+  });
+});
+
+describe("serializeBody / serializeBlock", () => {
+  it("joins key/value pairs with newlines", () => {
+    expect(serializeBody([
+      { key: "title", value: "X" },
+      { key: "tags", value: "[a, b]" },
+    ])).toBe("title: X\ntags: [a, b]");
+  });
+
+  it("drops rows with empty keys", () => {
+    expect(serializeBody([
+      { key: "", value: "orphan" },
+      { key: "title", value: "X" },
+    ])).toBe("title: X");
+  });
+
+  it("returns empty string for empty list in serializeBlock", () => {
+    expect(serializeBlock([])).toBe("");
+  });
+
+  it("wraps body in --- fences", () => {
+    expect(serializeBlock([{ key: "a", value: "1" }])).toBe("---\na: 1\n---\n");
+  });
+});
+
+describe("computeFrontmatterEdit", () => {
+  it("inserts new block + separator when adding first property to a doc with body", () => {
+    const doc = "# Body\n";
+    const edit = computeFrontmatterEdit(doc, [{ key: "title", value: "X" }]);
+    expect(edit).toEqual({ from: 0, to: 0, insert: "---\ntitle: X\n---\n" });
+    const after = doc.slice(0, edit.from) + edit.insert + doc.slice(edit.to);
+    expect(after).toBe("---\ntitle: X\n---\n# Body\n");
+  });
+
+  it("inserts new block without extra newline into empty doc", () => {
+    const edit = computeFrontmatterEdit("", [{ key: "a", value: "1" }]);
+    expect(edit.insert).toBe("---\na: 1\n---\n");
+  });
+
+  it("does nothing when props are empty and doc has no frontmatter", () => {
+    const edit = computeFrontmatterEdit("# Body\n", []);
+    expect(edit).toEqual({ from: 0, to: 0, insert: "" });
+  });
+
+  it("strips the block AND the trailing blank separator when removing all properties", () => {
+    const doc = "---\ntitle: X\n---\n\n# Body\n";
+    const edit = computeFrontmatterEdit(doc, []);
+    const after = doc.slice(0, edit.from) + edit.insert + doc.slice(edit.to);
+    expect(after).toBe("# Body\n");
+  });
+
+  it("replaces the existing block in place when edits change values", () => {
+    const doc = "---\ntitle: Old\n---\n# Body\n";
+    const edit = computeFrontmatterEdit(doc, [{ key: "title", value: "New" }]);
+    const after = doc.slice(0, edit.from) + edit.insert + doc.slice(edit.to);
+    expect(after).toBe("---\ntitle: New\n---\n# Body\n");
+  });
+});

--- a/src/lib/frontmatterIO.ts
+++ b/src/lib/frontmatterIO.ts
@@ -1,0 +1,84 @@
+// Minimal YAML-ish reader/writer for the Properties panel.
+// Scope: flat top-level `key: value` pairs only. Values are treated as
+// opaque strings (what the user typed, verbatim). Nested structures,
+// multi-line scalars, and YAML comments are preserved as raw-string
+// values on read but will be coerced to single-line on write — which is
+// acceptable for the "edit simple frontmatter from the sidebar" use case.
+
+import { detectFrontmatter } from "../components/Editor/frontmatterPlugin";
+
+export interface Property {
+  key: string;
+  value: string;
+}
+
+export interface FrontmatterParseResult {
+  properties: Property[];
+  region: { from: number; to: number } | null;
+}
+
+const KEY_RE = /^([A-Za-z_][\w-]*)\s*:\s?(.*)$/;
+
+export function parseFrontmatter(docText: string): FrontmatterParseResult {
+  const region = detectFrontmatter(docText);
+  if (!region) return { properties: [], region: null };
+
+  const lines = region.body.split(/\r?\n/);
+  const properties: Property[] = [];
+  for (const line of lines) {
+    const match = KEY_RE.exec(line);
+    if (!match) continue;
+    const [, key = "", rawValue = ""] = match;
+    properties.push({ key, value: rawValue });
+  }
+  return { properties, region: { from: region.from, to: region.to } };
+}
+
+export function serializeBody(properties: Property[]): string {
+  return properties
+    .filter((p) => p.key.trim().length > 0)
+    .map((p) => `${p.key}: ${p.value}`)
+    .join("\n");
+}
+
+export function serializeBlock(properties: Property[]): string {
+  const body = serializeBody(properties);
+  if (body.length === 0) return "";
+  return `---\n${body}\n---\n`;
+}
+
+// Compute the replacement transaction for going from the current doc to
+// the new property list. Returns the `from`/`to`/`insert` triple to pass
+// to `view.dispatch({ changes: ... })`.
+//
+// Rules:
+//   - If new list is empty AND doc has frontmatter: strip the block AND
+//     one trailing blank line (the separator between frontmatter and body).
+//   - If new list is non-empty AND doc has no frontmatter: insert the
+//     block at position 0, followed by one blank separator line.
+//   - Otherwise: replace the existing block in-place.
+export function computeFrontmatterEdit(
+  docText: string,
+  properties: Property[],
+): { from: number; to: number; insert: string } {
+  const existing = detectFrontmatter(docText);
+  const newBlock = serializeBlock(properties);
+
+  if (!existing && newBlock === "") {
+    return { from: 0, to: 0, insert: "" };
+  }
+
+  if (existing && newBlock === "") {
+    let to = existing.to;
+    if (docText.charAt(to) === "\n") to += 1;
+    return { from: 0, to, insert: "" };
+  }
+
+  if (!existing) {
+    // `newBlock` already ends with `\n`, so the existing doc content
+    // follows immediately on the next line — no extra separator needed.
+    return { from: 0, to: 0, insert: newBlock };
+  }
+
+  return { from: existing.from, to: existing.to, insert: newBlock };
+}

--- a/src/store/activeViewStore.ts
+++ b/src/store/activeViewStore.ts
@@ -1,0 +1,32 @@
+// Exposes the currently active CodeMirror 6 EditorView so right-sidebar
+// panels (e.g. PropertiesPanel) can read and dispatch changes to the
+// visible document. Updated by EditorPane whenever the active tab/pane
+// changes and when views mount/unmount.
+//
+// `docVersion` is a simple counter bumped on every doc-changed update of
+// ANY mounted view. Panels that derive state from `activeView.state.doc`
+// re-read on each bump — inactive-view bumps are cheap no-ops because the
+// active view's doc is unchanged.
+
+import { writable } from "svelte/store";
+import type { EditorView } from "@codemirror/view";
+
+export interface ActiveViewState {
+  view: EditorView | null;
+  docVersion: number;
+}
+
+const _store = writable<ActiveViewState>({ view: null, docVersion: 0 });
+
+export const activeViewStore = {
+  subscribe: _store.subscribe,
+  setActive(view: EditorView | null): void {
+    _store.update((s) => ({ view, docVersion: s.docVersion + 1 }));
+  },
+  bumpDocVersion(): void {
+    _store.update((s) => ({ ...s, docVersion: s.docVersion + 1 }));
+  },
+  clear(): void {
+    _store.set({ view: null, docVersion: 0 });
+  },
+};


### PR DESCRIPTION
Closes #2

## Summary
- Hides YAML frontmatter in the editor via a CM6 block-replace decoration (atomic, cursor can't enter)
- Adds a "Properties" panel in the right sidebar — editable key/value rows, add + delete, commits via `view.dispatch` so auto-save + undo work
- First property creates `---\n...\n---\n` at the top of the file; removing the last property strips the block entirely — no frontmatter in the file when there are no properties

## Details
- `livePreview` skips setext `HeaderMark` hides inside the frontmatter region so nothing leaks when the cursor is outside
- `activeViewStore` exposes the current `EditorView` + a `docVersion` counter bumped on every doc change
- `lib/frontmatterIO.ts` — pure parse/serialize/edit helpers (no YAML dependency)
- Unified sidebar headers; removed the redundant Backlinks close button (use the sidebar toggle)

## Test plan
- [x] Unit tests for `detectFrontmatter` (8) and `frontmatterIO` parse/serialize/edit (14) — all green
- [x] `pnpm exec vite build` clean
- [x] `pnpm exec svelte-check` clean on changed files
- [x] Manual: open a note with frontmatter → frontmatter invisible in editor, properties visible in sidebar
- [x] Manual: add first property to a note without frontmatter → `---...---` block appears at top of file on disk
- [x] Manual: delete last property → block is stripped from file entirely
- [x] Manual: edit a property value → change persists via auto-save