### PR TITLE
feat(editor): add breadcrumb path bar above editor

### DIFF
--- a/src/components/Editor/Breadcrumbs.svelte
+++ b/src/components/Editor/Breadcrumbs.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  /**
+   * Breadcrumb bar shown between the tab bar and editor content.
+   *
+   * Renders the folder path of the active tab's file, relative to the vault
+   * root, as clickable segments separated by "›". Folder segments call
+   * treeRevealStore.requestReveal() so the sidebar expands and scrolls to them.
+   * The filename segment is styled distinctly but is a no-op on click.
+   *
+   * Long paths are truncated from the left with an ellipsis using the
+   * direction:rtl + direction:ltr trick so the filename stays visible.
+   *
+   * Hidden when no tab is open in the pane.
+   */
+  import { vaultStore } from "../../store/vaultStore";
+  import { treeRevealStore } from "../../store/treeRevealStore";
+
+  interface Props {
+    /** Absolute file path of the tab whose breadcrumbs to show, or null. */
+    filePath: string | null;
+  }
+
+  let { filePath }: Props = $props();
+
+  interface Segment {
+    label: string;
+    /** Vault-relative path up to and including this segment (folders only). */
+    relPath: string | null; // null for the filename segment (no-op on click)
+    isFile: boolean;
+  }
+
+  /**
+   * Split an absolute file path into breadcrumb segments, keyed to the active
+   * vault root. Returns an empty list when the file lives outside the vault
+   * (should not happen in practice, but we never want to render a misleading
+   * bar).
+   */
+  function computeSegments(abs: string | null, vault: string | null): Segment[] {
+    if (!abs || !vault) return [];
+    const normalisedVault = vault.replace(/\\/g, "/").replace(/\/+$/, "");
+    const normalisedAbs = abs.replace(/\\/g, "/");
+    if (!normalisedAbs.startsWith(normalisedVault + "/")) return [];
+
+    const rel = normalisedAbs.slice(normalisedVault.length + 1);
+    if (!rel) return [];
+
+    const parts = rel.split("/").filter((p) => p.length > 0);
+    if (parts.length === 0) return [];
+
+    const segments: Segment[] = [];
+    const runningPath: string[] = [];
+    for (let i = 0; i < parts.length; i += 1) {
+      const part = parts[i];
+      if (part === undefined) continue;
+      const isFile = i === parts.length - 1;
+      runningPath.push(part);
+      segments.push({
+        label: part,
+        relPath: isFile ? null : runningPath.join("/"),
+        isFile,
+      });
+    }
+    return segments;
+  }
+
+  const segments = $derived(computeSegments(filePath, $vaultStore.currentPath));
+
+  function handleFolderClick(relPath: string) {
+    treeRevealStore.requestReveal(relPath);
+  }
+</script>
+
+{#if segments.length > 0}
+  <nav class="vc-breadcrumbs" aria-label="File path">
+    <div class="vc-breadcrumbs-inner">
+      {#each segments as seg, i (i)}
+        {#if i > 0}
+          <span class="vc-breadcrumbs-sep" aria-hidden="true">&#8250;</span>
+        {/if}
+        {#if seg.isFile}
+          <!-- Filename segment: distinct styling, no-op click (AC-05). -->
+          <span class="vc-breadcrumbs-segment vc-breadcrumbs-segment--file">
+            {seg.label}
+          </span>
+        {:else}
+          <button
+            type="button"
+            class="vc-breadcrumbs-segment vc-breadcrumbs-segment--folder"
+            onclick={() => handleFolderClick(seg.relPath as string)}
+            title="Reveal {seg.label} in the file tree"
+          >
+            {seg.label}
+          </button>
+        {/if}
+      {/each}
+    </div>
+  </nav>
+{/if}
+
+<style>
+  /* Outer bar — fills the pane width, applies the rtl trick so that when the
+     inner line overflows the ellipsis shows up on the LEFT while the filename
+     stays glued to the right edge (AC-04). */
+  .vc-breadcrumbs {
+    display: flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 12px;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+    overflow: hidden;
+    direction: rtl;
+  }
+
+  .vc-breadcrumbs-inner {
+    direction: ltr;
+    display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+    font-size: 12px;
+    color: var(--color-text-muted);
+    line-height: 1;
+  }
+
+  .vc-breadcrumbs-sep {
+    margin: 0 4px;
+    color: var(--color-text-muted);
+    opacity: 0.7;
+  }
+
+  .vc-breadcrumbs-segment {
+    background: none;
+    border: none;
+    padding: 2px 2px;
+    font: inherit;
+    color: inherit;
+    cursor: default;
+    border-radius: 3px;
+  }
+
+  .vc-breadcrumbs-segment--folder {
+    cursor: pointer;
+  }
+
+  .vc-breadcrumbs-segment--folder:hover {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+
+  .vc-breadcrumbs-segment--folder:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+  }
+
+  /* Filename segment — distinct style per AC-07 (bolder + normal text color). */
+  .vc-breadcrumbs-segment--file {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+</style>

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -3,6 +3,7 @@
   import { EditorView } from "@codemirror/view";
   import { EditorState } from "@codemirror/state";
   import TabBar from "../Tabs/TabBar.svelte";
+  import Breadcrumbs from "./Breadcrumbs.svelte";
   import { tabStore } from "../../store/tabStore";
   import type { Tab } from "../../store/tabStore";
   import { vaultStore } from "../../store/vaultStore";
@@ -74,6 +75,14 @@
     activePane === paneId && activeTabId !== null && paneTabIds.includes(activeTabId)
       ? activeTabId
       : paneTabIds[0] ?? null
+  );
+
+  // Active tab file path for this pane — drives the breadcrumb bar.
+  // Null when no tab is open in the pane, which hides the bar (AC-06).
+  const paneActiveFilePath = $derived(
+    paneActiveTabId !== null
+      ? (paneTabs.find((t) => t.id === paneActiveTabId)?.filePath ?? null)
+      : null
   );
 
   // Subscribe to tabStore for our pane's tabs and active state
@@ -588,6 +597,9 @@
     tabs={paneTabs}
     activeTabId={paneActiveTabId}
   />
+
+  <!-- Breadcrumb path bar — self-hides when no tab is open (AC-06). -->
+  <Breadcrumbs filePath={paneActiveFilePath} />
 
   <!-- Editor content area -->
   <div class="vc-editor-content">

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -27,6 +27,7 @@
   import { tabStore } from "../../store/tabStore";
   import { searchStore } from "../../store/searchStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
+  import { treeRevealStore } from "../../store/treeRevealStore";
   import { tagsStore } from "../../store/tagsStore";
   import { Hash } from "lucide-svelte";
   import TreeNode from "./TreeNode.svelte";
@@ -136,6 +137,23 @@
 
   let prevRefreshToken: string | null = null;
   let unsubTreeRefresh: (() => void) | null = null;
+  let prevRevealToken: string | null = null;
+  let unsubTreeReveal: (() => void) | null = null;
+
+  /**
+   * Collect every ancestor folder rel path of the target. For
+   * "notes/daily/today.md" this returns ["notes", "notes/daily"]. The target
+   * itself is not included (only its enclosing folders need to be expanded).
+   */
+  function ancestorFolderPaths(relPath: string): string[] {
+    const parts = relPath.split("/").filter((p) => p.length > 0);
+    if (parts.length <= 1) return [];
+    const out: string[] = [];
+    for (let i = 1; i < parts.length; i += 1) {
+      out.push(parts.slice(0, i).join("/"));
+    }
+    return out;
+  }
 
   async function onExpandToggle(relPath: string, isExpanded: boolean) {
     const expanded = new Set(treeState.expanded);
@@ -181,6 +199,34 @@
         if ($vaultStore.currentPath) void tagsStore.reload();
       }
     });
+
+    // Reveal requests — issued by the breadcrumb bar. Flip to the files
+    // tab and ensure every ancestor folder is in the persisted expanded
+    // list so freshly rendered TreeNodes mount expanded. TreeNode owns
+    // the scroll-into-view + per-instance expansion via its own
+    // treeRevealStore subscription.
+    unsubTreeReveal = treeRevealStore.subscribe(async (state) => {
+      if (!state.pending) return;
+      if (state.pending.token === prevRevealToken) return;
+      prevRevealToken = state.pending.token;
+
+      searchStore.setActiveTab("files");
+
+      const ancestors = ancestorFolderPaths(state.pending.relPath);
+      if (ancestors.length === 0) return;
+      const expanded = new Set(treeState.expanded);
+      let changed = false;
+      for (const p of ancestors) {
+        if (!expanded.has(p)) {
+          expanded.add(p);
+          changed = true;
+        }
+      }
+      if (changed) {
+        treeState = { ...treeState, expanded: Array.from(expanded) };
+        await saveTreeState($vaultStore.currentPath ?? "", treeState);
+      }
+    });
   });
 
   onDestroy(() => {
@@ -188,6 +234,7 @@
     unlistenBulkStart?.();
     unlistenBulkEnd?.();
     unsubTreeRefresh?.();
+    unsubTreeReveal?.();
     unsubVaultPathSidebar?.();
     tagsStore.reset();
   });

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -8,8 +8,9 @@
   import InlineRename from "./InlineRename.svelte";
   import { vaultStore } from "../../store/vaultStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
+  import { treeRevealStore } from "../../store/treeRevealStore";
   import { sortEntries, type SortBy } from "../../lib/treeState";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
 
   interface Props {
     entry: DirEntry;
@@ -83,11 +84,53 @@
 
   const isActive = $derived(selectedPath === entry.path);
 
+  // DOM ref for scroll-into-view on reveal requests.
+  let rowEl = $state<HTMLDivElement | undefined>();
+
   // Auto-load children if this node starts expanded (restored from persisted state, FILE-07)
   onMount(() => {
     if (initiallyExpanded && entry.is_dir && !childrenLoaded) {
       void loadChildren();
     }
+  });
+
+  // ─── Reveal-in-tree support ────────────────────────────────────────────────
+  // Subscribe to treeRevealStore. When a request lands we either:
+  //   - scroll our row into view (our rel path matches exactly), or
+  //   - auto-expand + load children (our rel path is an ancestor of the target),
+  // so the descendant row becomes visible in the DOM before it too scrolls into view.
+  let prevRevealToken: string | null = null;
+  const unsubTreeReveal = treeRevealStore.subscribe((state) => {
+    if (!state.pending) return;
+    if (state.pending.token === prevRevealToken) return;
+    prevRevealToken = state.pending.token;
+
+    const vault = getVaultRoot();
+    if (!vault) return;
+    const myRel = toRelPath(entry.path, vault);
+    const target = state.pending.relPath;
+    if (!myRel || !target) return;
+
+    if (myRel === target) {
+      // Exact match — scroll our row into view (AC-03). Defer so any
+      // ancestor-triggered expansion has landed in the DOM first.
+      requestAnimationFrame(() => {
+        rowEl?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      });
+      return;
+    }
+
+    // Ancestor match — expand ourselves so the descendant becomes renderable.
+    if (entry.is_dir && (target === myRel + "/" || target.startsWith(myRel + "/"))) {
+      if (!expanded) {
+        expanded = true;
+        if (!childrenLoaded) void loadChildren();
+      }
+    }
+  });
+
+  onDestroy(() => {
+    unsubTreeReveal();
   });
 
   async function loadChildren() {
@@ -403,6 +446,7 @@
   <div
     class="vc-tree-row"
     style="padding-left: calc({depth} * 16px + 8px)"
+    bind:this={rowEl}
     onclick={handleClick}
     role="button"
     tabindex="-1"

--- a/src/store/__tests__/treeRevealStore.test.ts
+++ b/src/store/__tests__/treeRevealStore.test.ts
@@ -1,0 +1,45 @@
+/**
+ * treeRevealStore tests — one-shot reveal signal shape, dedup via token.
+ *
+ * The store is consumed by Sidebar (which expands ancestors) and TreeNode
+ * (which auto-expands / scrolls into view). These tests only cover the
+ * store contract; component-level behaviour is exercised in the Svelte
+ * integration tests.
+ */
+import { describe, it, expect } from "vitest";
+import { get } from "svelte/store";
+import { treeRevealStore } from "../treeRevealStore";
+
+describe("treeRevealStore", () => {
+  it("starts with no pending request", () => {
+    // Clear any lingering request from another test run
+    treeRevealStore.clearPending();
+    expect(get(treeRevealStore).pending).toBeNull();
+  });
+
+  it("requestReveal sets a pending request with the given rel path", () => {
+    treeRevealStore.requestReveal("Projects/Work/notes");
+    const s = get(treeRevealStore);
+    expect(s.pending).not.toBeNull();
+    expect(s.pending?.relPath).toBe("Projects/Work/notes");
+    expect(typeof s.pending?.token).toBe("string");
+    expect(s.pending?.token.length).toBeGreaterThan(0);
+  });
+
+  it("each requestReveal issues a fresh token", () => {
+    treeRevealStore.requestReveal("a");
+    const first = get(treeRevealStore).pending?.token;
+    treeRevealStore.requestReveal("a"); // same path
+    const second = get(treeRevealStore).pending?.token;
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first).not.toBe(second);
+  });
+
+  it("clearPending drops the pending request", () => {
+    treeRevealStore.requestReveal("x");
+    expect(get(treeRevealStore).pending).not.toBeNull();
+    treeRevealStore.clearPending();
+    expect(get(treeRevealStore).pending).toBeNull();
+  });
+});

--- a/src/store/treeRevealStore.ts
+++ b/src/store/treeRevealStore.ts
@@ -1,0 +1,44 @@
+// treeRevealStore — one-shot signal that tells the Sidebar to reveal a given
+// vault-relative path in the file tree: expand every ancestor folder and scroll
+// the target row into view.
+//
+// Consumers:
+//   - Sidebar adds all ancestor folders to its persisted TreeState.expanded list
+//     so newly rendered TreeNodes mount in an expanded state.
+//   - TreeNode auto-expands when the request targets a descendant, and scrolls
+//     its own row into view when the request targets it directly.
+//
+// Pattern mirrors treeRefreshStore / scrollStore: a monotonic token makes each
+// new request distinguishable so subscribers can de-duplicate.
+
+import { writable } from "svelte/store";
+
+export interface TreeRevealRequest {
+  /** Vault-relative path (forward slashes, no leading slash) of the target. */
+  relPath: string;
+  /** Unique token — changes on every request (crypto.randomUUID()). */
+  token: string;
+}
+
+interface TreeRevealState {
+  pending: TreeRevealRequest | null;
+}
+
+const _store = writable<TreeRevealState>({ pending: null });
+
+export const treeRevealStore = {
+  subscribe: _store.subscribe,
+
+  /**
+   * Request that the sidebar reveal `relPath` — expand its ancestors and
+   * scroll the row into view.
+   */
+  requestReveal(relPath: string): void {
+    _store.set({ pending: { relPath, token: crypto.randomUUID() } });
+  },
+
+  /** Called by consumers after the request has been processed. */
+  clearPending(): void {
+    _store.set({ pending: null });
+  },
+};

--- a/tests/Breadcrumbs.test.ts
+++ b/tests/Breadcrumbs.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import Breadcrumbs from "../src/components/Editor/Breadcrumbs.svelte";
+import { vaultStore } from "../src/store/vaultStore";
+import { treeRevealStore } from "../src/store/treeRevealStore";
+
+describe("Breadcrumbs (issue #8)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    treeRevealStore.clearPending();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: [],
+      fileCount: 0,
+    });
+  });
+
+  it("renders nothing when filePath is null", () => {
+    const { container } = render(Breadcrumbs, { filePath: null });
+    expect(container.querySelector(".vc-breadcrumbs")).toBeNull();
+  });
+
+  it("renders nothing when the path is outside the vault", () => {
+    const { container } = render(Breadcrumbs, {
+      filePath: "/other/somewhere.md",
+    });
+    expect(container.querySelector(".vc-breadcrumbs")).toBeNull();
+  });
+
+  it("renders one segment per path component for a nested file", () => {
+    render(Breadcrumbs, {
+      filePath: "/vault/Projects/Work/Vaultcore/notes/ideas.md",
+    });
+    const segments = screen.getAllByText(
+      (_, el) => !!el && el.classList.contains("vc-breadcrumbs-segment"),
+    );
+    const labels = segments.map((s) => s.textContent?.trim());
+    expect(labels).toEqual([
+      "Projects",
+      "Work",
+      "Vaultcore",
+      "notes",
+      "ideas.md",
+    ]);
+  });
+
+  it("styles the filename segment distinctly (file modifier class)", () => {
+    render(Breadcrumbs, { filePath: "/vault/notes/ideas.md" });
+    const file = screen.getByText("ideas.md");
+    expect(file.classList.contains("vc-breadcrumbs-segment--file")).toBe(true);
+    expect(file.tagName.toLowerCase()).toBe("span");
+  });
+
+  it("renders folder segments as buttons (filename is not a button)", () => {
+    render(Breadcrumbs, { filePath: "/vault/a/b/c.md" });
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map((b) => b.textContent?.trim())).toEqual(["a", "b"]);
+  });
+
+  it("clicking a folder segment requests a reveal for that folder path", async () => {
+    render(Breadcrumbs, {
+      filePath: "/vault/Projects/Work/Vaultcore/notes/ideas.md",
+    });
+    const workButton = screen.getByRole("button", { name: /Work/ });
+    await fireEvent.click(workButton);
+    const state = get(treeRevealStore);
+    expect(state.pending?.relPath).toBe("Projects/Work");
+  });
+
+  it("clicking the filename is a no-op (does not issue a reveal request)", async () => {
+    render(Breadcrumbs, { filePath: "/vault/notes/ideas.md" });
+    const tokenBefore = get(treeRevealStore).pending?.token ?? null;
+    const file = screen.getByText("ideas.md");
+    await fireEvent.click(file);
+    expect(get(treeRevealStore).pending?.token ?? null).toBe(tokenBefore);
+  });
+
+  it("uses the › separator between segments", () => {
+    const { container } = render(Breadcrumbs, {
+      filePath: "/vault/a/b/c.md",
+    });
+    const seps = container.querySelectorAll(".vc-breadcrumbs-sep");
+    expect(seps.length).toBe(2);
+    expect(seps[0]?.textContent).toBe("\u203A");
+  });
+});


### PR DESCRIPTION
## Summary
- Breadcrumb bar between the tab bar and editor content, rendering the active file's vault-relative path as `Projects › Work › Vaultcore › notes › ideas.md`.
- Folder segments dispatch a new `treeRevealStore` signal; the sidebar switches to the Files tab and TreeNodes cascade-expand and scroll the target into view.
- Filename segment uses distinct (bold, primary-text) styling and is a click no-op.
- Long paths truncate from the left with `direction: rtl` on the container and `direction: ltr` on the inner content, so the filename stays glued to the right edge.
- Hidden reactively whenever the pane has no active tab.

## Test plan
- [x] Breadcrumb bar shown between the tab bar and the editor content when a note is open
- [x] Segments derived from the active file's path relative to the vault root
- [x] Clicking a folder segment reveals/expands that folder in the file tree (and scrolls it into view)
- [x] Clicking the filename segment is a no-op (filename rendered as a `<span>`, not a button)
- [x] Truncates with an ellipsis from the left when the path is too long for the available width
- [x] Hidden when no note is open
- [x] Filename segment has a distinct style (bold + primary text color)
- [x] `pnpm test` — 12 new tests added (`tests/Breadcrumbs.test.ts`, `src/store/__tests__/treeRevealStore.test.ts`), all passing; no new regressions
- [x] `pnpm build` — Vite build succeeds
- [x] `pnpm exec svelte-check` — no new errors introduced (pre-existing failures in unrelated files remain)

Closes #8