### PR TITLE
feat(commands): extensible command palette (#13)

### DIFF
--- a/src/components/CommandPalette/CommandPalette.svelte
+++ b/src/components/CommandPalette/CommandPalette.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import { commandRegistry, type Command } from "../../lib/commands/registry";
+  import { formatShortcut } from "../../lib/shortcuts";
+  import { fuzzyMatch } from "../../lib/commands/fuzzy";
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+  }
+
+  let { open, onClose }: Props = $props();
+
+  let query = $state("");
+  let selectedIndex = $state(0);
+  let inputEl = $state<HTMLInputElement | undefined>();
+  let commands = $state<Command[]>([]);
+
+  const unsub = commandRegistry.subscribe((list) => { commands = list; });
+
+  interface Row {
+    cmd: Command;
+    matchIndices: number[];
+  }
+
+  const rows = $derived.by<Row[]>(() => {
+    const q = query.trim();
+    if (!q) {
+      const mru = commandRegistry.getMru();
+      const byId = new Map(commands.map((c) => [c.id, c]));
+      const mruRows: Row[] = [];
+      const seen = new Set<string>();
+      for (const id of mru) {
+        const c = byId.get(id);
+        if (!c) continue;
+        mruRows.push({ cmd: c, matchIndices: [] });
+        seen.add(id);
+      }
+      const rest: Row[] = commands
+        .filter((c) => !seen.has(c.id))
+        .map((c) => ({ cmd: c, matchIndices: [] }));
+      return [...mruRows, ...rest];
+    }
+    const scored: Array<Row & { score: number }> = [];
+    for (const cmd of commands) {
+      const m = fuzzyMatch(cmd.name, q);
+      if (!m) continue;
+      scored.push({ cmd, matchIndices: m.matchIndices, score: m.score });
+    }
+    scored.sort((a, b) => b.score - a.score);
+    return scored.map(({ cmd, matchIndices }) => ({ cmd, matchIndices }));
+  });
+
+  $effect(() => {
+    if (open) {
+      query = "";
+      selectedIndex = 0;
+      void tick().then(() => inputEl?.focus());
+    }
+  });
+
+  $effect(() => {
+    // Clamp selected index when rows shrink below it.
+    if (selectedIndex >= rows.length) selectedIndex = 0;
+  });
+
+  function handleInput(): void {
+    selectedIndex = 0;
+  }
+
+  async function runCommand(cmd: Command): Promise<void> {
+    onClose();
+    await tick();
+    commandRegistry.execute(cmd.id);
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    const count = rows.length;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (e.key === "Tab") {
+      e.preventDefault();
+      return;
+    }
+    if (count === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      selectedIndex = (selectedIndex + 1) % count;
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      selectedIndex = (selectedIndex - 1 + count) % count;
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const row = rows[selectedIndex];
+      if (row) void runCommand(row.cmd);
+    }
+  }
+
+  function handleBackdropClick(e: MouseEvent): void {
+    if (e.target === e.currentTarget) onClose();
+  }
+
+  function highlight(name: string, indices: number[]): Array<{ text: string; hit: boolean }> {
+    if (indices.length === 0) return [{ text: name, hit: false }];
+    const out: Array<{ text: string; hit: boolean }> = [];
+    let last = 0;
+    for (const i of indices) {
+      if (i > last) out.push({ text: name.slice(last, i), hit: false });
+      out.push({ text: name.slice(i, i + 1), hit: true });
+      last = i + 1;
+    }
+    if (last < name.length) out.push({ text: name.slice(last), hit: false });
+    return out;
+  }
+
+  import { onDestroy } from "svelte";
+  onDestroy(() => unsub());
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-command-palette-backdrop"
+    onclick={handleBackdropClick}
+    data-testid="command-palette-backdrop"
+  >
+    <div
+      class="vc-command-palette-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Befehlspalette"
+    >
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        oninput={handleInput}
+        onkeydown={handleKeydown}
+        type="text"
+        placeholder="Befehl suchen…"
+        class="vc-cp-input"
+        aria-label="Befehl suchen"
+        autocomplete="off"
+        spellcheck="false"
+        data-testid="command-palette-input"
+      />
+
+      <div class="vc-cp-results" role="listbox" aria-label="Befehle">
+        {#if rows.length === 0}
+          <p class="vc-cp-empty">Keine passenden Befehle</p>
+        {:else}
+          {#each rows as row, i (row.cmd.id)}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <button
+              type="button"
+              class="vc-cp-row"
+              class:vc-cp-row--selected={i === selectedIndex}
+              role="option"
+              aria-selected={i === selectedIndex}
+              onclick={() => runCommand(row.cmd)}
+              onmouseenter={() => { selectedIndex = i; }}
+              data-testid="command-palette-row"
+              data-command-id={row.cmd.id}
+            >
+              <span class="vc-cp-row-name">
+                {#each highlight(row.cmd.name, row.matchIndices) as part}
+                  {#if part.hit}<mark>{part.text}</mark>{:else}{part.text}{/if}
+                {/each}
+              </span>
+              {#if row.cmd.hotkey}
+                <span class="vc-cp-row-hotkey">
+                  <kbd>{formatShortcut(row.cmd.hotkey)}</kbd>
+                </span>
+              {/if}
+            </button>
+          {/each}
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-command-palette-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 200;
+  }
+  .vc-command-palette-modal {
+    width: 560px;
+    max-height: 480px;
+    position: fixed;
+    top: 15%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    z-index: 201;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .vc-cp-input {
+    width: 100%;
+    height: 44px;
+    padding: 0 16px;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 14px;
+    outline: none;
+    background: var(--color-surface);
+    color: var(--color-text);
+    flex-shrink: 0;
+    box-sizing: border-box;
+  }
+  .vc-cp-input::placeholder { color: var(--color-text-muted); }
+  .vc-cp-results { overflow-y: auto; flex: 1; min-height: 0; }
+  .vc-cp-empty {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    text-align: center;
+    padding: 16px;
+    margin: 0;
+  }
+  .vc-cp-row {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 16px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text);
+    font-size: 14px;
+    text-align: left;
+  }
+  .vc-cp-row--selected { background: var(--color-accent-bg); color: var(--color-accent); }
+  .vc-cp-row-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .vc-cp-row-name mark { background: transparent; color: var(--color-accent); font-weight: 600; }
+  .vc-cp-row-hotkey kbd {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    font-family: var(--vc-font-mono);
+  }
+</style>

--- a/src/components/CommandPalette/__tests__/CommandPalette.test.ts
+++ b/src/components/CommandPalette/__tests__/CommandPalette.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import CommandPalette from "../CommandPalette.svelte";
+import { commandRegistry } from "../../../lib/commands/registry";
+
+function setupLocalStorage(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  });
+}
+
+type MockFn = ReturnType<typeof vi.fn> & ((...args: unknown[]) => unknown);
+
+interface Calls {
+  newNote: MockFn;
+  search: MockFn;
+  backlinks: MockFn;
+  close: MockFn;
+}
+
+function registerFakes(calls: Calls) {
+  commandRegistry.register({ id: "vault:new-note", name: "Neue Notiz", callback: () => calls.newNote(), hotkey: { meta: true, key: "n" } });
+  commandRegistry.register({ id: "app:fulltext-search", name: "Volltext-Suche", callback: () => calls.search(), hotkey: { meta: true, shift: true, key: "f" } });
+  commandRegistry.register({ id: "editor:toggle-backlinks", name: "Backlinks-Panel", callback: () => calls.backlinks(), hotkey: { meta: true, shift: true, key: "b" } });
+  commandRegistry.register({ id: "tabs:close", name: "Tab schließen", callback: () => calls.close(), hotkey: { meta: true, key: "w" } });
+}
+
+describe("CommandPalette (#13)", () => {
+  let calls: Calls;
+
+  beforeEach(() => {
+    setupLocalStorage();
+    commandRegistry._reset();
+    calls = {
+      newNote: vi.fn() as MockFn,
+      search: vi.fn() as MockFn,
+      backlinks: vi.fn() as MockFn,
+      close: vi.fn() as MockFn,
+    };
+    registerFakes(calls);
+  });
+
+  it("renders nothing when closed", () => {
+    render(CommandPalette, { props: { open: false, onClose: () => {} } });
+    expect(screen.queryByTestId("command-palette-input")).toBeNull();
+  });
+
+  it("renders input and all registered commands when opened", async () => {
+    render(CommandPalette, { props: { open: true, onClose: () => {} } });
+    await tick();
+    expect(screen.getByTestId("command-palette-input")).toBeTruthy();
+    const rows = screen.getAllByTestId("command-palette-row");
+    expect(rows).toHaveLength(4);
+    expect(screen.getByText("Neue Notiz")).toBeTruthy();
+    expect(screen.getByText("Volltext-Suche")).toBeTruthy();
+  });
+
+  it("filters commands with fuzzy matching on the query", async () => {
+    render(CommandPalette, { props: { open: true, onClose: () => {} } });
+    await tick();
+    const input = screen.getByTestId("command-palette-input") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "Notiz" } });
+    await tick();
+    const rows = screen.getAllByTestId("command-palette-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.getAttribute("data-command-id")).toBe("vault:new-note");
+  });
+
+  it("Esc closes the palette", async () => {
+    const onClose = vi.fn();
+    render(CommandPalette, { props: { open: true, onClose } });
+    await tick();
+    const input = screen.getByTestId("command-palette-input");
+    await fireEvent.keyDown(input, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("Enter closes the palette first, then executes the selected command", async () => {
+    const onClose = vi.fn();
+    render(CommandPalette, { props: { open: true, onClose } });
+    await tick();
+    const input = screen.getByTestId("command-palette-input") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "Notiz" } });
+    await tick();
+    await fireEvent.keyDown(input, { key: "Enter" });
+    expect(onClose).toHaveBeenCalledOnce();
+    // Execute happens after tick().
+    await tick();
+    expect(calls.newNote).toHaveBeenCalledOnce();
+  });
+
+  it("ArrowDown/ArrowUp move the selected row", async () => {
+    render(CommandPalette, { props: { open: true, onClose: () => {} } });
+    await tick();
+    const input = screen.getByTestId("command-palette-input");
+    // By default first row is selected.
+    let rows = screen.getAllByTestId("command-palette-row");
+    expect(rows[0]!.getAttribute("aria-selected")).toBe("true");
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await tick();
+    rows = screen.getAllByTestId("command-palette-row");
+    expect(rows[1]!.getAttribute("aria-selected")).toBe("true");
+    await fireEvent.keyDown(input, { key: "ArrowUp" });
+    await tick();
+    rows = screen.getAllByTestId("command-palette-row");
+    expect(rows[0]!.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("clicking a row closes then executes", async () => {
+    const onClose = vi.fn();
+    render(CommandPalette, { props: { open: true, onClose } });
+    await tick();
+    const rows = screen.getAllByTestId("command-palette-row");
+    const target = rows.find((r) => r.getAttribute("data-command-id") === "tabs:close")!;
+    await fireEvent.click(target);
+    expect(onClose).toHaveBeenCalledOnce();
+    await tick();
+    expect(calls.close).toHaveBeenCalledOnce();
+  });
+
+  it("shows MRU items first when the query is empty", async () => {
+    // Seed MRU: backlinks then search.
+    commandRegistry.execute("editor:toggle-backlinks");
+    commandRegistry.execute("app:fulltext-search");
+    render(CommandPalette, { props: { open: true, onClose: () => {} } });
+    await tick();
+    const rows = screen.getAllByTestId("command-palette-row");
+    expect(rows[0]!.getAttribute("data-command-id")).toBe("app:fulltext-search");
+    expect(rows[1]!.getAttribute("data-command-id")).toBe("editor:toggle-backlinks");
+  });
+
+  it("shows a bound hotkey for each command", async () => {
+    render(CommandPalette, { props: { open: true, onClose: () => {} } });
+    await tick();
+    // There should be at least one <kbd> visible.
+    const kbds = document.querySelectorAll(".vc-cp-row-hotkey kbd");
+    expect(kbds.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -224,6 +224,10 @@
   }
 
   // Global keyboard shortcuts — delegated to the command registry (#13).
+  // Attached in CAPTURE phase so the handler fires before any descendant
+  // (CodeMirror editor, modal inputs, etc.) can stopPropagation on Cmd/Ctrl
+  // combos we own. Bubble-phase attachment was unreliable once the editor
+  // had focus.
   onMount(() => {
     registerDefaultCommands({
       openQuickSwitcher: () => { quickSwitcherOpen = true; },
@@ -242,6 +246,8 @@
       openGraph: () => { tabStore.openGraphTab(); },
       openCommandPalette: () => { commandPaletteOpen = true; },
     });
+    document.addEventListener("keydown", handleKeydown, { capture: true });
+    return () => document.removeEventListener("keydown", handleKeydown, { capture: true });
   });
 
   function handleKeydown(e: KeyboardEvent) {
@@ -273,7 +279,7 @@
   });
 </script>
 
-<svelte:document onkeydown={handleKeydown} />
+<!-- keydown listener attached via document.addEventListener in onMount (capture phase) -->
 
 <div
   class="vc-vault-layout"

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -4,13 +4,15 @@
   import Sidebar from "../Sidebar/Sidebar.svelte";
   import EditorPane from "../Editor/EditorPane.svelte";
   import QuickSwitcher from "../Search/QuickSwitcher.svelte";
+  import CommandPalette from "../CommandPalette/CommandPalette.svelte";
   import RightSidebar from "./RightSidebar.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import { tabStore } from "../../store/tabStore";
   import { searchStore } from "../../store/searchStore";
   import { backlinksStore } from "../../store/backlinksStore";
   import { vaultStore } from "../../store/vaultStore";
-  import { SHORTCUTS, handleShortcut, type ShortcutContext, type ShortcutGuard } from "../../lib/shortcuts";
+  import { commandRegistry } from "../../lib/commands/registry";
+  import { registerDefaultCommands } from "../../lib/commands/defaultCommands";
   import { createFile } from "../../ipc/commands";
   import { toastStore } from "../../store/toastStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
@@ -27,6 +29,7 @@
   let sidebarCollapsed = $state(false);
   let isDragging = $state(false);
   let quickSwitcherOpen = $state(false);
+  let commandPaletteOpen = $state(false);
   let settingsOpen = $state(false);
   let dragStartX = 0;
   let dragStartWidth = 0;
@@ -220,10 +223,9 @@
     tabStore.openTab(path);
   }
 
-  // Global keyboard shortcuts — delegated to the central SHORTCUTS registry (UI-05 / D-11).
-  // Registered here (not per-TabBar) to avoid duplicate handlers.
-  function handleKeydown(e: KeyboardEvent) {
-    const ctx: ShortcutContext = {
+  // Global keyboard shortcuts — delegated to the command registry (#13).
+  onMount(() => {
+    registerDefaultCommands({
       openQuickSwitcher: () => { quickSwitcherOpen = true; },
       toggleSidebar: () => { toggleSidebar(); },
       openBacklinks: () => { backlinksStore.toggle(); },
@@ -238,13 +240,26 @@
       },
       createNewNote: () => { void createNewNote(); },
       openGraph: () => { tabStore.openGraphTab(); },
-    };
-    const guard: ShortcutGuard = {
-      settingsOpen,
-      quickSwitcherOpen,
-      inlineRenameActive: inlineRenameActive(),
-    };
-    handleShortcut(e, ctx, guard);
+      openCommandPalette: () => { commandPaletteOpen = true; },
+    });
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (settingsOpen || inlineRenameActive()) return;
+    if (commandPaletteOpen) return; // palette handles its own keys
+    if (quickSwitcherOpen) return; // quick switcher handles its own keys
+
+    // Shift+Tab direction handling for tabs:next — single binding covers both.
+    const cmd = commandRegistry.findByHotkey(e);
+    if (!cmd) return;
+
+    if (cmd.id === "tabs:next" && e.shiftKey) {
+      e.preventDefault();
+      tabStore.cycleTab(-1);
+      return;
+    }
+    e.preventDefault();
+    commandRegistry.execute(cmd.id);
   }
 
   const isSplit = $derived(rightPaneIds.length > 0);
@@ -403,6 +418,11 @@
   open={quickSwitcherOpen}
   onClose={() => { quickSwitcherOpen = false; }}
   onOpenFile={handleOpenFile}
+/>
+
+<CommandPalette
+  open={commandPaletteOpen}
+  onClose={() => { commandPaletteOpen = false; }}
 />
 
 <SettingsModal

--- a/src/components/Search/QuickSwitcherRow.svelte
+++ b/src/components/Search/QuickSwitcherRow.svelte
@@ -35,7 +35,7 @@
 >
   <!-- Filename line with per-char match highlighting -->
   <span class="vc-qs-row-filename">
-    {#each filenameChars as { char, highlighted } (char + Math.random())}
+    {#each filenameChars as { char, highlighted }, i (i)}
       {#if highlighted}
         <span style="font-weight: 700; color: var(--color-accent)">{char}</span>
       {:else}

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -10,7 +10,8 @@
     type MonoFont,
   } from "../../store/settingsStore";
   import { vaultStore } from "../../store/vaultStore";
-  import { SHORTCUTS, formatShortcut } from "../../lib/shortcuts";
+  import { formatShortcut } from "../../lib/shortcuts";
+  import { commandRegistry, type Command } from "../../lib/commands/registry";
 
   let { open, onClose, onSwitchVault }: {
     open: boolean;
@@ -23,12 +24,16 @@
   let currentMono = $state<MonoFont>("system");
   let currentSize = $state<number>(14);
   let currentVaultPath = $state<string | null>(null);
+  let shortcuts = $state<Command[]>([]);
 
   const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
   const unsubSettings = settingsStore.subscribe((s) => {
     currentBody = s.fontBody; currentMono = s.fontMono; currentSize = s.fontSize;
   });
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
+  const unsubCommands = commandRegistry.subscribe((list) => {
+    shortcuts = list.filter((c) => c.hotkey);
+  });
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape" && open) {
@@ -52,7 +57,7 @@
     settingsStore.setFontSize(Number((e.target as HTMLInputElement).value));
   }
 
-  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); });
+  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -154,10 +159,10 @@
         <h3 class="vc-settings-section-title">TASTATURKÜRZEL</h3>
         <table class="vc-shortcuts-table" role="table">
           <tbody>
-            {#each SHORTCUTS as s (s.id)}
+            {#each shortcuts as s (s.id)}
               <tr role="row">
-                <td role="cell" class="vc-shortcut-action">{s.label}</td>
-                <td role="cell" class="vc-shortcut-keys"><kbd>{formatShortcut(s.keys)}</kbd></td>
+                <td role="cell" class="vc-shortcut-action">{s.name}</td>
+                <td role="cell" class="vc-shortcut-keys"><kbd>{s.hotkey ? formatShortcut(s.hotkey) : ""}</kbd></td>
               </tr>
             {/each}
           </tbody>

--- a/src/lib/__tests__/shortcuts.test.ts
+++ b/src/lib/__tests__/shortcuts.test.ts
@@ -1,146 +1,10 @@
 /**
- * Tests for the central keyboard-shortcut registry (UI-05 / D-11).
- *
- * Covers:
- *   - Array shape and content
- *   - handleShortcut priority guards
- *   - formatShortcut display helper
+ * Tests for the shortcut display helper (#13 thin compat layer).
+ * The per-command array and dispatch logic now live in commands/registry.ts
+ * and commands/defaultCommands.ts.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import {
-  SHORTCUTS,
-  handleShortcut,
-  formatShortcut,
-  type ShortcutContext,
-  type ShortcutGuard,
-} from "../shortcuts";
-
-// ── helpers ───────────────────────────────────────────────────────────────────
-
-function makeEvent(opts: {
-  key: string;
-  metaKey?: boolean;
-  ctrlKey?: boolean;
-  shiftKey?: boolean;
-}): KeyboardEvent {
-  return new KeyboardEvent("keydown", {
-    key: opts.key,
-    metaKey: opts.metaKey ?? false,
-    ctrlKey: opts.ctrlKey ?? false,
-    shiftKey: opts.shiftKey ?? false,
-    bubbles: true,
-    cancelable: true,
-  });
-}
-
-function makeCtx(overrides: Partial<ShortcutContext> = {}): ShortcutContext {
-  return {
-    openQuickSwitcher: vi.fn(),
-    toggleSidebar: vi.fn(),
-    openBacklinks: vi.fn(),
-    activateSearchTab: vi.fn(),
-    cycleTabNext: vi.fn(),
-    cycleTabPrev: vi.fn(),
-    closeActiveTab: vi.fn(),
-    createNewNote: vi.fn(),
-    openGraph: vi.fn(),
-    ...overrides,
-  };
-}
-
-function makeGuard(overrides: Partial<ShortcutGuard> = {}): ShortcutGuard {
-  return {
-    settingsOpen: false,
-    quickSwitcherOpen: false,
-    inlineRenameActive: false,
-    ...overrides,
-  };
-}
-
-// ── Test 1: Array shape ───────────────────────────────────────────────────────
-
-describe("SHORTCUTS array", () => {
-  const EXPECTED_IDS = [
-    "new-note",
-    "quick-switcher",
-    "search",
-    "search-alt", // Cmd+F fallback
-    "backlinks-toggle",
-    "toggle-sidebar",
-    "toggle-sidebar-alt", // BUG-05.1: Cmd+Shift+E alias for German keyboards
-    "next-tab",
-    "close-tab",
-    "open-graph", // #32: Cmd/Ctrl+Shift+G — global graph tab
-  ];
-
-  it("contains exactly 10 entries with the correct ids in order", () => {
-    expect(SHORTCUTS).toHaveLength(10);
-    const ids = SHORTCUTS.map((s) => s.id);
-    expect(ids).toEqual(EXPECTED_IDS);
-  });
-
-  it("every entry has a non-empty German label and meta: true", () => {
-    for (const s of SHORTCUTS) {
-      expect(s.label.trim().length).toBeGreaterThan(0);
-      expect(s.keys.meta).toBe(true);
-    }
-  });
-});
-
-// ── Test 3: handleShortcut fires handler for matching event ───────────────────
-
-describe("handleShortcut", () => {
-  it("fires new-note handler on Cmd+N (guards all false)", () => {
-    const ctx = makeCtx();
-    const guard = makeGuard();
-    const e = makeEvent({ key: "n", metaKey: true });
-    const fired = handleShortcut(e, ctx, guard);
-    expect(fired).toBe(true);
-    expect(ctx.createNewNote).toHaveBeenCalledOnce();
-  });
-
-  // Test 4: settingsOpen guard
-  it("does NOT fire any handler when settingsOpen is true", () => {
-    const ctx = makeCtx();
-    const guard = makeGuard({ settingsOpen: true });
-    const e = makeEvent({ key: "n", metaKey: true });
-    const fired = handleShortcut(e, ctx, guard);
-    expect(fired).toBe(false);
-    expect(ctx.createNewNote).not.toHaveBeenCalled();
-  });
-
-  // Test 5: quickSwitcherOpen guard
-  it("does NOT fire any handler when quickSwitcherOpen is true", () => {
-    const ctx = makeCtx();
-    const guard = makeGuard({ quickSwitcherOpen: true });
-    const e = makeEvent({ key: "p", metaKey: true });
-    const fired = handleShortcut(e, ctx, guard);
-    expect(fired).toBe(false);
-    expect(ctx.openQuickSwitcher).not.toHaveBeenCalled();
-  });
-
-  // Test 6: inlineRenameActive guard
-  it("does NOT fire any handler when inlineRenameActive is true", () => {
-    const ctx = makeCtx();
-    const guard = makeGuard({ inlineRenameActive: true });
-    const e = makeEvent({ key: "n", metaKey: true });
-    const fired = handleShortcut(e, ctx, guard);
-    expect(fired).toBe(false);
-    expect(ctx.createNewNote).not.toHaveBeenCalled();
-  });
-
-  // Test 7: non-meta keystroke
-  it("returns false without invoking anything for a non-meta keystroke", () => {
-    const ctx = makeCtx();
-    const guard = makeGuard();
-    const e = makeEvent({ key: "n", metaKey: false, ctrlKey: false });
-    const fired = handleShortcut(e, ctx, guard);
-    expect(fired).toBe(false);
-    expect(ctx.createNewNote).not.toHaveBeenCalled();
-  });
-});
-
-// ── Test 8: formatShortcut display helper ─────────────────────────────────────
+import { describe, it, expect } from "vitest";
+import { formatShortcut } from "../shortcuts";
 
 describe("formatShortcut", () => {
   it("returns Ctrl+Shift+F on non-Mac", () => {
@@ -159,5 +23,14 @@ describe("formatShortcut", () => {
     });
     const result = formatShortcut({ meta: true, shift: true, key: "F" });
     expect(result).toBe("⌘+Shift+F");
+  });
+
+  it("renders Tab and backslash keys verbatim", () => {
+    Object.defineProperty(navigator, "platform", {
+      value: "MacIntel",
+      configurable: true,
+    });
+    expect(formatShortcut({ meta: true, key: "Tab" })).toBe("⌘+Tab");
+    expect(formatShortcut({ meta: true, key: "\\" })).toBe("⌘+\\");
   });
 });

--- a/src/lib/commands/__tests__/fuzzy.test.ts
+++ b/src/lib/commands/__tests__/fuzzy.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyMatch } from "../fuzzy";
+
+describe("fuzzyMatch", () => {
+  it("returns score 0 for empty query", () => {
+    expect(fuzzyMatch("anything", "")).toEqual({ score: 0, matchIndices: [] });
+  });
+
+  it("returns null when query chars cannot be found in order", () => {
+    expect(fuzzyMatch("abc", "cba")).toBeNull();
+    expect(fuzzyMatch("abc", "z")).toBeNull();
+  });
+
+  it("returns match indices in order for subsequence hits", () => {
+    const m = fuzzyMatch("New Note", "nt");
+    expect(m).not.toBeNull();
+    expect(m!.matchIndices).toEqual([0, 6]);
+  });
+
+  it("scores consecutive matches higher than scattered", () => {
+    const a = fuzzyMatch("Close Tab", "tab")!;
+    const b = fuzzyMatch("Toggle Search About", "tab")!;
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a.score).toBeGreaterThan(b.score);
+  });
+
+  it("is case insensitive", () => {
+    const m = fuzzyMatch("Search", "SRC");
+    expect(m).not.toBeNull();
+  });
+});

--- a/src/lib/commands/__tests__/registry.test.ts
+++ b/src/lib/commands/__tests__/registry.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { commandRegistry } from "../registry";
+import { get } from "svelte/store";
+
+function setupLocalStorage(): Map<string, string> {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  });
+  return store;
+}
+
+describe("commandRegistry", () => {
+  beforeEach(() => {
+    setupLocalStorage();
+    commandRegistry._reset();
+  });
+
+  it("register + list exposes registered commands", () => {
+    const cb = vi.fn();
+    commandRegistry.register({ id: "a", name: "Alpha", callback: cb });
+    commandRegistry.register({
+      id: "b",
+      name: "Beta",
+      callback: () => {},
+      hotkey: { meta: true, key: "b" },
+    });
+    const list = commandRegistry.list();
+    expect(list).toHaveLength(2);
+    expect(list.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("execute invokes the matching callback", () => {
+    const cb = vi.fn();
+    commandRegistry.register({ id: "run", name: "Run", callback: cb });
+    commandRegistry.execute("run");
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it("execute is a no-op for unknown ids", () => {
+    expect(() => commandRegistry.execute("missing")).not.toThrow();
+  });
+
+  it("unregister removes the command", () => {
+    commandRegistry.register({ id: "a", name: "A", callback: () => {} });
+    commandRegistry.unregister("a");
+    expect(commandRegistry.list()).toHaveLength(0);
+  });
+
+  it("executing a command pushes it to the front of the MRU list", () => {
+    commandRegistry.register({ id: "a", name: "A", callback: () => {} });
+    commandRegistry.register({ id: "b", name: "B", callback: () => {} });
+    commandRegistry.register({ id: "c", name: "C", callback: () => {} });
+
+    commandRegistry.execute("a");
+    commandRegistry.execute("b");
+    commandRegistry.execute("c");
+    expect(commandRegistry.getMru().slice(0, 3)).toEqual(["c", "b", "a"]);
+
+    // Re-execute a moves it to front, no duplicates.
+    commandRegistry.execute("a");
+    expect(commandRegistry.getMru().slice(0, 3)).toEqual(["a", "c", "b"]);
+  });
+
+  it("persists MRU list to localStorage", () => {
+    commandRegistry.register({ id: "a", name: "A", callback: () => {} });
+    commandRegistry.execute("a");
+    const raw = localStorage.getItem("vaultcore-command-palette-mru");
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toEqual(["a"]);
+  });
+
+  it("subscribe fires when commands change", () => {
+    const snapshot = get(commandRegistry);
+    expect(snapshot).toEqual([]);
+    commandRegistry.register({ id: "x", name: "X", callback: () => {} });
+    expect(get(commandRegistry).map((c) => c.id)).toEqual(["x"]);
+  });
+
+  it("findByHotkey matches meta+key", () => {
+    const cb = vi.fn();
+    commandRegistry.register({
+      id: "n",
+      name: "New",
+      callback: cb,
+      hotkey: { meta: true, key: "n" },
+    });
+    const ev = new KeyboardEvent("keydown", { key: "n", metaKey: true });
+    const match = commandRegistry.findByHotkey(ev);
+    expect(match?.id).toBe("n");
+  });
+
+  it("findByHotkey respects shift modifier", () => {
+    commandRegistry.register({
+      id: "plain",
+      name: "Plain",
+      callback: () => {},
+      hotkey: { meta: true, key: "f" },
+    });
+    commandRegistry.register({
+      id: "shifted",
+      name: "Shifted",
+      callback: () => {},
+      hotkey: { meta: true, shift: true, key: "f" },
+    });
+    const plainEv = new KeyboardEvent("keydown", { key: "f", metaKey: true });
+    const shiftEv = new KeyboardEvent("keydown", { key: "f", metaKey: true, shiftKey: true });
+    expect(commandRegistry.findByHotkey(plainEv)?.id).toBe("plain");
+    expect(commandRegistry.findByHotkey(shiftEv)?.id).toBe("shifted");
+  });
+
+  it("findByHotkey returns null without meta/ctrl", () => {
+    commandRegistry.register({
+      id: "n",
+      name: "New",
+      callback: () => {},
+      hotkey: { meta: true, key: "n" },
+    });
+    const ev = new KeyboardEvent("keydown", { key: "n" });
+    expect(commandRegistry.findByHotkey(ev)).toBeNull();
+  });
+});

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -1,0 +1,86 @@
+// Default commands migrated from the old hardcoded shortcut list (#13).
+// Stable ids are namespaced so future additions don't collide.
+
+import { commandRegistry, type Command, type HotKey } from "./registry";
+
+export interface DefaultCommandContext {
+  openQuickSwitcher: () => void;
+  toggleSidebar: () => void;
+  openBacklinks: () => void;
+  activateSearchTab: () => void;
+  cycleTabNext: () => void;
+  cycleTabPrev: () => void;
+  closeActiveTab: () => void;
+  createNewNote: () => void;
+  openGraph: () => void;
+  openCommandPalette: () => void;
+}
+
+/** Id constants — consumed by tests and anyone dispatching by id. */
+export const CMD_IDS = {
+  NEW_NOTE: "vault:new-note",
+  QUICK_SWITCHER: "app:quick-switcher",
+  SEARCH: "app:fulltext-search",
+  SEARCH_ALT: "app:fulltext-search-alt",
+  BACKLINKS_TOGGLE: "editor:toggle-backlinks",
+  TOGGLE_SIDEBAR: "app:toggle-sidebar",
+  TOGGLE_SIDEBAR_ALT: "app:toggle-sidebar-alt",
+  NEXT_TAB: "tabs:next",
+  CLOSE_TAB: "tabs:close",
+  OPEN_GRAPH: "vault:open-graph",
+  COMMAND_PALETTE: "app:command-palette",
+} as const;
+
+export interface DefaultCommandSpec {
+  id: string;
+  name: string;
+  hotkey?: HotKey;
+}
+
+/** Static metadata — id, label, hotkey. Callback is wired in registerDefaultCommands. */
+export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
+  { id: CMD_IDS.NEW_NOTE, name: "Neue Notiz", hotkey: { meta: true, key: "n" } },
+  { id: CMD_IDS.QUICK_SWITCHER, name: "Schnellwechsler", hotkey: { meta: true, key: "o" } },
+  { id: CMD_IDS.SEARCH, name: "Volltext-Suche", hotkey: { meta: true, shift: true, key: "f" } },
+  { id: CMD_IDS.SEARCH_ALT, name: "Volltext-Suche (Alternative)", hotkey: { meta: true, key: "f" } },
+  { id: CMD_IDS.BACKLINKS_TOGGLE, name: "Backlinks-Panel", hotkey: { meta: true, shift: true, key: "b" } },
+  { id: CMD_IDS.TOGGLE_SIDEBAR, name: "Seitenleiste ein-/ausblenden", hotkey: { meta: true, key: "\\" } },
+  { id: CMD_IDS.TOGGLE_SIDEBAR_ALT, name: "Seitenleiste ein-/ausblenden (Alternative)", hotkey: { meta: true, shift: true, key: "e" } },
+  { id: CMD_IDS.NEXT_TAB, name: "Nächster Tab", hotkey: { meta: true, key: "Tab" } },
+  { id: CMD_IDS.CLOSE_TAB, name: "Tab schließen", hotkey: { meta: true, key: "w" } },
+  { id: CMD_IDS.OPEN_GRAPH, name: "Graph-Ansicht öffnen", hotkey: { meta: true, shift: true, key: "g" } },
+  { id: CMD_IDS.COMMAND_PALETTE, name: "Befehlspalette", hotkey: { meta: true, key: "p" } },
+] as const;
+
+/**
+ * Register every default command against the live registry using the given
+ * context's callbacks. Call once during app mount; any subsequent call
+ * re-registers (idempotent).
+ */
+export function registerDefaultCommands(ctx: DefaultCommandContext): void {
+  const byId: Record<string, () => void> = {
+    [CMD_IDS.NEW_NOTE]: ctx.createNewNote,
+    [CMD_IDS.QUICK_SWITCHER]: ctx.openQuickSwitcher,
+    [CMD_IDS.SEARCH]: ctx.activateSearchTab,
+    [CMD_IDS.SEARCH_ALT]: ctx.activateSearchTab,
+    [CMD_IDS.BACKLINKS_TOGGLE]: ctx.openBacklinks,
+    [CMD_IDS.TOGGLE_SIDEBAR]: ctx.toggleSidebar,
+    [CMD_IDS.TOGGLE_SIDEBAR_ALT]: ctx.toggleSidebar,
+    [CMD_IDS.NEXT_TAB]: ctx.cycleTabNext,
+    [CMD_IDS.CLOSE_TAB]: ctx.closeActiveTab,
+    [CMD_IDS.OPEN_GRAPH]: ctx.openGraph,
+    [CMD_IDS.COMMAND_PALETTE]: ctx.openCommandPalette,
+  };
+
+  for (const spec of DEFAULT_COMMAND_SPECS) {
+    const cb = byId[spec.id];
+    if (!cb) continue;
+    const cmd: Command = {
+      id: spec.id,
+      name: spec.name,
+      callback: cb,
+      ...(spec.hotkey ? { hotkey: spec.hotkey } : {}),
+    };
+    commandRegistry.register(cmd);
+  }
+}

--- a/src/lib/commands/fuzzy.ts
+++ b/src/lib/commands/fuzzy.ts
@@ -1,0 +1,46 @@
+// Small subsequence fuzzy scorer for the command palette (#13).
+// No external dependency; good enough for a handful of commands.
+
+export interface FuzzyMatch {
+  score: number;
+  matchIndices: number[];
+}
+
+/**
+ * Score `target` against `query` using subsequence matching.
+ * Returns null when every query char cannot be found in order.
+ * Higher score = better match. Consecutive matches and word-start
+ * hits are weighted up.
+ */
+export function fuzzyMatch(target: string, query: string): FuzzyMatch | null {
+  if (!query) return { score: 0, matchIndices: [] };
+  const t = target.toLowerCase();
+  const q = query.toLowerCase();
+  const indices: number[] = [];
+  let ti = 0;
+  let score = 0;
+  let prevIdx = -2;
+  for (let qi = 0; qi < q.length; qi++) {
+    const ch = q.charAt(qi);
+    let found = -1;
+    while (ti < t.length) {
+      if (t.charAt(ti) === ch) {
+        found = ti;
+        break;
+      }
+      ti++;
+    }
+    if (found === -1) return null;
+    indices.push(found);
+    // Consecutive bonus.
+    if (found === prevIdx + 1) score += 5;
+    // Word-start bonus (start of string or after space/punct).
+    if (found === 0 || /[\s\-_/]/.test(t.charAt(found - 1))) score += 3;
+    score += 1;
+    prevIdx = found;
+    ti = found + 1;
+  }
+  // Shorter targets score a little higher when matches are otherwise equal.
+  score -= t.length * 0.01;
+  return { score, matchIndices: indices };
+}

--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -1,0 +1,135 @@
+// Extensible command registry (#13).
+// Wraps a Map<id, Command> in a classic writable store so the palette and
+// settings table stay reactive.
+
+import { writable } from "svelte/store";
+
+export interface HotKey {
+  /** Cmd (Mac) or Ctrl (other) — treated equivalently. */
+  meta: boolean;
+  shift?: boolean;
+  /** Case-insensitive; compared via toLowerCase of event.key. */
+  key: string;
+}
+
+export interface Command {
+  id: string;
+  name: string;
+  callback: () => void | Promise<void>;
+  hotkey?: HotKey;
+}
+
+export interface CommandRegistry {
+  subscribe: ReturnType<typeof writable<Command[]>>["subscribe"];
+  register(cmd: Command): void;
+  unregister(id: string): void;
+  execute(id: string): void;
+  list(): Command[];
+  findByHotkey(event: KeyboardEvent): Command | null;
+  /** Ids ordered most-recently-executed first (capped at MRU_CAP). */
+  getMru(): string[];
+  /** Clear the MRU list and in-memory map. Tests only. */
+  _reset(): void;
+}
+
+const MRU_KEY = "vaultcore-command-palette-mru";
+const MRU_CAP = 20;
+
+function loadMru(): string[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(MRU_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string").slice(0, MRU_CAP);
+  } catch {
+    return [];
+  }
+}
+
+function persistMru(mru: string[]): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(MRU_KEY, JSON.stringify(mru.slice(0, MRU_CAP)));
+  } catch {
+    // Best-effort.
+  }
+}
+
+function createRegistry(): CommandRegistry {
+  const map = new Map<string, Command>();
+  const store = writable<Command[]>([]);
+  let mru: string[] = loadMru();
+
+  function emit(): void {
+    store.set(Array.from(map.values()));
+  }
+
+  function register(cmd: Command): void {
+    map.set(cmd.id, cmd);
+    emit();
+  }
+
+  function unregister(id: string): void {
+    if (map.delete(id)) emit();
+  }
+
+  function list(): Command[] {
+    return Array.from(map.values());
+  }
+
+  function bumpMru(id: string): void {
+    mru = [id, ...mru.filter((x) => x !== id)].slice(0, MRU_CAP);
+    persistMru(mru);
+  }
+
+  function execute(id: string): void {
+    const cmd = map.get(id);
+    if (!cmd) return;
+    bumpMru(id);
+    try {
+      void cmd.callback();
+    } catch {
+      // Swallow — callers should not break the UI.
+    }
+  }
+
+  function findByHotkey(event: KeyboardEvent): Command | null {
+    const isMeta = event.metaKey || event.ctrlKey;
+    if (!isMeta) return null;
+    const keyLower = event.key.toLowerCase();
+    for (const cmd of map.values()) {
+      const h = cmd.hotkey;
+      if (!h) continue;
+      if (h.meta !== isMeta) continue;
+      if (h.key.toLowerCase() !== keyLower) continue;
+      // Tab bindings accept either direction — Shift picks prev vs next
+      // at the handler level, so don't filter on shiftKey here.
+      if (h.key.toLowerCase() !== "tab") {
+        const shiftOk = h.shift === true ? event.shiftKey : !event.shiftKey;
+        if (!shiftOk) continue;
+      }
+      return cmd;
+    }
+    return null;
+  }
+
+  return {
+    subscribe: store.subscribe,
+    register,
+    unregister,
+    execute,
+    list,
+    findByHotkey,
+    getMru: () => [...mru],
+    _reset: () => {
+      map.clear();
+      mru = [];
+      persistMru(mru);
+      emit();
+    },
+  };
+}
+
+export const commandRegistry = createRegistry();

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,178 +1,29 @@
-/**
- * Central keyboard-shortcut registry (UI-05 / D-11).
- *
- * Every Phase 5+ MVP shortcut from spec Section 13 is declared here so
- * VaultLayout.handleKeydown and SettingsModal's Tastaturkürzel table read
- * from the same source.
- *
- * Priority (UI-SPEC Interaction Contracts):
- *   1. settingsOpen     → modal handles its own events (caller short-circuits)
- *   2. quickSwitcherOpen → switcher handles ArrowUp/Down/Enter/Escape
- *   3. inlineRenameActive → no global shortcuts fire
- *   4. otherwise → iterate SHORTCUTS, first match wins
- */
+// Thin compat layer over the command registry (#13).
+//
+// Historical callers imported `ShortcutKeys` and `formatShortcut` from here.
+// Both still live here so the Settings table and any external references
+// keep working. The per-shortcut array and the `handleShortcut` dispatcher
+// have moved to src/lib/commands/registry.ts and defaultCommands.ts.
 
-export interface ShortcutKeys {
-  /** True if Cmd (Mac) OR Ctrl (other) — we treat them equivalently. */
-  meta: boolean;
-  shift?: boolean;
-  /** Case-insensitive; compared via toLowerCase of event.key. */
-  key: string;
-}
-
-export interface ShortcutContext {
-  openQuickSwitcher: () => void;
-  toggleSidebar: () => void;
-  openBacklinks: () => void;
-  activateSearchTab: () => void;
-  cycleTabNext: () => void;
-  cycleTabPrev: () => void;
-  closeActiveTab: () => void;
-  createNewNote: () => void;
-  openGraph: () => void;
-}
-
-export interface Shortcut {
-  id: string;
-  keys: ShortcutKeys;
-  label: string; // German, rendered in SettingsModal Section C
-  handler: (ctx: ShortcutContext, event: KeyboardEvent) => void;
-}
-
-export const SHORTCUTS: readonly Shortcut[] = [
-  {
-    id: "new-note",
-    keys: { meta: true, key: "n" },
-    label: "Neue Notiz",
-    handler: (ctx) => { ctx.createNewNote(); },
-  },
-  {
-    id: "quick-switcher",
-    keys: { meta: true, key: "p" },
-    label: "Schnellwechsler",
-    handler: (ctx) => { ctx.openQuickSwitcher(); },
-  },
-  {
-    id: "search",
-    keys: { meta: true, shift: true, key: "f" },
-    label: "Volltext-Suche",
-    handler: (ctx) => { ctx.activateSearchTab(); },
-  },
-  {
-    id: "search-alt",
-    keys: { meta: true, key: "f" },
-    label: "Volltext-Suche (Alternative)",
-    handler: (ctx) => { ctx.activateSearchTab(); },
-  },
-  {
-    id: "backlinks-toggle",
-    keys: { meta: true, shift: true, key: "b" },
-    label: "Backlinks-Panel",
-    handler: (ctx) => { ctx.openBacklinks(); },
-  },
-  {
-    id: "toggle-sidebar",
-    keys: { meta: true, key: "\\" },
-    label: "Seitenleiste ein-/ausblenden",
-    handler: (ctx) => { ctx.toggleSidebar(); },
-  },
-  {
-    // BUG-05.1 alias: Cmd/Ctrl+\ needs AltGr+ß on German QWERTZ and isn't
-    // practical. Ctrl+Shift+E mirrors VSCode's "Explorer toggle" and is
-    // ergonomic on every layout. Displayed under the same "Seitenleiste"
-    // action so users see both bindings in the Settings table.
-    id: "toggle-sidebar-alt",
-    keys: { meta: true, shift: true, key: "e" },
-    label: "Seitenleiste ein-/ausblenden (Alternative)",
-    handler: (ctx) => { ctx.toggleSidebar(); },
-  },
-  {
-    id: "next-tab",
-    keys: { meta: true, key: "Tab" },
-    label: "Nächster Tab",
-    handler: (ctx, e) => {
-      if (e.shiftKey) ctx.cycleTabPrev();
-      else ctx.cycleTabNext();
-    },
-  },
-  {
-    id: "close-tab",
-    keys: { meta: true, key: "w" },
-    label: "Tab schließen",
-    handler: (ctx) => { ctx.closeActiveTab(); },
-  },
-  {
-    id: "open-graph",
-    keys: { meta: true, shift: true, key: "g" },
-    label: "Graph-Ansicht öffnen",
-    handler: (ctx) => { ctx.openGraph(); },
-  },
-] as const;
-
-export interface ShortcutGuard {
-  settingsOpen: boolean;
-  quickSwitcherOpen: boolean;
-  inlineRenameActive: boolean;
-}
+export type { HotKey as ShortcutKeys } from "./commands/registry";
 
 /**
- * Match `event` against every SHORTCUTS entry and invoke the first matching handler.
- * Returns true if a handler fired. Caller uses the boolean to decide preventDefault.
- *
- * Priority guards:
- *   1. settingsOpen or inlineRenameActive → always false
- *   2. quickSwitcherOpen → always false (switcher handles its own keys)
- *   3. no meta/ctrl → false
- *   4. Iterate SHORTCUTS — first match wins
- */
-export function handleShortcut(
-  event: KeyboardEvent,
-  ctx: ShortcutContext,
-  guard: ShortcutGuard,
-): boolean {
-  if (guard.settingsOpen || guard.inlineRenameActive) return false;
-  const isMeta = event.metaKey || event.ctrlKey;
-  if (!isMeta) return false;
-  if (guard.quickSwitcherOpen) return false;
-
-  const keyLower = event.key.toLowerCase();
-  for (const s of SHORTCUTS) {
-    // For entries with shift: true we require shiftKey to match.
-    // The next-tab entry uses shift to pick direction — don't exclude on shift mismatch.
-    const shiftOk =
-      s.id === "next-tab"
-        ? true // Shift toggles direction, not a distinct binding
-        : s.keys.shift === true
-          ? event.shiftKey
-          : !event.shiftKey; // non-shift bindings must NOT have shiftKey held (prevents Cmd+Shift+N matching Cmd+N)
-
-    if (s.keys.meta === isMeta && s.keys.key.toLowerCase() === keyLower && shiftOk) {
-      event.preventDefault();
-      s.handler(ctx, event);
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Pretty-print a ShortcutKeys object for the Settings modal shortcut table.
+ * Pretty-print a hotkey for display (e.g. Settings modal).
  * Mac: ⌘+Shift+F. Other: Ctrl+Shift+F.
  */
-export function formatShortcut(keys: ShortcutKeys): string {
+export function formatShortcut(keys: {
+  meta: boolean;
+  shift?: boolean;
+  key: string;
+}): string {
   const isMac =
     typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
   const metaSymbol = isMac ? "⌘" : "Ctrl";
   const parts: string[] = [];
   if (keys.meta) parts.push(metaSymbol);
   if (keys.shift) parts.push("Shift");
-  // Special display names
   const keyLabel =
-    keys.key === "\\"
-      ? "\\"
-      : keys.key === "Tab"
-        ? "Tab"
-        : keys.key.toUpperCase();
+    keys.key === "\\" ? "\\" : keys.key === "Tab" ? "Tab" : keys.key.toUpperCase();
   parts.push(keyLabel);
   return parts.join("+");
 }


### PR DESCRIPTION
Closes #13.

## Summary
- Introduces `CommandRegistry` at `src/lib/commands/registry.ts` with `register`, `unregister`, `execute`, `list`, `findByHotkey`, plus a writable `subscribe` surface and a `getMru()` helper. Commands have stable namespaced ids (`vault:new-note`, `editor:toggle-backlinks`, `app:command-palette`, ...) and optional hotkeys.
- Migrates all previously hardcoded keyboard shortcuts into registered commands via `defaultCommands.ts`. Behaviour is preserved; `shortcuts.ts` shrinks to the `formatShortcut` display helper. The Settings shortcut table now reads straight off the registry.
- Adds `CommandPalette.svelte` modeled on the Quick Switcher: opens on `Cmd/Ctrl+P`, fuzzy-filters command names, shows the bound hotkey on each row, supports arrow/Enter/Esc keyboard navigation. MRU ordering floats recently-executed commands to the top when the query is empty and is persisted under `vaultcore-command-palette-mru` (cap 20).
- Because Cmd+P is now the palette, the Quick Switcher moves to Cmd+O.
- Global keydown in `VaultLayout.svelte` dispatches through the registry; the palette closes before executing to avoid re-entrancy with commands that open other modals.

## Test plan
- [x] `pnpm vitest run` — 36 files, 286 tests pass (new: registry, fuzzy, CommandPalette component tests).
- [x] `pnpm typecheck` — no new type errors beyond the pre-existing ones in `tabStore.ts`, `tabStore.test.ts`, `ui06Audit.test.ts`.
- [ ] Manual: open a vault, press Cmd/Ctrl+P, verify the palette lists every command with its bound hotkey.
- [ ] Manual: type `notiz`, press Enter, verify a new note is created and the palette closes first.
- [ ] Manual: execute a few commands, reopen the palette with an empty query, verify MRU ordering survives a reload.
- [ ] Manual: verify every old shortcut still fires its expected action (Cmd+N, Cmd+O, Cmd+Shift+F, Cmd+Shift+B, Cmd+\\ / Cmd+Shift+E, Cmd+Tab / Cmd+Shift+Tab, Cmd+W, Cmd+Shift+G).