### PR TITLE
fix(editor): eliminate double mountEditorView per tab click (#41)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -379,9 +379,6 @@
     // Guard against double-mount (async race)
     if (viewMap.has(tab.id)) return;
 
-    // Initialize lastSavedContent snapshot for three-way merge base
-    tabStore.setLastSavedContent(tab.id, content);
-
     const onSave = async (text: string): Promise<void> => {
       // ERR-03: skip auto-save when vault is unreachable
       if (!vaultReachable) return;
@@ -481,6 +478,11 @@
     });
 
     viewMap.set(tab.id, view);
+
+    // Initialize lastSavedContent snapshot AFTER viewMap.set so the store
+    // mutation can't re-trigger the mount-lifecycle $effect while this
+    // mount is still in-flight (issue #41).
+    tabStore.setLastSavedContent(tab.id, content);
 
     // Attach wiki-link-click listener to the CM6 DOM
     view.dom.addEventListener("wiki-link-click", handleWikiLinkClick);

--- a/src/components/Editor/__tests__/emptyComponent.svelte
+++ b/src/components/Editor/__tests__/emptyComponent.svelte
@@ -1,0 +1,1 @@
+<!-- Test-only stub used to shadow heavy child components in mount tests. -->

--- a/src/components/Editor/__tests__/mountEditorViewSingle.test.ts
+++ b/src/components/Editor/__tests__/mountEditorViewSingle.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression guard for issue #41: "mountEditorView runs twice per tab click".
+ *
+ * The pre-fix code wrote to tabStore via setLastSavedContent BEFORE the
+ * EditorView was registered in viewMap. That store mutation re-triggered
+ * EditorPane's mount-lifecycle $effect while the first mount was still
+ * awaiting the CM6 dynamic import, and the effect would schedule a second
+ * mountEditorView for the same tab id — producing a redundant read_file IPC.
+ *
+ * The fix moves the setLastSavedContent call to AFTER viewMap.set(tab.id, view),
+ * so the store mutation can no longer re-enter the mount-critical section.
+ *
+ * This test renders a real EditorPane, opens one tab, and asserts that
+ * readFile was invoked exactly once for that tab's path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const { readFile } = vi.hoisted(() => ({ readFile: vi.fn() }));
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile,
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  createFile: vi.fn().mockResolvedValue(""),
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+// GraphView pulls in sigma → WebGL2RenderingContext at module init, which
+// jsdom doesn't provide. We never render a graph tab in this test, so stub
+// the component with an empty placeholder to keep the import tree light.
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import EditorPane from "../EditorPane.svelte";
+
+async function flushAsync(): Promise<void> {
+  // Drain microtasks, macrotasks, and reactive ticks enough times to cover:
+  // readFile promise, dynamic import("@codemirror/view"), post-import guards,
+  // viewMap.set, the (post-fix) setLastSavedContent store emission, and the
+  // subsequent $effect re-run that the fix ensures is a no-op.
+  for (let i = 0; i < 60; i++) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+describe("EditorPane mountEditorView (#41)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    readFile.mockReset().mockResolvedValue("file contents");
+  });
+
+  it("invokes readFile exactly once when opening a tab (no double-mount)", async () => {
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+
+    render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+
+    tabStore.openTab("/vault/note.md");
+
+    await flushAsync();
+
+    const reads = readFile.mock.calls.filter((c) => c[0] === "/vault/note.md");
+    expect(reads.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #41.

## Summary
- `mountEditorView` was running twice per tab click because `tabStore.setLastSavedContent` fired a `tabStore.subscribe` callback mid-mount, re-triggering the mount-lifecycle `$effect` before the first call had populated `viewMap`.
- Moved the `setLastSavedContent` write to after `viewMap.set(tab.id, view)` so the reactive store mutation happens only once the guard is in place. The second mount is never scheduled, and the redundant `read_file` IPC is gone.

## Fix choice
Option 1 from the issue (smallest, lowest-risk). Verified `tab.lastSavedContent` has no reader in the mount-critical section — only `onSave` (runs on user edit, after mount), `handleExternalFileChange` (watcher), and `embedPlugin` (cache-invalidation signal, tolerant of either ordering).

## Test plan
- [ ] `pnpm tauri dev`, open devtools console, click notes in the sidebar: one `mountEditorView ENTER` and one `readFile start/resolved` pair per click.
- [ ] Tab switches preserve undo history (no accidental remounts).
- [ ] Three-way merge on external edits still works — `onSave` sees the correct `lastSavedContent` base.
- [ ] Split-pane mounts still work correctly on both sides.