### PR TITLE
feat(editor): render GFM task lists as interactive checkboxes (#6)

### DIFF
--- a/src/components/Editor/__tests__/taskList.test.ts
+++ b/src/components/Editor/__tests__/taskList.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { EditorView } from "@codemirror/view";
+import { EditorState } from "@codemirror/state";
+import { buildExtensions } from "../extensions";
+import { taskListPlugin } from "../taskList";
+
+function makeView(doc: string, cursorPos?: number): EditorView {
+  const state = EditorState.create({
+    doc,
+    selection: { anchor: cursorPos ?? 0 },
+    extensions: buildExtensions(() => {}),
+  });
+  return new EditorView({ state });
+}
+
+type DecoEntry = { from: number; to: number; cls: string | null; hasWidget: boolean };
+
+function getTaskDecorations(view: EditorView, from: number, to: number): DecoEntry[] {
+  const result: DecoEntry[] = [];
+  const instance = view.plugin(taskListPlugin);
+  if (!instance) return result;
+  const set = instance.decorations;
+  if (!set) return result;
+  set.between(from, to, (f: number, t: number, value: any) => {
+    result.push({
+      from: f,
+      to: t,
+      cls: (value.spec?.class as string | undefined) ?? null,
+      hasWidget: !!value.spec?.widget,
+    });
+  });
+  return result;
+}
+
+describe("taskListPlugin decorations", () => {
+  const doc = "- [ ] unchecked task\n- [x] checked task\n";
+  // Line 1: "- [ ] unchecked task"  => TaskMarker at positions 2-5
+  // Line 2: "- [x] checked task"   => TaskMarker at positions 23-26
+  // "checked task" text starts at 27
+
+  it("hides the TaskMarker with a widget when cursor is on a different line", () => {
+    // Put cursor at start of line 2 (pos 21) — line 1 marker should be hidden by widget
+    const view = makeView(doc, 21);
+    const decos = getTaskDecorations(view, 2, 5);
+    const widgetDeco = decos.find((d) => d.from === 2 && d.to === 5 && d.hasWidget);
+    expect(widgetDeco, "expected a replace widget hiding [ ] on line 1").toBeTruthy();
+    view.destroy();
+  });
+
+  it("does NOT add a replace widget when cursor is on the task line", () => {
+    // Put cursor inside line 1 (pos 2, right on the marker)
+    const view = makeView(doc, 2);
+    const decos = getTaskDecorations(view, 2, 5);
+    const widgetDeco = decos.find((d) => d.from === 2 && d.to === 5 && d.hasWidget);
+    expect(widgetDeco, "should not hide marker when cursor is on the same line").toBeUndefined();
+    view.destroy();
+  });
+
+  it("adds cm-task-done class to checked item text when cursor is elsewhere", () => {
+    // Cursor on line 1 — line 2 (checked) should have cm-task-done on its text
+    const view = makeView(doc, 0);
+    // "checked task" starts at 27, line 2 ends at 39 (before newline)
+    const decos = getTaskDecorations(view, 27, 40);
+    const doneDeco = decos.find((d) => d.cls === "cm-task-done");
+    expect(doneDeco, "expected cm-task-done mark on checked item text").toBeTruthy();
+    view.destroy();
+  });
+
+  it("does not add cm-task-done to unchecked item text", () => {
+    // Cursor on line 2 — line 1 (unchecked) should not have cm-task-done
+    const view = makeView(doc, 21);
+    // "unchecked task" starts at 6, ends at 20
+    const decos = getTaskDecorations(view, 6, 20);
+    const doneDeco = decos.find((d) => d.cls === "cm-task-done");
+    expect(doneDeco, "unchecked item should not have cm-task-done").toBeUndefined();
+    view.destroy();
+  });
+
+  it("toggle dispatch changes [ ] to [x]", () => {
+    const view = makeView("- [ ] my task\n", 14);
+    view.dispatch({
+      changes: { from: 2, to: 5, insert: "[x]" },
+      userEvent: "input",
+    });
+    expect(view.state.doc.toString()).toBe("- [x] my task\n");
+    view.destroy();
+  });
+
+  it("toggle dispatch changes [x] to [ ]", () => {
+    const view = makeView("- [x] my task\n", 14);
+    view.dispatch({
+      changes: { from: 2, to: 5, insert: "[ ]" },
+      userEvent: "input",
+    });
+    expect(view.state.doc.toString()).toBe("- [ ] my task\n");
+    view.destroy();
+  });
+
+  it("handles nested task lists", () => {
+    const nestedDoc = "- [ ] parent\n  - [x] child\n";
+    // parent marker: 2-5, child marker: pos of "[x]" inside "  - [x] child"
+    // Line 1: "- [ ] parent" (0-12), Line 2: "  - [x] child" (13-26)
+    // In line 2: "  - " is 4 chars from line start, so marker at 13+4=17..20
+    const view = makeView(nestedDoc, 0);
+    // scan broadly for any widget in line 2 range
+    const decos = getTaskDecorations(view, 13, 27);
+    const childWidget = decos.find((d) => d.hasWidget);
+    expect(childWidget, "nested task marker should be replaced with widget").toBeTruthy();
+    view.destroy();
+  });
+});

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -27,6 +27,7 @@ import { flashField } from "./flashHighlight";
 import { wikiLinkPlugin } from "./wikiLink";
 import { livePreviewPlugin } from "./livePreview";
 import { frontmatterPlugin } from "./frontmatterPlugin";
+import { taskListPlugin } from "./taskList";
 import { countsPlugin } from "./countsPlugin";
 import type { PaneId } from "../../store/countsStore";
 import { activeViewStore } from "../../store/activeViewStore";
@@ -79,6 +80,7 @@ export function buildExtensions(
     wikiLinkPlugin,
     livePreviewPlugin,
     frontmatterPlugin,
+    taskListPlugin,
     docVersionBumpListener,
   ];
 

--- a/src/components/Editor/taskList.ts
+++ b/src/components/Editor/taskList.ts
@@ -1,0 +1,178 @@
+import { ViewPlugin, Decoration, WidgetType } from "@codemirror/view";
+import type { EditorView, DecorationSet, ViewUpdate } from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+
+// ── Checkbox widget ────────────────────────────────────────────────────────────
+
+class TaskCheckboxWidget extends WidgetType {
+  constructor(readonly checked: boolean) {
+    super();
+  }
+
+  eq(other: TaskCheckboxWidget): boolean {
+    return this.checked === other.checked;
+  }
+
+  toDOM(): HTMLElement {
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.className = "cm-task-checkbox";
+    input.checked = this.checked;
+    input.setAttribute("aria-label", this.checked ? "completed task" : "incomplete task");
+    return input;
+  }
+
+  ignoreEvent(event: Event): boolean {
+    return event.type !== "mousedown";
+  }
+}
+
+// ── Decoration builder ─────────────────────────────────────────────────────────
+
+interface TaskRange {
+  markerFrom: number;
+  markerTo: number;
+  textFrom: number;
+  textTo: number;
+  checked: boolean;
+  line: number;
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const state = view.state;
+  const head = state.selection.main.head;
+  const cursorLine = state.doc.lineAt(head).number;
+
+  const tasks: TaskRange[] = [];
+
+  syntaxTree(state).iterate({
+    from: view.viewport.from,
+    to: view.viewport.to,
+    enter(node) {
+      if (node.name !== "TaskMarker") return;
+
+      const markerFrom = node.from;
+      const markerTo = node.to;
+      const markerText = state.doc.sliceString(markerFrom, markerTo);
+      const checked = markerText.toLowerCase() === "[x]";
+
+      const taskNode = node.node.parent;
+      const textFrom = markerTo + (state.doc.sliceString(markerTo, markerTo + 1) === " " ? 1 : 0);
+      const textTo = taskNode ? taskNode.to : markerTo;
+
+      const lineNum = state.doc.lineAt(markerFrom).number;
+
+      tasks.push({ markerFrom, markerTo, textFrom, textTo, checked, line: lineNum });
+    },
+  });
+
+  tasks.sort((a, b) => a.markerFrom - b.markerFrom);
+
+  for (const task of tasks) {
+    if (task.line === cursorLine) {
+      if (task.checked && task.textFrom < task.textTo) {
+        builder.add(
+          task.textFrom,
+          task.textTo,
+          Decoration.mark({ class: "cm-task-done" }),
+        );
+      }
+    } else {
+      builder.add(
+        task.markerFrom,
+        task.markerTo,
+        Decoration.replace({
+          widget: new TaskCheckboxWidget(task.checked),
+        }),
+      );
+
+      if (task.checked && task.textFrom < task.textTo) {
+        builder.add(
+          task.textFrom,
+          task.textTo,
+          Decoration.mark({ class: "cm-task-done" }),
+        );
+      }
+    }
+  }
+
+  return builder.finish();
+}
+
+// ── ViewPlugin ─────────────────────────────────────────────────────────────────
+
+export const taskListPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged || update.selectionSet) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+    eventHandlers: {
+      mousedown(event: MouseEvent, view: EditorView) {
+        const target = event.target as HTMLElement;
+        if (!(target instanceof HTMLInputElement) || target.type !== "checkbox" || !target.classList.contains("cm-task-checkbox")) {
+          return false;
+        }
+
+        event.preventDefault();
+
+        const pos = view.posAtDOM(target);
+        if (pos < 0) return false;
+
+        const state = view.state;
+
+        const node = syntaxTree(state).resolveInner(pos, 1);
+
+        let markerFrom = -1;
+        let markerTo = -1;
+        let isChecked = false;
+
+        let cur: typeof node | null = node;
+        while (cur) {
+          if (cur.type.name === "TaskMarker") {
+            markerFrom = cur.from;
+            markerTo = cur.to;
+            isChecked = state.doc.sliceString(markerFrom, markerTo).toLowerCase() === "[x]";
+            break;
+          }
+          cur = cur.parent;
+        }
+
+        if (markerFrom === -1) {
+          const line = state.doc.lineAt(pos);
+          const lineText = state.doc.sliceString(line.from, line.to);
+          const m = /^(\s*[-*+]\s+)(\[[ x]\])/i.exec(lineText);
+          if (!m) return false;
+          const prefix = m[1] ?? "";
+          const marker = m[2] ?? "";
+          markerFrom = line.from + prefix.length;
+          markerTo = markerFrom + marker.length;
+          isChecked = marker.toLowerCase() === "[x]";
+        }
+
+        view.dispatch({
+          changes: {
+            from: markerFrom,
+            to: markerTo,
+            insert: isChecked ? "[ ]" : "[x]",
+          },
+          userEvent: "input",
+        });
+
+        return true;
+      },
+    },
+  },
+);

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -117,4 +117,17 @@ export const markdownTheme = EditorView.theme({
   ".cm-frontmatter-hidden": {
     display: "none",
   },
+  // Task list checkboxes
+  ".cm-task-checkbox": {
+    verticalAlign: "middle",
+    marginRight: "0.35em",
+    marginTop: "-2px",
+    cursor: "pointer",
+    accentColor: "var(--color-accent)",
+  },
+  // Checked task item text: strikethrough + muted color
+  ".cm-task-done": {
+    textDecoration: "line-through",
+    color: "var(--color-text-muted)",
+  },
 });


### PR DESCRIPTION
## Summary
- Add `taskList.ts` ViewPlugin that replaces `TaskMarker` tokens with native `<input type="checkbox">` widgets when the cursor is off the task line
- Clicking a checkbox dispatches a CM6 transaction to toggle `[ ]` / `[x]` in the source (undoable via Cmd+Z)
- Checked items receive a `cm-task-done` mark decoration (strikethrough + muted color); cursor on the line reveals raw markers
- Register plugin in `buildExtensions`, add CSS classes to `markdownTheme`, and add a vitest suite (7 passing tests)

Closes #6.

## Test plan
- [ ] Type `- [ ] task` in a note — renders as a native checkbox with the text.
- [ ] Click the checkbox — toggles to `[x]` in the source.
- [ ] Cmd+Z undoes the toggle.
- [ ] Place cursor on the line — raw `[ ]` / `[x]` marker reappears.
- [ ] Checked items render with strikethrough + muted color.
- [ ] Nested tasks (`  - [ ] nested`) render correctly.