### PR TITLE
feat(sidebar): add outgoing links panel

### DIFF
--- a/src/components/Layout/RightSidebar.svelte
+++ b/src/components/Layout/RightSidebar.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import BacklinksPanel from "../Backlinks/BacklinksPanel.svelte";
+  import OutgoingLinksPanel from "../OutgoingLinks/OutgoingLinksPanel.svelte";
   import PropertiesPanel from "../Properties/PropertiesPanel.svelte";
 </script>
 <div class="vc-right-sidebar">
   <PropertiesPanel />
+  <OutgoingLinksPanel />
   <div class="vc-right-sidebar-backlinks">
     <BacklinksPanel />
   </div>

--- a/src/components/OutgoingLinks/OutgoingLinkRow.svelte
+++ b/src/components/OutgoingLinks/OutgoingLinkRow.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import type { OutgoingLink } from "../../lib/outgoingLinks";
+  export let entry: OutgoingLink;
+  export let onClick: (entry: OutgoingLink) => void;
+
+  $: resolved = entry.resolvedPath !== null;
+  $: displayLabel = entry.aliases[0] ?? entry.target;
+  $: secondary = resolved
+    ? (entry.aliases[0] !== undefined ? entry.target : (entry.resolvedPath ?? ""))
+    : "Nicht verknüpfte Notiz";
+</script>
+
+<button
+  class="vc-outlink-row"
+  class:vc-outlink-row--unresolved={!resolved}
+  on:click={() => onClick(entry)}
+  type="button"
+  title={resolved ? (entry.resolvedPath ?? entry.target) : entry.target}
+>
+  <div class="vc-outlink-title">{displayLabel}</div>
+  {#if secondary.length > 0}
+    <div class="vc-outlink-secondary">{secondary}</div>
+  {/if}
+</button>
+
+<style>
+  .vc-outlink-row {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 8px 16px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .vc-outlink-row:hover {
+    background: var(--color-accent-bg);
+  }
+  .vc-outlink-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .vc-outlink-secondary {
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--color-text-muted);
+    line-height: 1.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* Dim + italicize unresolved targets to differentiate them from resolved ones
+     (parity with CM6 cm-wikilink-unresolved styling). */
+  .vc-outlink-row--unresolved .vc-outlink-title {
+    color: var(--color-text-muted);
+    font-style: italic;
+    font-weight: 500;
+  }
+</style>

--- a/src/components/OutgoingLinks/OutgoingLinksPanel.svelte
+++ b/src/components/OutgoingLinks/OutgoingLinksPanel.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import { ChevronDown, ChevronRight } from "lucide-svelte";
+  import { activeViewStore } from "../../store/activeViewStore";
+  import { vaultStore } from "../../store/vaultStore";
+  import { tabStore } from "../../store/tabStore";
+  import { toastStore } from "../../store/toastStore";
+  import { treeRefreshStore } from "../../store/treeRefreshStore";
+  import { createFile } from "../../ipc/commands";
+  import { resolveTarget } from "../Editor/wikiLink";
+  import {
+    extractOutgoingLinks,
+    type OutgoingLink,
+  } from "../../lib/outgoingLinks";
+  import OutgoingLinkRow from "./OutgoingLinkRow.svelte";
+
+  const STORAGE_KEY_COLLAPSED = "vaultcore-outlinks-collapsed";
+
+  function loadCollapsed(): boolean {
+    try {
+      return localStorage.getItem(STORAGE_KEY_COLLAPSED) === "true";
+    } catch {
+      return false;
+    }
+  }
+
+  let collapsed = $state<boolean>(loadCollapsed());
+
+  // Reactive view + doc version — same pattern as PropertiesPanel.
+  // Depending on `docVersion` causes the derived list to recompute on every
+  // docChanged update of the active editor, which means the panel updates
+  // live as the user types wiki-links.
+  let view = $derived($activeViewStore.view);
+  let version = $derived($activeViewStore.docVersion);
+
+  // `links` reacts to both active-file switches (view identity changes) and
+  // in-file edits (docVersion bumps). `resolveTarget` reads the module-level
+  // resolution map owned by wikiLink.ts, so newly-created files become
+  // resolved as soon as EditorPane refreshes that map.
+  let links = $derived.by<OutgoingLink[]>(() => {
+    // Touch version so Svelte tracks it even when the view reference is unchanged.
+    void version;
+    if (!view) return [];
+    return extractOutgoingLinks(view.state.doc.toString(), resolveTarget);
+  });
+
+  function toggleCollapsed(): void {
+    collapsed = !collapsed;
+    try {
+      localStorage.setItem(STORAGE_KEY_COLLAPSED, String(collapsed));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function currentVault(): string | null {
+    let v: string | null = null;
+    const u = vaultStore.subscribe((s) => {
+      v = s.currentPath;
+    });
+    u();
+    return v;
+  }
+
+  function handleClick(entry: OutgoingLink): void {
+    const vault = currentVault();
+    if (!vault) return;
+
+    if (entry.resolvedPath !== null) {
+      tabStore.openTab(`${vault}/${entry.resolvedPath}`);
+      return;
+    }
+
+    // Unresolved: create the note at the vault root and open it.
+    // Mirrors the click-to-create path in EditorPane.handleWikiLinkClick so
+    // behavior matches clicking an unresolved `[[link]]` in the editor.
+    const filename = entry.target.endsWith(".md")
+      ? entry.target
+      : `${entry.target}.md`;
+    createFile(vault, filename)
+      .then((newAbsPath) => {
+        tabStore.openTab(newAbsPath);
+        // Trigger a sidebar tree reload so the newly-created file appears.
+        // EditorPane's vaultStore/FILE_CHANGE subscribers will refresh the
+        // wiki-link resolution map so the target resolves on subsequent
+        // renders.
+        treeRefreshStore.requestRefresh();
+      })
+      .catch(() =>
+        toastStore.push({
+          variant: "error",
+          message: "Notiz konnte nicht erstellt werden.",
+        }),
+      );
+  }
+
+  const resolvedCount = $derived(links.filter((l) => l.resolvedPath !== null).length);
+  const unresolvedCount = $derived(links.length - resolvedCount);
+</script>
+
+<div class="vc-outlinks-panel" role="complementary" aria-label="Outgoing Links">
+  <button
+    type="button"
+    class="vc-outlinks-header"
+    aria-expanded={!collapsed}
+    onclick={toggleCollapsed}
+  >
+    {#if collapsed}
+      <ChevronRight size={14} />
+    {:else}
+      <ChevronDown size={14} />
+    {/if}
+    <span class="vc-outlinks-label">Outgoing Links</span>
+    {#if links.length > 0}
+      <span class="vc-outlinks-count">{links.length}</span>
+    {/if}
+  </button>
+
+  {#if !collapsed}
+    <div class="vc-outlinks-body">
+      {#if !view}
+        <div class="vc-outlinks-empty">Keine Datei geöffnet.</div>
+      {:else if links.length === 0}
+        <div class="vc-outlinks-empty">
+          <div class="vc-outlinks-empty-heading">Keine ausgehenden Links</div>
+          <div class="vc-outlinks-empty-body">
+            Diese Notiz verweist auf keine andere Datei.
+          </div>
+        </div>
+      {:else}
+        <div role="list">
+          {#each links as entry (entry.key)}
+            <div role="listitem">
+              <OutgoingLinkRow {entry} onClick={handleClick} />
+            </div>
+          {/each}
+        </div>
+        {#if unresolvedCount > 0}
+          <div class="vc-outlinks-footer">
+            {resolvedCount} verknüpft · {unresolvedCount} unverknüpft
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .vc-outlinks-panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+  }
+  .vc-outlinks-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 16px;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    width: 100%;
+    text-align: left;
+  }
+  .vc-outlinks-header:hover {
+    color: var(--color-accent);
+  }
+  .vc-outlinks-label {
+    font-size: 12px;
+    font-weight: 600;
+    flex: 1;
+  }
+  .vc-outlinks-count {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+  .vc-outlinks-body {
+    flex: 0 0 auto;
+    max-height: 40vh;
+    overflow-y: auto;
+  }
+  .vc-outlinks-empty {
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 14px;
+  }
+  .vc-outlinks-empty-heading {
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .vc-outlinks-empty-body {
+    font-size: 13px;
+    font-weight: 400;
+  }
+  .vc-outlinks-footer {
+    padding: 8px 16px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+    border-top: 1px solid var(--color-border);
+  }
+</style>

--- a/src/lib/__tests__/outgoingLinks.test.ts
+++ b/src/lib/__tests__/outgoingLinks.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { extractOutgoingLinks } from "../outgoingLinks";
+
+function makeResolver(map: Record<string, string>) {
+  return (target: string) => {
+    const key = target.toLowerCase();
+    return map[key] ?? null;
+  };
+}
+
+describe("extractOutgoingLinks", () => {
+  it("returns an empty list when the document has no wiki-links", () => {
+    const res = extractOutgoingLinks("# Heading\n\nPlain prose.", () => null);
+    expect(res).toEqual([]);
+  });
+
+  it("parses simple [[target]] links", () => {
+    const resolve = makeResolver({ "alpha": "notes/Alpha.md" });
+    const res = extractOutgoingLinks("See [[Alpha]] for details.", resolve);
+    expect(res).toHaveLength(1);
+    expect(res[0]).toMatchObject({
+      target: "Alpha",
+      resolvedPath: "notes/Alpha.md",
+      aliases: [],
+    });
+  });
+
+  it("marks unresolved links with resolvedPath = null", () => {
+    const res = extractOutgoingLinks("A dangling [[Ghost]] link.", () => null);
+    expect(res).toHaveLength(1);
+    expect(res[0]?.resolvedPath).toBeNull();
+    expect(res[0]?.target).toBe("Ghost");
+  });
+
+  it("deduplicates repeated links by resolved path (resolved case)", () => {
+    const resolve = makeResolver({ "alpha": "notes/Alpha.md" });
+    const doc = "[[Alpha]] and again [[Alpha]] and [[alpha]].";
+    const res = extractOutgoingLinks(doc, resolve);
+    expect(res).toHaveLength(1);
+    expect(res[0]?.resolvedPath).toBe("notes/Alpha.md");
+  });
+
+  it("deduplicates repeated unresolved links by lowercased stem", () => {
+    const doc = "[[Ghost]] [[ghost]] [[GHOST]]";
+    const res = extractOutgoingLinks(doc, () => null);
+    expect(res).toHaveLength(1);
+    expect(res[0]?.target).toBe("Ghost"); // first-seen casing wins
+  });
+
+  it("collects aliases encountered for the same target", () => {
+    const resolve = makeResolver({ "alpha": "notes/Alpha.md" });
+    const doc = "[[Alpha|first alias]] and [[Alpha|second alias]] and [[Alpha]]";
+    const res = extractOutgoingLinks(doc, resolve);
+    expect(res).toHaveLength(1);
+    expect(res[0]?.aliases).toEqual(["first alias", "second alias"]);
+  });
+
+  it("preserves document order based on first occurrence", () => {
+    const resolve = makeResolver({
+      "zeta": "Zeta.md",
+      "alpha": "Alpha.md",
+    });
+    const doc = "[[Zeta]] then [[Alpha]] then [[Zeta]] again.";
+    const res = extractOutgoingLinks(doc, resolve);
+    expect(res.map((l) => l.target)).toEqual(["Zeta", "Alpha"]);
+  });
+
+  it("strips .md suffix from targets before resolution and dedup", () => {
+    const resolve = makeResolver({ "alpha": "notes/Alpha.md" });
+    const doc = "[[Alpha]] vs [[Alpha.md]]";
+    const res = extractOutgoingLinks(doc, resolve);
+    expect(res).toHaveLength(1);
+    expect(res[0]?.target).toBe("Alpha");
+    expect(res[0]?.resolvedPath).toBe("notes/Alpha.md");
+  });
+
+  it("tracks line numbers for first occurrence", () => {
+    const doc = "line 0\nline 1 [[Alpha]]\nline 2\n[[Beta]]";
+    const res = extractOutgoingLinks(doc, () => null);
+    expect(res[0]?.target).toBe("Alpha");
+    expect(res[0]?.lineNumber).toBe(1);
+    expect(res[1]?.target).toBe("Beta");
+    expect(res[1]?.lineNumber).toBe(3);
+  });
+
+  it("ignores empty or whitespace-only targets", () => {
+    const res = extractOutgoingLinks("[[ ]] and [[]]", () => null);
+    expect(res).toEqual([]);
+  });
+
+  it("does not surface embed syntax as outgoing links", () => {
+    // Embeds `![[...]]` are out of scope per issue #4. The current regex
+    // still matches the inner `[[...]]` — but the leading `!` is NOT the
+    // same logical entity. For now we accept the match: parity with the
+    // CM6 wikiLink plugin which also matches the inner `[[...]]`. If this
+    // ever changes we'd revise both parsers together.
+    const res = extractOutgoingLinks("![[embed.png]]", () => null);
+    expect(res.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/lib/outgoingLinks.ts
+++ b/src/lib/outgoingLinks.ts
@@ -1,0 +1,96 @@
+// Outgoing wiki-link extractor used by the right-sidebar OutgoingLinksPanel.
+//
+// Parses `[[target]]` and `[[target|alias]]` occurrences out of Markdown text
+// and returns a deduplicated list. Duplication rule matches Obsidian parity:
+// two links are considered the same outgoing entry when they resolve to the
+// same vault-relative path (for resolved links) or share the same normalized
+// target stem (for unresolved links). Aliases encountered along the way are
+// collected so the panel can surface them as secondary labels if needed.
+//
+// This mirrors the parse regex in `components/Editor/wikiLink.ts` so the
+// sidebar stays in sync with CM6 decorations on each keystroke — the two
+// parsers MUST agree on what counts as a wiki-link.
+
+/** Matches [[target]] and [[target|alias]]. Global flag — reset lastIndex before use. */
+const WIKI_LINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]*))?\]\]/g;
+
+/** A single deduplicated outgoing wiki-link ready for the sidebar list. */
+export interface OutgoingLink {
+  /** Raw target stem as authored, stripped of any `.md` suffix. */
+  target: string;
+  /** Vault-relative path the link resolves to, or `null` if unresolved. */
+  resolvedPath: string | null;
+  /** Label used for deduplication (lowercased resolved path, or lowercased stem). */
+  key: string;
+  /** All distinct aliases (`[[target|alias]]`) seen for this target, in order of first appearance. */
+  aliases: string[];
+  /** 0-based line number of the FIRST occurrence (for stable ordering). */
+  lineNumber: number;
+}
+
+function stripMdSuffix(target: string): string {
+  return target.endsWith(".md") ? target.slice(0, -3) : target;
+}
+
+/**
+ * Extract outgoing wiki-links from `text`, deduplicated in document order.
+ *
+ * @param text        Raw document text.
+ * @param resolve     Function that maps a raw target stem to a vault-relative
+ *                    path (or `null` if unresolved). Normally wired to
+ *                    `resolveTarget` from `components/Editor/wikiLink.ts`.
+ * @returns Unique outgoing links, ordered by first occurrence.
+ */
+export function extractOutgoingLinks(
+  text: string,
+  resolve: (target: string) => string | null,
+): OutgoingLink[] {
+  const seen = new Map<string, OutgoingLink>();
+
+  // Reset lastIndex — the regex is global and shared across calls.
+  WIKI_LINK_RE.lastIndex = 0;
+
+  // Track line numbers by counting newlines up to each match — avoids splitting
+  // the whole document for large files.
+  let lineNumber = 0;
+  let lastLineStart = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = WIKI_LINK_RE.exec(text)) !== null) {
+    const rawTarget = match[1];
+    if (rawTarget === undefined) continue;
+
+    // Advance line counter to this match's position.
+    while (true) {
+      const next = text.indexOf("\n", lastLineStart);
+      if (next === -1 || next >= match.index) break;
+      lineNumber += 1;
+      lastLineStart = next + 1;
+    }
+
+    const stem = stripMdSuffix(rawTarget).trim();
+    if (stem.length === 0) continue;
+
+    const resolvedPath = resolve(stem);
+    const key = (resolvedPath ?? stem).toLowerCase();
+    const alias = match[2];
+
+    const existing = seen.get(key);
+    if (existing) {
+      if (alias !== undefined && alias.length > 0 && !existing.aliases.includes(alias)) {
+        existing.aliases.push(alias);
+      }
+      continue;
+    }
+
+    seen.set(key, {
+      target: stem,
+      resolvedPath,
+      key,
+      aliases: alias !== undefined && alias.length > 0 ? [alias] : [],
+      lineNumber,
+    });
+  }
+
+  return Array.from(seen.values());
+}


### PR DESCRIPTION
## Summary
- Adds an **Outgoing Links** panel to the right sidebar, rendered between the Properties and Backlinks panels.
- Each entry lists a unique `[[wikilink]]` from the active note. Resolved links show the target stem + vault-relative path; unresolved links are dimmed + italicized.
- Clicking a resolved entry opens the target in the current tab. Clicking an unresolved entry creates the note at the vault root and opens it — same semantics as clicking an unresolved wikilink in the editor.
- Panel is driven by `activeViewStore.view` + `docVersion`, so it updates reactively on active-file switches and on every doc-changed update without any IPC.
- Resolution is done through `resolveTarget` from `components/Editor/wikiLink.ts`, so the sidebar reuses the same cached stem → rel-path map as the CM6 decorations (zero duplication of the 3-stage Obsidian resolver).

## Implementation notes
- Parser lives in `src/lib/outgoingLinks.ts` — reuses the regex from the CM6 `wikiLink` plugin so the two parsers stay in sync. Deduplication is by resolved path (resolved case) or lowercased stem (unresolved case); aliases are collected per target for display.
- No new Tauri command needed — the backend already exposes `get_outgoing_links`, but client-side parsing is strictly preferable here because it also reflects unsaved edits without waiting for the 2s autosave + watcher reindex cycle.
- The panel header is collapsible and persists its open/closed state in `localStorage` (`vaultcore-outlinks-collapsed`).

## Test plan
- [x] New collapsible Outgoing Links section renders in the right sidebar above Backlinks
- [x] Lists all `[[wikilinks]]` from the active note, deduplicated (see `src/lib/__tests__/outgoingLinks.test.ts`)
- [x] Differentiates resolved vs. unresolved links (dim + italic styling on `.vc-outlink-row--unresolved`)
- [x] Clicking a resolved link opens the target in the current tab (`tabStore.openTab`)
- [x] Clicking an unresolved link creates the note and opens it (same path as `EditorPane.handleWikiLinkClick`)
- [x] Panel updates reactively when the active file changes or its content is edited (`$derived` on `view` + `docVersion`)
- [x] `vitest` — new `outgoingLinks` suite passes (11 tests); unrelated pre-existing `shortcuts.test.ts` failure is not caused by this change
- [x] `svelte-check` — 0 new errors/warnings (pre-existing baseline unchanged)

Closes #4