### PR TITLE
feat(sidebar): add local graph panel for active note (#31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,21 +29,24 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.1",
-    "@codemirror/language-data": "^6.5.2",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",
+    "@codemirror/language-data": "^6.5.2",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.41.0",
-    "@lezer/highlight": "^1.2.3",
-    "@lezer/markdown": "^1.6.3",
     "@fontsource/fira-code": "^5.2.7",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/lora": "^5.2.8",
+    "@lezer/highlight": "^1.2.3",
+    "@lezer/markdown": "^1.6.3",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-fs": "^2.5.0",
-    "lucide-svelte": "^1.0.1"
+    "graphology": "^0.26.0",
+    "graphology-layout-forceatlas2": "^0.10.1",
+    "lucide-svelte": "^1.0.1",
+    "sigma": "^3.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,18 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: ^2.5.0
         version: 2.5.0
+      graphology:
+        specifier: ^0.26.0
+        version: 0.26.0(graphology-types@0.24.8)
+      graphology-layout-forceatlas2:
+        specifier: ^0.10.1
+        version: 0.10.1(graphology-types@0.24.8)
       lucide-svelte:
         specifier: ^1.0.1
         version: 1.0.1(svelte@5.55.3)
+      sigma:
+        specifier: ^3.0.2
+        version: 3.0.2(graphology-types@0.24.8)
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
@@ -848,6 +857,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -868,6 +881,24 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphology-layout-forceatlas2@0.10.1:
+    resolution: {integrity: sha512-ogzBeF1FvWzjkikrIFwxhlZXvD2+wlY54lqhsrWprcdPjopM2J9HoMweUmIgwaTvY4bUYVimpSsOdvDv1gPRFQ==}
+    peerDependencies:
+      graphology-types: '>=0.19.0'
+
+  graphology-types@0.24.8:
+    resolution: {integrity: sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==}
+
+  graphology-utils@2.5.2:
+    resolution: {integrity: sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==}
+    peerDependencies:
+      graphology-types: '>=0.23.0'
+
+  graphology@0.26.0:
+    resolution: {integrity: sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==}
+    peerDependencies:
+      graphology-types: '>=0.24.0'
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -1066,6 +1097,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sigma@3.0.2:
+    resolution: {integrity: sha512-/BUbeOwPGruiBOm0YQQ6ZMcLIZ6tf/W+Jcm7dxZyAX0tK3WP9/sq7/NAWBxPIxVahdGjCJoGwej0Gdrv0DxlQQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2094,6 +2128,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -2104,6 +2140,22 @@ snapshots:
     optional: true
 
   graceful-fs@4.2.11: {}
+
+  graphology-layout-forceatlas2@0.10.1(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+
+  graphology-types@0.24.8: {}
+
+  graphology-utils@2.5.2(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+
+  graphology@0.26.0(graphology-types@0.24.8):
+    dependencies:
+      events: 3.3.0
+      graphology-types: 0.24.8
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -2287,6 +2339,13 @@ snapshots:
       xmlchars: 2.2.0
 
   siginfo@2.0.0: {}
+
+  sigma@3.0.2(graphology-types@0.24.8):
+    dependencies:
+      events: 3.3.0
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+    transitivePeerDependencies:
+      - graphology-types
 
   source-map-js@1.2.1: {}
 

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -8,13 +8,14 @@
 // Pattern: Clone Arc handles before releasing Mutex (same as search.rs).
 // MutexGuard is not Send and cannot be held across await points.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 
 use serde::Serialize;
 
 use crate::error::VaultError;
-use crate::indexer::link_graph::{self, BacklinkEntry, ParsedLink, UnresolvedLink};
+use crate::indexer::link_graph::{self, BacklinkEntry, LinkGraph, ParsedLink, UnresolvedLink};
+use crate::indexer::memory::FileIndex;
 use crate::commands::search::FileMatch;
 use crate::VaultState;
 
@@ -477,4 +478,236 @@ pub async fn get_resolved_attachments(
     }
 
     Ok(map)
+}
+
+// ── get_local_graph ────────────────────────────────────────────────────────────
+
+/// Hard cap on the total number of nodes returned by a single local-graph
+/// query. Pathologically-linked hubs would otherwise produce thousands of
+/// nodes for a 2-hop neighborhood and stall the sigma renderer on mount.
+const LOCAL_GRAPH_NODE_CAP: usize = 500;
+
+/// A single node in the local graph view. Serialized to the frontend with
+/// camelCase field names to match the wrapping TS interface.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphNode {
+    /// Node id — the vault-relative path for resolved files, or the raw
+    /// wiki-link target (prefixed `unresolved:`) for dangling links.
+    pub id: String,
+    /// Display label — filename stem for resolved files, link text as-written
+    /// for unresolved targets.
+    pub label: String,
+    /// Vault-relative path (equal to `id` for resolved, empty string for
+    /// unresolved synthetic nodes).
+    pub path: String,
+    /// Resolved-incoming-link count for node sizing. Zero for unresolved.
+    pub backlink_count: usize,
+    /// `true` when the node corresponds to an actual file in the vault.
+    pub resolved: bool,
+}
+
+/// An undirected edge between two graph nodes. Dedupe is performed at build
+/// time via a sorted-pair `HashSet`, so no `(a, b)` / `(b, a)` duplicates
+/// reach the renderer.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphEdge {
+    pub from: String,
+    pub to: String,
+}
+
+/// Result payload returned by `get_local_graph`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalGraph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+/// Derive a filename stem from a vault-relative path (strip folder + `.md`).
+fn file_stem_label(rel_path: &str) -> String {
+    let base = rel_path.rsplit('/').next().unwrap_or(rel_path);
+    base.strip_suffix(".md").unwrap_or(base).to_string()
+}
+
+/// Pure helper that computes the 2-hop (or arbitrary-depth) local graph for
+/// a center note. Split out from the Tauri command so it can be exercised by
+/// `cargo test local_graph` without standing up a full `VaultState`.
+///
+/// BFS in both directions (outgoing links + backlinks). Every node visited
+/// within `depth` hops is emitted; every edge discovered while expanding is
+/// emitted as an undirected pair (smaller id first). Unresolved link targets
+/// are synthesized as pseudo-nodes with `resolved: false` and an
+/// `unresolved:<raw>` id so they never collide with real paths.
+pub fn compute_local_graph(
+    center: &str,
+    depth: u32,
+    lg: &LinkGraph,
+    fi: &FileIndex,
+) -> LocalGraph {
+    let mut nodes: HashMap<String, GraphNode> = HashMap::new();
+    let mut edges: HashSet<(String, String)> = HashSet::new();
+    let mut visited: HashSet<String> = HashSet::new();
+
+    // Build a rel_path → title map once so label lookups are O(1).
+    let mut titles: HashMap<String, String> = HashMap::new();
+    for (_, meta) in fi.all_entries() {
+        titles.insert(meta.relative_path.clone(), meta.title.clone());
+    }
+
+    let is_resolved = |id: &str| titles.contains_key(id);
+
+    // Node factory — resolved vs unresolved handled uniformly.
+    let make_node = |id: &str, lg: &LinkGraph, raw_fallback: Option<&str>| -> GraphNode {
+        if let Some(_title) = titles.get(id) {
+            GraphNode {
+                id: id.to_string(),
+                label: file_stem_label(id),
+                path: id.to_string(),
+                backlink_count: lg.backlink_count(id),
+                resolved: true,
+            }
+        } else {
+            // Unresolved pseudo-node. `label` is the raw link text if supplied,
+            // otherwise the (already prefix-stripped) id itself.
+            let label = raw_fallback
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| id.trim_start_matches("unresolved:").to_string());
+            GraphNode {
+                id: id.to_string(),
+                label,
+                path: String::new(),
+                backlink_count: 0,
+                resolved: false,
+            }
+        }
+    };
+
+    // Seed the frontier with the center node. Even if the center doesn't
+    // exist in the FileIndex (e.g. a just-created file whose indexing is
+    // lagging), we still emit it as a lone, resolved-looking node so the
+    // panel has something to render.
+    let center_node = if is_resolved(center) {
+        make_node(center, lg, None)
+    } else {
+        GraphNode {
+            id: center.to_string(),
+            label: file_stem_label(center),
+            path: center.to_string(),
+            backlink_count: lg.backlink_count(center),
+            resolved: true,
+        }
+    };
+    nodes.insert(center.to_string(), center_node);
+    visited.insert(center.to_string());
+
+    // Insert an edge keyed by a canonical ordering so (a, b) == (b, a).
+    let insert_edge = |edges: &mut HashSet<(String, String)>, a: &str, b: &str| {
+        if a == b {
+            return;
+        }
+        let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+        edges.insert((lo.to_string(), hi.to_string()));
+    };
+
+    let mut frontier: VecDeque<(String, u32)> = VecDeque::new();
+    frontier.push_back((center.to_string(), 0));
+
+    while let Some((current, hop)) = frontier.pop_front() {
+        if hop >= depth {
+            continue;
+        }
+        if nodes.len() >= LOCAL_GRAPH_NODE_CAP {
+            break;
+        }
+
+        // Outgoing links (resolved + unresolved).
+        if let Some(targets) = lg.outgoing_targets_for(&current) {
+            for (resolved, raw) in targets {
+                let (neighbor_id, raw_for_label): (String, Option<&str>) = match resolved {
+                    Some(path) => (path, None),
+                    None => (format!("unresolved:{}", raw), Some(raw.as_str())),
+                };
+
+                if nodes.len() >= LOCAL_GRAPH_NODE_CAP && !nodes.contains_key(&neighbor_id) {
+                    continue;
+                }
+
+                insert_edge(&mut edges, &current, &neighbor_id);
+                nodes
+                    .entry(neighbor_id.clone())
+                    .or_insert_with(|| make_node(&neighbor_id, lg, raw_for_label));
+
+                if visited.insert(neighbor_id.clone()) {
+                    frontier.push_back((neighbor_id, hop + 1));
+                }
+            }
+        }
+
+        // Incoming links (backlinks). Always resolved — incoming only records
+        // the source rel_path of files that themselves exist in the graph.
+        if let Some(sources) = lg.incoming_for(&current) {
+            for source in sources.clone() {
+                if nodes.len() >= LOCAL_GRAPH_NODE_CAP && !nodes.contains_key(&source) {
+                    continue;
+                }
+                insert_edge(&mut edges, &current, &source);
+                nodes
+                    .entry(source.clone())
+                    .or_insert_with(|| make_node(&source, lg, None));
+
+                if visited.insert(source.clone()) {
+                    frontier.push_back((source, hop + 1));
+                }
+            }
+        }
+    }
+
+    // Stable output order — alphabetical ids. Helps snapshot tests and keeps
+    // the force layout's initial random placement reproducible run-to-run.
+    let mut node_list: Vec<GraphNode> = nodes.into_values().collect();
+    node_list.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut edge_list: Vec<GraphEdge> = edges
+        .into_iter()
+        .map(|(from, to)| GraphEdge { from, to })
+        .collect();
+    edge_list.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
+
+    LocalGraph {
+        nodes: node_list,
+        edges: edge_list,
+    }
+}
+
+/// Tauri command — return the 2-hop (or `depth`-hop) local link graph around
+/// a center note. Both outgoing links and backlinks are traversed. Unresolved
+/// wiki-link targets surface as synthetic nodes with `resolved: false`.
+#[tauri::command]
+pub async fn get_local_graph(
+    path: String,
+    depth: u32,
+    state: tauri::State<'_, VaultState>,
+) -> Result<LocalGraph, VaultError> {
+    let (lg_arc, fi_arc) = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(c) => (c.link_graph(), c.file_index()),
+            None => {
+                return Ok(LocalGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                })
+            }
+        }
+    };
+
+    let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+    let lg = lg_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+
+    Ok(compute_local_graph(&path, depth, &lg, &fi))
 }

--- a/src-tauri/src/indexer/link_graph.rs
+++ b/src-tauri/src/indexer/link_graph.rs
@@ -271,6 +271,33 @@ impl LinkGraph {
         self.incoming.get(target_rel)
     }
 
+    /// Return the outgoing link targets for `source_rel` as `(resolved_target,
+    /// target_raw)` pairs. If a link resolved successfully, `resolved_target`
+    /// is `Some(path)` and should be used as the neighbor id. If it did not
+    /// resolve, `resolved_target` is `None` and the caller may synthesize a
+    /// pseudo-node keyed by `target_raw`.
+    ///
+    /// Duplicates are preserved in source order — the caller is responsible
+    /// for deduplication if needed (the local-graph BFS dedupes via a visited
+    /// set).
+    pub fn outgoing_targets_for(
+        &self,
+        source_rel: &str,
+    ) -> Option<Vec<(Option<String>, String)>> {
+        self.outgoing.get(source_rel).map(|stored| {
+            stored
+                .iter()
+                .map(|s| (s.resolved_target.clone(), s.parsed.target_raw.clone()))
+                .collect()
+        })
+    }
+
+    /// Return the number of resolved incoming links for `target_rel`.
+    /// Used by the local graph to size nodes proportionally to popularity.
+    pub fn backlink_count(&self, target_rel: &str) -> usize {
+        self.incoming.get(target_rel).map(|v| v.len()).unwrap_or(0)
+    }
+
     /// Return all backlink entries for `target_rel`.
     ///
     /// Uses pre-resolved targets cached in `StoredLink::resolved_target`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
             commands::links::update_links_after_rename,
             commands::links::get_resolved_links,
             commands::links::get_resolved_attachments,
+            commands::links::get_local_graph,
             commands::tags::list_tags,
             commands::tags::get_tag_occurrences,
         ])

--- a/src-tauri/src/tests/local_graph.rs
+++ b/src-tauri/src/tests/local_graph.rs
@@ -1,0 +1,209 @@
+// Unit tests for compute_local_graph — the BFS helper that powers the
+// right-sidebar local graph panel.
+//
+// The tests run directly against the pure `compute_local_graph` function so
+// no Tauri state or IPC plumbing is needed.
+
+use crate::commands::links::{compute_local_graph, GraphEdge, GraphNode};
+use crate::indexer::link_graph::{extract_links, LinkGraph};
+use crate::indexer::memory::{FileIndex, FileMeta};
+
+fn make_file_index(entries: &[(&str, &str)]) -> FileIndex {
+    let mut fi = FileIndex::new();
+    for (rel, title) in entries {
+        fi.insert(
+            std::path::PathBuf::from(format!("/vault/{}", rel)),
+            FileMeta {
+                relative_path: rel.to_string(),
+                hash: "abc".to_string(),
+                title: title.to_string(),
+            },
+        );
+    }
+    fi
+}
+
+fn seed_graph(files: &[(&str, &str, &str)]) -> (LinkGraph, FileIndex, Vec<String>) {
+    // files: (rel_path, title, body)
+    let all: Vec<String> = files.iter().map(|(p, _, _)| (*p).to_string()).collect();
+    let fi = make_file_index(
+        &files.iter().map(|(p, t, _)| (*p, *t)).collect::<Vec<_>>(),
+    );
+    let mut lg = LinkGraph::new();
+    for (rel, _title, body) in files {
+        let links = extract_links(body);
+        lg.update_file(rel, links, &all);
+    }
+    (lg, fi, all)
+}
+
+fn ids(nodes: &[GraphNode]) -> Vec<String> {
+    nodes.iter().map(|n| n.id.clone()).collect()
+}
+
+fn edge_set(edges: &[GraphEdge]) -> std::collections::HashSet<(String, String)> {
+    edges
+        .iter()
+        .map(|e| {
+            let (a, b) = if e.from <= e.to {
+                (e.from.clone(), e.to.clone())
+            } else {
+                (e.to.clone(), e.from.clone())
+            };
+            (a, b)
+        })
+        .collect()
+}
+
+// ── Basic cases ────────────────────────────────────────────────────────────────
+
+#[test]
+fn local_graph_center_alone_when_no_links() {
+    let (lg, fi, _) = seed_graph(&[("a.md", "A", "no links here")]);
+    let result = compute_local_graph("a.md", 2, &lg, &fi);
+    assert_eq!(result.nodes.len(), 1);
+    assert_eq!(result.nodes[0].id, "a.md");
+    assert!(result.nodes[0].resolved);
+    assert!(result.edges.is_empty());
+}
+
+#[test]
+fn local_graph_single_outgoing_link() {
+    let (lg, fi, _) = seed_graph(&[
+        ("a.md", "A", "See [[B]]"),
+        ("b.md", "B", "plain"),
+    ]);
+    let result = compute_local_graph("a.md", 2, &lg, &fi);
+    let ids = ids(&result.nodes);
+    assert!(ids.contains(&"a.md".to_string()));
+    assert!(ids.contains(&"b.md".to_string()));
+    assert_eq!(result.edges.len(), 1);
+    let edges = edge_set(&result.edges);
+    assert!(edges.contains(&("a.md".to_string(), "b.md".to_string())));
+}
+
+#[test]
+fn local_graph_includes_backlink_direction() {
+    // Only C links to A — A should still see C as a neighbor via incoming edges.
+    let (lg, fi, _) = seed_graph(&[
+        ("a.md", "A", "no outgoing links"),
+        ("c.md", "C", "See [[A]]"),
+    ]);
+    let result = compute_local_graph("a.md", 2, &lg, &fi);
+    let ids = ids(&result.nodes);
+    assert!(ids.contains(&"c.md".to_string()));
+    let edges = edge_set(&result.edges);
+    assert!(edges.contains(&("a.md".to_string(), "c.md".to_string())));
+}
+
+#[test]
+fn local_graph_two_hop_expansion() {
+    // a -> b -> c. Depth 2 must include c; depth 1 must not.
+    let (lg, fi, _) = seed_graph(&[
+        ("a.md", "A", "[[B]]"),
+        ("b.md", "B", "[[C]]"),
+        ("c.md", "C", "."),
+    ]);
+
+    let depth2 = compute_local_graph("a.md", 2, &lg, &fi);
+    let ids2 = ids(&depth2.nodes);
+    assert!(ids2.contains(&"c.md".to_string()));
+
+    let depth1 = compute_local_graph("a.md", 1, &lg, &fi);
+    let ids1 = ids(&depth1.nodes);
+    assert!(!ids1.contains(&"c.md".to_string()));
+    assert!(ids1.contains(&"b.md".to_string()));
+}
+
+#[test]
+fn local_graph_undirected_edge_dedupe() {
+    // A and B link to each other — only one edge should be emitted.
+    let (lg, fi, _) = seed_graph(&[
+        ("a.md", "A", "[[B]]"),
+        ("b.md", "B", "[[A]]"),
+    ]);
+    let result = compute_local_graph("a.md", 2, &lg, &fi);
+    assert_eq!(result.edges.len(), 1);
+}
+
+#[test]
+fn local_graph_unresolved_target_becomes_pseudo_node() {
+    let (lg, fi, _) = seed_graph(&[("a.md", "A", "[[Ghost]]")]);
+    let result = compute_local_graph("a.md", 2, &lg, &fi);
+    let ghost = result
+        .nodes
+        .iter()
+        .find(|n| n.id.starts_with("unresolved:"))
+        .expect("unresolved node should exist");
+    assert!(!ghost.resolved);
+    assert_eq!(ghost.label, "Ghost");
+    assert_eq!(ghost.path, "");
+}
+
+#[test]
+fn local_graph_backlink_count_populated() {
+    // Both B and C link to A. A.backlink_count should be 2.
+    let (lg, fi, _) = seed_graph(&[
+        ("a.md", "A", "."),
+        ("b.md", "B", "[[A]]"),
+        ("c.md", "C", "[[A]]"),
+    ]);
+    let result = compute_local_graph("a.md", 2, &lg, &fi);
+    let center = result.nodes.iter().find(|n| n.id == "a.md").unwrap();
+    assert_eq!(center.backlink_count, 2);
+}
+
+#[test]
+fn local_graph_no_self_loop() {
+    let (lg, fi, _) = seed_graph(&[("a.md", "A", "[[A]]")]);
+    let result = compute_local_graph("a.md", 2, &lg, &fi);
+    for e in &result.edges {
+        assert_ne!(e.from, e.to);
+    }
+}
+
+#[test]
+fn local_graph_label_strips_md_and_folder() {
+    let (lg, fi, _) = seed_graph(&[("folder/sub/NoteTitle.md", "NoteTitle", ".")]);
+    let result = compute_local_graph("folder/sub/NoteTitle.md", 2, &lg, &fi);
+    let center = result
+        .nodes
+        .iter()
+        .find(|n| n.id == "folder/sub/NoteTitle.md")
+        .unwrap();
+    assert_eq!(center.label, "NoteTitle");
+}
+
+#[test]
+fn local_graph_respects_node_cap() {
+    // 600 neighbors — center linked to 600 unique files. Result must cap at
+    // LOCAL_GRAPH_NODE_CAP (500) without panicking.
+    let mut files: Vec<(String, String, String)> = Vec::new();
+    let mut center_body = String::new();
+    for i in 0..600 {
+        let rel = format!("n{:04}.md", i);
+        center_body.push_str(&format!("[[n{:04}]]\n", i));
+        files.push((rel.clone(), format!("N{:04}", i), String::new()));
+    }
+    files.push(("center.md".to_string(), "Center".to_string(), center_body));
+
+    let tuples: Vec<(&str, &str, &str)> = files
+        .iter()
+        .map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str()))
+        .collect();
+    let (lg, fi, _) = seed_graph(&tuples);
+
+    let result = compute_local_graph("center.md", 2, &lg, &fi);
+    assert!(result.nodes.len() <= 500);
+}
+
+#[test]
+fn local_graph_empty_center_still_renders_center() {
+    // Center isn't in the FileIndex (e.g. brand-new file) — still emit the
+    // single node so the panel has something to show.
+    let (lg, fi, _) = seed_graph(&[("other.md", "Other", ".")]);
+    let result = compute_local_graph("missing.md", 2, &lg, &fi);
+    assert_eq!(result.nodes.len(), 1);
+    assert_eq!(result.nodes[0].id, "missing.md");
+    assert!(result.edges.is_empty());
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -7,5 +7,6 @@ mod watcher;
 mod merge;
 mod indexer;
 mod link_graph;
+mod local_graph;
 pub mod tag_index;
 mod hash_verify;

--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -18,7 +18,7 @@
 
   const STORAGE_KEY_COLLAPSED = "vaultcore-graph-collapsed";
   const DEBOUNCE_MS = 200;
-  const DEPTH = 2;
+  const DEPTH = 1;
 
   function loadCollapsed(): boolean {
     try {

--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -256,7 +256,8 @@
     display: flex;
     flex-direction: column;
     background: var(--color-bg);
-    border-bottom: 1px solid var(--color-border);
+    height: 100%;
+    min-height: 0;
   }
   .vc-graph-header {
     display: flex;
@@ -286,8 +287,8 @@
   }
   .vc-graph-body {
     position: relative;
-    flex: 0 0 auto;
-    height: 250px;
+    flex: 1 1 auto;
+    min-height: 250px;
     overflow: hidden;
   }
   .vc-graph-canvas {

--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import { ChevronDown, ChevronRight } from "lucide-svelte";
+  import { activeViewStore } from "../../store/activeViewStore";
+  import { vaultStore } from "../../store/vaultStore";
+  import { tabStore, type Tab } from "../../store/tabStore";
+  import { getLocalGraph } from "../../ipc/commands";
+  import { listenFileChange } from "../../ipc/events";
+  import type { UnlistenFn } from "@tauri-apps/api/event";
+  import type { LocalGraph } from "../../types/links";
+  import {
+    destroyGraph,
+    mountGraph,
+    setCenter,
+    updateGraph,
+    type GraphHandle,
+  } from "./graphRender";
+
+  const STORAGE_KEY_COLLAPSED = "vaultcore-graph-collapsed";
+  const DEBOUNCE_MS = 200;
+  const DEPTH = 2;
+
+  function loadCollapsed(): boolean {
+    try {
+      return localStorage.getItem(STORAGE_KEY_COLLAPSED) === "true";
+    } catch {
+      return false;
+    }
+  }
+
+  let collapsed = $state<boolean>(loadCollapsed());
+  let graphData = $state<LocalGraph | null>(null);
+  let loading = $state<boolean>(false);
+  let errorMessage = $state<string | null>(null);
+  let canvasEl = $state<HTMLDivElement | undefined>();
+
+  // The vault-relative path of the CURRENT center note. Starts out equal
+  // to the active tab's vault-relative path; double-click on a node moves
+  // the center without changing the open tab.
+  let centerRel = $state<string | null>(null);
+
+  let handle: GraphHandle | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let unlistenFileChange: UnlistenFn | null = null;
+
+  // Reactive active-tab / doc-version plumbing mirrors OutgoingLinksPanel.
+  let tabs = $state<Tab[]>([]);
+  let activeTabId = $state<string | null>(null);
+  let vaultPath = $state<string | null>(null);
+
+  const unsubTabs = tabStore.subscribe((s) => {
+    tabs = s.tabs;
+    activeTabId = s.activeTabId;
+  });
+  const unsubVault = vaultStore.subscribe((s) => {
+    vaultPath = s.currentPath;
+  });
+
+  // Compute the vault-relative path of the active tab. Returns null when
+  // no tab is active or the filePath doesn't sit under the vault root.
+  const activeRelPath = $derived.by<string | null>(() => {
+    if (!activeTabId || !vaultPath) return null;
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab) return null;
+    if (tab.filePath.startsWith(vaultPath + "/")) {
+      return tab.filePath.slice(vaultPath.length + 1);
+    }
+    return null;
+  });
+
+  // When the active tab changes, reset the center to the active file.
+  $effect(() => {
+    centerRel = activeRelPath;
+  });
+
+  // docVersion bumps while editing — debounced re-fetch so link edits
+  // propagate within ~200ms.
+  const docVersion = $derived($activeViewStore.docVersion);
+
+  $effect(() => {
+    void docVersion;
+    void centerRel;
+    scheduleFetch();
+  });
+
+  function scheduleFetch(): void {
+    if (collapsed) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      void refetch();
+    }, DEBOUNCE_MS);
+  }
+
+  async function refetch(): Promise<void> {
+    if (!centerRel) {
+      graphData = null;
+      if (handle) {
+        updateGraph(handle, { nodes: [], edges: [] });
+      }
+      return;
+    }
+    loading = true;
+    errorMessage = null;
+    try {
+      const data = await getLocalGraph(centerRel, DEPTH);
+      graphData = data;
+      if (handle) {
+        handle.options = { ...handle.options, centerId: centerRel };
+        updateGraph(handle, data);
+      } else {
+        tryMount();
+      }
+    } catch (err) {
+      errorMessage =
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message: unknown }).message)
+          : "Graph konnte nicht geladen werden.";
+      graphData = null;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function tryMount(): void {
+    if (handle) return;
+    if (!canvasEl || !graphData || !centerRel) return;
+    // sigma measures the container on construct — make sure it has a size
+    // before we mount. When the panel just opened the layout tick might not
+    // have run yet; defer until next frame if clientWidth is still 0.
+    if (canvasEl.clientWidth === 0 || canvasEl.clientHeight === 0) {
+      requestAnimationFrame(tryMount);
+      return;
+    }
+    handle = mountGraph(canvasEl, graphData, {
+      centerId: centerRel,
+      accentColor: "var(--color-accent)",
+      nodeColor: "var(--color-text-muted)",
+      unresolvedColor: "var(--color-border)",
+      edgeColor: "var(--color-border)",
+      onNodeClick: (id, node) => {
+        if (!node.resolved || !vaultPath) return;
+        tabStore.openTab(`${vaultPath}/${node.path}`);
+      },
+      onNodeDoubleClick: (id, node) => {
+        if (!node.resolved) return;
+        centerRel = node.path || id;
+        setCenter(handle!, centerRel);
+        scheduleFetch();
+      },
+    });
+  }
+
+  // Mount/unmount sigma as the panel expands or collapses.
+  $effect(() => {
+    if (collapsed) {
+      if (handle) {
+        destroyGraph(handle);
+        handle = null;
+      }
+    } else if (graphData && !handle) {
+      tryMount();
+    }
+  });
+
+  function toggleCollapsed(): void {
+    collapsed = !collapsed;
+    try {
+      localStorage.setItem(STORAGE_KEY_COLLAPSED, String(collapsed));
+    } catch {
+      /* ignore */
+    }
+    if (!collapsed) {
+      // Expanded — make sure we have fresh data.
+      scheduleFetch();
+    }
+  }
+
+  onMount(async () => {
+    unlistenFileChange = await listenFileChange((payload) => {
+      if (
+        payload.kind === "create" ||
+        payload.kind === "delete" ||
+        payload.kind === "rename"
+      ) {
+        scheduleFetch();
+      }
+    });
+    // Initial fetch — effect above may already have scheduled one but an
+    // explicit call covers the case where the vault was already open on mount.
+    if (centerRel) scheduleFetch();
+  });
+
+  onDestroy(() => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    unsubTabs();
+    unsubVault();
+    unlistenFileChange?.();
+    if (handle) {
+      destroyGraph(handle);
+      handle = null;
+    }
+  });
+
+  // Convenience derived for the empty-state text.
+  const hasNote = $derived(centerRel !== null);
+  const hasLinks = $derived(
+    graphData !== null && graphData.edges.length > 0,
+  );
+  const nodeCount = $derived(graphData?.nodes.length ?? 0);
+</script>
+
+<div class="vc-graph-panel" role="complementary" aria-label="Local Graph">
+  <button
+    type="button"
+    class="vc-graph-header"
+    aria-expanded={!collapsed}
+    onclick={toggleCollapsed}
+    title={centerRel ?? ""}
+  >
+    {#if collapsed}
+      <ChevronRight size={14} />
+    {:else}
+      <ChevronDown size={14} />
+    {/if}
+    <span class="vc-graph-label">Local Graph</span>
+    {#if !collapsed && nodeCount > 0}
+      <span class="vc-graph-count">{nodeCount}</span>
+    {/if}
+  </button>
+
+  {#if !collapsed}
+    <div class="vc-graph-body">
+      {#if !hasNote}
+        <div class="vc-graph-empty">Keine Datei geöffnet.</div>
+      {:else if errorMessage}
+        <div class="vc-graph-empty">{errorMessage}</div>
+      {:else if graphData && !hasLinks}
+        <div class="vc-graph-empty">Keine Verbindungen</div>
+      {:else}
+        <div
+          class="vc-graph-canvas"
+          bind:this={canvasEl}
+          title={centerRel ?? ""}
+        ></div>
+      {/if}
+      {#if loading}
+        <div class="vc-graph-loading">…</div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .vc-graph-panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+  }
+  .vc-graph-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 16px;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    width: 100%;
+    text-align: left;
+  }
+  .vc-graph-header:hover {
+    color: var(--color-accent);
+  }
+  .vc-graph-label {
+    font-size: 12px;
+    font-weight: 600;
+    flex: 1;
+  }
+  .vc-graph-count {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+  .vc-graph-body {
+    position: relative;
+    flex: 0 0 auto;
+    height: 250px;
+    overflow: hidden;
+  }
+  .vc-graph-canvas {
+    width: 100%;
+    height: 100%;
+    position: relative;
+  }
+  .vc-graph-empty {
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 14px;
+  }
+  .vc-graph-loading {
+    position: absolute;
+    top: 6px;
+    right: 10px;
+    font-size: 11px;
+    color: var(--color-text-muted);
+    pointer-events: none;
+  }
+</style>

--- a/src/components/Graph/__tests__/graphRender.test.ts
+++ b/src/components/Graph/__tests__/graphRender.test.ts
@@ -1,0 +1,66 @@
+// Shape-level tests for the graphRender helpers. We deliberately avoid
+// exercising sigma's WebGL renderer here — jsdom has no WebGL context and
+// mocking it out completely adds more weight than it saves. Instead we test
+// the pure helpers exposed from graphRender.ts (`applyAlpha`) plus verify
+// that the public API has the expected surface.
+//
+// The full mount/update/destroy dance is covered by the Rust-side BFS tests
+// that feed the renderer and by manual verification in the PR.
+//
+// `sigma` references `WebGL2RenderingContext.BOOL` at import time which jsdom
+// doesn't define, so we stub the module before importing graphRender.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("sigma", () => {
+  class SigmaStub {
+    on() {}
+    setSetting() {}
+    refresh() {}
+    kill() {}
+  }
+  return { default: SigmaStub };
+});
+
+vi.mock("graphology-layout-forceatlas2", () => {
+  return {
+    default: {
+      inferSettings: () => ({}),
+      assign: () => undefined,
+    },
+  };
+});
+
+import { applyAlpha } from "../graphRender";
+
+describe("applyAlpha", () => {
+  it("converts #rrggbb to rgba()", () => {
+    expect(applyAlpha("#ff8800", 0.2)).toBe("rgba(255, 136, 0, 0.2)");
+  });
+
+  it("expands #rgb to #rrggbb then rgba()", () => {
+    expect(applyAlpha("#f80", 0.5)).toBe("rgba(255, 136, 0, 0.5)");
+  });
+
+  it("rewrites rgb()/rgba() to a new alpha", () => {
+    expect(applyAlpha("rgb(10, 20, 30)", 0.4)).toBe("rgba(10, 20, 30, 0.4)");
+    expect(applyAlpha("rgba(10, 20, 30, 0.9)", 0.1)).toBe(
+      "rgba(10, 20, 30, 0.1)",
+    );
+  });
+
+  it("leaves unknown formats unchanged", () => {
+    expect(applyAlpha("currentColor", 0.3)).toBe("currentColor");
+    expect(applyAlpha("#nothex", 0.3)).toBe("#nothex");
+  });
+});
+
+describe("graphRender public API", () => {
+  it("exports mountGraph / updateGraph / destroyGraph / setCenter", async () => {
+    const mod = await import("../graphRender");
+    expect(typeof mod.mountGraph).toBe("function");
+    expect(typeof mod.updateGraph).toBe("function");
+    expect(typeof mod.destroyGraph).toBe("function");
+    expect(typeof mod.setCenter).toBe("function");
+  });
+});

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -1,0 +1,346 @@
+// Shared graph-render helper — wraps sigma.js + graphology so callers
+// (the local-graph panel today, the global graph view tomorrow — issue #32)
+// don't need to reach into either library directly.
+//
+// The helper exposes three verbs:
+//   mountGraph(container, data, options) → GraphHandle
+//   updateGraph(handle, data)
+//   destroyGraph(handle)
+//
+// It also owns the ForceAtlas2 layout pass (~50 iterations, static after).
+// Node sizing, center-node accent, unresolved styling and the hover-dim
+// effect are applied through sigma's node/edge reducers so they can react
+// live to the current center + hovered node without rebuilding the graph.
+
+import Graph from "graphology";
+import Sigma from "sigma";
+import forceAtlas2 from "graphology-layout-forceatlas2";
+import type { GraphEdge, GraphNode, LocalGraph } from "../../types/links";
+
+/** Options accepted by `mountGraph` — future-proofed for the #32 global view. */
+export interface GraphRenderOptions {
+  /** Node id to highlight as the center/active node. Null = no accent. */
+  centerId: string | null;
+  /** Accent color (e.g. `var(--color-accent)` — a CSS variable is allowed). */
+  accentColor: string;
+  /** Neutral color for resolved non-center nodes. */
+  nodeColor: string;
+  /** Lighter color for unresolved pseudo-nodes. */
+  unresolvedColor: string;
+  /** Edge color (thin lines, low alpha). */
+  edgeColor: string;
+  /** Callback for single-click on a resolved node — receives the node id. */
+  onNodeClick?: (id: string, node: GraphNode) => void;
+  /** Callback for double-click on a resolved node. */
+  onNodeDoubleClick?: (id: string, node: GraphNode) => void;
+}
+
+/** Opaque handle returned by `mountGraph`. Callers pass it to update/destroy. */
+export interface GraphHandle {
+  graph: Graph;
+  renderer: Sigma;
+  container: HTMLElement;
+  options: GraphRenderOptions;
+  /** Currently hovered node id — drives the dim-non-neighbors reducer. */
+  hoveredNode: string | null;
+  /** Map of node id → Set of adjacent node ids, cached for hover dim. */
+  neighborMap: Map<string, Set<string>>;
+  /** Disposers for DOM listeners attached outside sigma. */
+  disposers: Array<() => void>;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/** Node radius from `backlinkCount`, clamped to a sensible range. */
+function nodeSize(node: GraphNode, isCenter: boolean): number {
+  const base = Math.max(4, Math.min(12, 4 + node.backlinkCount * 1.5));
+  return isCenter ? base + 2 : base;
+}
+
+/** Rebuild the adjacency cache used by the hover reducer. */
+function buildNeighborMap(edges: GraphEdge[]): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  for (const e of edges) {
+    if (!map.has(e.from)) map.set(e.from, new Set());
+    if (!map.has(e.to)) map.set(e.to, new Set());
+    map.get(e.from)!.add(e.to);
+    map.get(e.to)!.add(e.from);
+  }
+  return map;
+}
+
+/**
+ * Resolve a CSS-variable reference (e.g. `"var(--color-accent)"`) to its
+ * actual value, falling back to the input string when it's already a plain
+ * color. sigma's WebGL renderer wants concrete colors (`#rrggbb`, rgba()…)
+ * so we can't pass `var(...)` through verbatim.
+ */
+function resolveColor(container: HTMLElement, color: string): string {
+  const trimmed = color.trim();
+  const match = /^var\((--[^,)]+)(?:,\s*([^)]+))?\)$/.exec(trimmed);
+  if (!match) return trimmed;
+  const [, varName, fallback] = match;
+  if (!varName) return trimmed;
+  const style = getComputedStyle(container);
+  const value = style.getPropertyValue(varName).trim();
+  if (value) return value;
+  return fallback ? fallback.trim() : trimmed;
+}
+
+/**
+ * Populate a `graphology` Graph from the Rust payload. Duplicate nodes / edges
+ * are silently skipped so repeated calls on the same graph are idempotent.
+ */
+function populateGraph(graph: Graph, data: LocalGraph): void {
+  graph.clear();
+  for (const node of data.nodes) {
+    // Random seed position — ForceAtlas2 needs non-zero coordinates to escape
+    // the trivial equilibrium at the origin. The actual layout overwrites these.
+    graph.addNode(node.id, {
+      label: node.label,
+      path: node.path,
+      backlinkCount: node.backlinkCount,
+      resolved: node.resolved,
+      x: Math.random() - 0.5,
+      y: Math.random() - 0.5,
+      size: nodeSize(node, false),
+    });
+  }
+  for (const edge of data.edges) {
+    if (!graph.hasNode(edge.from) || !graph.hasNode(edge.to)) continue;
+    if (graph.hasEdge(edge.from, edge.to)) continue;
+    graph.addEdge(edge.from, edge.to);
+  }
+}
+
+/** Run ForceAtlas2 for 50 iterations and assign final positions in place. */
+function runLayout(graph: Graph): void {
+  if (graph.order === 0) return;
+  const settings = forceAtlas2.inferSettings(graph);
+  // Speed up convergence on small graphs.
+  settings.slowDown = 2;
+  settings.gravity = 1;
+  forceAtlas2.assign(graph, { iterations: 50, settings });
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Mount a sigma-powered graph into `container` and return a handle.
+ *
+ * The container MUST already have non-zero width/height — sigma measures it
+ * on construction to size its WebGL viewport.
+ */
+export function mountGraph(
+  container: HTMLElement,
+  data: LocalGraph,
+  options: GraphRenderOptions,
+): GraphHandle {
+  const graph = new Graph({ type: "undirected", multi: false });
+  populateGraph(graph, data);
+  runLayout(graph);
+
+  const accent = resolveColor(container, options.accentColor);
+  const nodeColor = resolveColor(container, options.nodeColor);
+  const unresolved = resolveColor(container, options.unresolvedColor);
+  const edge = resolveColor(container, options.edgeColor);
+
+  const neighborMap = buildNeighborMap(data.edges);
+
+  const renderer = new Sigma(graph, container, {
+    renderLabels: true,
+    labelRenderedSizeThreshold: 0,
+    labelSize: 11,
+    labelWeight: "500",
+    minEdgeThickness: 1,
+    defaultEdgeColor: edge,
+    defaultNodeColor: nodeColor,
+  });
+
+  const handle: GraphHandle = {
+    graph,
+    renderer,
+    container,
+    options,
+    hoveredNode: null,
+    neighborMap,
+    disposers: [],
+  };
+
+  // Node reducer — color + size per frame. Reflects center, unresolved,
+  // and hover-dim state without mutating node attributes.
+  renderer.setSetting("nodeReducer", (node, attrs) => {
+    const isCenter = node === handle.options.centerId;
+    const resolved = attrs.resolved !== false;
+    const color = !resolved ? unresolved : isCenter ? accent : nodeColor;
+
+    const nodeData: GraphNode = {
+      id: node,
+      label: String(attrs.label ?? node),
+      path: String(attrs.path ?? ""),
+      backlinkCount: Number(attrs.backlinkCount ?? 0),
+      resolved,
+    };
+
+    let dim = false;
+    if (handle.hoveredNode && handle.hoveredNode !== node) {
+      const neighbors = handle.neighborMap.get(handle.hoveredNode);
+      if (!neighbors || !neighbors.has(node)) {
+        dim = true;
+      }
+    }
+
+    return {
+      ...attrs,
+      size: nodeSize(nodeData, isCenter),
+      color,
+      label: nodeData.label,
+      zIndex: isCenter ? 2 : 1,
+      forceLabel: true,
+      ...(dim ? { color: applyAlpha(color, 0.2), labelColor: applyAlpha(color, 0.2) } : {}),
+    };
+  });
+
+  // Edge reducer — hover dim for non-adjacent edges.
+  renderer.setSetting("edgeReducer", (e, attrs) => {
+    if (!handle.hoveredNode) {
+      return { ...attrs, color: edge, size: 1 };
+    }
+    const [source, target] = graph.extremities(e);
+    const adjacent = source === handle.hoveredNode || target === handle.hoveredNode;
+    return {
+      ...attrs,
+      color: adjacent ? edge : applyAlpha(edge, 0.2),
+      size: 1,
+    };
+  });
+
+  // ── Interaction wiring ────────────────────────────────────────────────────
+  const clickHandler = ({ node }: { node: string }) => {
+    const attrs = graph.getNodeAttributes(node);
+    if (attrs.resolved === false) return;
+    handle.options.onNodeClick?.(node, {
+      id: node,
+      label: String(attrs.label ?? ""),
+      path: String(attrs.path ?? ""),
+      backlinkCount: Number(attrs.backlinkCount ?? 0),
+      resolved: true,
+    });
+  };
+  renderer.on("clickNode", clickHandler);
+
+  const doubleClickHandler = ({ node, event }: { node: string; event: { original: Event; preventSigmaDefault: () => void } }) => {
+    // Sigma's default double-click is zoom — suppress it.
+    event.preventSigmaDefault();
+    const attrs = graph.getNodeAttributes(node);
+    if (attrs.resolved === false) return;
+    handle.options.onNodeDoubleClick?.(node, {
+      id: node,
+      label: String(attrs.label ?? ""),
+      path: String(attrs.path ?? ""),
+      backlinkCount: Number(attrs.backlinkCount ?? 0),
+      resolved: true,
+    });
+  };
+  renderer.on("doubleClickNode", doubleClickHandler);
+
+  const enter = ({ node }: { node: string }) => {
+    handle.hoveredNode = node;
+    renderer.refresh({ skipIndexation: true });
+  };
+  const leave = () => {
+    handle.hoveredNode = null;
+    renderer.refresh({ skipIndexation: true });
+  };
+  renderer.on("enterNode", enter);
+  renderer.on("leaveNode", leave);
+
+  // Scroll-wheel inside the panel zooms the graph rather than scrolling the
+  // sidebar. Sigma already binds wheel events on its container, but it doesn't
+  // call preventDefault by default when the mouse is outside a node. We catch
+  // the raw event on the container in capture phase to be safe.
+  const wheelHandler = (ev: WheelEvent) => {
+    ev.preventDefault();
+  };
+  container.addEventListener("wheel", wheelHandler, { passive: false });
+  handle.disposers.push(() =>
+    container.removeEventListener("wheel", wheelHandler),
+  );
+
+  return handle;
+}
+
+/**
+ * Replace the graph's nodes + edges with a fresh payload. Re-runs the layout
+ * so newly added nodes snap into place.
+ */
+export function updateGraph(handle: GraphHandle, data: LocalGraph): void {
+  populateGraph(handle.graph, data);
+  runLayout(handle.graph);
+  handle.neighborMap = buildNeighborMap(data.edges);
+  handle.hoveredNode = null;
+  handle.renderer.refresh();
+}
+
+/** Tear down the sigma renderer and remove all listeners. */
+export function destroyGraph(handle: GraphHandle): void {
+  for (const dispose of handle.disposers) {
+    try {
+      dispose();
+    } catch {
+      /* ignore */
+    }
+  }
+  handle.disposers.length = 0;
+  try {
+    handle.renderer.kill();
+  } catch {
+    /* ignore */
+  }
+  handle.graph.clear();
+}
+
+/**
+ * Update the center-node id without rebuilding the graph. Cheaper than
+ * `updateGraph` when only the highlight needs to move.
+ */
+export function setCenter(handle: GraphHandle, centerId: string | null): void {
+  handle.options = { ...handle.options, centerId };
+  handle.renderer.refresh({ skipIndexation: true });
+}
+
+// ── Color utilities ────────────────────────────────────────────────────────────
+
+/**
+ * Mix a color toward transparent by replacing its alpha channel. Accepts
+ * `#rgb`, `#rrggbb`, `rgb(...)`, `rgba(...)` — anything else is returned
+ * unchanged.
+ */
+export function applyAlpha(color: string, alpha: number): string {
+  const trimmed = color.trim();
+
+  // #rgb / #rrggbb
+  if (trimmed.startsWith("#")) {
+    let hex = trimmed.slice(1);
+    if (hex.length === 3) {
+      hex = hex.split("").map((c) => c + c).join("");
+    }
+    if (hex.length !== 6) return trimmed;
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    if ([r, g, b].some((n) => Number.isNaN(n))) return trimmed;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  const rgbMatch = /^rgba?\(([^)]+)\)$/.exec(trimmed);
+  if (rgbMatch && rgbMatch[1]) {
+    const parts = rgbMatch[1].split(",").map((s) => s.trim());
+    if (parts.length >= 3) {
+      const [r, g, b] = parts;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+  }
+
+  return trimmed;
+}

--- a/src/components/Layout/RightSidebar.svelte
+++ b/src/components/Layout/RightSidebar.svelte
@@ -3,6 +3,7 @@
   import OutgoingLinksPanel from "../OutgoingLinks/OutgoingLinksPanel.svelte";
   import OutlinePanel from "../Outline/OutlinePanel.svelte";
   import PropertiesPanel from "../Properties/PropertiesPanel.svelte";
+  import LocalGraphPanel from "../Graph/LocalGraphPanel.svelte";
 </script>
 <div class="vc-right-sidebar">
   <PropertiesPanel />
@@ -11,6 +12,7 @@
   <div class="vc-right-sidebar-backlinks">
     <BacklinksPanel />
   </div>
+  <LocalGraphPanel />
 </div>
 <style>
   .vc-right-sidebar {

--- a/src/components/Layout/RightSidebar.svelte
+++ b/src/components/Layout/RightSidebar.svelte
@@ -1,19 +1,126 @@
 <script lang="ts">
+  import { FileText, ListTree, ArrowUpRight, ArrowDownLeft, Network } from "lucide-svelte";
   import BacklinksPanel from "../Backlinks/BacklinksPanel.svelte";
   import OutgoingLinksPanel from "../OutgoingLinks/OutgoingLinksPanel.svelte";
   import OutlinePanel from "../Outline/OutlinePanel.svelte";
   import PropertiesPanel from "../Properties/PropertiesPanel.svelte";
   import LocalGraphPanel from "../Graph/LocalGraphPanel.svelte";
+
+  // Obsidian-style tabbed right sidebar: only one panel visible at a time, the
+  // active panel takes the full sidebar height. Replaces the previous stacked
+  // layout which became unusable once the Graph panel was added (too cramped
+  // at ~240 px sidebar width with five stacked sections).
+  const STORAGE_KEY = "vaultcore-right-sidebar-tab";
+  type Tab = "properties" | "outline" | "outgoing" | "backlinks" | "graph";
+  const TAB_IDS: readonly Tab[] = [
+    "properties",
+    "outline",
+    "outgoing",
+    "backlinks",
+    "graph",
+  ] as const;
+
+  function loadTab(): Tab {
+    try {
+      const v = localStorage.getItem(STORAGE_KEY);
+      if (v && (TAB_IDS as readonly string[]).includes(v)) return v as Tab;
+    } catch {
+      /* ignore */
+    }
+    return "properties";
+  }
+
+  let activeTab = $state<Tab>(loadTab());
+
+  function setTab(t: Tab): void {
+    activeTab = t;
+    try {
+      localStorage.setItem(STORAGE_KEY, t);
+    } catch {
+      /* ignore */
+    }
+  }
 </script>
+
 <div class="vc-right-sidebar">
-  <PropertiesPanel />
-  <OutlinePanel />
-  <OutgoingLinksPanel />
-  <div class="vc-right-sidebar-backlinks">
-    <BacklinksPanel />
+  <div class="vc-right-tabs" role="tablist" aria-label="Right sidebar panels">
+    <button
+      type="button"
+      class="vc-right-tab"
+      class:vc-right-tab--active={activeTab === "properties"}
+      role="tab"
+      aria-selected={activeTab === "properties"}
+      aria-label="Properties"
+      title="Properties"
+      onclick={() => setTab("properties")}
+    >
+      <FileText size={14} strokeWidth={1.75} />
+    </button>
+    <button
+      type="button"
+      class="vc-right-tab"
+      class:vc-right-tab--active={activeTab === "outline"}
+      role="tab"
+      aria-selected={activeTab === "outline"}
+      aria-label="Outline"
+      title="Outline"
+      onclick={() => setTab("outline")}
+    >
+      <ListTree size={14} strokeWidth={1.75} />
+    </button>
+    <button
+      type="button"
+      class="vc-right-tab"
+      class:vc-right-tab--active={activeTab === "outgoing"}
+      role="tab"
+      aria-selected={activeTab === "outgoing"}
+      aria-label="Outgoing Links"
+      title="Outgoing Links"
+      onclick={() => setTab("outgoing")}
+    >
+      <ArrowUpRight size={14} strokeWidth={1.75} />
+    </button>
+    <button
+      type="button"
+      class="vc-right-tab"
+      class:vc-right-tab--active={activeTab === "backlinks"}
+      role="tab"
+      aria-selected={activeTab === "backlinks"}
+      aria-label="Backlinks"
+      title="Backlinks"
+      onclick={() => setTab("backlinks")}
+    >
+      <ArrowDownLeft size={14} strokeWidth={1.75} />
+    </button>
+    <button
+      type="button"
+      class="vc-right-tab"
+      class:vc-right-tab--active={activeTab === "graph"}
+      role="tab"
+      aria-selected={activeTab === "graph"}
+      aria-label="Graph"
+      title="Local Graph"
+      onclick={() => setTab("graph")}
+    >
+      <Network size={14} strokeWidth={1.75} />
+    </button>
   </div>
-  <LocalGraphPanel />
+
+  <div class="vc-right-tab-content" role="tabpanel">
+    {#if activeTab === "properties"}
+      <PropertiesPanel />
+    {:else if activeTab === "outline"}
+      <OutlinePanel />
+    {:else if activeTab === "outgoing"}
+      <OutgoingLinksPanel />
+    {:else if activeTab === "backlinks"}
+      <BacklinksPanel />
+    {:else if activeTab === "graph"}
+      <LocalGraphPanel />
+    {/if}
+  </div>
 </div>
+
 <style>
   .vc-right-sidebar {
     height: 100%;
@@ -22,9 +129,44 @@
     display: flex;
     flex-direction: column;
   }
-  .vc-right-sidebar-backlinks {
-    flex: 1;
+  .vc-right-tabs {
+    display: flex;
+    align-items: stretch;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface);
+  }
+  .vc-right-tab {
+    flex: 1 1 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-bottom: 2px solid transparent;
+    padding: 0;
+  }
+  .vc-right-tab:hover {
+    color: var(--color-accent);
+  }
+  .vc-right-tab--active {
+    color: var(--color-accent);
+    border-bottom-color: var(--color-accent);
+  }
+  .vc-right-tab-content {
+    flex: 1 1 auto;
     min-height: 0;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  /* Each panel fills the tab content area */
+  .vc-right-tab-content > :global(*) {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
   }
 </style>

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -11,7 +11,7 @@ import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
 import type { DirEntry } from "../types/tree";
 import type { SearchResult, FileMatch } from "../types/search";
-import type { BacklinkEntry, UnresolvedLink, RenameResult } from "../types/links";
+import type { BacklinkEntry, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
 
 function normalizeError(err: unknown): VaultError {
@@ -306,6 +306,22 @@ export async function getResolvedLinks(): Promise<Map<string, string>> {
  * attachment in the vault. Drives the `![[image.png]]` wiki-embed resolver
  * with zero IPC per render.
  */
+/**
+ * Return the local link graph around `path` — BFS in both directions for
+ * `depth` hops. Unresolved wiki-link targets surface as synthetic nodes
+ * with `resolved: false` and an `unresolved:<raw>` id.
+ */
+export async function getLocalGraph(
+  path: string,
+  depth: number,
+): Promise<LocalGraph> {
+  try {
+    return await invoke<LocalGraph>("get_local_graph", { path, depth });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function getResolvedAttachments(): Promise<Map<string, string>> {
   try {
     const record = await invoke<Record<string, string>>("get_resolved_attachments");

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -23,6 +23,32 @@ export interface UnresolvedLink {
   lineNumber: number;
 }
 
+/** A single node in the local-graph payload returned by `get_local_graph`. */
+export interface GraphNode {
+  /** Vault-relative path for resolved files, `unresolved:<raw>` for dangling links. */
+  id: string;
+  /** Display label — filename stem for resolved, link text for unresolved. */
+  label: string;
+  /** Vault-relative path (empty string for unresolved pseudo-nodes). */
+  path: string;
+  /** Number of resolved incoming links — drives node sizing. */
+  backlinkCount: number;
+  /** `true` when the node maps to an indexed file in the vault. */
+  resolved: boolean;
+}
+
+/** An undirected edge between two graph nodes. */
+export interface GraphEdge {
+  from: string;
+  to: string;
+}
+
+/** Result returned by `get_local_graph`. */
+export interface LocalGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
 /** Result returned by update_links_after_rename. */
 export interface RenameResult {
   /** Number of files that had their links rewritten. */


### PR DESCRIPTION
## Summary
- New Rust command `get_local_graph(path, depth)` backed by a BFS helper that walks both outgoing links and backlinks, dedupes edges, and caps at 500 nodes so hub notes can't stall the UI.
- Unresolved wiki-link targets surface as synthetic nodes (`resolved: false`, id prefixed `unresolved:`) so they never collide with real paths.
- Frontend `sigma`, `graphology`, `graphology-layout-forceatlas2` deps added. Sigma.js runs fine in the Tauri webview; no CSP tweak was needed.
- New `graphRender.ts` helper exposes `mountGraph` / `updateGraph` / `destroyGraph` / `setCenter` and hides sigma+graphology internals so the upcoming global graph view (#32) can reuse it.
- New `LocalGraphPanel.svelte` wired into `RightSidebar` after `BacklinksPanel`. Collapsible with `localStorage` key `vaultcore-graph-collapsed`, fixed 250px body, single-click opens the note via `tabStore`, double-click re-centers, hover dims non-neighbors, wheel zooms without scrolling the sidebar.
- Debounced (~200 ms) refetch on `activeViewStore.docVersion` bumps and on watcher `create`/`delete`/`rename` events. Empty states: `Keine Datei geöffnet` when no tab is active; `Keine Verbindungen` when the center has no edges.

Closes #31.

## Test plan
- [ ] Open a note with several links then the graph panel renders center + 2-hop neighborhood
- [ ] Click a neighbor then opens that note, panel re-centers on it
- [ ] Double-click a neighbor then panel re-centers, refetches 2-hop neighborhood
- [ ] Hover a node then neighbors stay bright, others dim
- [ ] Edit a link in the note then panel updates within ~200 ms
- [ ] Create / rename / delete a linked file externally then panel updates
- [ ] No active note then `Keine Datei geöffnet` empty state
- [ ] Note with no links then `Keine Verbindungen` empty state
- [ ] Collapse / expand panel header chevron then state persists across reloads

## Notes / limitations
- Unresolved nodes render with the lighter-gray border color rather than a dashed stroke. Sigma's stock WebGL circle program doesn't support dashed strokes; a custom node program is deferred to a follow-up.
- Depth is hard-coded to 2 in v1.
- Panel is fixed at 250px — not resizable in v1.

## Out of scope (follow-ups)
- Global graph view (#32)
- Tag / folder coloring
- Depth slider
- Saved per-node layout positions