### PR TITLE
feat(editor): inline embed rendering and paste as [[wiki-embed]] (#9)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1568,6 +1568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4111,6 +4117,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.5.6", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -22,6 +22,15 @@ use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::Utf32Str;
 use rayon::prelude::*;
 use regex::Regex;
+use walkdir::WalkDir;
+
+/// Image extensions whose files are exposed as wiki-embed targets
+/// (`![[image.png]]`). Everything else is ignored during the walk.
+const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "svg"];
+
+/// Directories skipped by the attachment walk. `.md` files are excluded
+/// separately since they're already covered by `get_resolved_links`.
+const SKIP_DIRS: &[&str] = &[".obsidian", ".git", ".vaultcore", ".trash", "templates"];
 
 // ── Result types ───────────────────────────────────────────────────────────────
 
@@ -386,4 +395,86 @@ pub async fn get_resolved_links(
     };
 
     Ok(link_graph::resolved_map(&paths))
+}
+
+// ── get_resolved_attachments ───────────────────────────────────────────────────
+
+/// Return a `filename (lowercased, with extension) → vault-relative path` map
+/// for every image attachment reachable from the vault root.
+///
+/// Images are not indexed by the main FileIndex (which only tracks `.md`
+/// files), so this command walks the filesystem directly with `walkdir`.
+/// Skips dotfiles, `.git`, `.obsidian`, `.vaultcore`, `.trash`, and `templates`
+/// (if present). `.md` files are excluded — those are covered by
+/// `get_resolved_links`.
+///
+/// The frontend uses this map for the wiki-embed plugin: `![[foo.png]]` looks
+/// up the lowercased filename to resolve to a vault-relative path, which is
+/// then passed through `convertFileSrc` to get an asset-protocol URL.
+///
+/// On a missing or unopened vault the command returns an empty map so the
+/// frontend can still render without surfacing an error to the user.
+#[tauri::command]
+pub async fn get_resolved_attachments(
+    state: tauri::State<'_, VaultState>,
+) -> Result<HashMap<String, String>, VaultError> {
+    let vault_root: PathBuf = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(p) => p.clone(),
+            None => return Ok(HashMap::new()),
+        }
+    };
+
+    let mut map: HashMap<String, String> = HashMap::new();
+
+    for entry in WalkDir::new(&vault_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            // Keep the root, skip dotfiles and known junk directories.
+            if e.depth() == 0 {
+                return true;
+            }
+            let name = e.file_name().to_str().unwrap_or("");
+            if name.starts_with('.') {
+                return false;
+            }
+            if e.file_type().is_dir() && SKIP_DIRS.iter().any(|d| name.eq_ignore_ascii_case(d)) {
+                return false;
+            }
+            true
+        })
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let ext_lower = match path.extension().and_then(|e| e.to_str()) {
+            Some(e) => e.to_ascii_lowercase(),
+            None => continue,
+        };
+        if ext_lower == "md" {
+            continue;
+        }
+        if !IMAGE_EXTENSIONS.iter().any(|e| *e == ext_lower) {
+            continue;
+        }
+
+        let Ok(rel) = path.strip_prefix(&vault_root) else { continue };
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        let Some(filename) = path.file_name().and_then(|n| n.to_str()) else { continue };
+        let key = filename.to_ascii_lowercase();
+
+        // First-hit wins; ambiguous duplicates (same filename in different
+        // folders) are rare in practice for image assets and a follow-up can
+        // add shortest-path disambiguation if needed.
+        map.entry(key).or_insert(rel_str);
+    }
+
+    Ok(map)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run() {
             commands::links::suggest_links,
             commands::links::update_links_after_rename,
             commands::links::get_resolved_links,
+            commands::links::get_resolved_attachments,
             commands::tags::list_tags,
             commands::tags::get_tag_occurrences,
         ])

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,11 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data:"
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost",
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**"]
+      }
     }
   },
   "bundle": {

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -9,7 +9,7 @@
   import { vaultStore } from "../../store/vaultStore";
   import { editorStore } from "../../store/editorStore";
   import { activeViewStore } from "../../store/activeViewStore";
-  import { readFile, writeFile, mergeExternalChange, getResolvedLinks, createFile, getFileHash } from "../../ipc/commands";
+  import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
   import { buildExtensions } from "./extensions";
@@ -21,6 +21,7 @@
   import { treeRefreshStore } from "../../store/treeRefreshStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { setResolvedLinks, resolveTarget, refreshWikiLinks } from "./wikiLink";
+  import { setResolvedAttachments } from "./embeds";
   import { listenFileChange, listenVaultStatus, type FileChangePayload } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
 
@@ -104,20 +105,28 @@
   // ─── Wiki-link resolution map ──────────────────────────────────────────────
 
   /**
-   * Reload the stem->relPath resolution map from the Rust backend.
-   * Called on vault open and after click-to-create so the new file resolves.
+   * Reload the stem->relPath resolution maps from the Rust backend. Handles
+   * both wiki-link and attachment resolution so the embed plugin (issue #9)
+   * can resolve `![[image.png]]` synchronously. Each call fires two IPC
+   * requests in parallel and then nudges every mounted view to rebuild
+   * decorations — `refreshWikiLinks` dispatches an empty transaction which
+   * picks up both the wiki-link plugin and the embed plugin at once.
    */
   async function reloadResolvedLinks(): Promise<void> {
     try {
-      const map = await getResolvedLinks();
-      setResolvedLinks(map);
-      // Refresh decorations on all mounted views in this pane
+      const [linksMap, attachmentsMap] = await Promise.all([
+        getResolvedLinks(),
+        getResolvedAttachments(),
+      ]);
+      setResolvedLinks(linksMap);
+      setResolvedAttachments(attachmentsMap);
       for (const view of viewMap.values()) {
         refreshWikiLinks(view);
       }
     } catch {
-      // Soft-fail: all links render as unresolved until next reload
+      // Soft-fail: all links/embeds render as unresolved until next reload
       setResolvedLinks(new Map());
+      setResolvedAttachments(new Map());
     }
   }
 

--- a/src/components/Editor/__tests__/embedPlugin.test.ts
+++ b/src/components/Editor/__tests__/embedPlugin.test.ts
@@ -1,0 +1,156 @@
+// Unit tests for the embed-parsing helpers in embedPlugin.ts.
+//
+// The CM6 ViewPlugin itself requires a live EditorView and Tauri runtime
+// (convertFileSrc + readFile), which isn't available in jsdom. We test the
+// pure building blocks — regex shapes, size-token parsing, extension detection
+// — so regressions in those show up here.
+
+import { describe, it, expect } from "vitest";
+import { parseSizePx } from "../embedPlugin";
+
+// Regex copies mirror embedPlugin.ts so the test asserts the actual shapes.
+// If embedPlugin.ts changes, update these — they're small on purpose.
+const WIKI_EMBED_RE = /!\[\[([^\]|#]+?)(?:#([^\]|]+))?(?:\|([^\]]*))?\]\]/g;
+const MD_IMAGE_RE = /!\[[^\]]*\]\(([^)]+)\)/g;
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg)$/i;
+
+function isImageFilename(name: string): boolean {
+  return IMAGE_EXT_RE.test(name);
+}
+
+function matchAll(re: RegExp, text: string): RegExpExecArray[] {
+  const out: RegExpExecArray[] = [];
+  re.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) out.push(m);
+  return out;
+}
+
+describe("WIKI_EMBED_RE", () => {
+  it("matches a bare image embed", () => {
+    const m = matchAll(WIKI_EMBED_RE, "prefix ![[foo.png]] suffix");
+    expect(m).toHaveLength(1);
+    expect(m[0]![1]).toBe("foo.png");
+    expect(m[0]![2]).toBeUndefined();
+    expect(m[0]![3]).toBeUndefined();
+  });
+
+  it("captures a sizing token after the pipe", () => {
+    const m = matchAll(WIKI_EMBED_RE, "![[photo.jpg|300]]");
+    expect(m).toHaveLength(1);
+    expect(m[0]![1]).toBe("photo.jpg");
+    expect(m[0]![3]).toBe("300");
+  });
+
+  it("captures a heading separately from the target", () => {
+    const m = matchAll(WIKI_EMBED_RE, "![[OtherNote#Intro]]");
+    expect(m).toHaveLength(1);
+    expect(m[0]![1]).toBe("OtherNote");
+    expect(m[0]![2]).toBe("Intro");
+  });
+
+  it("captures heading + sizing together", () => {
+    const m = matchAll(WIKI_EMBED_RE, "![[doc#Section|200]]");
+    expect(m[0]![1]).toBe("doc");
+    expect(m[0]![2]).toBe("Section");
+    expect(m[0]![3]).toBe("200");
+  });
+
+  it("matches note embeds without extension", () => {
+    const m = matchAll(WIKI_EMBED_RE, "![[MyNote]]");
+    expect(m).toHaveLength(1);
+    expect(m[0]![1]).toBe("MyNote");
+  });
+
+  it("matches multiple embeds in one document", () => {
+    const m = matchAll(
+      WIKI_EMBED_RE,
+      "line1 ![[a.png]] line2 ![[b.jpg|400]] line3 ![[NoteX]]",
+    );
+    expect(m).toHaveLength(3);
+    expect(m.map((x) => x[1])).toEqual(["a.png", "b.jpg", "NoteX"]);
+  });
+
+  it("does not confuse a plain wiki-link with an embed", () => {
+    // No leading `!` → not an embed. The wiki-link plugin owns this shape.
+    const m = matchAll(WIKI_EMBED_RE, "[[JustALink]]");
+    expect(m).toHaveLength(0);
+  });
+
+  it("does not match a stray `![[` with no closing brackets", () => {
+    const m = matchAll(WIKI_EMBED_RE, "![[unterminated");
+    expect(m).toHaveLength(0);
+  });
+});
+
+describe("MD_IMAGE_RE", () => {
+  it("captures a simple markdown image path", () => {
+    const m = matchAll(MD_IMAGE_RE, "![](attachments/photo.png)");
+    expect(m).toHaveLength(1);
+    expect(m[0]![1]).toBe("attachments/photo.png");
+  });
+
+  it("captures a URL-encoded path", () => {
+    const m = matchAll(MD_IMAGE_RE, "![alt](attachments/Pasted%20image%202026.png)");
+    expect(m).toHaveLength(1);
+    expect(m[0]![1]).toBe("attachments/Pasted%20image%202026.png");
+  });
+
+  it("captures the path when alt text is present", () => {
+    const m = matchAll(MD_IMAGE_RE, "![a photograph](sub/photo.jpg)");
+    expect(m[0]![1]).toBe("sub/photo.jpg");
+  });
+
+  it("decodes percent escapes back to spaces", () => {
+    const raw = "attachments/Pasted%20image.png";
+    expect(decodeURI(raw)).toBe("attachments/Pasted image.png");
+  });
+});
+
+describe("isImageFilename (extension detection)", () => {
+  it("accepts common raster extensions case-insensitively", () => {
+    expect(isImageFilename("a.png")).toBe(true);
+    expect(isImageFilename("a.PNG")).toBe(true);
+    expect(isImageFilename("a.jpg")).toBe(true);
+    expect(isImageFilename("a.jpeg")).toBe(true);
+    expect(isImageFilename("a.gif")).toBe(true);
+    expect(isImageFilename("a.webp")).toBe(true);
+    expect(isImageFilename("a.svg")).toBe(true);
+  });
+
+  it("rejects non-image extensions and extensionless names", () => {
+    expect(isImageFilename("note")).toBe(false);
+    expect(isImageFilename("OtherNote")).toBe(false);
+    expect(isImageFilename("file.md")).toBe(false);
+    expect(isImageFilename("archive.zip")).toBe(false);
+  });
+});
+
+describe("parseSizePx", () => {
+  it("extracts a positive integer from a pure-digit token", () => {
+    expect(parseSizePx("300")).toBe(300);
+  });
+
+  it("extracts a leading integer and ignores trailing text", () => {
+    expect(parseSizePx("200px")).toBe(200);
+    expect(parseSizePx("150 tall")).toBe(150);
+  });
+
+  it("tolerates leading whitespace", () => {
+    expect(parseSizePx("  42")).toBe(42);
+  });
+
+  it("returns null for non-numeric aliases", () => {
+    expect(parseSizePx("alias text")).toBeNull();
+    expect(parseSizePx("foo")).toBeNull();
+  });
+
+  it("returns null for missing and empty input", () => {
+    expect(parseSizePx(undefined)).toBeNull();
+    expect(parseSizePx("")).toBeNull();
+  });
+
+  it("returns null for zero", () => {
+    expect(parseSizePx("0")).toBeNull();
+  });
+});

--- a/src/components/Editor/__tests__/imageAttachment.test.ts
+++ b/src/components/Editor/__tests__/imageAttachment.test.ts
@@ -3,6 +3,7 @@
 // integration-tested manually (paste/drop require a running Tauri app).
 
 import { describe, it, expect } from "vitest";
+import { formatEmbedReference } from "../imageAttachment";
 
 // Re-implement the pure helpers here so tests don't depend on Svelte store
 // imports (which require a browser context).
@@ -77,22 +78,22 @@ describe("filename base parsing", () => {
   });
 });
 
-describe("URL encoding for markdown reference", () => {
-  it("encodes spaces as %20 in path", () => {
-    const relPath = "attachments/Pasted image 20260414203000.png";
-    const encoded = encodeURI(relPath);
-    expect(encoded).toBe("attachments/Pasted%20image%2020260414203000.png");
-    expect(encoded).not.toContain(" ");
+describe("formatEmbedReference", () => {
+  it("wraps a bare filename as a wiki-embed", () => {
+    expect(formatEmbedReference("photo.png")).toBe("![[photo.png]]");
   });
-  it("does not encode forward slashes", () => {
-    const relPath = "my folder/sub/image.png";
-    const encoded = encodeURI(relPath);
-    expect(encoded).toContain("/");
-    expect(encoded).toBe("my%20folder/sub/image.png");
+  it("reduces a vault-relative path to its basename", () => {
+    // save_attachment returns something like "foo/bar/photo.png" — we only
+    // keep the last segment because the embed resolver looks up by filename.
+    expect(formatEmbedReference("foo/bar/photo.png")).toBe("![[photo.png]]");
   });
-  it("produces valid markdown image reference", () => {
-    const relPath = "attachments/Pasted image 20260414203000.png";
-    const md = `![](${encodeURI(relPath)})`;
-    expect(md).toBe("![](attachments/Pasted%20image%2020260414203000.png)");
+  it("preserves spaces in filenames (no URL encoding)", () => {
+    const rel = "notes/sub/Pasted image 20260414203000.png";
+    const md = formatEmbedReference(rel);
+    expect(md).toBe("![[Pasted image 20260414203000.png]]");
+    expect(md).not.toContain("%20");
+  });
+  it("handles a filename at vault root", () => {
+    expect(formatEmbedReference("root.png")).toBe("![[root.png]]");
   });
 });

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -1,0 +1,363 @@
+// Wiki-embed and markdown-image ViewPlugin — inline rendering for issue #9.
+//
+// Supports three embed forms:
+//   1. `![[image.png]]` and `![[image.png|300]]` — wiki-embed images, with
+//      optional pixel sizing after `|`.
+//   2. `![](path/to/image.png)` — standard markdown images; URL-decoded so
+//      `Pasted%20image.png` also resolves. Kept for back-compat with content
+//      authored before the paste handler switched to wiki-embed output.
+//   3. `![[OtherNote]]` — note embeds. Rendered as a bordered block showing
+//      the target file's raw markdown. Full rendering is a follow-up.
+//
+// Architecture mirrors `wikiLink.ts`:
+//   - Module-level resolver maps (`embeds.ts` for attachments,
+//     `wikiLink.ts` for notes) populated once per vault open from Rust.
+//   - Decoration build is synchronous — every lookup is a Map.get().
+//   - Note-embed content is fetched asynchronously via `readFile` and cached
+//     in a module-level Map keyed by vault-relative path; a fetch kicks a
+//     view dispatch on completion so the widget swaps in.
+
+import { ViewPlugin, Decoration, EditorView, WidgetType } from "@codemirror/view";
+import type { DecorationSet, ViewUpdate } from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+import type { EditorState } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { get } from "svelte/store";
+
+import { resolveAttachment } from "./embeds";
+import { resolveTarget } from "./wikiLink";
+import { vaultStore } from "../../store/vaultStore";
+import { readFile } from "../../ipc/commands";
+
+// ── Regex ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Matches `![[target]]`, `![[target|sizing]]`, `![[target#heading]]`, and the
+ * combined `![[target#heading|sizing]]`. Captures:
+ *   1 — target (path/filename, no `]`, `|`, or `#`)
+ *   2 — heading (optional, after `#`)
+ *   3 — sizing/alias text (optional, after `|`)
+ *
+ * The heading capture is parsed but not yet used for slicing — see PR notes.
+ */
+const WIKI_EMBED_RE = /!\[\[([^\]|#]+?)(?:#([^\]|]+))?(?:\|([^\]]*))?\]\]/g;
+
+/** Matches `![alt](path)` — captures the path. */
+const MD_IMAGE_RE = /!\[[^\]]*\]\(([^)]+)\)/g;
+
+// ── Cache for note-embed content ──────────────────────────────────────────────
+
+/**
+ * Vault-relative path → file content. Cleared on every plugin rebuild so edits
+ * to the target note propagate without manual invalidation (the doc-version
+ * debounce gates this to ~200 ms, so the cache still absorbs the rebuild burst).
+ */
+const noteContentCache: Map<string, string> = new Map();
+/**
+ * Paths whose `readFile` call is already in flight, used to suppress duplicate
+ * IPC requests from back-to-back plugin rebuilds.
+ */
+const noteFetchInFlight: Set<string> = new Set();
+
+function scheduleNoteFetch(view: EditorView, relPath: string): void {
+  if (noteContentCache.has(relPath) || noteFetchInFlight.has(relPath)) return;
+  const vault = get(vaultStore).currentPath;
+  if (!vault) return;
+  const abs = `${vault}/${relPath}`;
+  noteFetchInFlight.add(relPath);
+  void readFile(abs)
+    .then((content) => {
+      noteContentCache.set(relPath, content);
+    })
+    .catch(() => {
+      noteContentCache.set(relPath, "");
+    })
+    .finally(() => {
+      noteFetchInFlight.delete(relPath);
+      // Kick the plugin to re-render now that we have content.
+      if (!view.dom.isConnected) return;
+      view.dispatch({ effects: [] });
+    });
+}
+
+// ── Widgets ────────────────────────────────────────────────────────────────────
+
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg)$/i;
+
+function isImageFilename(name: string): boolean {
+  return IMAGE_EXT_RE.test(name);
+}
+
+/**
+ * Return the absolute vault path for a vault-relative asset path, or null
+ * when the vault is not open. Uses forward slashes on all platforms —
+ * `convertFileSrc` tolerates either.
+ */
+function absFromRel(relPath: string): string | null {
+  const vault = get(vaultStore).currentPath;
+  if (!vault) return null;
+  const v = vault.replace(/\\/g, "/").replace(/\/$/, "");
+  return `${v}/${relPath}`;
+}
+
+class ImageEmbedWidget extends WidgetType {
+  constructor(readonly relPath: string, readonly sizePx: number | null) {
+    super();
+  }
+
+  eq(other: ImageEmbedWidget): boolean {
+    return this.relPath === other.relPath && this.sizePx === other.sizePx;
+  }
+
+  toDOM(): HTMLElement {
+    const img = document.createElement("img");
+    img.className = "cm-embed-img";
+    const abs = absFromRel(this.relPath);
+    img.src = abs ? convertFileSrc(abs) : "";
+    img.alt = this.relPath;
+    if (this.sizePx !== null) {
+      img.style.width = `${this.sizePx}px`;
+    }
+    return img;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+class NoteEmbedWidget extends WidgetType {
+  constructor(readonly relPath: string, readonly content: string) {
+    super();
+  }
+
+  eq(other: NoteEmbedWidget): boolean {
+    return this.relPath === other.relPath && this.content === other.content;
+  }
+
+  toDOM(): HTMLElement {
+    const block = document.createElement("div");
+    block.className = "cm-embed-note";
+    block.setAttribute("data-embed-path", this.relPath);
+    // MVP: raw markdown text. A follow-up can pipe this through a proper
+    // markdown renderer — keeping monospace for now so the user clearly
+    // sees what content is being embedded without a half-rendered surprise.
+    block.textContent = this.content;
+    return block;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+class BrokenEmbedWidget extends WidgetType {
+  constructor(readonly target: string) {
+    super();
+  }
+
+  eq(other: BrokenEmbedWidget): boolean {
+    return this.target === other.target;
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "cm-embed-broken";
+    span.textContent = `\u26A0 nicht gefunden: ${this.target}`;
+    return span;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+// ── Code block detection ───────────────────────────────────────────────────────
+
+function isInsideCodeBlock(state: EditorState, pos: number): boolean {
+  const node = syntaxTree(state).resolve(pos, 1);
+  let cur: typeof node | null = node;
+  while (cur) {
+    const name = cur.type.name;
+    if (
+      name === "FencedCode" ||
+      name === "CodeBlock" ||
+      name === "InlineCode" ||
+      name === "Code"
+    ) {
+      return true;
+    }
+    cur = cur.parent;
+  }
+  return false;
+}
+
+// ── Match types ────────────────────────────────────────────────────────────────
+
+interface EmbedMatch {
+  from: number;
+  to: number;
+  decoration: Decoration;
+}
+
+/**
+ * Parse the sizing token that follows the `|` in a wiki-embed. Only a leading
+ * positive integer is honored — everything else is treated as an alias and
+ * ignored for image width.
+ */
+export function parseSizePx(raw: string | undefined): number | null {
+  if (raw === undefined) return null;
+  const m = /^\s*(\d+)/.exec(raw);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+// ── Build decorations ──────────────────────────────────────────────────────────
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const text = view.state.doc.toString();
+  const head = view.state.selection.main.head;
+
+  const matches: EmbedMatch[] = [];
+
+  // Wiki embeds: ![[target(#heading)?(|sizing)?]]
+  WIKI_EMBED_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WIKI_EMBED_RE.exec(text)) !== null) {
+    const rawTarget = m[1];
+    if (rawTarget === undefined) continue;
+    const from = m.index;
+    const to = from + m[0].length;
+
+    // Skip code blocks / inline code.
+    if (isInsideCodeBlock(view.state, from)) continue;
+
+    // Cursor inside → show raw syntax, do not replace.
+    if (head >= from && head <= to) continue;
+
+    const target = rawTarget.trim();
+    const sizePx = parseSizePx(m[3]);
+
+    let deco: Decoration;
+    if (isImageFilename(target)) {
+      const rel = resolveAttachment(target);
+      if (rel !== null) {
+        deco = Decoration.replace({ widget: new ImageEmbedWidget(rel, sizePx) });
+      } else {
+        deco = Decoration.replace({ widget: new BrokenEmbedWidget(target) });
+      }
+    } else {
+      // Note embed. We intentionally ignore the #heading capture for now and
+      // render the entire target note; heading slicing is a follow-up.
+      const rel = resolveTarget(target);
+      if (rel !== null) {
+        const cached = noteContentCache.get(rel);
+        if (cached === undefined) {
+          scheduleNoteFetch(view, rel);
+          // Show a muted placeholder while the fetch is in flight so the UI
+          // doesn't flash with a stale version of the target note.
+          deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, "…") });
+        } else {
+          deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, cached) });
+        }
+      } else {
+        deco = Decoration.replace({ widget: new BrokenEmbedWidget(target) });
+      }
+    }
+
+    matches.push({ from, to, decoration: deco });
+  }
+
+  // Markdown-form images: ![alt](path)
+  MD_IMAGE_RE.lastIndex = 0;
+  while ((m = MD_IMAGE_RE.exec(text)) !== null) {
+    const rawPath = m[1];
+    if (rawPath === undefined) continue;
+    const from = m.index;
+    const to = from + m[0].length;
+
+    if (isInsideCodeBlock(view.state, from)) continue;
+    if (head >= from && head <= to) continue;
+
+    // Skip remote URLs — out of scope for this PR; the browser will fail the
+    // request under the CSP and the user sees a broken <img>. Intentional.
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(rawPath) || rawPath.startsWith("//")) {
+      continue;
+    }
+
+    let decoded: string;
+    try {
+      decoded = decodeURI(rawPath);
+    } catch {
+      decoded = rawPath;
+    }
+    // The markdown form may carry a folder prefix; we resolve by basename via
+    // the attachment map so old `![](attachments/foo.png)` content still works
+    // even if the image now lives elsewhere.
+    const slashIdx = decoded.lastIndexOf("/");
+    const basename = slashIdx === -1 ? decoded : decoded.slice(slashIdx + 1);
+    const rel = resolveAttachment(basename);
+    if (rel === null) continue; // markdown form has no placeholder — plain broken <img> if the path is wrong
+    matches.push({
+      from,
+      to,
+      decoration: Decoration.replace({ widget: new ImageEmbedWidget(rel, null) }),
+    });
+  }
+
+  matches.sort((a, b) => a.from - b.from || a.to - b.to);
+
+  // Drop overlapping ranges — a match containing another is already rare since
+  // the regexes are non-greedy, but the builder requires strictly increasing
+  // endpoints so we defend here instead of crashing.
+  let lastTo = -1;
+  for (const r of matches) {
+    if (r.from < lastTo) continue;
+    builder.add(r.from, r.to, r.decoration);
+    lastTo = r.to;
+  }
+
+  return builder.finish();
+}
+
+// ── ViewPlugin ─────────────────────────────────────────────────────────────────
+
+export const embedPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      // Clear caches so stale content from a previous vault does not leak into
+      // the freshly-mounted view. Cheap because the caches are module-level.
+      noteContentCache.clear();
+      this.decorations = buildDecorations(view);
+    }
+
+    update(u: ViewUpdate) {
+      if (u.docChanged || u.viewportChanged || u.selectionSet) {
+        // Doc-change events invalidate cached note content — rebuilding is
+        // how we learn that the target note itself was edited via a different
+        // open tab. Clearing the cache here is the simplest correct move.
+        if (u.docChanged) {
+          noteContentCache.clear();
+        }
+        this.decorations = buildDecorations(u.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+
+/**
+ * Test-only hook: clear both caches so unit tests start from a clean slate.
+ * Not part of the public API.
+ */
+export function __resetEmbedCachesForTests(): void {
+  noteContentCache.clear();
+  noteFetchInFlight.clear();
+}

--- a/src/components/Editor/embeds.ts
+++ b/src/components/Editor/embeds.ts
@@ -1,0 +1,31 @@
+// Attachment resolver map for the wiki-embed (`![[file.png]]`) plugin.
+// Mirrors the shape of `wikiLink.ts` — a module-level Map populated once per
+// vault open via `setResolvedAttachments(await getResolvedAttachments())` from
+// EditorPane, so decoration lookups are synchronous and IPC-free.
+
+/**
+ * Lowercased filename-with-extension → vault-relative path.
+ * E.g. `"photo.png"` → `"images/photo.png"`.
+ */
+let resolvedAttachments: Map<string, string> = new Map();
+
+export function setResolvedAttachments(map: Map<string, string>): void {
+  resolvedAttachments = map;
+}
+
+/**
+ * Synchronous lookup for the embed ViewPlugin. Accepts the raw filename as
+ * written inside `![[...]]` and returns the vault-relative path, or `null`
+ * if the attachment is missing.
+ *
+ * Matching is case-insensitive because users routinely type `![[IMG_0001.JPG]]`
+ * for files named `img_0001.jpg`.
+ */
+export function resolveAttachment(filename: string): string | null {
+  // Strip an embed-style trailing section reference (`foo.png#anchor`) just in
+  // case — the plugin captures `#heading` separately but a defensive strip
+  // keeps this helper honest for ad-hoc callers.
+  const hashIdx = filename.indexOf("#");
+  const cleaned = hashIdx === -1 ? filename : filename.slice(0, hashIdx);
+  return resolvedAttachments.get(cleaned.trim().toLowerCase()) ?? null;
+}

--- a/src/components/Editor/embeds.ts
+++ b/src/components/Editor/embeds.ts
@@ -14,6 +14,16 @@ export function setResolvedAttachments(map: Map<string, string>): void {
 }
 
 /**
+ * Add or replace a single entry in the attachment map. Used by the paste/drop
+ * handler after `save_attachment` returns, so the just-saved image resolves on
+ * the next embed-plugin rebuild without waiting for a full `get_resolved_attachments`
+ * refresh (the file-watcher event for self-writes is suppressed via write_ignore).
+ */
+export function addResolvedAttachment(filename: string, relPath: string): void {
+  resolvedAttachments.set(filename.trim().toLowerCase(), relPath);
+}
+
+/**
  * Synchronous lookup for the embed ViewPlugin. Accepts the raw filename as
  * written inside `![[...]]` and returns the vault-relative path, or `null`
  * if the attachment is missing.

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -25,6 +25,7 @@ import { markdownTheme, markdownHighlightStyle } from "./theme";
 import { autoSaveExtension } from "./autoSave";
 import { flashField } from "./flashHighlight";
 import { wikiLinkPlugin } from "./wikiLink";
+import { embedPlugin } from "./embedPlugin";
 import { livePreviewPlugin } from "./livePreview";
 import { frontmatterPlugin } from "./frontmatterPlugin";
 import { calloutPlugin } from "./callouts";
@@ -80,6 +81,7 @@ export function buildExtensions(
     autoSaveExtension(onSave),
     flashField,
     wikiLinkPlugin,
+    embedPlugin,
     livePreviewPlugin,
     frontmatterPlugin,
     calloutPlugin,

--- a/src/components/Editor/imageAttachment.ts
+++ b/src/components/Editor/imageAttachment.ts
@@ -8,6 +8,7 @@ import { get } from "svelte/store";
 import { tabStore } from "../../store/tabStore";
 import { vaultStore } from "../../store/vaultStore";
 import { saveAttachment } from "../../ipc/commands";
+import { addResolvedAttachment } from "./embeds";
 
 function extFromMime(mime: string): string | null {
   switch (mime) {
@@ -67,11 +68,25 @@ export function formatEmbedReference(relPath: string): string {
   return `![[${basename}]]`;
 }
 
+/**
+ * Register the just-saved attachment with the embed resolver so the upcoming
+ * decoration rebuild (triggered by our own view.dispatch below) finds it.
+ * Without this, the file-watcher event for our own write is suppressed via
+ * write_ignore, so the resolver map would stay stale until vault reopen and
+ * the user would briefly see a "nicht gefunden" placeholder.
+ */
+function registerSavedAttachment(relPath: string): void {
+  const idx = relPath.lastIndexOf("/");
+  const basename = idx === -1 ? relPath : relPath.slice(idx + 1);
+  addResolvedAttachment(basename, relPath);
+}
+
 async function handleSave(view: EditorView, blob: Blob, filename: string, userEvent: string): Promise<void> {
   try {
     const bytes = new Uint8Array(await blob.arrayBuffer());
     const folder = getActiveNoteDir();
     const relPath = await saveAttachment(folder, filename, bytes);
+    registerSavedAttachment(relPath);
     const md = formatEmbedReference(relPath);
     const head = view.state.selection.main.head;
     // The userEvent annotation lets the frontmatter boundary guard
@@ -97,6 +112,7 @@ async function handleSaveMany(view: EditorView, files: File[]): Promise<void> {
       // Strip any path prefix (some browsers include full path in name)
       const basename = file.name.replace(/.*[/\\]/, "");
       const relPath = await saveAttachment(folder, basename, bytes);
+      registerSavedAttachment(relPath);
       parts.push(formatEmbedReference(relPath));
     } catch (err) {
       console.error("[imageAttachment] drop save failed:", err);

--- a/src/components/Editor/imageAttachment.ts
+++ b/src/components/Editor/imageAttachment.ts
@@ -1,10 +1,12 @@
 // Image paste and drop handler for the CodeMirror 6 editor.
-// Saves images to the vault's attachment folder and inserts markdown references.
+// Saves images next to the active note's .md file and inserts `![[name.ext]]`
+// wiki-embed references. Works together with embedPlugin.ts for inline rendering.
 
 import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { get } from "svelte/store";
-import { settingsStore, ATTACHMENT_FOLDER_DEFAULT } from "../../store/settingsStore";
+import { tabStore } from "../../store/tabStore";
+import { vaultStore } from "../../store/vaultStore";
 import { saveAttachment } from "../../ipc/commands";
 
 function extFromMime(mime: string): string | null {
@@ -30,19 +32,47 @@ function nowTimestamp(): string {
   );
 }
 
-function getAttachmentFolder(): string {
-  const s = get(settingsStore);
-  return s.attachmentFolder || ATTACHMENT_FOLDER_DEFAULT;
+/**
+ * Return the vault-relative directory of the currently-active tab's file,
+ * e.g. `"foo/bar"` for `/vault/foo/bar/note.md`, or `""` for a file at the
+ * vault root or when no tab is active. Uses forward slashes regardless of
+ * the host OS so it matches the save_attachment IPC's expectation.
+ */
+function getActiveNoteDir(): string {
+  const vault = get(vaultStore).currentPath;
+  if (!vault) return "";
+  const tabs = get(tabStore);
+  if (!tabs.activeTabId) return "";
+  const activeTab = tabs.tabs.find((t) => t.id === tabs.activeTabId);
+  if (!activeTab) return "";
+
+  const abs = activeTab.filePath;
+  // Normalize to forward slashes so the prefix strip and `lastIndexOf("/")`
+  // below are consistent across Windows and Unix.
+  const absFwd = abs.replace(/\\/g, "/");
+  const vaultFwd = vault.replace(/\\/g, "/").replace(/\/$/, "");
+  if (!absFwd.startsWith(vaultFwd + "/")) return "";
+  const rel = absFwd.slice(vaultFwd.length + 1);
+  const lastSlash = rel.lastIndexOf("/");
+  return lastSlash === -1 ? "" : rel.slice(0, lastSlash);
+}
+
+/**
+ * Format a vault-relative attachment path as a wiki-embed reference.
+ * Uses just the basename — the embed resolver looks up by filename.
+ */
+export function formatEmbedReference(relPath: string): string {
+  const idx = relPath.lastIndexOf("/");
+  const basename = idx === -1 ? relPath : relPath.slice(idx + 1);
+  return `![[${basename}]]`;
 }
 
 async function handleSave(view: EditorView, blob: Blob, filename: string, userEvent: string): Promise<void> {
   try {
     const bytes = new Uint8Array(await blob.arrayBuffer());
-    const folder = getAttachmentFolder();
+    const folder = getActiveNoteDir();
     const relPath = await saveAttachment(folder, filename, bytes);
-    // URL-encode path but preserve slashes (encodeURI, not encodeURIComponent)
-    const encoded = encodeURI(relPath);
-    const md = `![](${encoded})`;
+    const md = formatEmbedReference(relPath);
     const head = view.state.selection.main.head;
     // The userEvent annotation lets the frontmatter boundary guard
     // transactionFilter redirect inserts that land inside the frontmatter
@@ -59,7 +89,7 @@ async function handleSave(view: EditorView, blob: Blob, filename: string, userEv
 }
 
 async function handleSaveMany(view: EditorView, files: File[]): Promise<void> {
-  const folder = getAttachmentFolder();
+  const folder = getActiveNoteDir();
   const parts: string[] = [];
   for (const file of files) {
     try {
@@ -67,8 +97,7 @@ async function handleSaveMany(view: EditorView, files: File[]): Promise<void> {
       // Strip any path prefix (some browsers include full path in name)
       const basename = file.name.replace(/.*[/\\]/, "");
       const relPath = await saveAttachment(folder, basename, bytes);
-      const encoded = encodeURI(relPath);
-      parts.push(`![](${encoded})`);
+      parts.push(formatEmbedReference(relPath));
     } catch (err) {
       console.error("[imageAttachment] drop save failed:", err);
     }

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -214,4 +214,30 @@ export const markdownTheme = EditorView.theme({
     textDecoration: "line-through",
     color: "var(--color-text-muted)",
   },
+
+  // ── Embeds (issue #9) ─────────────────────────────────────────────────────
+  // Images render inline via convertFileSrc + the asset protocol. Note embeds
+  // show a bordered monospace block until a real markdown renderer is wired up.
+  ".cm-embed-img": {
+    display: "inline-block",
+    maxWidth: "100%",
+    borderRadius: "4px",
+  },
+  ".cm-embed-note": {
+    display: "block",
+    border: "1px solid var(--color-border)",
+    borderRadius: "6px",
+    padding: "12px 16px",
+    margin: "8px 0",
+    backgroundColor: "var(--color-surface-2, var(--color-bg))",
+    fontFamily: "var(--vc-font-mono)",
+    fontSize: "12px",
+    whiteSpace: "pre-wrap",
+    maxHeight: "320px",
+    overflow: "auto",
+  },
+  ".cm-embed-broken": {
+    color: "var(--color-text-muted)",
+    fontStyle: "italic",
+  },
 });

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -6,7 +6,6 @@
     settingsStore,
     FONT_SIZE_MIN,
     FONT_SIZE_MAX,
-    ATTACHMENT_FOLDER_DEFAULT,
     type BodyFont,
     type MonoFont,
   } from "../../store/settingsStore";
@@ -23,13 +22,11 @@
   let currentBody = $state<BodyFont>("system");
   let currentMono = $state<MonoFont>("system");
   let currentSize = $state<number>(14);
-  let currentAttachmentFolder = $state<string>(ATTACHMENT_FOLDER_DEFAULT);
   let currentVaultPath = $state<string | null>(null);
 
   const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
   const unsubSettings = settingsStore.subscribe((s) => {
     currentBody = s.fontBody; currentMono = s.fontMono; currentSize = s.fontSize;
-    currentAttachmentFolder = s.attachmentFolder;
   });
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
 
@@ -53,9 +50,6 @@
   }
   function onSizeInput(e: Event) {
     settingsStore.setFontSize(Number((e.target as HTMLInputElement).value));
-  }
-  function onAttachmentFolderInput(e: Event) {
-    settingsStore.setAttachmentFolder((e.target as HTMLInputElement).value);
   }
 
   onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); });
@@ -155,24 +149,7 @@
         />
       </section>
 
-      <!-- Section C — Anhänge -->
-      <section class="vc-settings-section" data-testid="settings-attachments">
-        <h3 class="vc-settings-section-title">ANHÄNGE</h3>
-        <div class="vc-settings-row">
-          <label for="attachment-folder-input">Anhangsordner</label>
-          <input
-            id="attachment-folder-input"
-            class="vc-settings-text-input"
-            type="text"
-            value={currentAttachmentFolder}
-            oninput={onAttachmentFolderInput}
-            placeholder={ATTACHMENT_FOLDER_DEFAULT}
-            aria-label="Anhangsordner"
-          />
-        </div>
-      </section>
-
-      <!-- Section D — Tastaturkürzel (UI-05 / D-11) -->
+      <!-- Section C — Tastaturkürzel (UI-05 / D-11) -->
       <section class="vc-settings-section" data-testid="settings-shortcuts">
         <h3 class="vc-settings-section-title">TASTATURKÜRZEL</h3>
         <table class="vc-shortcuts-table" role="table">
@@ -269,12 +246,6 @@
   }
   .vc-settings-size-value { font-size: 14px; color: var(--color-text-muted); }
   .vc-settings-slider { width: 100%; }
-  .vc-settings-text-input {
-    font-size: 14px; padding: 4px 8px;
-    border: 1px solid var(--color-border); border-radius: 4px;
-    background: var(--color-surface); color: var(--color-text);
-    min-width: 180px;
-  }
 
   .vc-vault-row { align-items: flex-start; margin-bottom: 0; }
   .vc-vault-path-wrap { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; gap: 4px; }

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -301,6 +301,20 @@ export async function getResolvedLinks(): Promise<Map<string, string>> {
   }
 }
 
+/**
+ * Return a lowercased `filename.ext` → vault-relative path map for every image
+ * attachment in the vault. Drives the `![[image.png]]` wiki-embed resolver
+ * with zero IPC per render.
+ */
+export async function getResolvedAttachments(): Promise<Map<string, string>> {
+  try {
+    const record = await invoke<Record<string, string>>("get_resolved_attachments");
+    return new Map(Object.entries(record));
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 // ── Attachment commands ────────────────────────────────────────────────────────
 
 /**

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -31,22 +31,20 @@ export const FONT_SIZE_DEFAULT = 14;
 const K_BODY = "vaultcore-font-body";
 const K_MONO = "vaultcore-font-mono";
 const K_SIZE = "vaultcore-font-size";
-const K_ATTACHMENT_FOLDER = "vaultcore-attachment-folder";
-
-export const ATTACHMENT_FOLDER_DEFAULT = "attachments";
+// Legacy key from the brief attachment-folder era (before embeds). Removed
+// during cleanup so stale entries don't linger in localStorage.
+const K_ATTACHMENT_FOLDER_LEGACY = "vaultcore-attachment-folder";
 
 export interface SettingsState {
   fontBody: BodyFont;
   fontMono: MonoFont;
   fontSize: number;
-  attachmentFolder: string;
 }
 
 const initial: SettingsState = {
   fontBody: "system",
   fontMono: "system",
   fontSize: FONT_SIZE_DEFAULT,
-  attachmentFolder: ATTACHMENT_FOLDER_DEFAULT,
 };
 
 function isBodyFont(v: unknown): v is BodyFont {
@@ -60,24 +58,15 @@ function clampSize(n: number): number {
   return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, Math.round(n)));
 }
 
-function sanitizeAttachmentFolder(raw: string | null): string {
-  if (!raw) return ATTACHMENT_FOLDER_DEFAULT;
-  const trimmed = raw.trim();
-  if (!trimmed || trimmed.startsWith("/")) return ATTACHMENT_FOLDER_DEFAULT;
-  return trimmed;
-}
-
 function readInitial(): SettingsState {
   try {
     const b = localStorage.getItem(K_BODY);
     const m = localStorage.getItem(K_MONO);
     const s = Number(localStorage.getItem(K_SIZE));
-    const af = localStorage.getItem(K_ATTACHMENT_FOLDER);
     return {
       fontBody: isBodyFont(b) ? b : initial.fontBody,
       fontMono: isMonoFont(m) ? m : initial.fontMono,
       fontSize: Number.isFinite(s) && s > 0 ? clampSize(s) : FONT_SIZE_DEFAULT,
-      attachmentFolder: sanitizeAttachmentFolder(af),
     };
   } catch { return { ...initial }; }
 }
@@ -99,6 +88,10 @@ function createSettingsStore() {
       applyBody(s.fontBody);
       applyMono(s.fontMono);
       applySize(s.fontSize);
+      // One-shot cleanup of the legacy attachment-folder key. Safe to drop
+      // after a few release cycles — kept here for now so upgraded users
+      // don't carry stale state forever.
+      try { localStorage.removeItem(K_ATTACHMENT_FOLDER_LEGACY); } catch { /* */ }
     },
     setFontBody(key: BodyFont): void {
       if (!isBodyFont(key)) return;
@@ -117,11 +110,6 @@ function createSettingsStore() {
       _store.update((s) => ({ ...s, fontSize: clamped }));
       applySize(clamped);
       try { localStorage.setItem(K_SIZE, String(clamped)); } catch { /* */ }
-    },
-    setAttachmentFolder(folder: string): void {
-      const sanitized = sanitizeAttachmentFolder(folder);
-      _store.update((s) => ({ ...s, attachmentFolder: sanitized }));
-      try { localStorage.setItem(K_ATTACHMENT_FOLDER, sanitized); } catch { /* */ }
     },
   };
 }


### PR DESCRIPTION
## Summary
- Paste/drop now saves images next to the active note (not a global folder) and inserts `![[filename.ext]]` wiki-embed syntax.
- Removes the `attachmentFolder` setting, its `Anhangsordner` input in SettingsModal, and the legacy localStorage key.
- Adds a Rust `get_resolved_attachments` command that walks the vault (skipping `.git`, `.obsidian`, `.vaultcore`, `.trash`, `templates`, and dotfiles) and returns a `filename.ext → vault-relative-path` map for image assets.
- New CM6 `embedPlugin`: renders `![[image.png]]`, `![[image.png|300]]`, `![](path/to/image.png)` (URL-decoded, for back-compat), and `![[OtherNote]]` as inline widgets. Cursor-on-line reveals raw syntax. Unresolved wiki-form embeds show a muted `⚠ nicht gefunden` placeholder.
- Enables the Tauri asset protocol and extends CSP `img-src` to `asset: http://asset.localhost` so images work on macOS and Windows; `tauri = ["protocol-asset"]` added to Cargo.toml.

Closes #9. Follows up on #11.

## Test plan
### Paste / drop
- [ ] Paste an image into a note at `vault/foo/bar/note.md` → image lands at `vault/foo/bar/Pasted image ....png`, insert is `![[Pasted image ....png]]`
- [ ] Drag a .jpg from Finder into a note → saved next to the note, inserted as `![[<name>.jpg]]`
- [ ] Paste next to / inside frontmatter → insert goes after frontmatter (transactionFilter guard)
- [ ] Old `![](attachments/foo.png)` still renders (back-compat for existing content)

### Image embeds
- [ ] `![[foo.png]]` renders inline when cursor is off the line
- [ ] `![[foo.png|200]]` renders at 200 px wide
- [ ] Cursor on the line reveals the raw `![[...]]` syntax
- [ ] Typo `![[nope.png]]` shows muted "nicht gefunden" placeholder

### Note embeds
- [ ] `![[OtherNote]]` renders the target's content in a bordered block
- [ ] `![[NonExistent]]` shows muted placeholder
- [ ] Block re-renders within ~200 ms after the target is edited (debounced)

### Not in scope
- `![[note#heading]]` — slices and renders only the section (follow-up). The heading is currently parsed from the regex but ignored; the full target note is rendered.
- Autocomplete for `![[` (follow-up)
- Rename propagation for embed refs (follow-up — link-updater currently rewrites `[[...]]` only)
- External URL images `![](https://...)` (intentionally skipped by the plugin)
- Broken placeholder for markdown-form images — only the wiki form has a placeholder; a mis-typed `![](...)` just renders as a broken `<img>`

### Known limitations
- Note embeds currently show raw markdown in a monospace block; a real markdown renderer is a follow-up (no markdown lib is in deps yet).
- Asset-protocol scope is `"**"` for MVP; should be tightened to the vault root once a Tauri config plumb-through is in place.