### PR TITLE
fix(search): stop input-reset feedback loop on every keystroke (#30)

### DIFF
--- a/src/components/Search/SearchInput.svelte
+++ b/src/components/Search/SearchInput.svelte
@@ -19,11 +19,18 @@
   let inputEl: HTMLInputElement | undefined = $state();
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-  // BUG-05.1: sync the input when an external caller (e.g. TagsPanel tag-click)
-  // updates the searchStore query. Skip if the external value matches what the
-  // user already typed to avoid clobbering mid-keystroke.
+  // BUG-05.1 (feedback-loop fix): the naive check `externalValue !== value`
+  // caused a reset on every keystroke — the effect tracked both `externalValue`
+  // AND `value`, so typing updated `value`, the effect re-ran, saw the stale
+  // store value still differing (search is debounced 200ms), and overwrote the
+  // input. Fix: track only changes to `externalValue` via a snapshot variable.
+  // The effect now only cares whether `externalValue` itself changed since the
+  // last time we saw it; typing changes `value` but not `lastSeenExternal`, so
+  // the guard fires false and the input is left alone.
+  let lastSeenExternal: string | undefined = $state(undefined);
   $effect(() => {
-    if (externalValue !== undefined && externalValue !== value) {
+    if (externalValue !== undefined && externalValue !== lastSeenExternal) {
+      lastSeenExternal = externalValue;
       value = externalValue;
     }
   });

--- a/src/components/Search/__tests__/SearchInput.test.ts
+++ b/src/components/Search/__tests__/SearchInput.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import SearchInput from "../SearchInput.svelte";
+
+describe("SearchInput", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("user-typing: characters persist and onSearch fires after debounce", async () => {
+    const onSearch = vi.fn();
+    render(SearchInput, { props: { onSearch, disabled: false, externalValue: "" } });
+
+    const input = screen.getByRole("searchbox") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "rust" } });
+    expect(input.value).toBe("rust");
+
+    // onSearch not yet fired (debounced)
+    expect(onSearch).not.toHaveBeenCalled();
+
+    // advance past 200ms debounce
+    vi.advanceTimersByTime(200);
+    expect(onSearch).toHaveBeenCalledWith("rust");
+  });
+
+  it("external-value-changes: re-render with new externalValue seeds the input", async () => {
+    const onSearch = vi.fn();
+    const { rerender } = render(SearchInput, {
+      props: { onSearch, disabled: false, externalValue: "" },
+    });
+
+    const input = screen.getByRole("searchbox") as HTMLInputElement;
+    expect(input.value).toBe("");
+
+    await rerender({ onSearch, disabled: false, externalValue: "hello" });
+    await tick();
+
+    expect(input.value).toBe("hello");
+  });
+
+  it("no-reset: typing does not get overwritten by stale externalValue before debounce fires", async () => {
+    const onSearch = vi.fn();
+    render(SearchInput, { props: { onSearch, disabled: false, externalValue: "" } });
+
+    const input = screen.getByRole("searchbox") as HTMLInputElement;
+
+    // User types "a" — externalValue is still "" (debounce not yet fired)
+    await fireEvent.input(input, { target: { value: "a" } });
+    await tick();
+
+    // Input must not have been reset to ""
+    expect(input.value).toBe("a");
+  });
+
+  it("concurrent: external update wins over in-flight user keystroke", async () => {
+    const onSearch = vi.fn();
+    const { rerender } = render(SearchInput, {
+      props: { onSearch, disabled: false, externalValue: "" },
+    });
+
+    const input = screen.getByRole("searchbox") as HTMLInputElement;
+
+    // User types "a" but debounce has not fired yet
+    await fireEvent.input(input, { target: { value: "a" } });
+    await tick();
+    expect(input.value).toBe("a");
+
+    // External caller (TagsPanel tag-click) updates store before debounce fires
+    await rerender({ onSearch, disabled: false, externalValue: "xyz" });
+    await tick();
+
+    // External value wins
+    expect(input.value).toBe("xyz");
+  });
+});


### PR DESCRIPTION
## Summary
- The `$effect` in `SearchInput.svelte` tracked both `externalValue` and `value` and re-assigned `value = externalValue` whenever they differed, so every user keystroke triggered the effect while the store was still debouncing the previous search — the effect reset the input to the stale external value.
- Switch to a snapshot pattern: keep a `lastSeenExternal` snapshot and only overwrite `value` when `externalValue` itself changes from the last-seen value. Typing no longer triggers a reset; programmatic updates (TagsPanel tag-click → searchStore) still seed the input correctly.

Closes #30.

## Test plan
- [ ] Open Suche tab, type a query — characters stick, results arrive after ~200ms debounce.
- [ ] Click a tag in the Tags panel — Suche tab's input auto-fills with that tag and results show.
- [ ] Click "Clear" button (X) → input empties, callback fires.