### PR TITLE
fix(outline): exclude frontmatter properties from heading list (#29)

### DIFF
--- a/src/lib/__tests__/headings.test.ts
+++ b/src/lib/__tests__/headings.test.ts
@@ -86,3 +86,34 @@ describe("extractHeadings", () => {
     expect(result[0]?.text).toBe("Real Heading");
   });
 });
+
+describe("extractHeadings — frontmatter filtering", () => {
+  it("excludes frontmatter property keys from heading results", () => {
+    const doc = "---\ntitle: Foo\ntags: [a, b]\n---\n\n# Real Heading\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("Real Heading");
+  });
+
+  it("returns empty array when document has only frontmatter and no body headings", () => {
+    const doc = "---\ntitle: Foo\ntags: [a, b]\n---\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns all body headings when there is no frontmatter (regression)", () => {
+    const doc = "# First\n\n## Second\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.text).toBe("First");
+    expect(result[1]?.text).toBe("Second");
+  });
+
+  it("detects a setext-H2 in the body after frontmatter", () => {
+    const doc = "---\ntitle: Foo\n---\n\nSection\n-------\n";
+    const result = extractHeadings(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.level).toBe(2);
+    expect(result[0]?.text).toBe("Section");
+  });
+});

--- a/src/lib/headings.ts
+++ b/src/lib/headings.ts
@@ -6,6 +6,7 @@
 
 import type { EditorState } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
+import { detectFrontmatter } from "../components/Editor/frontmatterPlugin";
 
 /** A single heading entry. */
 export interface Heading {
@@ -30,9 +31,13 @@ const SETEXT_NODE_RE = /^SetextHeading([1-2])$/;
  */
 export function extractHeadingsFromState(state: EditorState): Heading[] {
   const results: Heading[] = [];
+  const frontmatter = detectFrontmatter(state.doc.toString());
 
   syntaxTree(state).iterate({
     enter(node) {
+      if (frontmatter && node.from >= frontmatter.from && node.from < frontmatter.to) {
+        return;
+      }
       let level: number | null = null;
 
       const atxMatch = ATX_NODE_RE.exec(node.name);
@@ -85,11 +90,17 @@ const ATX_RE = /^(#{1,6})\s+(.*?)(?:\s+#+\s*)?$/m;
  */
 export function extractHeadings(text: string): Heading[] {
   const results: Heading[] = [];
+  const frontmatter = detectFrontmatter(text);
   const lines = text.split("\n");
   let offset = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const lineText = lines[i] ?? "";
+
+    if (frontmatter && offset >= frontmatter.from && offset < frontmatter.to) {
+      offset += lineText.length + 1;
+      continue;
+    }
 
     // ATX heading
     const atxMatch = /^(#{1,6})\s+(.*)$/.exec(lineText);


### PR DESCRIPTION
## Summary
- `@lezer/markdown` parses the closing `---` of a YAML frontmatter block as a Setext-H2 underline, so every `key: value` inside was tagged as SetextHeading2 and the Outline panel listed them as headings.
- `extractHeadingsFromState` and the regex fallback now compute the frontmatter region via `detectFrontmatter` and skip any heading node whose `from` position lies inside it.

Closes #29.

## Test plan
- [ ] Note with frontmatter `title: Foo` + `tags: [a, b]` + body `# Real` — Outline shows only `Real`.
- [ ] Note with only frontmatter — Outline empty state.
- [ ] Note with no frontmatter — all body headings still appear.
- [ ] Note with a Setext-H2 in the body — still detected as a heading.