### PR TITLE
feat(editor): paste and drop images into vault attachments (#11)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -510,6 +510,91 @@ pub async fn get_file_hash(
     get_file_hash_impl(&state, path)
 }
 
+// ─── save_attachment ─────────────────────────────────────────────────────────
+
+/// Save raw bytes as an attachment inside the vault's attachment folder.
+/// Returns the vault-relative path using forward slashes.
+///
+/// Security: the target folder is canonicalized and verified to sit inside the
+/// vault (T-02 guard), mirroring write_file. The folder is auto-created on
+/// first use. Collision avoidance appends ` 1`, ` 2`, … (capped at 1000).
+#[tauri::command]
+pub async fn save_attachment(
+    state: tauri::State<'_, VaultState>,
+    folder: String,
+    filename: String,
+    bytes: Vec<u8>,
+) -> Result<String, VaultError> {
+    let vault_root = get_vault_root(&state)?;
+
+    // Build and create the target folder.
+    let target_folder = vault_root.join(&folder);
+    std::fs::create_dir_all(&target_folder).map_err(VaultError::Io)?;
+
+    // Canonicalize the folder now that it exists and verify it is inside the vault.
+    let canonical_folder = std::fs::canonicalize(&target_folder).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound {
+            path: target_folder.display().to_string(),
+        },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+            path: target_folder.display().to_string(),
+        },
+        _ => VaultError::Io(e),
+    })?;
+    if !canonical_folder.starts_with(&vault_root) {
+        return Err(VaultError::PermissionDenied {
+            path: canonical_folder.display().to_string(),
+        });
+    }
+
+    // Determine final filename with collision avoidance (cap at 1000).
+    let (stem, ext) = if let Some(dot) = filename.rfind('.') {
+        (&filename[..dot], &filename[dot..])
+    } else {
+        (filename.as_str(), "")
+    };
+    let mut final_path = canonical_folder.join(&filename);
+    if final_path.exists() {
+        let mut found = false;
+        for n in 1u32..=1000 {
+            let candidate_name = format!("{} {}{}", stem, n, ext);
+            let candidate = canonical_folder.join(&candidate_name);
+            if !candidate.exists() {
+                final_path = candidate;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return Err(VaultError::Io(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "too many collisions for attachment filename",
+            )));
+        }
+    }
+
+    // D-12 self-filtering: record before the fs call.
+    if let Ok(mut list) = state.write_ignore.lock() {
+        list.record(final_path.clone());
+    }
+
+    std::fs::write(&final_path, &bytes).map_err(|e| match e.kind() {
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+            path: final_path.display().to_string(),
+        },
+        std::io::ErrorKind::StorageFull => VaultError::DiskFull,
+        _ => VaultError::Io(e),
+    })?;
+
+    // Return vault-relative path with forward slashes.
+    let rel = final_path.strip_prefix(&vault_root).map_err(|_| {
+        VaultError::PermissionDenied {
+            path: final_path.display().to_string(),
+        }
+    })?;
+    Ok(rel.to_string_lossy().replace('\\', "/"))
+}
+
 // ─── count_wiki_links ────────────────────────────────────────────────────────
 
 /// Testable implementation body for count_wiki_links.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ pub fn run() {
             commands::files::create_folder,
             commands::files::count_wiki_links,
             commands::files::get_file_hash,
+            commands::files::save_attachment,
             commands::tree::list_directory,
             commands::vault::merge_external_change,
             commands::search::search_fulltext,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 1200,
         "height": 800,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/src/components/Editor/__tests__/imageAttachment.test.ts
+++ b/src/components/Editor/__tests__/imageAttachment.test.ts
@@ -1,0 +1,98 @@
+// Unit tests for imageAttachment helpers.
+// These tests cover the pure utility functions; the actual DOM handlers are
+// integration-tested manually (paste/drop require a running Tauri app).
+
+import { describe, it, expect } from "vitest";
+
+// Re-implement the pure helpers here so tests don't depend on Svelte store
+// imports (which require a browser context).
+
+function extFromMime(mime: string): string | null {
+  switch (mime) {
+    case "image/png":  return "png";
+    case "image/jpeg": return "jpg";
+    case "image/gif":  return "gif";
+    case "image/webp": return "webp";
+    default:           return null;
+  }
+}
+
+function nowTimestamp(date: Date): string {
+  const pad = (n: number, len = 2) => String(n).padStart(len, "0");
+  return (
+    String(date.getFullYear()) +
+    pad(date.getMonth() + 1) +
+    pad(date.getDate()) +
+    pad(date.getHours()) +
+    pad(date.getMinutes()) +
+    pad(date.getSeconds())
+  );
+}
+
+describe("extFromMime", () => {
+  it("maps image/png to png", () => {
+    expect(extFromMime("image/png")).toBe("png");
+  });
+  it("maps image/jpeg to jpg", () => {
+    expect(extFromMime("image/jpeg")).toBe("jpg");
+  });
+  it("maps image/gif to gif", () => {
+    expect(extFromMime("image/gif")).toBe("gif");
+  });
+  it("maps image/webp to webp", () => {
+    expect(extFromMime("image/webp")).toBe("webp");
+  });
+  it("returns null for unknown mime", () => {
+    expect(extFromMime("image/bmp")).toBeNull();
+    expect(extFromMime("text/plain")).toBeNull();
+  });
+});
+
+describe("nowTimestamp", () => {
+  it("produces a 14-character string of digits", () => {
+    const ts = nowTimestamp(new Date(2026, 3, 14, 20, 30, 0)); // April = month 3
+    expect(ts).toMatch(/^\d{14}$/);
+  });
+  it("formats YYYYMMDDHHMMSS correctly", () => {
+    const ts = nowTimestamp(new Date(2026, 3, 14, 20, 30, 5));
+    expect(ts).toBe("20260414203005");
+  });
+  it("zero-pads single-digit month and day", () => {
+    const ts = nowTimestamp(new Date(2026, 0, 5, 9, 7, 3));
+    expect(ts).toBe("20260105090703");
+  });
+});
+
+describe("filename base parsing", () => {
+  it("extracts png extension from filename", () => {
+    const filename = "Pasted image 20260414203000.png";
+    const dot = filename.lastIndexOf(".");
+    expect(dot).toBeGreaterThan(0);
+    expect(filename.slice(dot + 1)).toBe("png");
+  });
+  it("extracts stem from filename with spaces", () => {
+    const filename = "Pasted image 20260414203000.png";
+    const dot = filename.lastIndexOf(".");
+    expect(filename.slice(0, dot)).toBe("Pasted image 20260414203000");
+  });
+});
+
+describe("URL encoding for markdown reference", () => {
+  it("encodes spaces as %20 in path", () => {
+    const relPath = "attachments/Pasted image 20260414203000.png";
+    const encoded = encodeURI(relPath);
+    expect(encoded).toBe("attachments/Pasted%20image%2020260414203000.png");
+    expect(encoded).not.toContain(" ");
+  });
+  it("does not encode forward slashes", () => {
+    const relPath = "my folder/sub/image.png";
+    const encoded = encodeURI(relPath);
+    expect(encoded).toContain("/");
+    expect(encoded).toBe("my%20folder/sub/image.png");
+  });
+  it("produces valid markdown image reference", () => {
+    const relPath = "attachments/Pasted image 20260414203000.png";
+    const md = `![](${encodeURI(relPath)})`;
+    expect(md).toBe("![](attachments/Pasted%20image%2020260414203000.png)");
+  });
+});

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -32,6 +32,7 @@ import { taskListPlugin } from "./taskList";
 import { countsPlugin } from "./countsPlugin";
 import type { PaneId } from "../../store/countsStore";
 import { activeViewStore } from "../../store/activeViewStore";
+import { imageAttachmentExtension } from "./imageAttachment";
 
 // Debounce sidebar panel re-renders during typing: rapid docChanged updates
 // otherwise flood PropertiesPanel and OutgoingLinksPanel with re-parses on
@@ -84,6 +85,7 @@ export function buildExtensions(
     calloutPlugin,
     taskListPlugin,
     docVersionBumpListener,
+    imageAttachmentExtension(),
   ];
 
   if (paneId !== undefined) {

--- a/src/components/Editor/imageAttachment.ts
+++ b/src/components/Editor/imageAttachment.ts
@@ -35,7 +35,7 @@ function getAttachmentFolder(): string {
   return s.attachmentFolder || ATTACHMENT_FOLDER_DEFAULT;
 }
 
-async function handleSave(view: EditorView, blob: Blob, filename: string): Promise<void> {
+async function handleSave(view: EditorView, blob: Blob, filename: string, userEvent: string): Promise<void> {
   try {
     const bytes = new Uint8Array(await blob.arrayBuffer());
     const folder = getAttachmentFolder();
@@ -44,9 +44,13 @@ async function handleSave(view: EditorView, blob: Blob, filename: string): Promi
     const encoded = encodeURI(relPath);
     const md = `![](${encoded})`;
     const head = view.state.selection.main.head;
+    // The userEvent annotation lets the frontmatter boundary guard
+    // transactionFilter redirect inserts that land inside the frontmatter
+    // region (e.g. head === 0 because the drop missed any text target).
     view.dispatch({
       changes: { from: head, insert: md },
       selection: { anchor: head + md.length },
+      userEvent,
     });
     view.focus();
   } catch (err) {
@@ -85,6 +89,7 @@ async function handleSaveMany(view: EditorView, files: File[]): Promise<void> {
   view.dispatch({
     changes: { from: head, insert },
     selection: { anchor: head + insert.length },
+    userEvent: "input.drop",
   });
   view.focus();
 }
@@ -117,7 +122,7 @@ export function imageAttachmentExtension(): Extension {
       const ts = nowTimestamp();
       const filename = `Pasted image ${ts}.${ext}`;
 
-      void handleSave(view, blob, filename);
+      void handleSave(view, blob, filename, "input.paste");
       return true;
     },
 

--- a/src/components/Editor/imageAttachment.ts
+++ b/src/components/Editor/imageAttachment.ts
@@ -1,0 +1,129 @@
+// Image paste and drop handler for the CodeMirror 6 editor.
+// Saves images to the vault's attachment folder and inserts markdown references.
+
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { get } from "svelte/store";
+import { settingsStore, ATTACHMENT_FOLDER_DEFAULT } from "../../store/settingsStore";
+import { saveAttachment } from "../../ipc/commands";
+
+function extFromMime(mime: string): string | null {
+  switch (mime) {
+    case "image/png":  return "png";
+    case "image/jpeg": return "jpg";
+    case "image/gif":  return "gif";
+    case "image/webp": return "webp";
+    default:           return null;
+  }
+}
+
+function nowTimestamp(): string {
+  const d = new Date();
+  const pad = (n: number, len = 2) => String(n).padStart(len, "0");
+  return (
+    String(d.getFullYear()) +
+    pad(d.getMonth() + 1) +
+    pad(d.getDate()) +
+    pad(d.getHours()) +
+    pad(d.getMinutes()) +
+    pad(d.getSeconds())
+  );
+}
+
+function getAttachmentFolder(): string {
+  const s = get(settingsStore);
+  return s.attachmentFolder || ATTACHMENT_FOLDER_DEFAULT;
+}
+
+async function handleSave(view: EditorView, blob: Blob, filename: string): Promise<void> {
+  try {
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    const folder = getAttachmentFolder();
+    const relPath = await saveAttachment(folder, filename, bytes);
+    // URL-encode path but preserve slashes (encodeURI, not encodeURIComponent)
+    const encoded = encodeURI(relPath);
+    const md = `![](${encoded})`;
+    const head = view.state.selection.main.head;
+    view.dispatch({
+      changes: { from: head, insert: md },
+      selection: { anchor: head + md.length },
+    });
+    view.focus();
+  } catch (err) {
+    console.error("[imageAttachment] save failed:", err);
+  }
+}
+
+async function handleSaveMany(view: EditorView, files: File[]): Promise<void> {
+  const folder = getAttachmentFolder();
+  const parts: string[] = [];
+  for (const file of files) {
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      // Strip any path prefix (some browsers include full path in name)
+      const basename = file.name.replace(/.*[/\\]/, "");
+      const relPath = await saveAttachment(folder, basename, bytes);
+      const encoded = encodeURI(relPath);
+      parts.push(`![](${encoded})`);
+    } catch (err) {
+      console.error("[imageAttachment] drop save failed:", err);
+    }
+  }
+  if (parts.length === 0) return;
+
+  const head = view.state.selection.main.head;
+  const line = view.state.doc.lineAt(head);
+  const atLineStart = head === line.from;
+
+  let insert: string;
+  if (atLineStart) {
+    insert = parts.join("\n") + "\n";
+  } else {
+    insert = "\n" + parts.join("\n") + "\n";
+  }
+
+  view.dispatch({
+    changes: { from: head, insert },
+    selection: { anchor: head + insert.length },
+  });
+  view.focus();
+}
+
+export function imageAttachmentExtension(): Extension {
+  return EditorView.domEventHandlers({
+    paste(event: ClipboardEvent, view: EditorView): boolean {
+      const items = event.clipboardData?.items;
+      if (!items) return false;
+
+      let imageItem: DataTransferItem | null = null;
+      for (const item of Array.from(items)) {
+        if (item.kind === "file" && item.type.startsWith("image/")) {
+          imageItem = item;
+          break;
+        }
+      }
+      if (!imageItem) return false;
+
+      event.preventDefault();
+      const blob = imageItem.getAsFile();
+      if (!blob) return false;
+
+      const ext = extFromMime(blob.type) ?? "png";
+      const ts = nowTimestamp();
+      const filename = `Pasted image ${ts}.${ext}`;
+
+      void handleSave(view, blob, filename);
+      return true;
+    },
+
+    drop(event: DragEvent, view: EditorView): boolean {
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      const images = files.filter((f) => f.type.startsWith("image/"));
+      if (images.length === 0) return false;
+
+      event.preventDefault();
+      void handleSaveMany(view, images);
+      return true;
+    },
+  });
+}

--- a/src/components/Editor/imageAttachment.ts
+++ b/src/components/Editor/imageAttachment.ts
@@ -89,6 +89,11 @@ async function handleSaveMany(view: EditorView, files: File[]): Promise<void> {
   view.focus();
 }
 
+function hasFileDrag(dt: DataTransfer | null): boolean {
+  if (!dt) return false;
+  return Array.from(dt.types).includes("Files");
+}
+
 export function imageAttachmentExtension(): Extension {
   return EditorView.domEventHandlers({
     paste(event: ClipboardEvent, view: EditorView): boolean {
@@ -113,6 +118,15 @@ export function imageAttachmentExtension(): Extension {
       const filename = `Pasted image ${ts}.${ext}`;
 
       void handleSave(view, blob, filename);
+      return true;
+    },
+
+    // The browser only fires `drop` on a target whose `dragover` had its
+    // default prevented — otherwise the OS treats it as "copy not allowed"
+    // and the drop never happens.
+    dragover(event: DragEvent): boolean {
+      if (!hasFileDrag(event.dataTransfer)) return false;
+      event.preventDefault();
       return true;
     },
 

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -6,6 +6,7 @@
     settingsStore,
     FONT_SIZE_MIN,
     FONT_SIZE_MAX,
+    ATTACHMENT_FOLDER_DEFAULT,
     type BodyFont,
     type MonoFont,
   } from "../../store/settingsStore";
@@ -22,11 +23,13 @@
   let currentBody = $state<BodyFont>("system");
   let currentMono = $state<MonoFont>("system");
   let currentSize = $state<number>(14);
+  let currentAttachmentFolder = $state<string>(ATTACHMENT_FOLDER_DEFAULT);
   let currentVaultPath = $state<string | null>(null);
 
   const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
   const unsubSettings = settingsStore.subscribe((s) => {
     currentBody = s.fontBody; currentMono = s.fontMono; currentSize = s.fontSize;
+    currentAttachmentFolder = s.attachmentFolder;
   });
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
 
@@ -50,6 +53,9 @@
   }
   function onSizeInput(e: Event) {
     settingsStore.setFontSize(Number((e.target as HTMLInputElement).value));
+  }
+  function onAttachmentFolderInput(e: Event) {
+    settingsStore.setAttachmentFolder((e.target as HTMLInputElement).value);
   }
 
   onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); });
@@ -149,7 +155,24 @@
         />
       </section>
 
-      <!-- Section C — Tastaturkürzel (UI-05 / D-11) -->
+      <!-- Section C — Anhänge -->
+      <section class="vc-settings-section" data-testid="settings-attachments">
+        <h3 class="vc-settings-section-title">ANHÄNGE</h3>
+        <div class="vc-settings-row">
+          <label for="attachment-folder-input">Anhangsordner</label>
+          <input
+            id="attachment-folder-input"
+            class="vc-settings-text-input"
+            type="text"
+            value={currentAttachmentFolder}
+            oninput={onAttachmentFolderInput}
+            placeholder={ATTACHMENT_FOLDER_DEFAULT}
+            aria-label="Anhangsordner"
+          />
+        </div>
+      </section>
+
+      <!-- Section D — Tastaturkürzel (UI-05 / D-11) -->
       <section class="vc-settings-section" data-testid="settings-shortcuts">
         <h3 class="vc-settings-section-title">TASTATURKÜRZEL</h3>
         <table class="vc-shortcuts-table" role="table">
@@ -246,6 +269,12 @@
   }
   .vc-settings-size-value { font-size: 14px; color: var(--color-text-muted); }
   .vc-settings-slider { width: 100%; }
+  .vc-settings-text-input {
+    font-size: 14px; padding: 4px 8px;
+    border: 1px solid var(--color-border); border-radius: 4px;
+    background: var(--color-surface); color: var(--color-text);
+    min-width: 180px;
+  }
 
   .vc-vault-row { align-items: flex-start; margin-bottom: 0; }
   .vc-vault-path-wrap { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; gap: 4px; }

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -301,6 +301,31 @@ export async function getResolvedLinks(): Promise<Map<string, string>> {
   }
 }
 
+// ── Attachment commands ────────────────────────────────────────────────────────
+
+/**
+ * Save raw image bytes into the vault's attachment folder.
+ * Returns the vault-relative path using forward slashes.
+ * folder: vault-relative path, e.g. "attachments"
+ * filename: desired base name with extension, collision-avoidance handled by Rust
+ * bytes: raw image bytes as a plain Array<number> (Tauri serializes Vec<u8> from JS Array)
+ */
+export async function saveAttachment(
+  folder: string,
+  filename: string,
+  bytes: Uint8Array,
+): Promise<string> {
+  try {
+    return await invoke<string>("save_attachment", {
+      folder,
+      filename,
+      bytes: Array.from(bytes),
+    });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 // ── Tag commands ───────────────────────────────────────────────────────────────
 
 /** TAG-03: list all tags with usage counts, sorted alphabetically. */

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -31,17 +31,22 @@ export const FONT_SIZE_DEFAULT = 14;
 const K_BODY = "vaultcore-font-body";
 const K_MONO = "vaultcore-font-mono";
 const K_SIZE = "vaultcore-font-size";
+const K_ATTACHMENT_FOLDER = "vaultcore-attachment-folder";
+
+export const ATTACHMENT_FOLDER_DEFAULT = "attachments";
 
 export interface SettingsState {
   fontBody: BodyFont;
   fontMono: MonoFont;
   fontSize: number;
+  attachmentFolder: string;
 }
 
 const initial: SettingsState = {
   fontBody: "system",
   fontMono: "system",
   fontSize: FONT_SIZE_DEFAULT,
+  attachmentFolder: ATTACHMENT_FOLDER_DEFAULT,
 };
 
 function isBodyFont(v: unknown): v is BodyFont {
@@ -55,15 +60,24 @@ function clampSize(n: number): number {
   return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, Math.round(n)));
 }
 
+function sanitizeAttachmentFolder(raw: string | null): string {
+  if (!raw) return ATTACHMENT_FOLDER_DEFAULT;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.startsWith("/")) return ATTACHMENT_FOLDER_DEFAULT;
+  return trimmed;
+}
+
 function readInitial(): SettingsState {
   try {
     const b = localStorage.getItem(K_BODY);
     const m = localStorage.getItem(K_MONO);
     const s = Number(localStorage.getItem(K_SIZE));
+    const af = localStorage.getItem(K_ATTACHMENT_FOLDER);
     return {
       fontBody: isBodyFont(b) ? b : initial.fontBody,
       fontMono: isMonoFont(m) ? m : initial.fontMono,
       fontSize: Number.isFinite(s) && s > 0 ? clampSize(s) : FONT_SIZE_DEFAULT,
+      attachmentFolder: sanitizeAttachmentFolder(af),
     };
   } catch { return { ...initial }; }
 }
@@ -103,6 +117,11 @@ function createSettingsStore() {
       _store.update((s) => ({ ...s, fontSize: clamped }));
       applySize(clamped);
       try { localStorage.setItem(K_SIZE, String(clamped)); } catch { /* */ }
+    },
+    setAttachmentFolder(folder: string): void {
+      const sanitized = sanitizeAttachmentFolder(folder);
+      _store.update((s) => ({ ...s, attachmentFolder: sanitized }));
+      try { localStorage.setItem(K_ATTACHMENT_FOLDER, sanitized); } catch { /* */ }
     },
   };
 }


### PR DESCRIPTION
## Summary
- New Rust command `save_attachment` in `src-tauri/src/commands/files.rs`: auto-creates the attachment folder, enforces vault-containment (T-02), applies collision-avoidance (`name 1.ext`, `name 2.ext`, …), records in `write_ignore` before writing, returns vault-relative forward-slash path.
- New TS IPC wrapper `saveAttachment` in `src/ipc/commands.ts` following the same `normalizeError` pattern as `writeFile`.
- New CM6 extension `imageAttachmentExtension` in `src/components/Editor/imageAttachment.ts`: `domEventHandlers` for `paste` (clipboard image -> `Pasted image YYYYMMDDHHMMSS.ext`) and `drop` (preserve original filename); inserts `![](url-encoded-path)` at cursor; multiple dropped files each get their own line.
- `settingsStore` extended with `attachmentFolder` field (default `"attachments"`, persisted under `vaultcore-attachment-folder`, trimmed + leading-slash rejected).
- "Anhangsordner" input added to `SettingsModal.svelte` under a new ANHANGE section, visually consistent with existing rows.

Closes #11.

## Test plan
- [ ] Copy an image in the OS (screenshot tool / browser) -> paste into a note -> file appears in `attachments/` and `![](...)` reference at cursor.
- [ ] Paste twice within the same second -> second file gets ` 1` suffix (collision handling).
- [ ] Drag a PNG from Finder onto the editor -> same result with original filename.
- [ ] Drag multiple images -> each gets its own line.
- [ ] Drag a .txt / non-image -> nothing inserted, no error.
- [ ] Change "Attachment folder" in settings to `media/img` -> next paste saves there, folder is auto-created.
- [ ] Paste image whose blob type is `image/jpeg` -> filename ends in `.jpg`.