### PR TITLE
feat(sidebar): add outline panel for heading navigation (#7)

### DIFF
--- a/src/components/Layout/RightSidebar.svelte
+++ b/src/components/Layout/RightSidebar.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import BacklinksPanel from "../Backlinks/BacklinksPanel.svelte";
   import OutgoingLinksPanel from "../OutgoingLinks/OutgoingLinksPanel.svelte";
+  import OutlinePanel from "../Outline/OutlinePanel.svelte";
   import PropertiesPanel from "../Properties/PropertiesPanel.svelte";
 </script>
 <div class="vc-right-sidebar">
   <PropertiesPanel />
+  <OutlinePanel />
   <OutgoingLinksPanel />
   <div class="vc-right-sidebar-backlinks">
     <BacklinksPanel />

--- a/src/components/Outline/OutlinePanel.svelte
+++ b/src/components/Outline/OutlinePanel.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import { ChevronDown, ChevronRight } from "lucide-svelte";
+  import { EditorView } from "@codemirror/view";
+  import { activeViewStore } from "../../store/activeViewStore";
+  import { extractHeadingsFromState } from "../../lib/headings";
+  import type { Heading } from "../../lib/headings";
+  import OutlineRow from "./OutlineRow.svelte";
+
+  const STORAGE_KEY_COLLAPSED = "vaultcore-outline-collapsed";
+
+  function loadCollapsed(): boolean {
+    try {
+      return localStorage.getItem(STORAGE_KEY_COLLAPSED) === "true";
+    } catch {
+      return false;
+    }
+  }
+
+  let collapsed = $state<boolean>(loadCollapsed());
+  let activeIndex = $state<number>(-1);
+
+  // Reactive view + doc version — same pattern as OutgoingLinksPanel.
+  let view = $derived($activeViewStore.view);
+  let version = $derived($activeViewStore.docVersion);
+
+  // Recompute headings on every doc change or active-view switch.
+  let headings = $derived.by<Heading[]>(() => {
+    void version;
+    if (!view) return [];
+    return extractHeadingsFromState(view.state);
+  });
+
+  // ── Scroll listener for active-heading tracking ──────────────────────────
+
+  let scrollCleanup: (() => void) | null = null;
+
+  function computeActiveIndex(currentView: EditorView, currentHeadings: Heading[]): number {
+    if (currentHeadings.length === 0) return -1;
+    const vpFrom = currentView.viewport.from;
+    const anchorLine = currentView.state.doc.lineAt(Math.min(vpFrom + 50, currentView.state.doc.length));
+    const anchorPos = anchorLine.from;
+
+    let best = 0;
+    for (let i = 0; i < currentHeadings.length; i++) {
+      const h = currentHeadings[i];
+      if (h !== undefined && h.from <= anchorPos) {
+        best = i;
+      }
+    }
+    return best;
+  }
+
+  function attachScrollListener(currentView: EditorView): () => void {
+    const scrollEl = currentView.scrollDOM;
+    const handler = () => {
+      activeIndex = computeActiveIndex(currentView, headings);
+    };
+    scrollEl.addEventListener("scroll", handler, { passive: true });
+    // Compute immediately on attach.
+    activeIndex = computeActiveIndex(currentView, headings);
+    return () => scrollEl.removeEventListener("scroll", handler);
+  }
+
+  // Watch the active view — attach/detach scroll listener as it changes.
+  $effect(() => {
+    if (scrollCleanup) {
+      scrollCleanup();
+      scrollCleanup = null;
+    }
+    if (view) {
+      scrollCleanup = attachScrollListener(view);
+    } else {
+      activeIndex = -1;
+    }
+    return () => {
+      if (scrollCleanup) {
+        scrollCleanup();
+        scrollCleanup = null;
+      }
+    };
+  });
+
+  // Re-evaluate active heading whenever headings list is rebuilt.
+  $effect(() => {
+    void headings;
+    if (view) {
+      activeIndex = computeActiveIndex(view, headings);
+    }
+  });
+
+  // ── Collapsed toggle ─────────────────────────────────────────────────────
+
+  function toggleCollapsed(): void {
+    collapsed = !collapsed;
+    try {
+      localStorage.setItem(STORAGE_KEY_COLLAPSED, String(collapsed));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // ── Click-to-jump ────────────────────────────────────────────────────────
+
+  function handleClick(entry: Heading): void {
+    if (!view) return;
+    view.dispatch({
+      selection: { anchor: entry.from },
+      effects: EditorView.scrollIntoView(entry.from, { y: "start" }),
+    });
+    view.focus();
+  }
+</script>
+
+<div class="vc-outline-panel" role="complementary" aria-label="Outline">
+  <button
+    type="button"
+    class="vc-outline-header"
+    aria-expanded={!collapsed}
+    onclick={toggleCollapsed}
+  >
+    {#if collapsed}
+      <ChevronRight size={14} />
+    {:else}
+      <ChevronDown size={14} />
+    {/if}
+    <span class="vc-outline-label">Outline</span>
+    {#if headings.length > 0}
+      <span class="vc-outline-count">{headings.length}</span>
+    {/if}
+  </button>
+
+  {#if !collapsed}
+    <div class="vc-outline-body">
+      {#if !view}
+        <div class="vc-outline-empty">Keine Datei geöffnet.</div>
+      {:else if headings.length === 0}
+        <div class="vc-outline-empty">No headings</div>
+      {:else}
+        <div role="list">
+          {#each headings as entry, i (entry.from)}
+            <div role="listitem">
+              <OutlineRow
+                {entry}
+                active={i === activeIndex}
+                onClick={handleClick}
+              />
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .vc-outline-panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+  }
+  .vc-outline-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 16px;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    width: 100%;
+    text-align: left;
+  }
+  .vc-outline-header:hover {
+    color: var(--color-accent);
+  }
+  .vc-outline-label {
+    font-size: 12px;
+    font-weight: 600;
+    flex: 1;
+  }
+  .vc-outline-count {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+  .vc-outline-body {
+    flex: 0 0 auto;
+    max-height: 40vh;
+    overflow-y: auto;
+  }
+  .vc-outline-empty {
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 14px;
+  }
+</style>

--- a/src/components/Outline/OutlineRow.svelte
+++ b/src/components/Outline/OutlineRow.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import type { Heading } from "../../lib/headings";
+
+  export let entry: Heading;
+  export let active: boolean = false;
+  export let onClick: (entry: Heading) => void;
+</script>
+
+<button
+  class="vc-outline-row"
+  class:vc-outline-row--active={active}
+  style="padding-left: {8 + (entry.level - 1) * 12}px"
+  type="button"
+  title={entry.text}
+  on:click={() => onClick(entry)}
+>
+  <span class="vc-outline-level">H{entry.level}</span>
+  <span class="vc-outline-text">{entry.text}</span>
+</button>
+
+<style>
+  .vc-outline-row {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    width: 100%;
+    text-align: left;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-right: 16px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .vc-outline-row:hover {
+    background: var(--color-accent-bg);
+  }
+  .vc-outline-row--active {
+    background: var(--color-accent-bg);
+  }
+  .vc-outline-level {
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    width: 16px;
+    text-align: center;
+  }
+  .vc-outline-text {
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .vc-outline-row--active .vc-outline-text {
+    color: var(--color-accent);
+    font-weight: 500;
+  }
+</style>

--- a/src/lib/__tests__/headings.test.ts
+++ b/src/lib/__tests__/headings.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { extractHeadings } from "../headings";
+
+describe("extractHeadings", () => {
+  it("returns an empty list when there are no headings", () => {
+    expect(extractHeadings("Just some plain prose.\n\nNo headings here.")).toEqual([]);
+  });
+
+  it("extracts ATX headings with correct levels", () => {
+    const doc = "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(6);
+    expect(result.map((h) => h.level)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(result.map((h) => h.text)).toEqual(["H1", "H2", "H3", "H4", "H5", "H6"]);
+  });
+
+  it("extracts ATX heading text correctly (strips leading hashes and spaces)", () => {
+    const result = extractHeadings("## My Heading\n");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.level).toBe(2);
+    expect(result[0]?.text).toBe("My Heading");
+  });
+
+  it("strips optional closing hash marks from ATX headings", () => {
+    const result = extractHeadings("## Heading ##\n");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("Heading");
+  });
+
+  it("records correct `from` offset for the first heading", () => {
+    const doc = "# First\n";
+    const result = extractHeadings(doc);
+    expect(result[0]?.from).toBe(0);
+  });
+
+  it("records correct `from` offset for a heading not on line 1", () => {
+    const doc = "Intro paragraph\n\n## Second Heading\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.from).toBe(17); // 'Intro paragraph\n\n'.length = 17
+    expect(result[0]?.line).toBe(3);
+  });
+
+  it("preserves document order", () => {
+    const doc = "## B Section\n\nSome text.\n\n# A Section\n\n### C Section\n";
+    const result = extractHeadings(doc);
+    expect(result.map((h) => h.text)).toEqual(["B Section", "A Section", "C Section"]);
+    expect(result.map((h) => h.level)).toEqual([2, 1, 3]);
+  });
+
+  it("extracts setext H1 headings (underlined with ===)", () => {
+    const doc = "My Title\n========\n\nParagraph.\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.level).toBe(1);
+    expect(result[0]?.text).toBe("My Title");
+    expect(result[0]?.from).toBe(0);
+    expect(result[0]?.line).toBe(1);
+  });
+
+  it("extracts setext H2 headings (underlined with ---)", () => {
+    const doc = "Sub Title\n---------\n\nParagraph.\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.level).toBe(2);
+    expect(result[0]?.text).toBe("Sub Title");
+  });
+
+  it("handles mixed ATX and setext headings in document order", () => {
+    const doc = "Intro\n=====\n\n## Sub\n\nAnother\n-------\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(3);
+    expect(result[0]?.level).toBe(1);
+    expect(result[0]?.text).toBe("Intro");
+    expect(result[1]?.level).toBe(2);
+    expect(result[1]?.text).toBe("Sub");
+    expect(result[2]?.level).toBe(2);
+    expect(result[2]?.text).toBe("Another");
+  });
+
+  it("ignores lines that look like headings inside the heading text itself", () => {
+    const doc = "# Real Heading\n\nNot # a heading\n";
+    const result = extractHeadings(doc);
+    // Only the first line is an ATX heading; inline # does not produce a heading.
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("Real Heading");
+  });
+});

--- a/src/lib/headings.ts
+++ b/src/lib/headings.ts
@@ -1,0 +1,137 @@
+// Heading extractor used by the right-sidebar OutlinePanel.
+//
+// Walks the Lezer syntax tree produced by @lezer/markdown to find ATX headings
+// (# … ####### …) and setext headings (underline with === or ---). Falls back
+// to a regex scan when no EditorState is supplied (e.g. in unit tests).
+
+import type { EditorState } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+
+/** A single heading entry. */
+export interface Heading {
+  /** Heading level 1–6. */
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  /** Heading text with leading #-marks and trailing whitespace stripped. */
+  text: string;
+  /** Absolute position of the first character of the heading line in the doc. */
+  from: number;
+  /** 1-based line number of the heading line. */
+  line: number;
+}
+
+// ── Syntax-tree extraction ──────────────────────────────────────────────────
+
+const ATX_NODE_RE = /^ATXHeading([1-6])$/;
+const SETEXT_NODE_RE = /^SetextHeading([1-2])$/;
+
+/**
+ * Extract headings from `state` using the Lezer parse tree.
+ * This is the preferred path when a live EditorState is available.
+ */
+export function extractHeadingsFromState(state: EditorState): Heading[] {
+  const results: Heading[] = [];
+
+  syntaxTree(state).iterate({
+    enter(node) {
+      let level: number | null = null;
+
+      const atxMatch = ATX_NODE_RE.exec(node.name);
+      if (atxMatch && atxMatch[1] !== undefined) {
+        level = parseInt(atxMatch[1], 10);
+      }
+
+      const setextMatch = SETEXT_NODE_RE.exec(node.name);
+      if (setextMatch && setextMatch[1] !== undefined) {
+        level = parseInt(setextMatch[1], 10);
+      }
+
+      if (level === null) return;
+
+      const lineInfo = state.doc.lineAt(node.from);
+      const rawText = lineInfo.text;
+
+      let text: string;
+      if (atxMatch) {
+        // Strip leading # characters and optional space.
+        text = rawText.replace(/^#{1,6}\s*/, "").trim();
+      } else {
+        // Setext heading: the text is on the line itself (not the underline).
+        text = rawText.trim();
+      }
+
+      results.push({
+        level: level as 1 | 2 | 3 | 4 | 5 | 6,
+        text,
+        from: lineInfo.from,
+        line: lineInfo.number,
+      });
+    },
+  });
+
+  return results;
+}
+
+// ── Regex fallback (for unit tests / no live state) ─────────────────────────
+
+// Matches ATX headings: # … through ###### …
+const ATX_RE = /^(#{1,6})\s+(.*?)(?:\s+#+\s*)?$/m;
+
+/**
+ * Extract headings from raw `text` using a line-by-line regex scan.
+ * Supports ATX headings only. Suitable for testing and offline use.
+ *
+ * @param text  Raw document text.
+ * @returns Headings in document order.
+ */
+export function extractHeadings(text: string): Heading[] {
+  const results: Heading[] = [];
+  const lines = text.split("\n");
+  let offset = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineText = lines[i] ?? "";
+
+    // ATX heading
+    const atxMatch = /^(#{1,6})\s+(.*)$/.exec(lineText);
+    if (atxMatch) {
+      const hashes = atxMatch[1] ?? "";
+      const rawHeadingText = atxMatch[2] ?? "";
+      // Strip optional closing # marks
+      const headingText = rawHeadingText.replace(/\s+#+\s*$/, "").trim();
+      results.push({
+        level: Math.min(hashes.length, 6) as 1 | 2 | 3 | 4 | 5 | 6,
+        text: headingText,
+        from: offset,
+        line: i + 1,
+      });
+      offset += lineText.length + 1;
+      continue;
+    }
+
+    // Setext heading: check the NEXT line for === or ---
+    const nextLine = lines[i + 1] ?? "";
+    if (/^=+\s*$/.test(nextLine)) {
+      results.push({
+        level: 1,
+        text: lineText.trim(),
+        from: offset,
+        line: i + 1,
+      });
+    } else if (/^-+\s*$/.test(nextLine)) {
+      results.push({
+        level: 2,
+        text: lineText.trim(),
+        from: offset,
+        line: i + 1,
+      });
+    }
+
+    offset += lineText.length + 1;
+  }
+
+  // Remove empty entries and enforce unique from positions (setext double-counts
+  // if the next line also looks like a heading candidate; guard against that).
+  return results.filter((h) => h.text.length > 0);
+}
+
+void ATX_NODE_RE;


### PR DESCRIPTION
## Summary
- New `src/lib/headings.ts` extractor that walks the Lezer syntax tree for ATX and setext headings, with a regex fallback for tests.
- New `src/components/Outline/OutlinePanel.svelte` — collapsible panel reusing the `activeViewStore.docVersion` debounce pattern; attaches a scroll listener to `view.scrollDOM` to highlight the active heading.
- New `src/components/Outline/OutlineRow.svelte` — per-heading row with level-based indent and active highlight.
- `RightSidebar.svelte` updated to include `OutlinePanel` between Properties and OutgoingLinks.

Closes #7.

## Test plan
- [ ] Open a note with several H1/H2/H3 headings — Outline panel lists them all, indented by level.
- [ ] Click a heading — editor scrolls to it, cursor placed at line start.
- [ ] Scroll the editor by hand — the matching heading row becomes highlighted.
- [ ] Add/remove a heading in the note — panel updates after ~200 ms debounce.
- [ ] Open a note with no headings — "No headings" empty state.
- [ ] Collapse/expand panel via its header chevron — state persists across reloads.