### PR TITLE
feat(editor): add word and character count status bar

### DIFF
--- a/src/components/Editor/CountStatusBar.svelte
+++ b/src/components/Editor/CountStatusBar.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  // Thin status bar at the bottom of an editor pane showing live word and
+  // character counts. Reads per-pane counts from `countsStore`, which is
+  // published by the CM6 `countsPlugin` on docChanged/selectionSet (100ms
+  // debounce for doc edits, immediate for selection changes).
+  //
+  // Rendered by EditorPane only when a tab is open in that pane, so the
+  // bar disappears on the "No file open" placeholder.
+
+  import { onDestroy } from "svelte";
+  import { countsStore, type PaneId, type PaneCounts } from "../../store/countsStore";
+
+  let { paneId }: { paneId: PaneId } = $props();
+
+  let counts = $state<PaneCounts | null>(null);
+  const unsub = countsStore.subscribe((s) => { counts = s[paneId]; });
+  onDestroy(() => unsub());
+
+  const label = $derived.by(() => {
+    if (!counts) return "";
+    const { words, characters, selection } = counts;
+    const wordsLabel = words === 1 ? "word" : "words";
+    const charsLabel = characters === 1 ? "character" : "characters";
+    const suffix = selection ? " selected" : "";
+    return `${words.toLocaleString()} ${wordsLabel} · ${characters.toLocaleString()} ${charsLabel}${suffix}`;
+  });
+</script>
+
+{#if counts}
+  <div class="vc-count-status-bar" role="status" aria-live="polite">
+    <span class="vc-count-status-text">{label}</span>
+  </div>
+{/if}
+
+<style>
+  .vc-count-status-bar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    height: 22px;
+    padding: 0 10px;
+    border-top: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-text-muted);
+    font-size: 12px;
+    flex-shrink: 0;
+    user-select: none;
+  }
+
+  .vc-count-status-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -12,6 +12,9 @@
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
   import { buildExtensions } from "./extensions";
+  import CountStatusBar from "./CountStatusBar.svelte";
+  import { countsStore } from "../../store/countsStore";
+  import { computeCounts } from "../../lib/wordCount";
   import { scrollToMatch } from "./flashHighlight";
   import { scrollStore } from "../../store/scrollStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
@@ -292,6 +295,27 @@
     }
   });
 
+  // Republish counts for THIS pane whenever the active tab changes. Each
+  // view has its own countsPlugin instance, but because they all write to
+  // the same paneId slot, a tab switch alone doesn't re-trigger publication
+  // on the newly-active view. Publish directly from the shared `computeCounts`
+  // helper so the status bar updates immediately on switch.
+  $effect(() => {
+    const activeId = paneActiveTabId;
+    if (!activeId) {
+      countsStore.clear(paneId);
+      return;
+    }
+    const view = viewMap.get(activeId);
+    if (!view) return;
+    const sel = view.state.selection.main;
+    const text = sel.empty
+      ? view.state.doc.toString()
+      : view.state.sliceDoc(sel.from, sel.to);
+    const { words, characters } = computeCounts(text);
+    countsStore.set(paneId, { words, characters, selection: !sel.empty });
+  });
+
   // Also publish the active view whenever the active pane itself switches.
   // The block above only fires on tab-id changes within this pane — moving
   // focus between panes wouldn't otherwise update the sidebar's source view.
@@ -413,7 +437,7 @@
       tabStore.setDirty(tab.id, true);
     };
 
-    const extensions = buildExtensions(onSave);
+    const extensions = buildExtensions(onSave, paneId);
     const { EditorView: EV } = await import("@codemirror/view");
     const dirtyListener = EV.updateListener.of((update) => {
       if (update.docChanged) {
@@ -607,6 +631,10 @@
       ></div>
     {/each}
   </div>
+
+  {#if paneTabs.length > 0}
+    <CountStatusBar {paneId} />
+  {/if}
 
   {#if !vaultReachable}
     <div class="vc-editor-readonly-overlay"></div>

--- a/src/components/Editor/countsPlugin.ts
+++ b/src/components/Editor/countsPlugin.ts
@@ -1,0 +1,71 @@
+// CodeMirror 6 ViewPlugin that publishes word/character counts for the
+// active document (or current selection) into the Svelte `countsStore`.
+//
+// Debounce: 100ms. Enough to collapse a fast typing burst into a single
+// count computation without feeling laggy. Selection-only transactions
+// bypass the debounce so click-and-drag feels instant.
+
+import { ViewPlugin, type EditorView, type ViewUpdate } from "@codemirror/view";
+import { countsStore, type PaneId } from "../../store/countsStore";
+import { computeCounts } from "../../lib/wordCount";
+
+const DEBOUNCE_MS = 100;
+
+function publish(view: EditorView, paneId: PaneId): void {
+  const selection = view.state.selection.main;
+  const hasSelection = !selection.empty;
+
+  const text = hasSelection
+    ? view.state.sliceDoc(selection.from, selection.to)
+    : view.state.doc.toString();
+
+  const { words, characters } = computeCounts(text);
+  countsStore.set(paneId, { words, characters, selection: hasSelection });
+}
+
+export function countsPlugin(paneId: PaneId) {
+  return ViewPlugin.fromClass(
+    class {
+      private timer: ReturnType<typeof setTimeout> | null = null;
+      private view: EditorView;
+
+      constructor(view: EditorView) {
+        this.view = view;
+        // Initial snapshot — no debounce, so the bar appears with correct
+        // counts as soon as the editor mounts.
+        publish(view, paneId);
+      }
+
+      update(update: ViewUpdate): void {
+        if (!update.docChanged && !update.selectionSet) return;
+
+        // Selection-only updates are cheap and the user expects the count
+        // to track the drag in real time — skip the debounce.
+        if (update.selectionSet && !update.docChanged) {
+          if (this.timer !== null) {
+            clearTimeout(this.timer);
+            this.timer = null;
+          }
+          publish(update.view, paneId);
+          return;
+        }
+
+        if (this.timer !== null) clearTimeout(this.timer);
+        this.timer = setTimeout(() => {
+          this.timer = null;
+          publish(this.view, paneId);
+        }, DEBOUNCE_MS);
+      }
+
+      destroy(): void {
+        if (this.timer !== null) {
+          clearTimeout(this.timer);
+          this.timer = null;
+        }
+        countsStore.clear(paneId);
+      }
+    },
+  );
+}
+
+export const COUNTS_DEBOUNCE_FOR_TESTS = DEBOUNCE_MS;

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -27,14 +27,19 @@ import { flashField } from "./flashHighlight";
 import { wikiLinkPlugin } from "./wikiLink";
 import { livePreviewPlugin } from "./livePreview";
 import { frontmatterPlugin } from "./frontmatterPlugin";
+import { countsPlugin } from "./countsPlugin";
+import type { PaneId } from "../../store/countsStore";
 import { activeViewStore } from "../../store/activeViewStore";
 
 const docVersionBumpListener = EditorView.updateListener.of((update) => {
   if (update.docChanged) activeViewStore.bumpDocVersion();
 });
 
-export function buildExtensions(onSave: (text: string) => void): Extension[] {
-  return [
+export function buildExtensions(
+  onSave: (text: string) => void,
+  paneId?: PaneId,
+): Extension[] {
+  const extensions: Extension[] = [
     history(),
     drawSelection(),
     dropCursor(),
@@ -65,4 +70,10 @@ export function buildExtensions(onSave: (text: string) => void): Extension[] {
     frontmatterPlugin,
     docVersionBumpListener,
   ];
+
+  if (paneId !== undefined) {
+    extensions.push(countsPlugin(paneId));
+  }
+
+  return extensions;
 }

--- a/src/lib/__tests__/wordCount.test.ts
+++ b/src/lib/__tests__/wordCount.test.ts
@@ -113,9 +113,9 @@ describe("countCharacters", () => {
     expect(countCharacters("ab🌳cd")).toBe(5);
   });
 
-  it("does NOT strip frontmatter — characters reflect raw document length", () => {
+  it("strips leading frontmatter from the character count", () => {
     const doc = "---\nx: y\n---\nhi";
-    expect(countCharacters(doc)).toBe(doc.length);
+    expect(countCharacters(doc)).toBe(2);
   });
 });
 

--- a/src/lib/__tests__/wordCount.test.ts
+++ b/src/lib/__tests__/wordCount.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  countWords,
+  countCharacters,
+  computeCounts,
+  stripLeadingFrontmatter,
+} from "../wordCount";
+
+describe("stripLeadingFrontmatter", () => {
+  it("returns the original text when no frontmatter is present", () => {
+    expect(stripLeadingFrontmatter("# Heading\nBody")).toBe("# Heading\nBody");
+  });
+
+  it("strips a leading frontmatter block but keeps the body intact", () => {
+    const doc = "---\ntitle: X\ntags: [a, b]\n---\n# Body\nhello";
+    expect(stripLeadingFrontmatter(doc)).toBe("# Body\nhello");
+  });
+
+  it("does NOT strip `---` sections that are not at the very start", () => {
+    const doc = "# Heading\n\n---\nnot: frontmatter\n---\nBody";
+    expect(stripLeadingFrontmatter(doc)).toBe(doc);
+  });
+});
+
+describe("countWords", () => {
+  it("returns 0 for an empty string", () => {
+    expect(countWords("")).toBe(0);
+  });
+
+  it("returns 0 for whitespace-only input", () => {
+    expect(countWords("   \n\t  \n")).toBe(0);
+  });
+
+  it("counts simple words separated by whitespace", () => {
+    expect(countWords("the quick brown fox")).toBe(4);
+  });
+
+  it("ignores markdown heading markers", () => {
+    expect(countWords("# Hello world")).toBe(2);
+    expect(countWords("### Another heading here")).toBe(3);
+  });
+
+  it("ignores markdown emphasis markers", () => {
+    expect(countWords("**bold** and *italic* and ~strike~")).toBe(5);
+  });
+
+  it("ignores list bullets and ordered list markers", () => {
+    expect(countWords("- one\n- two\n- three")).toBe(3);
+    expect(countWords("1. alpha\n2. beta")).toBe(2);
+  });
+
+  it("ignores blockquote markers", () => {
+    expect(countWords("> quoted text here")).toBe(3);
+  });
+
+  it("ignores inline code contents", () => {
+    expect(countWords("use `const foo = 1` here")).toBe(2);
+  });
+
+  it("ignores fenced code blocks entirely", () => {
+    const doc = "before\n```\nlots of code words here\n```\nafter";
+    expect(countWords(doc)).toBe(2);
+  });
+
+  it("keeps link/image alt text but strips the URL", () => {
+    expect(countWords("see [the docs](https://example.com/page) now")).toBe(4);
+    expect(countWords("![alt caption here](img.png)")).toBe(3);
+  });
+
+  it("keeps wiki-link target text", () => {
+    expect(countWords("see [[Some Note]] for details")).toBe(5);
+  });
+
+  it("prefers wiki-link alias over target when present", () => {
+    expect(countWords("see [[Some Note|the alias text]] now")).toBe(5);
+  });
+
+  it("counts hyphenated words as one word", () => {
+    expect(countWords("a well-known fact")).toBe(3);
+  });
+
+  it("counts contractions as one word", () => {
+    expect(countWords("don't won't can't")).toBe(3);
+  });
+
+  it("ignores leading frontmatter entirely", () => {
+    const doc = "---\ntitle: Ignored\ntags: [a, b, c]\n---\nactual body here";
+    expect(countWords(doc)).toBe(3);
+  });
+
+  it("counts Unicode letters outside ASCII", () => {
+    expect(countWords("café naïve")).toBe(2);
+    expect(countWords("über straße")).toBe(2);
+  });
+});
+
+describe("countCharacters", () => {
+  it("returns 0 for empty input", () => {
+    expect(countCharacters("")).toBe(0);
+  });
+
+  it("counts ASCII characters including whitespace", () => {
+    expect(countCharacters("hello world")).toBe(11);
+  });
+
+  it("counts newlines and tabs", () => {
+    expect(countCharacters("a\nb\tc")).toBe(5);
+  });
+
+  it("counts emoji as single code points (surrogate pairs collapsed)", () => {
+    // 🌳 is U+1F333, represented in UTF-16 as 2 code units but is a single code point.
+    expect(countCharacters("🌳")).toBe(1);
+    expect(countCharacters("ab🌳cd")).toBe(5);
+  });
+
+  it("does NOT strip frontmatter — characters reflect raw document length", () => {
+    const doc = "---\nx: y\n---\nhi";
+    expect(countCharacters(doc)).toBe(doc.length);
+  });
+});
+
+describe("computeCounts", () => {
+  it("returns both word and character counts in one call", () => {
+    expect(computeCounts("the quick brown fox")).toEqual({
+      words: 4,
+      characters: 19,
+    });
+  });
+
+  it("handles empty input", () => {
+    expect(computeCounts("")).toEqual({ words: 0, characters: 0 });
+  });
+});

--- a/src/lib/wordCount.ts
+++ b/src/lib/wordCount.ts
@@ -1,0 +1,117 @@
+// Pure helpers for the status-bar word/character counter.
+//
+// Scope: compute word and character counts for a plain-text/markdown document
+// or an arbitrary selection, matching Obsidian's behavior:
+//   - Characters: code-point count, INCLUDING whitespace and newlines.
+//   - Words: contiguous runs of letters/digits, after stripping leading
+//     frontmatter and common markdown syntax tokens. See WORD_RE comment.
+//
+// Non-goals: a full markdown AST, CJK word-segmentation, or grapheme-cluster
+// counting. A code-point count is close enough to what users expect and
+// matches what Obsidian shows.
+
+import { detectFrontmatter } from "../components/Editor/frontmatterPlugin";
+
+/**
+ * Strip the leading `---\n...\n---\n` frontmatter block (only — not any
+ * `---` that appears later in the document). Falls back to the original
+ * text when no frontmatter is present.
+ */
+export function stripLeadingFrontmatter(text: string): string {
+  const region = detectFrontmatter(text);
+  if (!region) return text;
+  return text.slice(region.to);
+}
+
+/**
+ * Remove common markdown syntax tokens so word-splitting counts content
+ * rather than punctuation. Pragmatic — not a parser:
+ *
+ *   - Fenced code blocks (```...```) — dropped wholesale (Obsidian counts
+ *     code words, but its counter is known to over/undercount; dropping
+ *     is simpler and closer to what the user perceives as "text").
+ *   - Inline code spans (`...`) — contents dropped.
+ *   - Image/link URL portions  — drop `](url)` tails, keep link text.
+ *   - HTML comments — dropped.
+ *   - Leading list/heading/blockquote markers on a line.
+ *   - Emphasis/strike markers *, _, ~, backticks.
+ *   - Wiki-link/embed brackets  [[..]], ![[..]] — keep the target text.
+ *   - Stray `[`, `]`, `(`, `)` used by links.
+ */
+function stripMarkdownSyntax(text: string): string {
+  let out = text;
+
+  // Fenced code blocks — greedy-enough: three backticks, anything, three
+  // backticks. Multiline dot via the `[\s\S]` trick (no /s flag for wider
+  // runtime compatibility).
+  out = out.replace(/```[\s\S]*?```/g, " ");
+
+  // Inline code spans — single-backtick runs on one line.
+  out = out.replace(/`[^`\n]*`/g, " ");
+
+  // HTML comments.
+  out = out.replace(/<!--[\s\S]*?-->/g, " ");
+
+  // Embeds and wiki links: ![[target|alias]] / [[target|alias]] — keep the
+  // alias if present, else the target (the portion users actually see).
+  out = out.replace(/!?\[\[([^\]\n|]+)(?:\|([^\]\n]+))?\]\]/g, (_m, t, a) => a ?? t);
+
+  // Markdown links ![alt](url) / [text](url) — keep the visible text.
+  out = out.replace(/!?\[([^\]\n]*)\]\([^)\n]*\)/g, "$1");
+
+  // Leading line markers: heading #, blockquote >, list bullets -/*/+, and
+  // ordered-list "1." style. Applied per-line so a `*` mid-text is kept.
+  out = out.replace(/^[ \t]*(?:>+[ \t]*)?(?:#{1,6}[ \t]+|[-*+][ \t]+|\d+\.[ \t]+)/gm, "");
+
+  // Emphasis / strong / strikethrough markers. We just drop the runs of
+  // these characters — the surrounding text is preserved for word counting.
+  out = out.replace(/[*_~]+/g, " ");
+
+  // Stray bracket characters from partial/edge-case links.
+  out = out.replace(/[\[\]()]+/g, " ");
+
+  return out;
+}
+
+/**
+ * A "word" is a contiguous run of Unicode letters or digits. Hyphens and
+ * apostrophes inside a run keep it as one word (e.g. "don't", "well-known").
+ * Regex uses Unicode property escapes (supported in all modern V8 runtimes).
+ */
+const WORD_RE = /[\p{L}\p{N}](?:[\p{L}\p{N}'’\-]*[\p{L}\p{N}])?/gu;
+
+/**
+ * Count words in a markdown-ish text, ignoring leading frontmatter and
+ * markdown syntax tokens.
+ */
+export function countWords(text: string): number {
+  if (text.length === 0) return 0;
+  const body = stripMarkdownSyntax(stripLeadingFrontmatter(text));
+  const matches = body.match(WORD_RE);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Count characters as code points (spread-and-length). Obsidian counts all
+ * characters including spaces and newlines — we do the same. Operates on
+ * the raw text, NOT the frontmatter-stripped body, because when nothing is
+ * selected the user expects to see the full document length.
+ */
+export function countCharacters(text: string): number {
+  if (text.length === 0) return 0;
+  // eslint-disable-next-line @typescript-eslint/prefer-spread
+  let n = 0;
+  // Iterating with for-of walks code points, avoiding UTF-16 surrogate double-counting.
+  for (const _ of text) n += 1;
+  return n;
+}
+
+export interface Counts {
+  words: number;
+  characters: number;
+}
+
+/** Compute both counts for a chunk of text in one pass-friendly call. */
+export function computeCounts(text: string): Counts {
+  return { words: countWords(text), characters: countCharacters(text) };
+}

--- a/src/lib/wordCount.ts
+++ b/src/lib/wordCount.ts
@@ -92,17 +92,15 @@ export function countWords(text: string): number {
 }
 
 /**
- * Count characters as code points (spread-and-length). Obsidian counts all
- * characters including spaces and newlines — we do the same. Operates on
- * the raw text, NOT the frontmatter-stripped body, because when nothing is
- * selected the user expects to see the full document length.
+ * Count characters as code points. Frontmatter is stripped (same policy as
+ * word count): frontmatter isn't visible prose and shouldn't inflate the
+ * character total either. Whitespace and newlines in the body still count.
  */
 export function countCharacters(text: string): number {
   if (text.length === 0) return 0;
-  // eslint-disable-next-line @typescript-eslint/prefer-spread
+  const body = stripLeadingFrontmatter(text);
   let n = 0;
-  // Iterating with for-of walks code points, avoiding UTF-16 surrogate double-counting.
-  for (const _ of text) n += 1;
+  for (const _ of body) n += 1;
   return n;
 }
 

--- a/src/store/countsStore.ts
+++ b/src/store/countsStore.ts
@@ -1,0 +1,40 @@
+// countsStore — per-pane word/character counts published by the CM6
+// countsPlugin and consumed by the status bar in EditorPane.
+//
+// Two panes can each host their own EditorView, so the store is keyed by
+// pane id. `selection` is true when the counts reflect a non-empty
+// selection rather than the full document — the status bar uses this to
+// switch its label from "X words" to "X words selected".
+
+import { writable } from "svelte/store";
+
+export interface PaneCounts {
+  words: number;
+  characters: number;
+  /** True when the counts reflect a non-empty selection rather than the whole doc. */
+  selection: boolean;
+}
+
+export type PaneId = "left" | "right";
+
+interface CountsState {
+  left: PaneCounts | null;
+  right: PaneCounts | null;
+}
+
+const initial: CountsState = { left: null, right: null };
+
+const _store = writable<CountsState>({ ...initial });
+
+export const countsStore = {
+  subscribe: _store.subscribe,
+  set(paneId: PaneId, counts: PaneCounts): void {
+    _store.update((s) => ({ ...s, [paneId]: counts }));
+  },
+  clear(paneId: PaneId): void {
+    _store.update((s) => ({ ...s, [paneId]: null }));
+  },
+  reset(): void {
+    _store.set({ ...initial });
+  },
+};


### PR DESCRIPTION
## Summary
- Adds a thin status bar at the bottom of each editor pane showing `{words} words · {characters} characters`, modelled after Obsidian's counter.
- Counts are produced by a CodeMirror 6 `ViewPlugin` that subscribes to `docChanged` / `selectionSet`, debounced ~100 ms for doc edits and immediate for selection changes, and published into a per-pane Svelte store.
- Word counter ignores leading YAML frontmatter and strips common markdown tokens (headings, lists, blockquotes, emphasis, inline + fenced code, link/image URLs, wiki-link brackets) so only visible words count. Character counter is code-point based and includes whitespace.
- Status bar is hidden when a pane has no open tab; selection-aware label appends " selected" when counting a selection.

Closes #5

## Test plan
- [x] Unit tests for `countWords` / `countCharacters` / `stripLeadingFrontmatter` (`src/lib/__tests__/wordCount.test.ts`, 26 cases).
- [x] Open a note — the bar appears at the bottom of the pane and shows the correct counts.
- [x] Type into the note — the bar updates (within ~100 ms).
- [x] Select a range — the bar switches to "N words selected / N characters selected" and tracks the selection live.
- [x] Add YAML frontmatter — the words inside `---` fences are not counted toward word totals.
- [x] Close every tab in the pane — the bar disappears.
- [x] Split the view — each pane shows its own counts.