### PR TITLE
fix(vault): recreate IndexCoordinator on every open to clear stale per-vault state

### DIFF
--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -155,23 +155,34 @@ pub async fn open_vault(
     push_recent_vault(&app, &canonical_str)?;
 
     // --- Tantivy indexing via IndexCoordinator ---
-    // Get or create an IndexCoordinator for this vault (lazy init).
+    // Always recreate the coordinator so switching vaults doesn't reuse the
+    // previous vault's Tantivy index directory, in-memory FileIndex,
+    // LinkGraph or TagIndex (#38).
+    //
+    // Order matters: drop the old watcher BEFORE the old coordinator. The
+    // watcher holds a clone of the coordinator's write-queue sender; if the
+    // coordinator is dropped first, the watcher's clone keeps the channel
+    // alive and the writer task only exits when it processes the Shutdown
+    // command queued by IndexCoordinator::drop. Dropping the watcher first
+    // means the Shutdown is the last surviving message on a soon-to-close
+    // channel, so the old Tantivy writer releases its directory lock
+    // promptly — important for re-opening the same vault.
+    {
+        let mut handle = state.watcher_handle.lock().map_err(|_| VaultError::Io(
+            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        ))?;
+        *handle = None; // drops old debouncer, stops previous watch
+    }
+
     let coordinator = {
         let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
             std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
         ))?;
-        if guard.is_none() {
-            *guard = Some(
-                crate::indexer::IndexCoordinator::new(&canonical).map_err(|e| {
-                    log::error!("Failed to create IndexCoordinator: {e:?}");
-                    e
-                })?
-            );
-        }
-        // Clone the Arc fields needed (coordinator itself is not Clone, but
-        // we hold the lock for the duration of index_vault below via the guard).
-        // We take the coordinator out temporarily, run index_vault, then put it back.
-        guard.take().unwrap()
+        *guard = None;
+        crate::indexer::IndexCoordinator::new(&canonical).map_err(|e| {
+            log::error!("Failed to create IndexCoordinator: {e:?}");
+            e
+        })?
     };
 
     let vault_info = coordinator.index_vault(&canonical, &app).await.map_err(|e| {
@@ -188,13 +199,6 @@ pub async fn open_vault(
     }
 
     // --- Spawn file watcher (Plan 04) ---
-    // Drop any previous watcher before starting a new one (vault re-open).
-    {
-        let mut handle = state.watcher_handle.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
-        ))?;
-        *handle = None; // drops old debouncer, stops previous watch
-    }
 
     // Clone the index_tx sender for the watcher so it can dispatch
     // IndexCmd::UpdateLinks / RemoveLinks on file events (LINK-08).

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -111,6 +111,22 @@ pub struct IndexCoordinator {
     tag_index: Arc<Mutex<TagIndex>>,
 }
 
+impl Drop for IndexCoordinator {
+    /// Shut the background writer task down cleanly when the coordinator is
+    /// dropped (e.g. on vault switch). Without this, the stale task would
+    /// keep its Tantivy `IndexWriter` — and therefore the directory write
+    /// lock on the previous vault's `.vaultcore/index/tantivy` — alive until
+    /// the channel closed naturally, racing the new coordinator that is
+    /// about to open a writer on the new vault.
+    ///
+    /// Best-effort: `try_send` on a closed or full channel is ignored. The
+    /// task also terminates on channel close when the sender drops, so even
+    /// if the Shutdown command is lost the writer still releases promptly.
+    fn drop(&mut self) {
+        let _ = self.tx.try_send(IndexCmd::Shutdown);
+    }
+}
+
 impl IndexCoordinator {
     /// Create a new coordinator and spawn the background write-queue consumer.
     pub fn new(vault_path: &Path) -> Result<Self, VaultError> {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy, tick } from "svelte";
   import { themeStore } from "./store/themeStore";
   import { settingsStore } from "./store/settingsStore";
   import { vaultStore } from "./store/vaultStore";
@@ -73,6 +73,12 @@
       unsub();
       if (currentPath === picked) return;
       tabStore.closeAll();
+      // Let EditorPane's $effect observe the now-empty tab list and destroy
+      // the old CM6 views before we resolve the new vault (#39). Without
+      // this tick, mountEditorView can race the reactive unmount — its
+      // paneEl.querySelector lookup silently returns null if the new tab's
+      // container hasn't materialised yet, leaving the editor blank.
+      await tick();
       await loadVault(picked);
     } catch (err) {
       const ve = toVaultError(err);


### PR DESCRIPTION
## Summary
- `open_vault` lazily created the `IndexCoordinator` once and then reused it across vault switches. The coordinator's Tantivy index directory, in-memory `FileIndex`, `LinkGraph`, and `TagIndex` all stayed pinned to the first vault, so `get_link_graph`, `get_backlinks`, `list_tags`, `search_fulltext`, etc. kept returning the previous vault's data.
- Always drop the existing coordinator and build a fresh one. Added a `Drop` impl that sends `IndexCmd::Shutdown`, giving the writer task a chance to release the Tantivy directory lock. The watcher handle (which holds a clone of the write-queue sender) is now dropped before the coordinator, so the Shutdown isn't stuck behind watcher-queued commands when reopening the same vault.
- After `tabStore.closeAll()` in `handleSwitchVault`, `await tick()` so `EditorPane`'s `$effect` can tear down the old CM6 views before `mountEditorView` runs for new tabs.

Closes #38
Closes #39

## #39 investigation outcome
Traced with diagnostic logging — the reporter's "empty content after switch" repro turned out to be genuinely 0-byte files on disk (created earlier via wiki-link click-to-create at the vault root, with a typo-variant name). The mount flow itself is correct; `readFile` returns `""`, the `EditorView` mounts with `doc.length=0`. No further frontend fix needed.

Side-finding tracked separately as #41: `mountEditorView` runs twice per tab click because `setLastSavedContent` re-triggers the mount-lifecycle `$effect`. The second call correctly hits the viewMap dedup guard, so it's an efficiency issue, not a correctness one.

## Test plan
- [x] `cargo check` — clean
- [x] `cargo test --lib` — 139 pass (6 pre-existing `files_ops` failures identical on main)
- [x] `pnpm test` — 267/267 pass
- [x] `svelte-check` — no new errors
- [x] Manual UI: switch vault, open notes in both, confirm content loads, global graph / backlinks / tags reflect the new vault