### PR TITLE
feat(graph): full-vault graph view as a new tab type (#32)

### DIFF
--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use crate::error::VaultError;
 use crate::indexer::link_graph::{self, BacklinkEntry, LinkGraph, ParsedLink, UnresolvedLink};
 use crate::indexer::memory::FileIndex;
+use crate::indexer::tag_index::TagIndex;
 use crate::commands::search::FileMatch;
 use crate::VaultState;
 
@@ -505,6 +506,11 @@ pub struct GraphNode {
     pub backlink_count: usize,
     /// `true` when the node corresponds to an actual file in the vault.
     pub resolved: bool,
+    /// Lowercased tags present in the file (deduplicated, sorted).
+    /// Empty for unresolved pseudo-nodes and for callers that don't populate
+    /// tag information (e.g. the local-graph command).
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// An undirected edge between two graph nodes. Dedupe is performed at build
@@ -567,6 +573,7 @@ pub fn compute_local_graph(
                 path: id.to_string(),
                 backlink_count: lg.backlink_count(id),
                 resolved: true,
+                tags: Vec::new(),
             }
         } else {
             // Unresolved pseudo-node. `label` is the raw link text if supplied,
@@ -580,6 +587,7 @@ pub fn compute_local_graph(
                 path: String::new(),
                 backlink_count: 0,
                 resolved: false,
+                tags: Vec::new(),
             }
         }
     };
@@ -597,6 +605,7 @@ pub fn compute_local_graph(
             path: center.to_string(),
             backlink_count: lg.backlink_count(center),
             resolved: true,
+            tags: Vec::new(),
         }
     };
     nodes.insert(center.to_string(), center_node);
@@ -710,4 +719,122 @@ pub async fn get_local_graph(
     let lg = lg_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
 
     Ok(compute_local_graph(&path, depth, &lg, &fi))
+}
+
+// ── get_link_graph ─────────────────────────────────────────────────────────────
+
+/// Pure helper that builds the whole-vault link graph. Split out from the
+/// Tauri command so unit tests can exercise it without standing up a
+/// VaultState.
+///
+/// Every indexed `.md` file becomes a resolved node. Every resolved outgoing
+/// link becomes an undirected edge (deduped via a sorted-pair set). Every
+/// unresolved link target becomes a pseudo-node with `resolved: false`,
+/// mirroring the local-graph convention so the frontend reducers can share
+/// code.
+pub fn compute_link_graph(
+    lg: &LinkGraph,
+    fi: &FileIndex,
+    ti: &TagIndex,
+) -> LocalGraph {
+    let all_paths: Vec<String> = fi.all_relative_paths();
+
+    let mut nodes: HashMap<String, GraphNode> = HashMap::with_capacity(all_paths.len());
+    let mut edges: HashSet<(String, String)> = HashSet::new();
+
+    // Resolved nodes — every indexed file.
+    for rel in &all_paths {
+        nodes.insert(
+            rel.clone(),
+            GraphNode {
+                id: rel.clone(),
+                label: file_stem_label(rel),
+                path: rel.clone(),
+                backlink_count: lg.backlink_count(rel),
+                resolved: true,
+                tags: ti.tags_for_file(rel),
+            },
+        );
+    }
+
+    let insert_edge = |edges: &mut HashSet<(String, String)>, a: &str, b: &str| {
+        if a == b {
+            return;
+        }
+        let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+        edges.insert((lo.to_string(), hi.to_string()));
+    };
+
+    // Walk every file's outgoing targets. Resolved targets → direct edge;
+    // unresolved targets → synthesize a pseudo-node + edge.
+    for rel in &all_paths {
+        let Some(targets) = lg.outgoing_targets_for(rel) else {
+            continue;
+        };
+        for (resolved_target, raw) in targets {
+            match resolved_target {
+                Some(target) => {
+                    insert_edge(&mut edges, rel, &target);
+                }
+                None => {
+                    let id = format!("unresolved:{}", raw);
+                    nodes.entry(id.clone()).or_insert_with(|| GraphNode {
+                        id: id.clone(),
+                        label: raw.clone(),
+                        path: String::new(),
+                        backlink_count: 0,
+                        resolved: false,
+                        tags: Vec::new(),
+                    });
+                    insert_edge(&mut edges, rel, &id);
+                }
+            }
+        }
+    }
+
+    // Stable output order — alphabetical ids. Keeps force layout seed
+    // reproducible and snapshot tests tidy.
+    let mut node_list: Vec<GraphNode> = nodes.into_values().collect();
+    node_list.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut edge_list: Vec<GraphEdge> = edges
+        .into_iter()
+        .map(|(from, to)| GraphEdge { from, to })
+        .collect();
+    edge_list.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
+
+    LocalGraph {
+        nodes: node_list,
+        edges: edge_list,
+    }
+}
+
+/// Tauri command — return the full vault link graph. One resolved node per
+/// indexed `.md` file, one pseudo-node per unique unresolved target, one
+/// undirected edge per resolved wiki-link (deduped).
+#[tauri::command]
+pub async fn get_link_graph(
+    state: tauri::State<'_, VaultState>,
+) -> Result<LocalGraph, VaultError> {
+    let (lg_arc, fi_arc, ti_arc) = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(c) => (c.link_graph(), c.file_index(), c.tag_index()),
+            None => {
+                return Ok(LocalGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                })
+            }
+        }
+    };
+
+    let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+    let lg = lg_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+    let ti = ti_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+
+    Ok(compute_link_graph(&lg, &fi, &ti))
 }

--- a/src-tauri/src/indexer/tag_index.rs
+++ b/src-tauri/src/indexer/tag_index.rs
@@ -209,4 +209,24 @@ impl TagIndex {
             .cloned()
             .unwrap_or_default()
     }
+
+    /// Return the deduplicated, sorted list of tags for `rel_path`.
+    ///
+    /// `by_file` stores per-file tag occurrences with duplicates (needed for
+    /// the "three hits of #test" count). The graph view only cares whether a
+    /// tag is present — dedupe + sort for stable output.
+    pub fn tags_for_file(&self, rel_path: &str) -> Vec<String> {
+        let Some(tags) = self.by_file.get(rel_path) else {
+            return Vec::new();
+        };
+        let mut uniq: Vec<String> = {
+            let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+            tags.iter()
+                .filter(|t| seen.insert(t.as_str()))
+                .cloned()
+                .collect()
+        };
+        uniq.sort();
+        uniq
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() {
             commands::links::get_resolved_links,
             commands::links::get_resolved_attachments,
             commands::links::get_local_graph,
+            commands::links::get_link_graph,
             commands::tags::list_tags,
             commands::tags::get_tag_occurrences,
         ])

--- a/src-tauri/src/tests/global_graph.rs
+++ b/src-tauri/src/tests/global_graph.rs
@@ -1,0 +1,189 @@
+// Unit tests for compute_link_graph — the whole-vault enumeration that
+// powers the global graph tab (issue #32).
+//
+// Runs against the pure `compute_link_graph` function — no Tauri state or
+// IPC plumbing involved.
+
+use crate::commands::links::{compute_link_graph, GraphEdge, GraphNode};
+use crate::indexer::link_graph::{extract_links, LinkGraph};
+use crate::indexer::memory::{FileIndex, FileMeta};
+use crate::indexer::tag_index::TagIndex;
+
+fn make_file_index(entries: &[(&str, &str)]) -> FileIndex {
+    let mut fi = FileIndex::new();
+    for (rel, title) in entries {
+        fi.insert(
+            std::path::PathBuf::from(format!("/vault/{}", rel)),
+            FileMeta {
+                relative_path: rel.to_string(),
+                hash: "abc".to_string(),
+                title: title.to_string(),
+            },
+        );
+    }
+    fi
+}
+
+fn seed(
+    files: &[(&str, &str, &str)],
+) -> (LinkGraph, FileIndex, TagIndex) {
+    // files: (rel_path, title, body)
+    let all: Vec<String> = files.iter().map(|(p, _, _)| (*p).to_string()).collect();
+    let fi = make_file_index(
+        &files.iter().map(|(p, t, _)| (*p, *t)).collect::<Vec<_>>(),
+    );
+    let mut lg = LinkGraph::new();
+    let mut ti = TagIndex::new();
+    for (rel, _title, body) in files {
+        let links = extract_links(body);
+        lg.update_file(rel, links, &all);
+        ti.update_file(rel, body);
+    }
+    (lg, fi, ti)
+}
+
+fn ids(nodes: &[GraphNode]) -> Vec<String> {
+    nodes.iter().map(|n| n.id.clone()).collect()
+}
+
+fn edge_set(edges: &[GraphEdge]) -> std::collections::HashSet<(String, String)> {
+    edges
+        .iter()
+        .map(|e| {
+            let (a, b) = if e.from <= e.to {
+                (e.from.clone(), e.to.clone())
+            } else {
+                (e.to.clone(), e.from.clone())
+            };
+            (a, b)
+        })
+        .collect()
+}
+
+#[test]
+fn empty_vault_yields_empty_graph() {
+    let (lg, fi, ti) = seed(&[]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    assert!(g.nodes.is_empty());
+    assert!(g.edges.is_empty());
+}
+
+#[test]
+fn every_indexed_file_becomes_resolved_node() {
+    let (lg, fi, ti) = seed(&[
+        ("a.md", "A", ""),
+        ("b.md", "B", ""),
+        ("sub/c.md", "C", ""),
+    ]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    let node_ids = ids(&g.nodes);
+    assert!(node_ids.contains(&"a.md".to_string()));
+    assert!(node_ids.contains(&"b.md".to_string()));
+    assert!(node_ids.contains(&"sub/c.md".to_string()));
+    for n in &g.nodes {
+        assert!(n.resolved, "all file-nodes must be resolved");
+    }
+}
+
+#[test]
+fn resolved_link_produces_undirected_edge() {
+    let (lg, fi, ti) = seed(&[
+        ("a.md", "A", "See [[B]]"),
+        ("b.md", "B", "plain"),
+    ]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    let e = edge_set(&g.edges);
+    assert_eq!(g.edges.len(), 1);
+    assert!(e.contains(&("a.md".to_string(), "b.md".to_string())));
+}
+
+#[test]
+fn mutual_links_are_deduped_to_single_edge() {
+    let (lg, fi, ti) = seed(&[
+        ("a.md", "A", "[[B]]"),
+        ("b.md", "B", "[[A]]"),
+    ]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    assert_eq!(g.edges.len(), 1);
+}
+
+#[test]
+fn unresolved_target_surfaces_as_pseudo_node() {
+    let (lg, fi, ti) = seed(&[("a.md", "A", "[[Ghost]]")]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    let ghost = g
+        .nodes
+        .iter()
+        .find(|n| n.id.starts_with("unresolved:"))
+        .expect("ghost node expected");
+    assert!(!ghost.resolved);
+    assert_eq!(ghost.label, "Ghost");
+    assert_eq!(ghost.path, "");
+    // Edge to the ghost must exist.
+    let e = edge_set(&g.edges);
+    assert!(e.iter().any(|(x, y)| x.starts_with("unresolved:") || y.starts_with("unresolved:")));
+}
+
+#[test]
+fn backlink_count_reflects_vault_wide_incoming() {
+    let (lg, fi, ti) = seed(&[
+        ("a.md", "A", "."),
+        ("b.md", "B", "[[A]]"),
+        ("c.md", "C", "[[A]]"),
+    ]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    let a = g.nodes.iter().find(|n| n.id == "a.md").unwrap();
+    assert_eq!(a.backlink_count, 2);
+}
+
+#[test]
+fn tags_are_populated_per_node() {
+    let (lg, fi, ti) = seed(&[
+        ("a.md", "A", "hello #rust and #note-taking"),
+        ("b.md", "B", "no tags"),
+    ]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    let a = g.nodes.iter().find(|n| n.id == "a.md").unwrap();
+    assert!(a.tags.contains(&"rust".to_string()));
+    assert!(a.tags.contains(&"note-taking".to_string()));
+    let b = g.nodes.iter().find(|n| n.id == "b.md").unwrap();
+    assert!(b.tags.is_empty());
+}
+
+#[test]
+fn self_link_does_not_create_self_loop() {
+    let (lg, fi, ti) = seed(&[("a.md", "A", "[[A]]")]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    for e in &g.edges {
+        assert_ne!(e.from, e.to);
+    }
+}
+
+#[test]
+fn node_order_is_stable_across_runs() {
+    let (lg, fi, ti) = seed(&[
+        ("c.md", "C", ""),
+        ("a.md", "A", ""),
+        ("b.md", "B", ""),
+    ]);
+    let g1 = compute_link_graph(&lg, &fi, &ti);
+    let g2 = compute_link_graph(&lg, &fi, &ti);
+    assert_eq!(ids(&g1.nodes), ids(&g2.nodes));
+    // Sorted alphabetically.
+    let sorted: Vec<String> = ids(&g1.nodes);
+    let mut expected = sorted.clone();
+    expected.sort();
+    assert_eq!(sorted, expected);
+}
+
+#[test]
+fn orphan_file_still_emitted_with_no_edges() {
+    // `orphan.md` has no in/outbound links — must still appear as a node.
+    let (lg, fi, ti) = seed(&[
+        ("a.md", "A", "[[B]]"),
+        ("b.md", "B", ""),
+        ("orphan.md", "Orphan", ""),
+    ]);
+    let g = compute_link_graph(&lg, &fi, &ti);
+    assert!(ids(&g.nodes).contains(&"orphan.md".to_string()));
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -8,5 +8,6 @@ mod merge;
 mod indexer;
 mod link_graph;
 mod local_graph;
+mod global_graph;
 pub mod tag_index;
 mod hash_verify;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost",
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:; img-src 'self' data: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -4,6 +4,7 @@
   import { EditorState } from "@codemirror/state";
   import TabBar from "../Tabs/TabBar.svelte";
   import Breadcrumbs from "./Breadcrumbs.svelte";
+  import GraphView from "../Graph/GraphView.svelte";
   import { tabStore } from "../../store/tabStore";
   import type { Tab } from "../../store/tabStore";
   import { vaultStore } from "../../store/vaultStore";
@@ -83,11 +84,14 @@
 
   // Active tab file path for this pane — drives the breadcrumb bar.
   // Null when no tab is open in the pane, which hides the bar (AC-06).
-  const paneActiveFilePath = $derived(
-    paneActiveTabId !== null
-      ? (paneTabs.find((t) => t.id === paneActiveTabId)?.filePath ?? null)
-      : null
-  );
+  // Graph tabs have no on-disk path and should hide the breadcrumb.
+  const paneActiveFilePath = $derived.by<string | null>(() => {
+    if (paneActiveTabId === null) return null;
+    const t = paneTabs.find((x) => x.id === paneActiveTabId);
+    if (!t) return null;
+    if (t.type === "graph") return null;
+    return t.filePath;
+  });
 
   // Subscribe to tabStore for our pane's tabs and active state
   const unsubTab = tabStore.subscribe((state) => {
@@ -256,11 +260,12 @@
     }
 
     // Create views for new tabs (async — the container div is already in the DOM
-    // via the Svelte template, so we just need to mount the EditorView into it)
+    // via the Svelte template, so we just need to mount the EditorView into it).
+    // Graph tabs are rendered via <GraphView /> and must NOT get a CM6 view.
     for (const tabId of paneTabIds) {
       if (!viewMap.has(tabId)) {
         const tab = allTabs.find((t) => t.id === tabId);
-        if (tab) {
+        if (tab && tab.type !== "graph") {
           mountEditorView(tab);
         }
       }
@@ -643,17 +648,29 @@
       </div>
     {/if}
     <!-- Svelte renders one container per tab. Visibility is driven by
-         style:display reacting to paneActiveTabId — no manual DOM needed. -->
+         style:display reacting to paneActiveTabId — no manual DOM needed.
+         Graph tabs render <GraphView /> instead of a CM6 container so the
+         file-load path is skipped entirely (#32). -->
     {#each paneTabs as tab (tab.id)}
-      <div
-        class="vc-editor-container"
-        data-tab-id={tab.id}
-        style:display={tab.id === paneActiveTabId ? "block" : "none"}
-      ></div>
+      {#if tab.type === "graph"}
+        <div
+          class="vc-editor-container"
+          data-tab-id={tab.id}
+          style:display={tab.id === paneActiveTabId ? "block" : "none"}
+        >
+          <GraphView />
+        </div>
+      {:else}
+        <div
+          class="vc-editor-container"
+          data-tab-id={tab.id}
+          style:display={tab.id === paneActiveTabId ? "block" : "none"}
+        ></div>
+      {/if}
     {/each}
   </div>
 
-  {#if paneTabs.length > 0}
+  {#if paneTabs.length > 0 && paneTabs.find((t) => t.id === paneActiveTabId)?.type !== "graph"}
     <CountStatusBar {paneId} />
   {/if}
 

--- a/src/components/Graph/GraphCanvas.svelte
+++ b/src/components/Graph/GraphCanvas.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import {
+    destroyGraph,
+    mountGraph,
+    updateGraph,
+    type GraphHandle,
+  } from "./graphRender";
+  import type { LocalGraph, GraphNode } from "../../types/links";
+
+  // Camera state persisted by the parent GraphView via localStorage — passed
+  // in as a prop so the canvas stays agnostic of persistence keys.
+  interface SavedCamera {
+    x: number;
+    y: number;
+    ratio: number;
+    angle: number;
+  }
+
+  interface Props {
+    data: LocalGraph | null;
+    activeId: string | null;
+    savedCamera: SavedCamera | null;
+    dimForNode: (id: string, attrs: Record<string, unknown>) => number | undefined;
+    alwaysShowLabel?: (id: string) => boolean;
+    onNodeClick: (id: string, node: GraphNode) => void;
+    onCameraChange?: (cam: SavedCamera) => void;
+    /** Bumped by the parent when the underlying vault identity changes so
+     *  we re-run the force layout from scratch. Identity unchanged =
+     *  keep positions, only refresh topology. */
+    datasetVersion: number;
+  }
+
+  let {
+    data,
+    activeId,
+    savedCamera,
+    dimForNode,
+    alwaysShowLabel,
+    onNodeClick,
+    onCameraChange,
+    datasetVersion,
+  }: Props = $props();
+
+  let canvasEl = $state<HTMLDivElement | undefined>();
+  let handle: GraphHandle | null = null;
+  let lastDatasetVersion = -1;
+
+  function restoreCamera(): void {
+    if (!handle || !savedCamera) return;
+    try {
+      handle.renderer.getCamera().setState({
+        x: savedCamera.x,
+        y: savedCamera.y,
+        ratio: savedCamera.ratio,
+        angle: savedCamera.angle,
+      });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function tryMount(): void {
+    if (handle) return;
+    if (!canvasEl || !data) return;
+    if (canvasEl.clientWidth === 0 || canvasEl.clientHeight === 0) {
+      requestAnimationFrame(tryMount);
+      return;
+    }
+    handle = mountGraph(canvasEl, data, {
+      centerId: activeId,
+      accentColor: "var(--color-accent)",
+      nodeColor: "var(--color-text-muted)",
+      unresolvedColor: "var(--color-border)",
+      edgeColor: "var(--color-border)",
+      layoutIterations: 300,
+      enableNodeDrag: true,
+      dimForNode,
+      alwaysShowLabel,
+      onNodeClick,
+      onStageDoubleClick: () => {
+        if (!handle) return;
+        // Fit camera to graph extents.
+        try {
+          handle.renderer.getCamera().animatedReset({ duration: 300 });
+        } catch {
+          /* ignore */
+        }
+      },
+    });
+    lastDatasetVersion = datasetVersion;
+
+    restoreCamera();
+
+    // Persist camera on every change.
+    if (onCameraChange) {
+      const cam = handle.renderer.getCamera();
+      const onUpdated = () => {
+        const s = cam.getState();
+        onCameraChange({ x: s.x, y: s.y, ratio: s.ratio, angle: s.angle });
+      };
+      cam.on("updated", onUpdated);
+      handle.disposers.push(() => {
+        try {
+          cam.removeListener("updated", onUpdated);
+        } catch {
+          /* ignore */
+        }
+      });
+    }
+  }
+
+  // Mount when the canvas gets sized + data arrives.
+  $effect(() => {
+    if (data && !handle) {
+      tryMount();
+    }
+  });
+
+  // Topology refresh — keep existing positions unless the dataset identity
+  // (vault) changed.
+  $effect(() => {
+    if (!handle || !data) return;
+    const versionChanged = datasetVersion !== lastDatasetVersion;
+    handle.options = { ...handle.options, centerId: activeId, dimForNode, alwaysShowLabel, onNodeClick };
+    updateGraph(handle, data, {
+      relayout: versionChanged,
+      iterations: versionChanged ? 300 : 30,
+    });
+    lastDatasetVersion = datasetVersion;
+  });
+
+  // activeId-only changes → just refresh reducers.
+  $effect(() => {
+    if (!handle) return;
+    handle.options = { ...handle.options, centerId: activeId };
+    handle.renderer.refresh({ skipIndexation: true });
+  });
+
+  onMount(() => {
+    tryMount();
+  });
+
+  onDestroy(() => {
+    if (handle) {
+      destroyGraph(handle);
+      handle = null;
+    }
+  });
+</script>
+
+<div class="vc-graph-canvas" bind:this={canvasEl}></div>
+
+<style>
+  .vc-graph-canvas {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    background: var(--color-bg);
+  }
+</style>

--- a/src/components/Graph/GraphCanvas.svelte
+++ b/src/components/Graph/GraphCanvas.svelte
@@ -3,7 +3,10 @@
   import {
     destroyGraph,
     mountGraph,
+    setForceSettings,
+    setLayoutFrozen,
     updateGraph,
+    type ForceSettings,
     type GraphHandle,
   } from "./graphRender";
   import type { LocalGraph, GraphNode } from "../../types/links";
@@ -29,6 +32,10 @@
      *  we re-run the force layout from scratch. Identity unchanged =
      *  keep positions, only refresh topology. */
     datasetVersion: number;
+    /** Live force settings — enables the continuous (organic) simulation. */
+    forceSettings?: ForceSettings;
+    /** Freeze/thaw the continuous simulation. */
+    frozen?: boolean;
   }
 
   let {
@@ -40,6 +47,8 @@
     onNodeClick,
     onCameraChange,
     datasetVersion,
+    forceSettings,
+    frozen,
   }: Props = $props();
 
   let canvasEl = $state<HTMLDivElement | undefined>();
@@ -75,6 +84,8 @@
       edgeColor: "var(--color-border)",
       layoutIterations: 300,
       enableNodeDrag: true,
+      forceSettings,
+      startFrozen: frozen === true,
       dimForNode,
       alwaysShowLabel,
       onNodeClick,
@@ -135,6 +146,16 @@
     if (!handle) return;
     handle.options = { ...handle.options, centerId: activeId };
     handle.renderer.refresh({ skipIndexation: true });
+  });
+
+  // Live propagation of force settings + freeze into the running supervisor.
+  $effect(() => {
+    if (!handle || !forceSettings) return;
+    setForceSettings(handle, forceSettings);
+  });
+  $effect(() => {
+    if (!handle) return;
+    setLayoutFrozen(handle, frozen === true);
   });
 
   onMount(() => {

--- a/src/components/Graph/GraphFilters.svelte
+++ b/src/components/Graph/GraphFilters.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+  import { ChevronDown, ChevronRight, Search } from "lucide-svelte";
+
+  export interface GraphFilterState {
+    search: string;
+    tags: string[];
+    folders: string[];
+    showOrphans: boolean;
+    showUnresolved: boolean;
+    showAttachments: boolean;
+  }
+
+  interface Props {
+    state: GraphFilterState;
+    availableTags: string[];
+    availableFolders: string[];
+    collapsed: boolean;
+    onChange: (next: GraphFilterState) => void;
+    onCollapsedChange: (collapsed: boolean) => void;
+  }
+
+  let {
+    state,
+    availableTags,
+    availableFolders,
+    collapsed,
+    onChange,
+    onCollapsedChange,
+  }: Props = $props();
+
+  function setField<K extends keyof GraphFilterState>(key: K, value: GraphFilterState[K]): void {
+    onChange({ ...state, [key]: value });
+  }
+
+  function toggleTag(tag: string): void {
+    const next = state.tags.includes(tag)
+      ? state.tags.filter((t) => t !== tag)
+      : [...state.tags, tag];
+    setField("tags", next);
+  }
+
+  function toggleFolder(folder: string): void {
+    const next = state.folders.includes(folder)
+      ? state.folders.filter((f) => f !== folder)
+      : [...state.folders, folder];
+    setField("folders", next);
+  }
+</script>
+
+<aside class="vc-graph-filters" aria-label="Graph-Filter">
+  <button
+    type="button"
+    class="vc-graph-filters-header"
+    aria-expanded={!collapsed}
+    onclick={() => onCollapsedChange(!collapsed)}
+  >
+    {#if collapsed}
+      <ChevronRight size={14} />
+    {:else}
+      <ChevronDown size={14} />
+    {/if}
+    <span class="vc-graph-filters-title">Filter</span>
+  </button>
+
+  {#if !collapsed}
+    <div class="vc-graph-filters-body">
+      <!-- Text search -->
+      <label class="vc-graph-filters-search">
+        <Search size={13} />
+        <input
+          type="text"
+          placeholder="Suche nach Titel / Pfad"
+          value={state.search}
+          oninput={(e) => setField("search", (e.currentTarget as HTMLInputElement).value)}
+        />
+      </label>
+
+      <!-- Toggles -->
+      <div class="vc-graph-filters-group">
+        <label class="vc-graph-filters-toggle">
+          <input
+            type="checkbox"
+            checked={state.showOrphans}
+            onchange={(e) => setField("showOrphans", (e.currentTarget as HTMLInputElement).checked)}
+          />
+          <span>Orphans anzeigen</span>
+        </label>
+        <label class="vc-graph-filters-toggle">
+          <input
+            type="checkbox"
+            checked={state.showUnresolved}
+            onchange={(e) => setField("showUnresolved", (e.currentTarget as HTMLInputElement).checked)}
+          />
+          <span>Unresolved anzeigen</span>
+        </label>
+        <label class="vc-graph-filters-toggle">
+          <input
+            type="checkbox"
+            checked={state.showAttachments}
+            onchange={(e) => setField("showAttachments", (e.currentTarget as HTMLInputElement).checked)}
+          />
+          <span>Attachments anzeigen</span>
+        </label>
+      </div>
+
+      <!-- Tag filter -->
+      {#if availableTags.length > 0}
+        <div class="vc-graph-filters-group">
+          <div class="vc-graph-filters-grouplabel">Tags</div>
+          <div class="vc-graph-filters-chips">
+            {#each availableTags as tag (tag)}
+              <button
+                type="button"
+                class="vc-graph-filters-chip"
+                class:vc-graph-filters-chip--active={state.tags.includes(tag)}
+                onclick={() => toggleTag(tag)}
+              >
+                #{tag}
+              </button>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      <!-- Folder filter -->
+      {#if availableFolders.length > 0}
+        <div class="vc-graph-filters-group">
+          <div class="vc-graph-filters-grouplabel">Ordner</div>
+          <div class="vc-graph-filters-chips">
+            {#each availableFolders as folder (folder)}
+              <button
+                type="button"
+                class="vc-graph-filters-chip"
+                class:vc-graph-filters-chip--active={state.folders.includes(folder)}
+                onclick={() => toggleFolder(folder)}
+              >
+                {folder}
+              </button>
+            {/each}
+          </div>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</aside>
+
+<style>
+  .vc-graph-filters {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 5;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    width: 260px;
+    max-height: calc(100% - 24px);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .vc-graph-filters-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text);
+    width: 100%;
+    text-align: left;
+  }
+
+  .vc-graph-filters-header:hover {
+    color: var(--color-accent);
+  }
+
+  .vc-graph-filters-title {
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .vc-graph-filters-body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 12px;
+    overflow-y: auto;
+  }
+
+  .vc-graph-filters-search {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 4px 8px;
+    background: var(--color-bg);
+    color: var(--color-text-muted);
+  }
+
+  .vc-graph-filters-search input {
+    border: none;
+    outline: none;
+    background: transparent;
+    flex: 1;
+    font-size: 12px;
+    color: var(--color-text);
+  }
+
+  .vc-graph-filters-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .vc-graph-filters-grouplabel {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .vc-graph-filters-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .vc-graph-filters-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .vc-graph-filters-chip {
+    font-size: 11px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-text-muted);
+    border-radius: 999px;
+    padding: 2px 8px;
+    cursor: pointer;
+  }
+
+  .vc-graph-filters-chip:hover {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  .vc-graph-filters-chip--active {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+</style>

--- a/src/components/Graph/GraphForces.svelte
+++ b/src/components/Graph/GraphForces.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+  import { X, Pause, Play } from "lucide-svelte";
+  import type { ForceSettings } from "./graphRender";
+
+  interface Props {
+    settings: ForceSettings;
+    frozen: boolean;
+    onSettingsChange: (s: ForceSettings) => void;
+    onFrozenChange: (f: boolean) => void;
+    onClose: () => void;
+  }
+
+  let {
+    settings,
+    frozen,
+    onSettingsChange,
+    onFrozenChange,
+    onClose,
+  }: Props = $props();
+
+  // Local staging so the slider is smooth — each `oninput` writes through
+  // to the parent, which mutates the live supervisor's settings in place.
+  function update(patch: Partial<ForceSettings>): void {
+    onSettingsChange({ ...settings, ...patch });
+  }
+</script>
+
+<div class="vc-forces-panel" role="dialog" aria-label="Graph forces">
+  <div class="vc-forces-header">
+    <span class="vc-forces-title">Forces</span>
+    <button
+      type="button"
+      class="vc-forces-close"
+      onclick={onClose}
+      aria-label="Close forces panel"
+      title="Schließen"
+    >
+      <X size={14} strokeWidth={1.75} />
+    </button>
+  </div>
+
+  <button
+    type="button"
+    class="vc-forces-freeze"
+    class:vc-forces-freeze--on={frozen}
+    onclick={() => onFrozenChange(!frozen)}
+    aria-pressed={frozen}
+    title={frozen ? "Simulation weiterlaufen lassen" : "Simulation pausieren"}
+  >
+    {#if frozen}
+      <Play size={14} strokeWidth={1.75} />
+      <span>Weiterlaufen</span>
+    {:else}
+      <Pause size={14} strokeWidth={1.75} />
+      <span>Einfrieren</span>
+    {/if}
+  </button>
+
+  <label class="vc-forces-row">
+    <span class="vc-forces-label">
+      Center
+      <span class="vc-forces-value">{settings.gravity.toFixed(2)}</span>
+    </span>
+    <input
+      type="range"
+      min="0"
+      max="5"
+      step="0.1"
+      value={settings.gravity}
+      oninput={(e) => update({ gravity: Number(e.currentTarget.value) })}
+    />
+  </label>
+
+  <label class="vc-forces-row">
+    <span class="vc-forces-label">
+      Repel
+      <span class="vc-forces-value">{settings.scalingRatio.toFixed(0)}</span>
+    </span>
+    <input
+      type="range"
+      min="1"
+      max="50"
+      step="1"
+      value={settings.scalingRatio}
+      oninput={(e) => update({ scalingRatio: Number(e.currentTarget.value) })}
+    />
+  </label>
+
+  <label class="vc-forces-row">
+    <span class="vc-forces-label">
+      Link
+      <span class="vc-forces-value">{settings.edgeWeightInfluence.toFixed(2)}</span>
+    </span>
+    <input
+      type="range"
+      min="0"
+      max="3"
+      step="0.1"
+      value={settings.edgeWeightInfluence}
+      oninput={(e) =>
+        update({ edgeWeightInfluence: Number(e.currentTarget.value) })}
+    />
+  </label>
+
+  <label class="vc-forces-row">
+    <span class="vc-forces-label">
+      Friction
+      <span class="vc-forces-value">{settings.slowDown.toFixed(1)}</span>
+    </span>
+    <input
+      type="range"
+      min="0.5"
+      max="20"
+      step="0.5"
+      value={settings.slowDown}
+      oninput={(e) => update({ slowDown: Number(e.currentTarget.value) })}
+    />
+  </label>
+</div>
+
+<style>
+  .vc-forces-panel {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 10;
+    width: 220px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  }
+  .vc-forces-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .vc-forces-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .vc-forces-close {
+    width: 22px;
+    height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: 3px;
+  }
+  .vc-forces-close:hover {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+  .vc-forces-freeze {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+  .vc-forces-freeze:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+  .vc-forces-freeze--on {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+  .vc-forces-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .vc-forces-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+  .vc-forces-value {
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text);
+  }
+  .vc-forces-row input[type="range"] {
+    width: 100%;
+    accent-color: var(--color-accent);
+  }
+</style>

--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
+  import { Settings as SettingsIcon } from "lucide-svelte";
   import GraphCanvas from "./GraphCanvas.svelte";
   import GraphFilters, { type GraphFilterState } from "./GraphFilters.svelte";
+  import GraphForces from "./GraphForces.svelte";
+  import { DEFAULT_FORCE_SETTINGS, type ForceSettings } from "./graphRender";
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore, type Tab, GRAPH_TAB_PATH } from "../../store/tabStore";
   import { getLinkGraph } from "../../ipc/commands";
@@ -12,6 +15,8 @@
   // ── Persistence ─────────────────────────────────────────────────────────────
   const CAMERA_KEY_PREFIX = "vaultcore-graph-camera-";
   const FILTER_KEY_PREFIX = "vaultcore-graph-filters-";
+  const FORCES_KEY_PREFIX = "vaultcore-graph-forces-";
+  const FROZEN_KEY_PREFIX = "vaultcore-graph-frozen-";
 
   /**
    * Small synchronous string hash — used to key per-vault localStorage slots.
@@ -89,6 +94,41 @@
     }
   }
 
+  function loadForces(vaultPath: string): ForceSettings {
+    try {
+      const raw = localStorage.getItem(FORCES_KEY_PREFIX + hashVaultPath(vaultPath));
+      if (!raw) return { ...DEFAULT_FORCE_SETTINGS };
+      const parsed = JSON.parse(raw) as Partial<ForceSettings>;
+      return { ...DEFAULT_FORCE_SETTINGS, ...parsed };
+    } catch {
+      return { ...DEFAULT_FORCE_SETTINGS };
+    }
+  }
+
+  function saveForces(vaultPath: string, s: ForceSettings): void {
+    try {
+      localStorage.setItem(FORCES_KEY_PREFIX + hashVaultPath(vaultPath), JSON.stringify(s));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function loadFrozen(vaultPath: string): boolean {
+    try {
+      return localStorage.getItem(FROZEN_KEY_PREFIX + hashVaultPath(vaultPath)) === "true";
+    } catch {
+      return false;
+    }
+  }
+
+  function saveFrozen(vaultPath: string, frozen: boolean): void {
+    try {
+      localStorage.setItem(FROZEN_KEY_PREFIX + hashVaultPath(vaultPath), String(frozen));
+    } catch {
+      /* ignore */
+    }
+  }
+
   // ── State ───────────────────────────────────────────────────────────────────
   let vaultPath = $state<string | null>(null);
   let tabs = $state<Tab[]>([]);
@@ -101,6 +141,9 @@
 
   let filters = $state<GraphFilterState>({ ...DEFAULT_FILTERS });
   let filtersCollapsed = $state<boolean>(false);
+  let forces = $state<ForceSettings>({ ...DEFAULT_FORCE_SETTINGS });
+  let frozen = $state<boolean>(false);
+  let forcesPanelOpen = $state<boolean>(false);
 
   let unlistenFileChange: UnlistenFn | null = null;
   let refetchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -111,6 +154,8 @@
       vaultPath = s.currentPath;
       if (vaultPath) {
         filters = loadFilters(vaultPath);
+        forces = loadForces(vaultPath);
+        frozen = loadFrozen(vaultPath);
       }
       // Vault identity changed → refetch with full relayout.
       datasetVersion += 1;
@@ -277,6 +322,16 @@
     if (vaultPath) saveFilters(vaultPath, next);
   }
 
+  function onForcesChange(next: ForceSettings): void {
+    forces = next;
+    if (vaultPath) saveForces(vaultPath, next);
+  }
+
+  function onFrozenChange(next: boolean): void {
+    frozen = next;
+    if (vaultPath) saveFrozen(vaultPath, next);
+  }
+
   function onNodeClick(_id: string, node: GraphNode): void {
     if (!node.resolved || !vaultPath || !node.path) return;
     tabStore.openTab(`${vaultPath}/${node.path}`);
@@ -357,6 +412,8 @@
       onNodeClick={onNodeClick}
       {onCameraChange}
       datasetVersion={datasetVersion}
+      forceSettings={forces}
+      {frozen}
     />
     <GraphFilters
       state={filters}
@@ -366,6 +423,26 @@
       onChange={onFiltersChange}
       onCollapsedChange={(c) => (filtersCollapsed = c)}
     />
+    <button
+      type="button"
+      class="vc-graph-forces-btn"
+      class:vc-graph-forces-btn--active={forcesPanelOpen}
+      onclick={() => (forcesPanelOpen = !forcesPanelOpen)}
+      aria-label="Forces"
+      aria-pressed={forcesPanelOpen}
+      title="Forces"
+    >
+      <SettingsIcon size={16} strokeWidth={1.75} />
+    </button>
+    {#if forcesPanelOpen}
+      <GraphForces
+        settings={forces}
+        {frozen}
+        onSettingsChange={onForcesChange}
+        onFrozenChange={onFrozenChange}
+        onClose={() => (forcesPanelOpen = false)}
+      />
+    {/if}
     {#if loading}
       <div class="vc-graph-loading">Aktualisiere...</div>
     {/if}
@@ -392,7 +469,8 @@
   .vc-graph-loading {
     position: absolute;
     top: 12px;
-    right: 12px;
+    left: 50%;
+    transform: translateX(-50%);
     padding: 4px 10px;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
@@ -400,5 +478,30 @@
     font-size: 11px;
     color: var(--color-text-muted);
     pointer-events: none;
+  }
+  .vc-graph-forces-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 11;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .vc-graph-forces-btn:hover {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+  .vc-graph-forces-btn--active {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+    background: var(--color-accent-bg);
   }
 </style>

--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -1,0 +1,404 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import GraphCanvas from "./GraphCanvas.svelte";
+  import GraphFilters, { type GraphFilterState } from "./GraphFilters.svelte";
+  import { vaultStore } from "../../store/vaultStore";
+  import { tabStore, type Tab, GRAPH_TAB_PATH } from "../../store/tabStore";
+  import { getLinkGraph } from "../../ipc/commands";
+  import { listenFileChange } from "../../ipc/events";
+  import type { UnlistenFn } from "@tauri-apps/api/event";
+  import type { LocalGraph, GraphNode } from "../../types/links";
+
+  // ── Persistence ─────────────────────────────────────────────────────────────
+  const CAMERA_KEY_PREFIX = "vaultcore-graph-camera-";
+  const FILTER_KEY_PREFIX = "vaultcore-graph-filters-";
+
+  /**
+   * Small synchronous string hash — used to key per-vault localStorage slots.
+   * Not cryptographic; just enough to avoid collisions between vaults whose
+   * absolute paths only differ at the tail.
+   */
+  function hashVaultPath(path: string): string {
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < path.length; i += 1) {
+      h = (h ^ path.charCodeAt(i)) >>> 0;
+      h = Math.imul(h, 16777619) >>> 0;
+    }
+    return h.toString(16);
+  }
+
+  interface SavedCamera {
+    x: number;
+    y: number;
+    ratio: number;
+    angle: number;
+  }
+
+  const DEFAULT_FILTERS: GraphFilterState = {
+    search: "",
+    tags: [],
+    folders: [],
+    showOrphans: true,
+    showUnresolved: true,
+    showAttachments: false,
+  };
+
+  function loadCamera(vaultPath: string): SavedCamera | null {
+    try {
+      const raw = localStorage.getItem(CAMERA_KEY_PREFIX + hashVaultPath(vaultPath));
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as SavedCamera;
+      if (
+        typeof parsed.x === "number" &&
+        typeof parsed.y === "number" &&
+        typeof parsed.ratio === "number" &&
+        typeof parsed.angle === "number"
+      ) {
+        return parsed;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  function saveCamera(vaultPath: string, cam: SavedCamera): void {
+    try {
+      localStorage.setItem(CAMERA_KEY_PREFIX + hashVaultPath(vaultPath), JSON.stringify(cam));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function loadFilters(vaultPath: string): GraphFilterState {
+    try {
+      const raw = localStorage.getItem(FILTER_KEY_PREFIX + hashVaultPath(vaultPath));
+      if (!raw) return { ...DEFAULT_FILTERS };
+      const parsed = JSON.parse(raw) as Partial<GraphFilterState>;
+      return { ...DEFAULT_FILTERS, ...parsed };
+    } catch {
+      return { ...DEFAULT_FILTERS };
+    }
+  }
+
+  function saveFilters(vaultPath: string, s: GraphFilterState): void {
+    try {
+      localStorage.setItem(FILTER_KEY_PREFIX + hashVaultPath(vaultPath), JSON.stringify(s));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // ── State ───────────────────────────────────────────────────────────────────
+  let vaultPath = $state<string | null>(null);
+  let tabs = $state<Tab[]>([]);
+  let activeTabId = $state<string | null>(null);
+
+  let data = $state<LocalGraph | null>(null);
+  let loading = $state<boolean>(false);
+  let errorMessage = $state<string | null>(null);
+  let datasetVersion = $state<number>(0);
+
+  let filters = $state<GraphFilterState>({ ...DEFAULT_FILTERS });
+  let filtersCollapsed = $state<boolean>(false);
+
+  let unlistenFileChange: UnlistenFn | null = null;
+  let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+  const REFETCH_DEBOUNCE_MS = 300;
+
+  const unsubVault = vaultStore.subscribe((s) => {
+    if (s.currentPath !== vaultPath) {
+      vaultPath = s.currentPath;
+      if (vaultPath) {
+        filters = loadFilters(vaultPath);
+      }
+      // Vault identity changed → refetch with full relayout.
+      datasetVersion += 1;
+      scheduleRefetch();
+    }
+  });
+
+  const unsubTabs = tabStore.subscribe((s) => {
+    tabs = s.tabs;
+    activeTabId = s.activeTabId;
+  });
+
+  // Derive the currently active FILE tab's rel path (used as center-node
+  // accent in the global graph).
+  const activeRelPath = $derived.by<string | null>(() => {
+    if (!activeTabId || !vaultPath) return null;
+    const t = tabs.find((tab) => tab.id === activeTabId);
+    if (!t) return null;
+    if (t.type === "graph" || t.filePath === GRAPH_TAB_PATH) return null;
+    if (t.filePath.startsWith(vaultPath + "/")) {
+      return t.filePath.slice(vaultPath.length + 1);
+    }
+    return null;
+  });
+
+  // Available tag/folder filter options derived from the current dataset.
+  const availableTags = $derived.by<string[]>(() => {
+    if (!data) return [];
+    const set = new Set<string>();
+    for (const n of data.nodes) {
+      if (n.tags) for (const t of n.tags) set.add(t);
+    }
+    return Array.from(set).sort();
+  });
+
+  const availableFolders = $derived.by<string[]>(() => {
+    if (!data) return [];
+    const set = new Set<string>();
+    for (const n of data.nodes) {
+      if (!n.resolved || !n.path) continue;
+      const idx = n.path.indexOf("/");
+      if (idx > 0) set.add(n.path.slice(0, idx));
+    }
+    return Array.from(set).sort();
+  });
+
+  // Adjacency cache — used to decide orphan status.
+  const orphanSet = $derived.by<Set<string>>(() => {
+    if (!data) return new Set();
+    const touched = new Set<string>();
+    for (const e of data.edges) {
+      touched.add(e.from);
+      touched.add(e.to);
+    }
+    const orphans = new Set<string>();
+    for (const n of data.nodes) {
+      if (n.resolved && !touched.has(n.id)) orphans.add(n.id);
+    }
+    return orphans;
+  });
+
+  // Hover-lookup friendly map of node → its attributes (tags, path, resolved).
+  type NodeInfo = { path: string; resolved: boolean; tags: string[]; label: string };
+  const nodeInfo = $derived.by<Map<string, NodeInfo>>(() => {
+    const m = new Map<string, NodeInfo>();
+    if (!data) return m;
+    for (const n of data.nodes) {
+      m.set(n.id, {
+        path: n.path,
+        resolved: n.resolved,
+        tags: n.tags ?? [],
+        label: n.label,
+      });
+    }
+    return m;
+  });
+
+  // ── Reducers consumed by GraphCanvas ───────────────────────────────────────
+  const DIM_ALPHA = 0.15;
+  const HIDE_ALPHA = 0; // treated by applyAlpha as fully transparent
+
+  function dimForNode(id: string): number | undefined {
+    const info = nodeInfo.get(id);
+    if (!info) return undefined;
+
+    // HIDE via toggles.
+    if (!info.resolved && !filters.showUnresolved) return HIDE_ALPHA;
+    if (info.resolved && orphanSet.has(id) && !filters.showOrphans) return HIDE_ALPHA;
+
+    // Attachments: placeholder — dataset currently only contains .md files,
+    // toggle just respects future payloads that include images. Hide if the
+    // path ends with a known image ext and showAttachments is off.
+    const lower = info.path.toLowerCase();
+    const isAttachment =
+      lower.endsWith(".png") ||
+      lower.endsWith(".jpg") ||
+      lower.endsWith(".jpeg") ||
+      lower.endsWith(".gif") ||
+      lower.endsWith(".webp") ||
+      lower.endsWith(".svg");
+    if (isAttachment && !filters.showAttachments) return HIDE_ALPHA;
+
+    // DIM via filters.
+    const searchQ = filters.search.trim().toLowerCase();
+    if (searchQ.length > 0) {
+      const label = info.label.toLowerCase();
+      const path = info.path.toLowerCase();
+      if (!label.includes(searchQ) && !path.includes(searchQ)) return DIM_ALPHA;
+    }
+
+    if (filters.tags.length > 0) {
+      const intersects = info.tags.some((t) => filters.tags.includes(t));
+      if (!intersects) return DIM_ALPHA;
+    }
+
+    if (filters.folders.length > 0) {
+      const idx = info.path.indexOf("/");
+      const top = idx > 0 ? info.path.slice(0, idx) : "";
+      if (!filters.folders.includes(top)) return DIM_ALPHA;
+    }
+
+    return undefined;
+  }
+
+  // ── Data loading ────────────────────────────────────────────────────────────
+  function scheduleRefetch(): void {
+    if (refetchTimer) clearTimeout(refetchTimer);
+    refetchTimer = setTimeout(() => {
+      refetchTimer = null;
+      void refetch();
+    }, REFETCH_DEBOUNCE_MS);
+  }
+
+  async function refetch(): Promise<void> {
+    if (!vaultPath) {
+      data = { nodes: [], edges: [] };
+      return;
+    }
+    loading = true;
+    errorMessage = null;
+    try {
+      data = await getLinkGraph();
+    } catch (err) {
+      errorMessage =
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message: unknown }).message)
+          : "Graph konnte nicht geladen werden.";
+      data = { nodes: [], edges: [] };
+    } finally {
+      loading = false;
+    }
+  }
+
+  function onCameraChange(cam: SavedCamera): void {
+    if (vaultPath) saveCamera(vaultPath, cam);
+  }
+
+  const savedCamera = $derived.by<SavedCamera | null>(() => {
+    return vaultPath ? loadCamera(vaultPath) : null;
+  });
+
+  function onFiltersChange(next: GraphFilterState): void {
+    filters = next;
+    if (vaultPath) saveFilters(vaultPath, next);
+  }
+
+  function onNodeClick(_id: string, node: GraphNode): void {
+    if (!node.resolved || !vaultPath || !node.path) return;
+    tabStore.openTab(`${vaultPath}/${node.path}`);
+  }
+
+  // Esc closes the graph tab (but not when the user is inside a text input).
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key !== "Escape") return;
+    const t = e.target as HTMLElement | null;
+    if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+    let graphTabId: string | null = null;
+    const unsub = tabStore.subscribe((s) => {
+      const tab = s.tabs.find((x) => x.type === "graph");
+      graphTabId = tab?.id ?? null;
+    });
+    unsub();
+    if (graphTabId) tabStore.closeTab(graphTabId);
+  }
+
+  // Re-fetch on file-watcher events that could change link structure.
+  onMount(async () => {
+    void refetch();
+    unlistenFileChange = await listenFileChange((payload) => {
+      if (
+        payload.kind === "create" ||
+        payload.kind === "delete" ||
+        payload.kind === "rename" ||
+        payload.kind === "modify"
+      ) {
+        scheduleRefetch();
+      }
+    });
+  });
+
+  // Detect content changes on open tabs whose lastSavedContent moved. Keeps
+  // behavior parity with LocalGraphPanel's docVersion debounce for global
+  // link structure updates after auto-save.
+  let lastSavedSignatures = new Map<string, string>();
+  const unsubTabsContent = tabStore.subscribe((s) => {
+    let anyChanged = false;
+    const nextSig = new Map<string, string>();
+    for (const t of s.tabs) {
+      if (t.type === "graph") continue;
+      nextSig.set(t.id, t.lastSavedContent);
+      const prev = lastSavedSignatures.get(t.id);
+      if (prev !== undefined && prev !== t.lastSavedContent) {
+        anyChanged = true;
+      }
+    }
+    lastSavedSignatures = nextSig;
+    if (anyChanged) scheduleRefetch();
+  });
+
+  onDestroy(() => {
+    unsubVault();
+    unsubTabs();
+    unsubTabsContent();
+    unlistenFileChange?.();
+    if (refetchTimer) clearTimeout(refetchTimer);
+  });
+</script>
+
+<svelte:document onkeydown={handleKeydown} />
+
+<div class="vc-graph-view" role="region" aria-label="Graph-Ansicht">
+  {#if errorMessage}
+    <div class="vc-graph-empty">{errorMessage}</div>
+  {:else if !data || data.nodes.length === 0}
+    <div class="vc-graph-empty">
+      {loading ? "Graph wird geladen..." : "Keine Notizen im Vault."}
+    </div>
+  {:else}
+    <GraphCanvas
+      {data}
+      activeId={activeRelPath}
+      {savedCamera}
+      dimForNode={(id) => dimForNode(id)}
+      onNodeClick={onNodeClick}
+      {onCameraChange}
+      datasetVersion={datasetVersion}
+    />
+    <GraphFilters
+      state={filters}
+      availableTags={availableTags}
+      availableFolders={availableFolders}
+      collapsed={filtersCollapsed}
+      onChange={onFiltersChange}
+      onCollapsedChange={(c) => (filtersCollapsed = c)}
+    />
+    {#if loading}
+      <div class="vc-graph-loading">Aktualisiere...</div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .vc-graph-view {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: var(--color-bg);
+    overflow: hidden;
+  }
+  .vc-graph-empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+    font-size: 14px;
+  }
+  .vc-graph-loading {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    padding: 4px 10px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-size: 11px;
+    color: var(--color-text-muted);
+    pointer-events: none;
+  }
+</style>

--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -13,6 +13,7 @@
     mountGraph,
     setCenter,
     updateGraph,
+    DEFAULT_FORCE_SETTINGS,
     type GraphHandle,
   } from "./graphRender";
 
@@ -138,6 +139,11 @@
       nodeColor: "var(--color-text-muted)",
       unresolvedColor: "var(--color-border)",
       edgeColor: "var(--color-border)",
+      // Continuous / organic sim — same Obsidian-like feel as the global graph.
+      // No Forces UI in the panel to keep it minimal; the defaults are tuned
+      // for a small neighborhood view.
+      forceSettings: DEFAULT_FORCE_SETTINGS,
+      enableNodeDrag: true,
       onNodeClick: (id, node) => {
         if (!node.resolved || !vaultPath) return;
         tabStore.openTab(`${vaultPath}/${node.path}`);

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -15,7 +15,41 @@
 import Graph from "graphology";
 import Sigma from "sigma";
 import forceAtlas2 from "graphology-layout-forceatlas2";
+import FA2LayoutSupervisor from "graphology-layout-forceatlas2/worker";
 import type { GraphEdge, GraphNode, LocalGraph } from "../../types/links";
+
+/**
+ * User-tunable force parameters. Mapped onto the subset of ForceAtlas2
+ * settings that actually shape the "organic" feel — gravity, repulsion,
+ * edge-weight influence, and the motion damping (`slowDown`). Defaults are
+ * tuned for an Obsidian-like drift rather than FA2's aggressive convergence.
+ */
+export interface ForceSettings {
+  /** Center pull. 0 = graph drifts apart, 5 = strong clump. */
+  gravity: number;
+  /** Node repulsion strength. Higher = nodes push apart more. */
+  scalingRatio: number;
+  /** How much edge weight / existence attracts endpoints. */
+  edgeWeightInfluence: number;
+  /** Motion damping. Higher = slower, calmer movement. */
+  slowDown: number;
+}
+
+export const DEFAULT_FORCE_SETTINGS: ForceSettings = {
+  gravity: 1,
+  scalingRatio: 10,
+  edgeWeightInfluence: 1,
+  slowDown: 5,
+};
+
+/** Interface shape of the running FA2 supervisor we care about. */
+interface FA2Supervisor {
+  start(): unknown;
+  stop(): unknown;
+  kill(): unknown;
+  isRunning(): boolean;
+  settings: Record<string, unknown>;
+}
 
 /** Options accepted by `mountGraph` — future-proofed for the #32 global view.
  *  The `| undefined` on every optional member is deliberate: svelte-check runs
@@ -50,6 +84,13 @@ export interface GraphRenderOptions {
   dimForNode?: ((id: string, attrs: Record<string, unknown>) => number | undefined) | undefined;
   /** Labels always shown for these node ids regardless of zoom threshold. */
   alwaysShowLabel?: ((id: string) => boolean) | undefined;
+  /** Force-simulation parameters. Passing this enables continuous (live)
+   *  layout via the ForceAtlas2 worker — the default batch `layoutIterations`
+   *  path is used when this field is absent. */
+  forceSettings?: ForceSettings | undefined;
+  /** Start the continuous simulation paused. Toggle later via
+   *  `setLayoutFrozen`. No effect when `forceSettings` is absent. */
+  startFrozen?: boolean | undefined;
 }
 
 /** Opaque handle returned by `mountGraph`. Callers pass it to update/destroy. */
@@ -64,6 +105,10 @@ export interface GraphHandle {
   neighborMap: Map<string, Set<string>>;
   /** Disposers for DOM listeners attached outside sigma. */
   disposers: Array<() => void>;
+  /** Live ForceAtlas2 supervisor when continuous sim is active. */
+  layoutSupervisor: FA2Supervisor | null;
+  /** Frozen state mirror — drives pause/resume without reading the supervisor. */
+  frozen: boolean;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -155,7 +200,10 @@ export function mountGraph(
 ): GraphHandle {
   const graph = new Graph({ type: "undirected", multi: false });
   populateGraph(graph, data);
-  runLayout(graph, options.layoutIterations ?? 50);
+  // Short seed pass so nodes spread out before the live supervisor (or the
+  // final rendered frame) takes over. Without this FA2 starts from near-zero
+  // positions and the first few frames look like a single cluster.
+  runLayout(graph, options.forceSettings ? 30 : (options.layoutIterations ?? 50));
 
   const accent = resolveColor(container, options.accentColor);
   const nodeColor = resolveColor(container, options.nodeColor);
@@ -187,7 +235,35 @@ export function mountGraph(
     hoveredNode: null,
     neighborMap,
     disposers: [],
+    layoutSupervisor: null,
+    frozen: options.startFrozen === true,
   };
+
+  // Live ForceAtlas2 supervisor — organic, Obsidian-style drift. Sigma
+  // listens to node-attr changes emitted by the worker and redraws each
+  // time, so we don't need an explicit requestAnimationFrame loop here.
+  if (options.forceSettings) {
+    try {
+      const supervisor = new (FA2LayoutSupervisor as unknown as {
+        new (g: Graph, p: { settings: Record<string, unknown> }): FA2Supervisor;
+      })(graph, {
+        settings: {
+          ...forceAtlas2.inferSettings(graph),
+          ...options.forceSettings,
+          barnesHutOptimize: graph.order > 200,
+          adjustSizes: true,
+        },
+      });
+      handle.layoutSupervisor = supervisor;
+      if (!handle.frozen) supervisor.start();
+    } catch (err) {
+      // Worker spawn can fail in CSP-restricted or jsdom environments.
+      // Fall back to the existing static layout and log so we notice.
+      // eslint-disable-next-line no-console
+      console.warn("[graphRender] live layout unavailable, static fallback:", err);
+      handle.layoutSupervisor = null;
+    }
+  }
 
   // Node reducer — color + size per frame. Reflects center, unresolved,
   // and hover-dim state without mutating node attributes.
@@ -322,9 +398,19 @@ export function mountGraph(
     let draggedNode: string | null = null;
     let draggingActive = false;
 
+    let resumeOnRelease = false;
+
     renderer.on("downNode", ({ node, event }) => {
       draggedNode = node;
       draggingActive = true;
+      // Pause the live supervisor while dragging so it doesn't fight the
+      // user's finger. Remember whether it was running so we can resume.
+      if (handle.layoutSupervisor && handle.layoutSupervisor.isRunning()) {
+        handle.layoutSupervisor.stop();
+        resumeOnRelease = true;
+      } else {
+        resumeOnRelease = false;
+      }
       // Disable camera movement while dragging a node.
       renderer.getCamera().disable();
       event.preventSigmaDefault();
@@ -343,6 +429,12 @@ export function mountGraph(
         draggingActive = false;
         draggedNode = null;
         renderer.getCamera().enable();
+        // Resume only if the user hasn't frozen the sim via the Forces panel
+        // while the drag was in flight.
+        if (resumeOnRelease && handle.layoutSupervisor && !handle.frozen) {
+          handle.layoutSupervisor.start();
+        }
+        resumeOnRelease = false;
       }
     };
     mouseCaptor.on("mousemovebody", onMouseMove);
@@ -384,6 +476,14 @@ export function updateGraph(
   const relayout = opts.relayout ?? true;
   const iterations = opts.iterations ?? handle.options.layoutIterations ?? 50;
 
+  // Pause the live supervisor so it doesn't race with `graph.clear()` /
+  // re-seed. We'll restart it at the end if it was running and the view is
+  // not frozen.
+  const wasRunning =
+    handle.layoutSupervisor !== null &&
+    handle.layoutSupervisor.isRunning();
+  if (wasRunning && handle.layoutSupervisor) handle.layoutSupervisor.stop();
+
   if (!relayout) {
     // Preserve positions for nodes that already exist.
     const prevPos = new Map<string, { x: number; y: number }>();
@@ -416,6 +516,10 @@ export function updateGraph(
   handle.neighborMap = buildNeighborMap(data.edges);
   handle.hoveredNode = null;
   handle.renderer.refresh();
+
+  if (wasRunning && handle.layoutSupervisor && !handle.frozen) {
+    handle.layoutSupervisor.start();
+  }
 }
 
 /** Tear down the sigma renderer and remove all listeners. */
@@ -428,12 +532,48 @@ export function destroyGraph(handle: GraphHandle): void {
     }
   }
   handle.disposers.length = 0;
+  if (handle.layoutSupervisor) {
+    try {
+      handle.layoutSupervisor.kill();
+    } catch {
+      /* ignore */
+    }
+    handle.layoutSupervisor = null;
+  }
   try {
     handle.renderer.kill();
   } catch {
     /* ignore */
   }
   handle.graph.clear();
+}
+
+/**
+ * Update the live force parameters. Mutates the supervisor's settings in place
+ * — the next iteration message to the worker picks them up. No-op when the
+ * handle has no supervisor (static-layout mode).
+ */
+export function setForceSettings(
+  handle: GraphHandle,
+  settings: ForceSettings,
+): void {
+  handle.options = { ...handle.options, forceSettings: settings };
+  if (!handle.layoutSupervisor) return;
+  Object.assign(handle.layoutSupervisor.settings, settings);
+}
+
+/**
+ * Pause or resume the live simulation. When a node drag is in progress the
+ * drag handler still pauses on mousedown and only resumes on mouseup — this
+ * function mirrors the frozen state so the drag handler knows whether to
+ * resume.
+ */
+export function setLayoutFrozen(handle: GraphHandle, frozen: boolean): void {
+  handle.frozen = frozen;
+  if (!handle.layoutSupervisor) return;
+  const running = handle.layoutSupervisor.isRunning();
+  if (frozen && running) handle.layoutSupervisor.stop();
+  if (!frozen && !running) handle.layoutSupervisor.start();
 }
 
 /**

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -37,7 +37,7 @@ export interface ForceSettings {
 
 export const DEFAULT_FORCE_SETTINGS: ForceSettings = {
   gravity: 1,
-  scalingRatio: 10,
+  scalingRatio: 20,
   edgeWeightInfluence: 1,
   slowDown: 5,
 };

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -37,9 +37,9 @@ export interface ForceSettings {
 
 export const DEFAULT_FORCE_SETTINGS: ForceSettings = {
   gravity: 1,
-  scalingRatio: 20,
+  scalingRatio: 40,
   edgeWeightInfluence: 1,
-  slowDown: 5,
+  slowDown: 10,
 };
 
 /** Interface shape of the running FA2 supervisor we care about. */

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -17,7 +17,10 @@ import Sigma from "sigma";
 import forceAtlas2 from "graphology-layout-forceatlas2";
 import type { GraphEdge, GraphNode, LocalGraph } from "../../types/links";
 
-/** Options accepted by `mountGraph` — future-proofed for the #32 global view. */
+/** Options accepted by `mountGraph` — future-proofed for the #32 global view.
+ *  The `| undefined` on every optional member is deliberate: svelte-check runs
+ *  with `exactOptionalPropertyTypes` and would otherwise reject callers that
+ *  forward `undefined` explicitly. */
 export interface GraphRenderOptions {
   /** Node id to highlight as the center/active node. Null = no accent. */
   centerId: string | null;
@@ -30,9 +33,23 @@ export interface GraphRenderOptions {
   /** Edge color (thin lines, low alpha). */
   edgeColor: string;
   /** Callback for single-click on a resolved node — receives the node id. */
-  onNodeClick?: (id: string, node: GraphNode) => void;
+  onNodeClick?: ((id: string, node: GraphNode) => void) | undefined;
   /** Callback for double-click on a resolved node. */
-  onNodeDoubleClick?: (id: string, node: GraphNode) => void;
+  onNodeDoubleClick?: ((id: string, node: GraphNode) => void) | undefined;
+  /** Callback for double-click on empty space (used by the global graph's
+   *  "fit to view" reset). */
+  onStageDoubleClick?: (() => void) | undefined;
+  /** Number of ForceAtlas2 iterations. Local graph uses the default 50
+   *  for snappy redraws; global graph passes ~300 for a 2 s warm-up. */
+  layoutIterations?: number | undefined;
+  /** Enable drag-to-reposition on individual nodes. Defaults to false. */
+  enableNodeDrag?: boolean | undefined;
+  /** Per-node dim alpha multiplier — 0..1. 0 effectively hides, 1 is fully
+   *  visible. Called every nodeReducer tick; return undefined to use the
+   *  default. */
+  dimForNode?: ((id: string, attrs: Record<string, unknown>) => number | undefined) | undefined;
+  /** Labels always shown for these node ids regardless of zoom threshold. */
+  alwaysShowLabel?: ((id: string) => boolean) | undefined;
 }
 
 /** Opaque handle returned by `mountGraph`. Callers pass it to update/destroy. */
@@ -113,14 +130,14 @@ function populateGraph(graph: Graph, data: LocalGraph): void {
   }
 }
 
-/** Run ForceAtlas2 for 50 iterations and assign final positions in place. */
-function runLayout(graph: Graph): void {
+/** Run ForceAtlas2 and assign final positions in place. */
+function runLayout(graph: Graph, iterations = 50): void {
   if (graph.order === 0) return;
   const settings = forceAtlas2.inferSettings(graph);
   // Speed up convergence on small graphs.
   settings.slowDown = 2;
   settings.gravity = 1;
-  forceAtlas2.assign(graph, { iterations: 50, settings });
+  forceAtlas2.assign(graph, { iterations, settings });
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -138,7 +155,7 @@ export function mountGraph(
 ): GraphHandle {
   const graph = new Graph({ type: "undirected", multi: false });
   populateGraph(graph, data);
-  runLayout(graph);
+  runLayout(graph, options.layoutIterations ?? 50);
 
   const accent = resolveColor(container, options.accentColor);
   const nodeColor = resolveColor(container, options.nodeColor);
@@ -147,9 +164,14 @@ export function mountGraph(
 
   const neighborMap = buildNeighborMap(data.edges);
 
+  // Label threshold: 0 = always show (local graph). Global graph raises this
+  // so only higher-zoom / larger nodes show labels; hovered+neighbors are
+  // force-labeled via the reducer.
+  const labelThreshold = options.layoutIterations && options.layoutIterations > 50 ? 6 : 0;
+
   const renderer = new Sigma(graph, container, {
     renderLabels: true,
-    labelRenderedSizeThreshold: 0,
+    labelRenderedSizeThreshold: labelThreshold,
     labelSize: 11,
     labelWeight: "500",
     minEdgeThickness: 1,
@@ -182,23 +204,54 @@ export function mountGraph(
       resolved,
     };
 
-    let dim = false;
+    // External dim filter (text/tag/folder filters in the global graph).
+    const externalAlpha = handle.options.dimForNode?.(node, attrs);
+
+    // Hover dim: non-hovered, non-neighbor nodes get dimmed.
+    let hoverDim = false;
     if (handle.hoveredNode && handle.hoveredNode !== node) {
       const neighbors = handle.neighborMap.get(handle.hoveredNode);
       if (!neighbors || !neighbors.has(node)) {
-        dim = true;
+        hoverDim = true;
       }
     }
 
-    return {
+    // Always-label contract: hovered node + direct neighbors always show
+    // labels regardless of the renderer threshold.
+    const neighborsOfHover = handle.hoveredNode
+      ? handle.neighborMap.get(handle.hoveredNode)
+      : null;
+    const isHoverNeighbor =
+      handle.hoveredNode === node ||
+      (neighborsOfHover ? neighborsOfHover.has(node) : false);
+    const forceLabel =
+      labelThreshold === 0 ||
+      isHoverNeighbor ||
+      (handle.options.alwaysShowLabel?.(node) ?? false);
+
+    let finalColor = color;
+    let finalLabelColor: string | undefined;
+    if (hoverDim) {
+      finalColor = applyAlpha(color, 0.2);
+      finalLabelColor = applyAlpha(color, 0.2);
+    }
+    if (typeof externalAlpha === "number" && externalAlpha < 1) {
+      finalColor = applyAlpha(finalColor, externalAlpha);
+      finalLabelColor = applyAlpha(finalColor, externalAlpha);
+    }
+
+    const result: Record<string, unknown> = {
       ...attrs,
       size: nodeSize(nodeData, isCenter),
-      color,
+      color: finalColor,
       label: nodeData.label,
       zIndex: isCenter ? 2 : 1,
-      forceLabel: true,
-      ...(dim ? { color: applyAlpha(color, 0.2), labelColor: applyAlpha(color, 0.2) } : {}),
+      forceLabel,
     };
+    if (finalLabelColor !== undefined) {
+      result.labelColor = finalLabelColor;
+    }
+    return result;
   });
 
   // Edge reducer — hover dim for non-adjacent edges.
@@ -255,6 +308,51 @@ export function mountGraph(
   renderer.on("enterNode", enter);
   renderer.on("leaveNode", leave);
 
+  // Stage double-click — used by the global graph to reset zoom.
+  if (options.onStageDoubleClick) {
+    renderer.on("doubleClickStage", ({ event }) => {
+      event.preventSigmaDefault();
+      handle.options.onStageDoubleClick?.();
+    });
+  }
+
+  // Drag-to-reposition — sigma 3 exposes raw mouse events; capture & convert
+  // viewport coords to graph coords and write back to the node attributes.
+  if (options.enableNodeDrag) {
+    let draggedNode: string | null = null;
+    let draggingActive = false;
+
+    renderer.on("downNode", ({ node, event }) => {
+      draggedNode = node;
+      draggingActive = true;
+      // Disable camera movement while dragging a node.
+      renderer.getCamera().disable();
+      event.preventSigmaDefault();
+    });
+
+    const mouseCaptor = renderer.getMouseCaptor();
+    const onMouseMove = (ev: { x: number; y: number; preventSigmaDefault: () => void }) => {
+      if (!draggingActive || !draggedNode) return;
+      const coords = renderer.viewportToGraph({ x: ev.x, y: ev.y });
+      graph.setNodeAttribute(draggedNode, "x", coords.x);
+      graph.setNodeAttribute(draggedNode, "y", coords.y);
+      ev.preventSigmaDefault();
+    };
+    const onMouseUp = () => {
+      if (draggingActive) {
+        draggingActive = false;
+        draggedNode = null;
+        renderer.getCamera().enable();
+      }
+    };
+    mouseCaptor.on("mousemovebody", onMouseMove);
+    mouseCaptor.on("mouseup", onMouseUp);
+    handle.disposers.push(() => {
+      mouseCaptor.removeListener("mousemovebody", onMouseMove);
+      mouseCaptor.removeListener("mouseup", onMouseUp);
+    });
+  }
+
   // Scroll-wheel inside the panel zooms the graph rather than scrolling the
   // sidebar. Sigma already binds wheel events on its container, but it doesn't
   // call preventDefault by default when the mouse is outside a node. We catch
@@ -273,10 +371,48 @@ export function mountGraph(
 /**
  * Replace the graph's nodes + edges with a fresh payload. Re-runs the layout
  * so newly added nodes snap into place.
+ *
+ * If `relayout` is false, existing node positions are preserved for any id
+ * still present in the new dataset — useful for incremental refreshes in the
+ * global graph so the view doesn't jump on every file-save.
  */
-export function updateGraph(handle: GraphHandle, data: LocalGraph): void {
-  populateGraph(handle.graph, data);
-  runLayout(handle.graph);
+export function updateGraph(
+  handle: GraphHandle,
+  data: LocalGraph,
+  opts: { relayout?: boolean; iterations?: number } = {},
+): void {
+  const relayout = opts.relayout ?? true;
+  const iterations = opts.iterations ?? handle.options.layoutIterations ?? 50;
+
+  if (!relayout) {
+    // Preserve positions for nodes that already exist.
+    const prevPos = new Map<string, { x: number; y: number }>();
+    handle.graph.forEachNode((id, attrs) => {
+      prevPos.set(id, {
+        x: Number(attrs.x ?? 0),
+        y: Number(attrs.y ?? 0),
+      });
+    });
+    populateGraph(handle.graph, data);
+    for (const [id, pos] of prevPos) {
+      if (handle.graph.hasNode(id)) {
+        handle.graph.setNodeAttribute(id, "x", pos.x);
+        handle.graph.setNodeAttribute(id, "y", pos.y);
+      }
+    }
+    // Only run a short refinement pass if there are new nodes.
+    let newCount = 0;
+    handle.graph.forEachNode((id) => {
+      if (!prevPos.has(id)) newCount += 1;
+    });
+    if (newCount > 0) {
+      runLayout(handle.graph, Math.min(iterations, 30));
+    }
+  } else {
+    populateGraph(handle.graph, data);
+    runLayout(handle.graph, iterations);
+  }
+
   handle.neighborMap = buildNeighborMap(data.edges);
   handle.hoveredNode = null;
   handle.renderer.refresh();

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -109,7 +109,27 @@ export interface GraphHandle {
   layoutSupervisor: FA2Supervisor | null;
   /** Frozen state mirror — drives pause/resume without reading the supervisor. */
   frozen: boolean;
+  /** Active cooling monitor — responsible for stopping the supervisor once
+   *  the graph has settled. Null when no monitor is running. */
+  cooling: CoolingMonitor | null;
 }
+
+/** RAF-driven settlement watcher. Each frame samples node positions, computes
+ *  average per-node movement², and stops the supervisor once motion falls
+ *  below the threshold for enough consecutive frames (or a hard time cap). */
+interface CoolingMonitor {
+  raf: number | null;
+  lastSample: Map<string, { x: number; y: number }>;
+  lowEnergyFrames: number;
+  startTime: number;
+}
+
+/** Average per-node movement² below this counts as "quiet" for cooldown. */
+const COOLING_STOP_ENERGY = 0.005;
+/** Consecutive quiet frames needed to declare the graph settled. */
+const COOLING_STOP_FRAMES = 30;
+/** Hard cap on simulation runtime — safety net for pathological graphs. */
+const COOLING_MAX_MS = 15_000;
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -175,6 +195,106 @@ function populateGraph(graph: Graph, data: LocalGraph): void {
   }
 }
 
+/** Start (or restart) the cooling monitor. Cancels any previous monitor,
+ *  seeds with current node positions, and polls each frame. When the graph
+ *  settles or the time cap is hit the supervisor is stopped. */
+function startCooling(handle: GraphHandle): void {
+  stopCooling(handle);
+  if (!handle.layoutSupervisor) return;
+
+  const state: CoolingMonitor = {
+    raf: null,
+    lastSample: new Map(),
+    lowEnergyFrames: 0,
+    startTime: performance.now(),
+  };
+  handle.cooling = state;
+
+  // Seed snapshot so the first tick's delta is against the current frame.
+  handle.graph.forEachNode((id, attrs) => {
+    state.lastSample.set(id, {
+      x: Number(attrs.x ?? 0),
+      y: Number(attrs.y ?? 0),
+    });
+  });
+
+  const tick = (): void => {
+    const sv = handle.layoutSupervisor;
+    if (!sv || !sv.isRunning()) {
+      state.raf = null;
+      return;
+    }
+
+    let totalSq = 0;
+    let count = 0;
+    handle.graph.forEachNode((id, attrs) => {
+      const prev = state.lastSample.get(id);
+      const x = Number(attrs.x ?? 0);
+      const y = Number(attrs.y ?? 0);
+      if (prev) {
+        const dx = x - prev.x;
+        const dy = y - prev.y;
+        totalSq += dx * dx + dy * dy;
+        count += 1;
+      }
+      state.lastSample.set(id, { x, y });
+    });
+    const avg = count > 0 ? totalSq / count : 0;
+
+    if (avg < COOLING_STOP_ENERGY) {
+      state.lowEnergyFrames += 1;
+    } else {
+      state.lowEnergyFrames = 0;
+    }
+
+    const elapsed = performance.now() - state.startTime;
+    if (
+      state.lowEnergyFrames >= COOLING_STOP_FRAMES ||
+      elapsed > COOLING_MAX_MS
+    ) {
+      try {
+        sv.stop();
+      } catch {
+        /* ignore */
+      }
+      state.raf = null;
+      return;
+    }
+
+    state.raf = requestAnimationFrame(tick);
+  };
+
+  state.raf = requestAnimationFrame(tick);
+}
+
+/** Cancel the cooling monitor without touching the supervisor. */
+function stopCooling(handle: GraphHandle): void {
+  if (!handle.cooling) return;
+  if (handle.cooling.raf !== null) {
+    try {
+      cancelAnimationFrame(handle.cooling.raf);
+    } catch {
+      /* ignore */
+    }
+  }
+  handle.cooling = null;
+}
+
+/** Reheat the sim: ensure the supervisor is running (unless frozen) and
+ *  restart the cooldown clock. Called after drag-release, slider tweaks,
+ *  and data updates so the user sees movement in response. */
+function reheat(handle: GraphHandle): void {
+  if (!handle.layoutSupervisor || handle.frozen) return;
+  if (!handle.layoutSupervisor.isRunning()) {
+    try {
+      handle.layoutSupervisor.start();
+    } catch {
+      return;
+    }
+  }
+  startCooling(handle);
+}
+
 /** Run ForceAtlas2 and assign final positions in place. */
 function runLayout(graph: Graph, iterations = 50): void {
   if (graph.order === 0) return;
@@ -237,6 +357,7 @@ export function mountGraph(
     disposers: [],
     layoutSupervisor: null,
     frozen: options.startFrozen === true,
+    cooling: null,
   };
 
   // Live ForceAtlas2 supervisor — organic, Obsidian-style drift. Sigma
@@ -255,7 +376,10 @@ export function mountGraph(
         },
       });
       handle.layoutSupervisor = supervisor;
-      if (!handle.frozen) supervisor.start();
+      if (!handle.frozen) {
+        supervisor.start();
+        startCooling(handle);
+      }
     } catch (err) {
       // Worker spawn can fail in CSP-restricted or jsdom environments.
       // Fall back to the existing static layout and log so we notice.
@@ -403,14 +527,13 @@ export function mountGraph(
     renderer.on("downNode", ({ node, event }) => {
       draggedNode = node;
       draggingActive = true;
-      // Pause the live supervisor while dragging so it doesn't fight the
-      // user's finger. Remember whether it was running so we can resume.
+      // Pause cooling + supervisor while dragging so they don't fight the
+      // user's finger. On release we reheat so the drop rings through.
+      stopCooling(handle);
       if (handle.layoutSupervisor && handle.layoutSupervisor.isRunning()) {
         handle.layoutSupervisor.stop();
-        resumeOnRelease = true;
-      } else {
-        resumeOnRelease = false;
       }
+      resumeOnRelease = true;
       // Disable camera movement while dragging a node.
       renderer.getCamera().disable();
       event.preventSigmaDefault();
@@ -429,11 +552,9 @@ export function mountGraph(
         draggingActive = false;
         draggedNode = null;
         renderer.getCamera().enable();
-        // Resume only if the user hasn't frozen the sim via the Forces panel
-        // while the drag was in flight.
-        if (resumeOnRelease && handle.layoutSupervisor && !handle.frozen) {
-          handle.layoutSupervisor.start();
-        }
+        // Reheat after drop so neighbors physically respond to the released
+        // node. reheat() is a no-op when the sim is frozen by the user.
+        if (resumeOnRelease) reheat(handle);
         resumeOnRelease = false;
       }
     };
@@ -518,7 +639,7 @@ export function updateGraph(
   handle.renderer.refresh();
 
   if (wasRunning && handle.layoutSupervisor && !handle.frozen) {
-    handle.layoutSupervisor.start();
+    reheat(handle);
   }
 }
 
@@ -532,6 +653,7 @@ export function destroyGraph(handle: GraphHandle): void {
     }
   }
   handle.disposers.length = 0;
+  stopCooling(handle);
   if (handle.layoutSupervisor) {
     try {
       handle.layoutSupervisor.kill();
@@ -560,6 +682,8 @@ export function setForceSettings(
   handle.options = { ...handle.options, forceSettings: settings };
   if (!handle.layoutSupervisor) return;
   Object.assign(handle.layoutSupervisor.settings, settings);
+  // Reheat so the change is visible — the graph may have already settled.
+  reheat(handle);
 }
 
 /**
@@ -572,8 +696,14 @@ export function setLayoutFrozen(handle: GraphHandle, frozen: boolean): void {
   handle.frozen = frozen;
   if (!handle.layoutSupervisor) return;
   const running = handle.layoutSupervisor.isRunning();
-  if (frozen && running) handle.layoutSupervisor.stop();
-  if (!frozen && !running) handle.layoutSupervisor.start();
+  if (frozen) {
+    stopCooling(handle);
+    if (running) handle.layoutSupervisor.stop();
+    return;
+  }
+  // Un-freezing — reheat so the user sees motion resume.
+  if (!running) handle.layoutSupervisor.start();
+  startCooling(handle);
 }
 
 /**

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -237,6 +237,7 @@
         if (activeId) tabStore.closeTab(activeId);
       },
       createNewNote: () => { void createNewNote(); },
+      openGraph: () => { tabStore.openGraphTab(); },
     };
     const guard: ShortcutGuard = {
       settingsOpen,

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { FilePlus, FolderPlus } from "lucide-svelte";
+  import { FilePlus, FolderPlus, Network } from "lucide-svelte";
   import { listDirectory, createFile, createFolder } from "../../ipc/commands";
   // BUG-05.1: SortMenu was descoped per UAT — keep treeState for FILE-07
   // (expand persistence) but default sortBy stays "name" without a UI toggle.
@@ -346,6 +346,14 @@
           title="New folder"
         >
           <FolderPlus size={16} strokeWidth={1.5} />
+        </button>
+        <button
+          class="vc-sidebar-action-btn"
+          onclick={() => tabStore.openGraphTab()}
+          aria-label="Graph öffnen"
+          title="Graph öffnen (Cmd/Ctrl+Shift+G)"
+        >
+          <Network size={16} strokeWidth={1.5} />
         </button>
       </div>
     {/if}

--- a/src/components/Tabs/Tab.svelte
+++ b/src/components/Tabs/Tab.svelte
@@ -14,8 +14,13 @@
     onclose: () => void;
   } = $props();
 
-  // Derive the display filename from the full path
-  const filename = $derived(tab.filePath.split("/").pop() ?? tab.filePath);
+  // Derive the display filename from the full path. Graph tabs use a
+  // friendly label instead of the sentinel filePath.
+  const filename = $derived(
+    tab.type === "graph"
+      ? "Graph"
+      : (tab.filePath.split("/").pop() ?? tab.filePath),
+  );
 
   function handleClick(e: MouseEvent) {
     onactivate();

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -322,6 +322,20 @@ export async function getLocalGraph(
   }
 }
 
+/**
+ * Return the whole-vault link graph — one resolved node per indexed `.md`
+ * file, one pseudo-node per unique unresolved wiki-link target, one
+ * undirected edge per resolved link. Nodes carry their tags so the graph
+ * filter panel can intersect without another IPC round-trip.
+ */
+export async function getLinkGraph(): Promise<LocalGraph> {
+  try {
+    return await invoke<LocalGraph>("get_link_graph");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function getResolvedAttachments(): Promise<Map<string, string>> {
   try {
     const record = await invoke<Record<string, string>>("get_resolved_attachments");

--- a/src/lib/__tests__/shortcuts.test.ts
+++ b/src/lib/__tests__/shortcuts.test.ts
@@ -43,6 +43,7 @@ function makeCtx(overrides: Partial<ShortcutContext> = {}): ShortcutContext {
     cycleTabPrev: vi.fn(),
     closeActiveTab: vi.fn(),
     createNewNote: vi.fn(),
+    openGraph: vi.fn(),
     ...overrides,
   };
 }
@@ -63,15 +64,17 @@ describe("SHORTCUTS array", () => {
     "new-note",
     "quick-switcher",
     "search",
+    "search-alt", // Cmd+F fallback
     "backlinks-toggle",
     "toggle-sidebar",
     "toggle-sidebar-alt", // BUG-05.1: Cmd+Shift+E alias for German keyboards
     "next-tab",
     "close-tab",
+    "open-graph", // #32: Cmd/Ctrl+Shift+G — global graph tab
   ];
 
-  it("contains exactly 8 entries with the correct ids in order", () => {
-    expect(SHORTCUTS).toHaveLength(8);
+  it("contains exactly 10 entries with the correct ids in order", () => {
+    expect(SHORTCUTS).toHaveLength(10);
     const ids = SHORTCUTS.map((s) => s.id);
     expect(ids).toEqual(EXPECTED_IDS);
   });

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -29,6 +29,7 @@ export interface ShortcutContext {
   cycleTabPrev: () => void;
   closeActiveTab: () => void;
   createNewNote: () => void;
+  openGraph: () => void;
 }
 
 export interface Shortcut {
@@ -99,6 +100,12 @@ export const SHORTCUTS: readonly Shortcut[] = [
     keys: { meta: true, key: "w" },
     label: "Tab schließen",
     handler: (ctx) => { ctx.closeActiveTab(); },
+  },
+  {
+    id: "open-graph",
+    keys: { meta: true, shift: true, key: "g" },
+    label: "Graph-Ansicht öffnen",
+    handler: (ctx) => { ctx.openGraph(); },
   },
 ] as const;
 

--- a/src/store/tabStore.test.ts
+++ b/src/store/tabStore.test.ts
@@ -246,6 +246,50 @@ describe("tabStore", () => {
     });
   });
 
+  describe("openGraphTab", () => {
+    it("creates a singleton graph tab and activates it", () => {
+      const id = tabStore.openGraphTab();
+      const state = get(tabStore);
+      expect(state.tabs).toHaveLength(1);
+      const tab = state.tabs.find((t) => t.id === id);
+      expect(tab?.type).toBe("graph");
+      expect(tab?.filePath).toBe("vault://graph");
+      expect(state.activeTabId).toBe(id);
+    });
+
+    it("focuses the existing graph tab when called twice (no duplicate)", () => {
+      const id1 = tabStore.openGraphTab();
+      tabStore.openTab("/vault/a.md");
+      const id2 = tabStore.openGraphTab();
+      const state = get(tabStore);
+      expect(id2).toBe(id1);
+      expect(state.tabs.filter((t) => t.type === "graph")).toHaveLength(1);
+      expect(state.activeTabId).toBe(id1);
+    });
+
+    it("graph tab can be closed like any other tab", () => {
+      tabStore.openTab("/vault/a.md");
+      const gid = tabStore.openGraphTab();
+      tabStore.closeTab(gid);
+      const state = get(tabStore);
+      expect(state.tabs.find((t) => t.type === "graph")).toBeUndefined();
+    });
+
+    it("cycleTab traverses graph + file tabs uniformly", () => {
+      const a = tabStore.openTab("/vault/a.md");
+      const gid = tabStore.openGraphTab();
+      tabStore.activateTab(a);
+      tabStore.cycleTab(1);
+      expect(get(tabStore).activeTabId).toBe(gid);
+    });
+
+    it("file tabs default to type undefined (backwards-compatible)", () => {
+      const id = tabStore.openTab("/vault/a.md");
+      const tab = get(tabStore).tabs.find((t) => t.id === id);
+      expect(tab?.type).toBeUndefined();
+    });
+  });
+
   describe("activateTab", () => {
     it("sets activeTabId and switches activePane", () => {
       const id1 = tabStore.openTab("/vault/a.md");

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -4,6 +4,18 @@
 
 import { writable } from "svelte/store";
 
+/**
+ * Tab `type` discriminant — "file" is the default (normal markdown tab);
+ * "graph" is the whole-vault graph view (issue #32). Graph tabs store a
+ * sentinel filePath so any existing code paths that look at filePath
+ * (e.g. absolute-path matching, sidebar sync) keep working without a
+ * widespread refactor.
+ */
+export type TabType = "file" | "graph";
+
+/** Sentinel filePath used by the singleton graph tab. */
+export const GRAPH_TAB_PATH = "vault://graph";
+
 export interface Tab {
   id: string;
   filePath: string;
@@ -12,6 +24,8 @@ export interface Tab {
   cursorPos: number;
   lastSaved: number;
   lastSavedContent: string;  // base snapshot for three-way merge (Plan 05)
+  /** Tab kind — "file" when omitted. */
+  type?: TabType;
 }
 
 export interface SplitState {
@@ -89,6 +103,53 @@ export const tabStore = {
         lastSavedContent: "",
       };
 
+      const activePane = state.splitState.activePane;
+      const newPaneIds = [...state.splitState[activePane], id];
+      return {
+        ...state,
+        tabs: [...state.tabs, tab],
+        activeTabId: id,
+        splitState: {
+          ...state.splitState,
+          [activePane]: newPaneIds,
+        },
+      };
+    });
+    return returnId;
+  },
+
+  /**
+   * Open (or focus) the singleton whole-vault graph tab.
+   * Returns the graph tab's ID. Uses a reserved filePath sentinel so the
+   * existing dedupe-by-filePath logic in openTab still applies when called
+   * repeatedly.
+   */
+  openGraphTab(): string {
+    let returnId = "";
+    _store.update((state) => {
+      const existing = state.tabs.find((t) => t.type === "graph");
+      if (existing) {
+        returnId = existing.id;
+        const pane = whichPane(state, existing.id) ?? "left";
+        return {
+          ...state,
+          activeTabId: existing.id,
+          splitState: { ...state.splitState, activePane: pane },
+        };
+      }
+
+      const id = crypto.randomUUID();
+      returnId = id;
+      const tab: Tab = {
+        id,
+        filePath: GRAPH_TAB_PATH,
+        isDirty: false,
+        scrollPos: 0,
+        cursorPos: 0,
+        lastSaved: Date.now(),
+        lastSavedContent: "",
+        type: "graph",
+      };
       const activePane = state.splitState.activePane;
       const newPaneIds = [...state.splitState[activePane], id];
       return {

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -23,7 +23,7 @@ export interface UnresolvedLink {
   lineNumber: number;
 }
 
-/** A single node in the local-graph payload returned by `get_local_graph`. */
+/** A single node in the link-graph payload (local or global). */
 export interface GraphNode {
   /** Vault-relative path for resolved files, `unresolved:<raw>` for dangling links. */
   id: string;
@@ -35,6 +35,9 @@ export interface GraphNode {
   backlinkCount: number;
   /** `true` when the node maps to an indexed file in the vault. */
   resolved: boolean;
+  /** Tags contained in the file (lowercased, deduped, sorted). Populated only
+   * by `get_link_graph`; the local-graph command leaves this empty. */
+  tags?: string[];
 }
 
 /** An undirected edge between two graph nodes. */


### PR DESCRIPTION
## Summary
- New Rust command `get_link_graph` enumerates every `.md` file (resolved nodes), every wiki-link (undirected edges), and every dangling target (pseudo-nodes); `GraphNode` gains a `tags` field so the frontend filter can intersect without another IPC round-trip.
- `tabStore` grows a `type` discriminant (`file` / `graph`) plus `openGraphTab()` for the singleton graph tab. `EditorPane` skips the CM6 load path for graph tabs and renders `GraphView` instead.
- Entry points: a `Network` icon button in the left-sidebar header (next to FilePlus / FolderPlus) and a `Cmd/Ctrl+Shift+G` shortcut wired through the central SHORTCUTS registry.
- `GraphView` / `GraphCanvas` / `GraphFilters` live under `components/Graph` and reuse `graphRender.ts`; the renderer now supports drag-to-reposition, stage-double-click reset (animated `camera.animatedReset`), per-node dim reducers, and configurable layout iterations (~300 for the global view's 2 s warm-up, 50 for the local panel).
- Filter panel offers text search, tag chips, folder chips, plus `Orphans anzeigen` / `Unresolved anzeigen` / `Attachments anzeigen` toggles. Filters DIM rather than hide so topology stays stable.
- Zoom / pan (sigma camera state) and filter state persist to `localStorage` keyed by a hash of the vault path. File-watcher events and auto-save content changes debounce-refetch at ~300 ms.

Closes #32.

## Test plan
- [ ] Click the graph icon in the left sidebar header OR press Cmd/Ctrl+Shift+G -> a new \"Graph\" tab opens.
- [ ] Press the shortcut again while the tab is open -> focuses the existing tab (no duplicate).
- [ ] Scroll-zoom, drag-pan, drag a node to reposition it -- all work smoothly.
- [ ] Hover a node -> neighbors stay bright, rest dims; labels appear on hover even when zoomed out.
- [ ] Click a node -> opens that note in the active file tab.
- [ ] Create / rename / delete a note -> graph refreshes within ~300 ms.
- [ ] Edit + auto-save a note whose links changed -> graph refreshes after auto-save.
- [ ] Text filter: type part of a filename -> non-matching nodes dim to ~15 percent alpha.
- [ ] Tag filter: select a tag -> nodes without that tag dim.
- [ ] Folder filter: select a top-level folder -> nodes outside dim.
- [ ] \"Orphans anzeigen\" toggle: off -> orphan nodes hide. On -> they return.
- [ ] \"Unresolved anzeigen\" toggle: off -> unresolved ghost nodes hide.
- [ ] Close graph tab (Cmd+W or X or Esc) -> tab closes, editor area returns to last focused file tab.
- [ ] Reopen graph tab -> zoom/pan and filter state restored from localStorage.

## Out of scope (follow-ups)
- Tag-based / folder-based coloring (\"Groups\" panel).
- 3D graph.
- Export to PNG / SVG.
- Per-node saved layout positions.
- Attachments as nodes: the \"Attachments anzeigen\" toggle is a stub; the backend currently only emits `.md` nodes, so the toggle only filters paths whose extension matches a known image type (no-op on current data).
- Off-thread force simulation.