### PR TITLE
fix(sidebar): dedupe backlinks activeFile dispatch to stop typing flicker (#18)

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -144,8 +144,14 @@
     };
   });
 
-  // Subscribe to tabStore to sync active file to backlinksStore
+  // Subscribe to tabStore to sync active file to backlinksStore.
+  // tabStore emits on every per-keystroke mutation (setDirty, scroll position,
+  // lastSavedContent); re-dispatching setActiveFile on every emit flips the
+  // panel into loading state and fires an IPC round-trip, causing the sidebar
+  // to flicker as the user types. Only push through when the resolved rel
+  // path actually changes.
   let unsubBacklinksTab: (() => void) | null = null;
+  let lastDispatchedRelPath: string | null | undefined = undefined;
   onMount(() => {
     unsubBacklinksTab = tabStore.subscribe((state) => {
       const activeTab = state.tabs.find((t) => t.id === state.activeTabId);
@@ -155,15 +161,20 @@
         u();
         return v;
       })();
+
+      let nextRelPath: string | null;
       if (!activeTab || !vault) {
-        backlinksStore.setActiveFile(null);
-        return;
+        nextRelPath = null;
+      } else {
+        const absPath = activeTab.filePath;
+        nextRelPath = absPath.startsWith(vault + "/")
+          ? absPath.slice((vault as string).length + 1)
+          : absPath;
       }
-      const absPath = activeTab.filePath;
-      const relPath = absPath.startsWith(vault + "/")
-        ? absPath.slice((vault as string).length + 1)
-        : absPath;
-      backlinksStore.setActiveFile(relPath);
+
+      if (nextRelPath === lastDispatchedRelPath) return;
+      lastDispatchedRelPath = nextRelPath;
+      backlinksStore.setActiveFile(nextRelPath);
     });
   });
 


### PR DESCRIPTION
## Summary
- Root cause of the remaining flicker: `VaultLayout` subscribed to `tabStore` and re-dispatched `backlinksStore.setActiveFile(relPath)` on every emission. `tabStore` emits on every keystroke via `setDirty`, so each keystroke flipped `BacklinksPanel` into `loading: true`, fired a `getBacklinks` IPC round-trip, then flipped back — visible as rapid flashing between "Lade Backlinks…" and the list.
- The earlier 200 ms `docVersion` debounce didn't help because `setDirty` is an independent per-keystroke signal on a different store.
- Fix: track the last-dispatched rel path in the subscription closure and early-return when unchanged, so `setDirty` / scroll / cursor updates no longer retrigger the backlinks fetch.

Closes #18.

## Test plan
- [ ] Open a vault, open any note, ensure backlinks panel is open.
- [ ] Type continuously in the editor — sidebar should remain static (no flashing between loading state and list).
- [ ] Switch tabs — backlinks panel must still refresh for the new file.
- [ ] Close active tab / switch to empty pane — panel clears as before.