### PR TITLE
feat(bookmarks): bookmarked notes with sidebar panel (#12)

### DIFF
--- a/src-tauri/src/commands/bookmarks.rs
+++ b/src-tauri/src/commands/bookmarks.rs
@@ -1,0 +1,97 @@
+// Bookmarks IPC (#12). Persists the user-ordered list of vault-relative
+// bookmarked paths to `<vault>/.vaultcore/bookmarks.json`.
+//
+// Security: both commands canonicalize `vault_path` and require it to match
+// the currently-open vault root (same T-02 guard pattern used by files.rs).
+// We never read/write outside `<vault_root>/.vaultcore/`.
+//
+// Write path: serialize -> temp file -> atomic rename, so a crash mid-write
+// cannot corrupt the existing file.
+
+use crate::error::VaultError;
+use crate::VaultState;
+use std::path::{Path, PathBuf};
+
+const BOOKMARKS_DIR: &str = ".vaultcore";
+const BOOKMARKS_FILE: &str = "bookmarks.json";
+
+/// Resolve `<vault>/.vaultcore/bookmarks.json` after confirming `vault_path`
+/// matches the currently-open vault.
+fn bookmarks_path_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, VaultError> {
+    let canonical = std::fs::canonicalize(vault_path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: vault_path.to_string() },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: vault_path.to_string() },
+        _ => VaultError::Io(e),
+    })?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
+        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+    ))?;
+    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
+        path: vault_path.to_string(),
+    })?;
+    if canonical != *vault {
+        return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
+    }
+    Ok(canonical.join(BOOKMARKS_DIR).join(BOOKMARKS_FILE))
+}
+
+pub fn load_bookmarks_impl(state: &VaultState, vault_path: String) -> Result<Vec<String>, VaultError> {
+    let path = bookmarks_path_for(state, &vault_path)?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let bytes = std::fs::read(&path).map_err(VaultError::Io)?;
+    if bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let parsed: Vec<String> = serde_json::from_slice(&bytes).map_err(|e| {
+        VaultError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
+    })?;
+    Ok(parsed)
+}
+
+#[tauri::command]
+pub async fn load_bookmarks(
+    state: tauri::State<'_, VaultState>,
+    vault_path: String,
+) -> Result<Vec<String>, VaultError> {
+    load_bookmarks_impl(&state, vault_path)
+}
+
+pub fn save_bookmarks_impl(
+    state: &VaultState,
+    vault_path: String,
+    bookmarks: Vec<String>,
+) -> Result<(), VaultError> {
+    let path = bookmarks_path_for(state, &vault_path)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(VaultError::Io)?;
+    }
+    let json = serde_json::to_vec_pretty(&bookmarks).map_err(|e| {
+        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+    })?;
+    atomic_write(&path, &json)
+}
+
+#[tauri::command]
+pub async fn save_bookmarks(
+    state: tauri::State<'_, VaultState>,
+    vault_path: String,
+    bookmarks: Vec<String>,
+) -> Result<(), VaultError> {
+    save_bookmarks_impl(&state, vault_path, bookmarks)
+}
+
+fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), VaultError> {
+    let parent = target.parent().ok_or_else(|| VaultError::PermissionDenied {
+        path: target.display().to_string(),
+    })?;
+    let tmp_name = match target.file_name() {
+        Some(n) => format!(".{}.tmp", n.to_string_lossy()),
+        None => ".bookmarks.tmp".to_string(),
+    };
+    let tmp = parent.join(tmp_name);
+    std::fs::write(&tmp, bytes).map_err(VaultError::Io)?;
+    std::fs::rename(&tmp, target).map_err(VaultError::Io)?;
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod tree;
 pub mod search;
 pub mod links;
 pub mod tags;
+pub mod bookmarks;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,6 +117,8 @@ pub fn run() {
             commands::links::get_link_graph,
             commands::tags::list_tags,
             commands::tags::get_tag_occurrences,
+            commands::bookmarks::load_bookmarks,
+            commands::bookmarks::save_bookmarks,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/tests/bookmarks.rs
+++ b/src-tauri/src/tests/bookmarks.rs
@@ -1,0 +1,76 @@
+// Tests for bookmarks commands (#12).
+// Mirrors the `_impl` test pattern used in files_ops.rs.
+
+use crate::commands::bookmarks::{load_bookmarks_impl, save_bookmarks_impl};
+use crate::VaultState;
+use std::fs;
+use tempfile::tempdir;
+
+fn state_with_vault(root: &std::path::Path) -> VaultState {
+    let canonical = fs::canonicalize(root).unwrap();
+    let s = VaultState::default();
+    *s.current_vault.lock().unwrap() = Some(canonical);
+    s
+}
+
+#[test]
+fn load_returns_empty_when_file_missing() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let result = load_bookmarks_impl(&state, dir.path().to_string_lossy().into_owned()).unwrap();
+    assert_eq!(result, Vec::<String>::new());
+}
+
+#[test]
+fn save_then_load_roundtrip() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let vault_path = dir.path().to_string_lossy().into_owned();
+    let bookmarks = vec!["notes/a.md".to_string(), "notes/sub/b.md".to_string()];
+    save_bookmarks_impl(&state, vault_path.clone(), bookmarks.clone()).unwrap();
+
+    // .vaultcore/bookmarks.json exists
+    let bookmarks_file = dir.path().join(".vaultcore").join("bookmarks.json");
+    assert!(bookmarks_file.exists(), "bookmarks.json should exist");
+
+    let loaded = load_bookmarks_impl(&state, vault_path).unwrap();
+    assert_eq!(loaded, bookmarks);
+}
+
+#[test]
+fn save_creates_vaultcore_dir_when_missing() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let vault_path = dir.path().to_string_lossy().into_owned();
+    save_bookmarks_impl(&state, vault_path, vec!["x.md".to_string()]).unwrap();
+    assert!(dir.path().join(".vaultcore").is_dir(), ".vaultcore/ should be created");
+}
+
+#[test]
+fn save_overwrites_existing_file_atomically() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let vault_path = dir.path().to_string_lossy().into_owned();
+    save_bookmarks_impl(&state, vault_path.clone(), vec!["one.md".to_string()]).unwrap();
+    save_bookmarks_impl(&state, vault_path.clone(), vec!["two.md".to_string(), "three.md".to_string()]).unwrap();
+    let loaded = load_bookmarks_impl(&state, vault_path).unwrap();
+    assert_eq!(loaded, vec!["two.md".to_string(), "three.md".to_string()]);
+}
+
+#[test]
+fn load_rejects_vault_path_not_matching_current_vault() {
+    let vault_dir = tempdir().unwrap();
+    let other_dir = tempdir().unwrap();
+    let state = state_with_vault(vault_dir.path());
+    let result = load_bookmarks_impl(&state, other_dir.path().to_string_lossy().into_owned());
+    assert!(result.is_err(), "should reject non-matching vault path");
+}
+
+#[test]
+fn save_rejects_vault_path_not_matching_current_vault() {
+    let vault_dir = tempdir().unwrap();
+    let other_dir = tempdir().unwrap();
+    let state = state_with_vault(vault_dir.path());
+    let result = save_bookmarks_impl(&state, other_dir.path().to_string_lossy().into_owned(), vec![]);
+    assert!(result.is_err(), "should reject non-matching vault path");
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -11,3 +11,4 @@ mod local_graph;
 mod global_graph;
 pub mod tag_index;
 mod hash_verify;
+mod bookmarks;

--- a/src/components/Bookmarks/BookmarksPanel.svelte
+++ b/src/components/Bookmarks/BookmarksPanel.svelte
@@ -1,0 +1,400 @@
+<script lang="ts">
+  // Bookmarks panel (#12). Collapsible section rendered above the file tree.
+  // State:
+  //   - collapsed: persisted in localStorage under BOOKMARKS_COLLAPSED_KEY
+  //   - rows: derived from bookmarksStore.paths
+  //   - broken-bookmark detection: bookmark rel path not present in
+  //     $vaultStore.fileList renders dimmed with a hover-visible Remove button.
+  import { Star, ChevronRight, ChevronDown, X } from "lucide-svelte";
+  import { bookmarksStore } from "../../store/bookmarksStore";
+  import { vaultStore } from "../../store/vaultStore";
+  import { tabStore } from "../../store/tabStore";
+
+  const BOOKMARKS_COLLAPSED_KEY = "vaultcore-bookmarks-panel-collapsed";
+
+  let collapsed = $state(false);
+  let contextMenu = $state<{ path: string; x: number; y: number } | null>(null);
+
+  // Drag-to-reorder state
+  let dragSourceIdx = $state<number | null>(null);
+  let dragOverIdx = $state<number | null>(null);
+
+  // Restore collapsed state from localStorage on mount.
+  (function restoreCollapsed() {
+    try {
+      const raw = localStorage.getItem(BOOKMARKS_COLLAPSED_KEY);
+      if (raw !== null) collapsed = raw === "true";
+    } catch {
+      // localStorage unavailable (SSR, etc.) — keep default.
+    }
+  })();
+
+  function toggleCollapsed(): void {
+    collapsed = !collapsed;
+    try {
+      localStorage.setItem(BOOKMARKS_COLLAPSED_KEY, String(collapsed));
+    } catch {
+      // ignore
+    }
+  }
+
+  function toAbsPath(relPath: string): string {
+    const vaultPath = $vaultStore.currentPath ?? "";
+    if (!vaultPath) return relPath;
+    return `${vaultPath}/${relPath}`;
+  }
+
+  function displayName(relPath: string): string {
+    const parts = relPath.split("/");
+    return parts[parts.length - 1] ?? relPath;
+  }
+
+  function isBroken(relPath: string): boolean {
+    const list = $vaultStore.fileList;
+    if (!list || list.length === 0) return false;
+    return !list.includes(relPath);
+  }
+
+  function handleRowClick(relPath: string): void {
+    tabStore.openTab(toAbsPath(relPath));
+  }
+
+  function handleRowKeydown(e: KeyboardEvent, relPath: string): void {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleRowClick(relPath);
+    }
+  }
+
+  function openContextMenu(e: MouseEvent, relPath: string): void {
+    e.preventDefault();
+    e.stopPropagation();
+    contextMenu = { path: relPath, x: e.clientX, y: e.clientY };
+  }
+
+  function closeContextMenu(): void {
+    contextMenu = null;
+  }
+
+  function handleOpenInNewTab(relPath: string): void {
+    closeContextMenu();
+    // tabStore.openTab dedupes by filePath and focuses existing — call it to
+    // open/focus the note in the active pane.
+    tabStore.openTab(toAbsPath(relPath));
+  }
+
+  function handleOpenInSplit(relPath: string): void {
+    closeContextMenu();
+    const absPath = toAbsPath(relPath);
+    tabStore.openTab(absPath);
+    tabStore.moveToPane("right");
+  }
+
+  async function handleRemoveBookmark(relPath: string): Promise<void> {
+    closeContextMenu();
+    const vaultPath = $vaultStore.currentPath;
+    if (!vaultPath) return;
+    await bookmarksStore.remove(relPath, vaultPath);
+  }
+
+  // Drag-and-drop reorder — mirror TabBar pattern.
+  function handleDragStart(e: DragEvent, idx: number): void {
+    if (!e.dataTransfer) return;
+    e.dataTransfer.setData("text/vaultcore-bookmark", String(idx));
+    e.dataTransfer.effectAllowed = "move";
+    dragSourceIdx = idx;
+  }
+
+  function handleDragEnd(): void {
+    dragSourceIdx = null;
+    dragOverIdx = null;
+  }
+
+  function handleDragOver(e: DragEvent, idx: number): void {
+    if (!e.dataTransfer?.types.includes("text/vaultcore-bookmark")) return;
+    e.preventDefault();
+    dragOverIdx = idx;
+  }
+
+  async function handleDrop(e: DragEvent, idx: number): Promise<void> {
+    if (!e.dataTransfer?.types.includes("text/vaultcore-bookmark")) return;
+    e.preventDefault();
+    const fromRaw = e.dataTransfer.getData("text/vaultcore-bookmark");
+    const from = Number.parseInt(fromRaw, 10);
+    dragOverIdx = null;
+    dragSourceIdx = null;
+    if (!Number.isFinite(from) || from === idx) return;
+
+    const vaultPath = $vaultStore.currentPath;
+    if (!vaultPath) return;
+
+    const current = [...$bookmarksStore.paths];
+    if (from < 0 || from >= current.length) return;
+    const moved = current[from];
+    if (moved === undefined) return;
+    current.splice(from, 1);
+    const insertAt = idx > from ? idx - 1 : idx;
+    current.splice(insertAt, 0, moved);
+    await bookmarksStore.reorder(current, vaultPath);
+  }
+</script>
+
+<svelte:window onclick={closeContextMenu} />
+
+<section class="vc-bookmarks-panel" aria-label="Lesezeichen">
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <button
+    type="button"
+    class="vc-bookmarks-header"
+    aria-expanded={!collapsed}
+    onclick={toggleCollapsed}
+  >
+    <span class="vc-bookmarks-chevron" aria-hidden="true">
+      {#if collapsed}
+        <ChevronRight size={14} strokeWidth={1.5} />
+      {:else}
+        <ChevronDown size={14} strokeWidth={1.5} />
+      {/if}
+    </span>
+    <Star size={14} strokeWidth={1.5} />
+    <span class="vc-bookmarks-title">Bookmarks</span>
+    <span class="vc-bookmarks-count">{$bookmarksStore.paths.length}</span>
+  </button>
+
+  {#if !collapsed}
+    <ul class="vc-bookmarks-list" data-testid="vc-bookmarks-list">
+      {#each $bookmarksStore.paths as relPath, idx (relPath)}
+        {@const broken = isBroken(relPath)}
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <li
+          class="vc-bookmark-row"
+          class:vc-bookmark-row--broken={broken}
+          class:vc-bookmark-row--drag-over={dragOverIdx === idx && dragSourceIdx !== idx}
+          draggable="true"
+          ondragstart={(e) => handleDragStart(e, idx)}
+          ondragend={handleDragEnd}
+          ondragover={(e) => handleDragOver(e, idx)}
+          ondrop={(e) => void handleDrop(e, idx)}
+          oncontextmenu={(e) => openContextMenu(e, relPath)}
+        >
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <button
+            type="button"
+            class="vc-bookmark-label"
+            onclick={() => handleRowClick(relPath)}
+            onkeydown={(e) => handleRowKeydown(e, relPath)}
+            title={broken ? `${relPath} (nicht gefunden)` : relPath}
+          >
+            <Star size={12} strokeWidth={1.5} />
+            <span class="vc-bookmark-name">{displayName(relPath)}</span>
+          </button>
+          {#if broken}
+            <button
+              type="button"
+              class="vc-bookmark-remove"
+              aria-label="Lesezeichen entfernen"
+              title="Lesezeichen entfernen"
+              onclick={() => void handleRemoveBookmark(relPath)}
+            >
+              <X size={12} strokeWidth={1.5} />
+            </button>
+          {/if}
+        </li>
+      {/each}
+      {#if $bookmarksStore.paths.length === 0}
+        <li class="vc-bookmarks-empty">Keine Lesezeichen</li>
+      {/if}
+    </ul>
+  {/if}
+
+  {#if contextMenu}
+    <div
+      class="vc-bookmark-menu"
+      role="menu"
+      style="top: {contextMenu.y}px; left: {contextMenu.x}px"
+    >
+      <button
+        type="button"
+        class="vc-bookmark-menu-item"
+        role="menuitem"
+        onclick={() => handleOpenInNewTab(contextMenu!.path)}
+      >
+        In neuem Tab öffnen
+      </button>
+      <button
+        type="button"
+        class="vc-bookmark-menu-item"
+        role="menuitem"
+        onclick={() => handleOpenInSplit(contextMenu!.path)}
+      >
+        Im Split öffnen
+      </button>
+      <button
+        type="button"
+        class="vc-bookmark-menu-item vc-bookmark-menu-item--danger"
+        role="menuitem"
+        onclick={() => void handleRemoveBookmark(contextMenu!.path)}
+      >
+        Lesezeichen entfernen
+      </button>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .vc-bookmarks-panel {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg);
+    flex-shrink: 0;
+  }
+
+  .vc-bookmarks-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 6px 12px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    text-align: left;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .vc-bookmarks-header:hover {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-bookmarks-chevron {
+    display: flex;
+    align-items: center;
+  }
+
+  .vc-bookmarks-title {
+    flex: 1;
+  }
+
+  .vc-bookmarks-count {
+    color: var(--color-text-muted);
+    font-weight: 400;
+  }
+
+  .vc-bookmarks-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 4px 0;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+
+  .vc-bookmark-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 8px;
+    position: relative;
+  }
+
+  .vc-bookmark-row:hover {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-bookmark-row--broken .vc-bookmark-label {
+    color: var(--color-text-muted);
+    font-style: italic;
+    opacity: 0.6;
+  }
+
+  .vc-bookmark-row--drag-over {
+    border-top: 2px solid var(--color-accent);
+  }
+
+  .vc-bookmark-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    padding: 4px 0 4px 16px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text);
+    font-size: 13px;
+    text-align: left;
+  }
+
+  .vc-bookmark-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .vc-bookmark-remove {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    border-radius: 3px;
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  .vc-bookmark-row:hover .vc-bookmark-remove {
+    display: flex;
+  }
+
+  .vc-bookmark-remove:hover {
+    background: var(--color-surface);
+    color: var(--color-error);
+  }
+
+  .vc-bookmarks-empty {
+    padding: 6px 24px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .vc-bookmark-menu {
+    position: fixed;
+    z-index: 400;
+    min-width: 180px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+    padding: 4px 0;
+  }
+
+  .vc-bookmark-menu-item {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    font-size: 13px;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  .vc-bookmark-menu-item:hover {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-bookmark-menu-item--danger {
+    color: var(--color-error);
+  }
+</style>

--- a/src/components/Bookmarks/__tests__/BookmarksPanel.test.ts
+++ b/src/components/Bookmarks/__tests__/BookmarksPanel.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  loadBookmarks: vi.fn(),
+  saveBookmarks: vi.fn(),
+}));
+
+import { loadBookmarks, saveBookmarks } from "../../../ipc/commands";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { vaultStore } from "../../../store/vaultStore";
+import { tabStore } from "../../../store/tabStore";
+import BookmarksPanel from "../BookmarksPanel.svelte";
+
+const VAULT = "/tmp/test-vault";
+
+describe("BookmarksPanel (#12)", () => {
+  beforeEach(() => {
+    bookmarksStore.reset();
+    vaultStore.reset();
+    tabStore._reset();
+    vi.clearAllMocks();
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    (loadBookmarks as any).mockResolvedValue([]);
+    try { localStorage.clear(); } catch { /* ignore */ }
+  });
+
+  it("renders empty state when no bookmarks", () => {
+    render(BookmarksPanel);
+    expect(screen.getByText("Keine Lesezeichen")).toBeTruthy();
+  });
+
+  it("renders rows sourced from bookmarksStore.paths", async () => {
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["a.md", "b.md"], fileCount: 2 });
+    await bookmarksStore.toggle("a.md", VAULT);
+    await bookmarksStore.toggle("b.md", VAULT);
+    render(BookmarksPanel);
+    await tick();
+    expect(screen.getByText("a.md")).toBeTruthy();
+    expect(screen.getByText("b.md")).toBeTruthy();
+  });
+
+  it("clicking a row calls tabStore.openTab with absolute path", async () => {
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["notes/a.md"], fileCount: 1 });
+    await bookmarksStore.toggle("notes/a.md", VAULT);
+    const spy = vi.spyOn(tabStore, "openTab");
+    render(BookmarksPanel);
+    await tick();
+    const label = screen.getByText("a.md");
+    await fireEvent.click(label);
+    expect(spy).toHaveBeenCalledWith(`${VAULT}/notes/a.md`);
+  });
+
+  it("renders a broken bookmark dimmed and shows a remove button", async () => {
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["real.md"], fileCount: 1 });
+    await bookmarksStore.toggle("missing.md", VAULT);
+    const { container } = render(BookmarksPanel);
+    await tick();
+    const brokenRow = container.querySelector(".vc-bookmark-row--broken");
+    expect(brokenRow).toBeTruthy();
+    const removeBtn = brokenRow?.querySelector(".vc-bookmark-remove");
+    expect(removeBtn).toBeTruthy();
+  });
+
+  it("remove button on broken row removes the bookmark and persists", async () => {
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["real.md"], fileCount: 1 });
+    await bookmarksStore.toggle("missing.md", VAULT);
+    vi.clearAllMocks();
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    const { container } = render(BookmarksPanel);
+    await tick();
+    const removeBtn = container.querySelector(".vc-bookmark-row--broken .vc-bookmark-remove") as HTMLButtonElement;
+    await fireEvent.click(removeBtn);
+    await tick();
+    expect(saveBookmarks).toHaveBeenCalledWith(VAULT, []);
+  });
+
+  it("drag-and-drop reorder updates the store via reorder()", async () => {
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["a.md", "b.md", "c.md"], fileCount: 3 });
+    await bookmarksStore.toggle("a.md", VAULT);
+    await bookmarksStore.toggle("b.md", VAULT);
+    await bookmarksStore.toggle("c.md", VAULT);
+    vi.clearAllMocks();
+    (saveBookmarks as any).mockResolvedValue(undefined);
+
+    const { container } = render(BookmarksPanel);
+    await tick();
+    const rows = Array.from(container.querySelectorAll<HTMLLIElement>(".vc-bookmark-row"));
+    expect(rows).toHaveLength(3);
+    const row0 = rows[0]!;
+    const row2 = rows[2]!;
+
+    // Simulate drag from index 0 (a.md) to index 2 (drop before c.md).
+    const dataTransfer = {
+      _data: new Map<string, string>(),
+      types: ["text/vaultcore-bookmark"] as string[],
+      setData(key: string, val: string) { this._data.set(key, val); this.types = Array.from(this._data.keys()); },
+      getData(key: string) { return this._data.get(key) ?? ""; },
+      effectAllowed: "move",
+    };
+    await fireEvent.dragStart(row0, { dataTransfer });
+    await fireEvent.dragOver(row2, { dataTransfer });
+    await fireEvent.drop(row2, { dataTransfer });
+    await tick();
+
+    // From 0 to 2 => insertAt = 2 - 1 = 1 after splice; order becomes [b, a, c].
+    expect(saveBookmarks).toHaveBeenCalled();
+    const lastCall = (saveBookmarks as any).mock.calls[(saveBookmarks as any).mock.calls.length - 1];
+    expect(lastCall[0]).toBe(VAULT);
+    expect(lastCall[1]).toEqual(["b.md", "a.md", "c.md"]);
+  });
+
+  it("collapsing hides the list", async () => {
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["a.md"], fileCount: 1 });
+    await bookmarksStore.toggle("a.md", VAULT);
+    const { container } = render(BookmarksPanel);
+    await tick();
+    expect(container.querySelector("[data-testid='vc-bookmarks-list']")).toBeTruthy();
+    const header = screen.getByRole("button", { name: /Bookmarks/i });
+    await fireEvent.click(header);
+    await tick();
+    expect(container.querySelector("[data-testid='vc-bookmarks-list']")).toBeNull();
+  });
+});

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -9,6 +9,7 @@
   import { tabStore } from "../../store/tabStore";
   import { searchStore } from "../../store/searchStore";
   import { backlinksStore } from "../../store/backlinksStore";
+  import { bookmarksStore } from "../../store/bookmarksStore";
   import { vaultStore } from "../../store/vaultStore";
   import { SHORTCUTS, handleShortcut, type ShortcutContext, type ShortcutGuard } from "../../lib/shortcuts";
   import { createFile } from "../../ipc/commands";
@@ -210,6 +211,22 @@
     }
   }
 
+  /** Issue #12: toggle bookmark on the active tab's file path. */
+  async function toggleActiveBookmark() {
+    let captured: string | null = null;
+    const u1 = vaultStore.subscribe((s) => { captured = s.currentPath; });
+    u1();
+    const vaultPath: string | null = captured;
+    if (vaultPath === null) return;
+    const active = tabStore.getActiveTab();
+    if (!active || active.type === "graph") return;
+    const abs = active.filePath;
+    const prefix = `${vaultPath}/`;
+    if (!abs.startsWith(prefix)) return;
+    const rel = abs.slice(prefix.length).replace(/\\/g, "/");
+    await bookmarksStore.toggle(rel, vaultPath);
+  }
+
   function handleSelect(path: string) {
     selectedPath = path;
   }
@@ -238,6 +255,7 @@
       },
       createNewNote: () => { void createNewNote(); },
       openGraph: () => { tabStore.openGraphTab(); },
+      toggleBookmark: () => { void toggleActiveBookmark(); },
     };
     const guard: ShortcutGuard = {
       settingsOpen,

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -34,6 +34,8 @@
   import ProgressBar from "../Progress/ProgressBar.svelte";
   import SearchPanel from "../Search/SearchPanel.svelte";
   import TagsPanel from "../Tags/TagsPanel.svelte";
+  import BookmarksPanel from "../Bookmarks/BookmarksPanel.svelte";
+  import { bookmarksStore } from "../../store/bookmarksStore";
 
   interface Props {
     selectedPath: string | null;
@@ -177,6 +179,9 @@
         treeState = await loadTreeState(state.currentPath);
         void loadRoot();
         void tagsStore.reload();
+        void bookmarksStore.load(state.currentPath);
+      } else {
+        bookmarksStore.reset();
       }
     }
   });
@@ -358,6 +363,9 @@
       </div>
     {/if}
   </header>
+
+  <!-- Bookmarks panel (#12) — collapsible, sits above the tree -->
+  <BookmarksPanel />
 
   <!-- Tree area -->
   <div class="vc-sidebar-tree" role="tree" aria-label="Vault file tree">

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronRight, Folder, FolderOpen, FileText, File, MoreHorizontal } from "lucide-svelte";
+  import { ChevronRight, Folder, FolderOpen, FileText, File, MoreHorizontal, Star } from "lucide-svelte";
   import { listDirectory, createFile, createFolder, deleteFile, moveFile, updateLinksAfterRename, getBacklinks } from "../../ipc/commands";
   import { toastStore } from "../../store/toastStore";
   import type { RenameResult } from "../../types/links";
@@ -9,6 +9,7 @@
   import { vaultStore } from "../../store/vaultStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
+  import { bookmarksStore } from "../../store/bookmarksStore";
   import { sortEntries, type SortBy } from "../../lib/treeState";
   import { onMount, onDestroy } from "svelte";
 
@@ -83,6 +84,27 @@
   } | null>(null);
 
   const isActive = $derived(selectedPath === entry.path);
+
+  // Bookmark state for this entry (#12). Files only — folders aren't
+  // bookmarkable in the MVP.
+  const entryRelPath = $derived(relPathOf(entry.path));
+  const isBookmarked = $derived(
+    !entry.is_dir && entryRelPath !== null && $bookmarksStore.paths.includes(entryRelPath)
+  );
+
+  function relPathOf(absPath: string): string | null {
+    const vault = getVaultRoot();
+    if (!vault) return null;
+    return toRelPath(absPath, vault);
+  }
+
+  async function toggleBookmark() {
+    closeContextMenu();
+    const vault = getVaultRoot();
+    if (!vault || entry.is_dir) return;
+    const rel = toRelPath(entry.path, vault);
+    await bookmarksStore.toggle(rel, vault);
+  }
 
   // DOM ref for scroll-into-view on reveal requests.
   let rowEl = $state<HTMLDivElement | undefined>();
@@ -212,10 +234,14 @@
 
   async function handleRenameConfirm(newPath: string, linkCount: number) {
     renaming = false;
+    const vault = getVaultRoot();
+    const oldRelPath = vault ? toRelPath(entry.path, vault) : entry.path;
+    const newRelPath = vault ? toRelPath(newPath, vault) : newPath;
+    // Rename tracking for bookmarks (#12): update any matching bookmark entry.
+    if (vault) {
+      void bookmarksStore.renamePath(oldRelPath, newRelPath, vault);
+    }
     if (linkCount > 0) {
-      const vault = getVaultRoot();
-      const oldRelPath = vault ? toRelPath(entry.path, vault) : entry.path;
-      const newRelPath = vault ? toRelPath(newPath, vault) : newPath;
       // Get unique source file count for the dialog copy
       let fileCount = 1;
       try {
@@ -378,6 +404,10 @@
     // No backlinks — proceed directly
     try {
       await moveFile(sourcePath, entry.path);
+      // Update bookmark in-place if the moved file was bookmarked (#12).
+      if (vault) {
+        void bookmarksStore.renamePath(sourceRelPath, newRelPath, vault);
+      }
       await loadChildren();
       onRefreshParent();
     } catch (err) {
@@ -392,6 +422,11 @@
     pendingMove = null;
     try {
       await moveFile(sourcePath, targetDirPath);
+      // Update bookmark in-place if the moved file was bookmarked (#12).
+      const vaultForBookmarks = getVaultRoot();
+      if (vaultForBookmarks) {
+        void bookmarksStore.renamePath(sourceRelPath, newRelPath, vaultForBookmarks);
+      }
       await loadChildren();
       onRefreshParent();
       const result = await updateLinksAfterRename(sourceRelPath, newRelPath);
@@ -498,6 +533,11 @@
           <em class="vc-tree-symlink">(link)</em>
         {/if}
       </span>
+      {#if isBookmarked}
+        <span class="vc-tree-bookmark" aria-label="Bookmarked" title="Bookmark">
+          <Star size={12} strokeWidth={1.5} />
+        </span>
+      {/if}
     {/if}
 
     <!-- More options button (hover-visible) -->
@@ -523,6 +563,11 @@
     ></div>
     <div class="vc-context-menu" bind:this={contextMenuRef}>
       <button class="vc-context-item" onclick={startRename}>Rename</button>
+      {#if !entry.is_dir}
+        <button class="vc-context-item" onclick={() => void toggleBookmark()}>
+          {isBookmarked ? "Remove bookmark" : "Bookmark"}
+        </button>
+      {/if}
       <button class="vc-context-item vc-context-item--danger" onclick={openDeleteConfirm}>Move to Trash</button>
       {#if entry.is_dir}
         <button class="vc-context-item" onclick={handleNewFileHere}>New file here</button>
@@ -714,6 +759,14 @@
     font-size: 12px;
     color: var(--color-text-muted);
     margin-left: 4px;
+  }
+
+  .vc-tree-bookmark {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 4px;
+    color: var(--color-accent);
+    flex-shrink: 0;
   }
 
   .vc-tree-more {

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -389,3 +389,23 @@ export async function getTagOccurrences(tag: string): Promise<TagOccurrence[]> {
     throw normalizeError(e);
   }
 }
+
+// ── Bookmarks commands (#12) ───────────────────────────────────────────────────
+
+/** Load the vault's bookmark list (vault-relative paths) from .vaultcore/bookmarks.json. */
+export async function loadBookmarks(vaultPath: string): Promise<string[]> {
+  try {
+    return await invoke<string[]>("load_bookmarks", { vaultPath });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/** Persist the vault's bookmark list to .vaultcore/bookmarks.json (atomic rename). */
+export async function saveBookmarks(vaultPath: string, bookmarks: string[]): Promise<void> {
+  try {
+    await invoke<void>("save_bookmarks", { vaultPath, bookmarks });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}

--- a/src/lib/__tests__/shortcuts.test.ts
+++ b/src/lib/__tests__/shortcuts.test.ts
@@ -44,6 +44,7 @@ function makeCtx(overrides: Partial<ShortcutContext> = {}): ShortcutContext {
     closeActiveTab: vi.fn(),
     createNewNote: vi.fn(),
     openGraph: vi.fn(),
+    toggleBookmark: vi.fn(),
     ...overrides,
   };
 }
@@ -71,10 +72,11 @@ describe("SHORTCUTS array", () => {
     "next-tab",
     "close-tab",
     "open-graph", // #32: Cmd/Ctrl+Shift+G — global graph tab
+    "toggle-bookmark", // #12: Cmd/Ctrl+D — toggle bookmark on active note
   ];
 
-  it("contains exactly 10 entries with the correct ids in order", () => {
-    expect(SHORTCUTS).toHaveLength(10);
+  it("contains exactly 11 entries with the correct ids in order", () => {
+    expect(SHORTCUTS).toHaveLength(11);
     const ids = SHORTCUTS.map((s) => s.id);
     expect(ids).toEqual(EXPECTED_IDS);
   });

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -30,6 +30,7 @@ export interface ShortcutContext {
   closeActiveTab: () => void;
   createNewNote: () => void;
   openGraph: () => void;
+  toggleBookmark: () => void;
 }
 
 export interface Shortcut {
@@ -106,6 +107,14 @@ export const SHORTCUTS: readonly Shortcut[] = [
     keys: { meta: true, shift: true, key: "g" },
     label: "Graph-Ansicht öffnen",
     handler: (ctx) => { ctx.openGraph(); },
+  },
+  {
+    // Issue #12: Cmd/Ctrl+D toggles the bookmark on the active note.
+    // Cmd+Shift+B is already bound to the Backlinks panel (backlinks-toggle).
+    id: "toggle-bookmark",
+    keys: { meta: true, key: "d" },
+    label: "Lesezeichen umschalten",
+    handler: (ctx) => { ctx.toggleBookmark(); },
   },
 ] as const;
 

--- a/src/store/__tests__/bookmarksStore.test.ts
+++ b/src/store/__tests__/bookmarksStore.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("../../ipc/commands", () => ({
+  loadBookmarks: vi.fn(),
+  saveBookmarks: vi.fn(),
+}));
+
+import { loadBookmarks, saveBookmarks } from "../../ipc/commands";
+import { bookmarksStore } from "../bookmarksStore";
+
+const VAULT = "/tmp/test-vault";
+
+describe("bookmarksStore (#12)", () => {
+  beforeEach(() => {
+    bookmarksStore.reset();
+    vi.clearAllMocks();
+  });
+
+  it("initial state has empty paths and loaded=false", () => {
+    expect(get(bookmarksStore)).toEqual({ paths: [], loaded: false });
+  });
+
+  it("load() populates paths from loadBookmarks IPC", async () => {
+    (loadBookmarks as any).mockResolvedValueOnce(["a.md", "b.md"]);
+    await bookmarksStore.load(VAULT);
+    const s = get(bookmarksStore);
+    expect(s.paths).toEqual(["a.md", "b.md"]);
+    expect(s.loaded).toBe(true);
+    expect(loadBookmarks).toHaveBeenCalledWith(VAULT);
+  });
+
+  it("toggle() adds a path when missing and persists", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.toggle("notes/a.md", VAULT);
+    expect(get(bookmarksStore).paths).toEqual(["notes/a.md"]);
+    expect(saveBookmarks).toHaveBeenCalledWith(VAULT, ["notes/a.md"]);
+  });
+
+  it("toggle() removes a path when already present and persists", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.toggle("a.md", VAULT);
+    await bookmarksStore.toggle("b.md", VAULT);
+    await bookmarksStore.toggle("a.md", VAULT);
+    expect(get(bookmarksStore).paths).toEqual(["b.md"]);
+    // Last save call should contain only b.md
+    expect(saveBookmarks).toHaveBeenLastCalledWith(VAULT, ["b.md"]);
+  });
+
+  it("remove() is a no-op when path is not bookmarked", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.remove("unknown.md", VAULT);
+    expect(saveBookmarks).not.toHaveBeenCalled();
+  });
+
+  it("remove() deletes and persists", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.toggle("a.md", VAULT);
+    vi.clearAllMocks();
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.remove("a.md", VAULT);
+    expect(get(bookmarksStore).paths).toEqual([]);
+    expect(saveBookmarks).toHaveBeenCalledWith(VAULT, []);
+  });
+
+  it("reorder() updates the stored order and persists", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.toggle("a.md", VAULT);
+    await bookmarksStore.toggle("b.md", VAULT);
+    await bookmarksStore.toggle("c.md", VAULT);
+    vi.clearAllMocks();
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.reorder(["c.md", "a.md", "b.md"], VAULT);
+    expect(get(bookmarksStore).paths).toEqual(["c.md", "a.md", "b.md"]);
+    expect(saveBookmarks).toHaveBeenCalledWith(VAULT, ["c.md", "a.md", "b.md"]);
+  });
+
+  it("renamePath() swaps in-place and persists", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.toggle("old.md", VAULT);
+    await bookmarksStore.toggle("keep.md", VAULT);
+    vi.clearAllMocks();
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.renamePath("old.md", "new.md", VAULT);
+    expect(get(bookmarksStore).paths).toEqual(["new.md", "keep.md"]);
+    expect(saveBookmarks).toHaveBeenCalledWith(VAULT, ["new.md", "keep.md"]);
+  });
+
+  it("renamePath() is a no-op when path not bookmarked", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.renamePath("missing.md", "other.md", VAULT);
+    expect(saveBookmarks).not.toHaveBeenCalled();
+  });
+
+  it("isBookmarked() reflects current state", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.toggle("a.md", VAULT);
+    expect(bookmarksStore.isBookmarked("a.md")).toBe(true);
+    expect(bookmarksStore.isBookmarked("b.md")).toBe(false);
+  });
+
+  it("reset() restores initial state", async () => {
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    await bookmarksStore.toggle("a.md", VAULT);
+    bookmarksStore.reset();
+    expect(get(bookmarksStore)).toEqual({ paths: [], loaded: false });
+  });
+});

--- a/src/store/bookmarksStore.ts
+++ b/src/store/bookmarksStore.ts
@@ -1,0 +1,88 @@
+// bookmarksStore — classic writable per D-06 / RC-01 (#12).
+// Holds the user-ordered list of vault-relative bookmarked paths.
+// Every mutation persists immediately via the saveBookmarks IPC.
+
+import { writable, get } from "svelte/store";
+import { loadBookmarks, saveBookmarks } from "../ipc/commands";
+import { toastStore } from "./toastStore";
+import { isVaultError, vaultErrorCopy } from "../types/errors";
+
+export interface BookmarksState {
+  paths: string[];
+  loaded: boolean;
+}
+
+const initial: BookmarksState = { paths: [], loaded: false };
+
+const _store = writable<BookmarksState>({ ...initial });
+
+function pushError(e: unknown): void {
+  const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
+  toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+}
+
+async function persist(vaultPath: string, paths: string[]): Promise<void> {
+  try {
+    await saveBookmarks(vaultPath, paths);
+  } catch (e) {
+    pushError(e);
+  }
+}
+
+export const bookmarksStore = {
+  subscribe: _store.subscribe,
+
+  async load(vaultPath: string): Promise<void> {
+    try {
+      const paths = await loadBookmarks(vaultPath);
+      _store.set({ paths, loaded: true });
+    } catch (e) {
+      _store.set({ paths: [], loaded: true });
+      pushError(e);
+    }
+  },
+
+  async toggle(relPath: string, vaultPath: string): Promise<void> {
+    if (!relPath) return;
+    const current = get(_store).paths;
+    const idx = current.indexOf(relPath);
+    const next = idx >= 0 ? current.filter((p) => p !== relPath) : [...current, relPath];
+    _store.update((s) => ({ ...s, paths: next }));
+    await persist(vaultPath, next);
+  },
+
+  async remove(relPath: string, vaultPath: string): Promise<void> {
+    const current = get(_store).paths;
+    if (!current.includes(relPath)) return;
+    const next = current.filter((p) => p !== relPath);
+    _store.update((s) => ({ ...s, paths: next }));
+    await persist(vaultPath, next);
+  },
+
+  async reorder(newPaths: string[], vaultPath: string): Promise<void> {
+    _store.update((s) => ({ ...s, paths: [...newPaths] }));
+    await persist(vaultPath, newPaths);
+  },
+
+  /**
+   * Internal helper used by the rename-tracker. Replaces `oldRel` with
+   * `newRel` in-place (preserves order). Persists when the path was bookmarked.
+   */
+  async renamePath(oldRel: string, newRel: string, vaultPath: string): Promise<void> {
+    const current = get(_store).paths;
+    const idx = current.indexOf(oldRel);
+    if (idx < 0) return;
+    const next = [...current];
+    next[idx] = newRel;
+    _store.update((s) => ({ ...s, paths: next }));
+    await persist(vaultPath, next);
+  },
+
+  isBookmarked(relPath: string): boolean {
+    return get(_store).paths.includes(relPath);
+  },
+
+  reset(): void {
+    _store.set({ ...initial });
+  },
+};


### PR DESCRIPTION
Closes #12.

## Summary
- New Bookmarks panel in the left sidebar: collapsible, above the file tree, renders the vault's bookmarked notes with click-to-open, drag-to-reorder, and a right-click menu (Open in new tab / Open in split / Remove).
- Per-note bookmark toggle via the TreeNode context menu, a small star indicator next to bookmarked files, and a Cmd/Ctrl+D keyboard shortcut that toggles the active tab's bookmark. Cmd+Shift+B is already bound to the Backlinks panel, so the spec's 'e.g., Cmd+Shift+B' becomes Cmd+D.
- Persistence via two new Tauri commands (`load_bookmarks`, `save_bookmarks`) that read/write `.vaultcore/bookmarks.json` at the vault root. Saves use a temp file + atomic rename and both commands enforce the T-02 vault-scope guard by canonicalizing the supplied vault path.
- Broken bookmarks (path missing from `vaultStore.fileList`) render dimmed with a hover Remove button; inside-app renames and moves update the bookmark entry in-place so the panel follows the file automatically.
- Collapsed state for the panel persists to localStorage under `vaultcore-bookmarks-panel-collapsed`; bookmarks reload whenever a vault opens and reset when it closes.

## Test plan
- [x] `cd src-tauri && cargo check` clean.
- [x] `cd src-tauri && cargo test --lib tests::bookmarks` — 6 new tests pass (load-empty, save-then-load roundtrip, .vaultcore autocreate, atomic overwrite, reject non-matching vault_path on load + save). Other `files_ops` failures on this machine are pre-existing `/var` vs `/private/var` canonicalization issues unrelated to this change.
- [x] `pnpm vitest run` — 35 files / 286 tests pass (+2 files / +18 tests from this PR).
- [x] `pnpm typecheck` — no new errors beyond the pre-existing ones in `tabStore.ts`, `tabStore.test.ts`, and `ui06Audit.test.ts`.
- [ ] Manual: open a vault, right-click a file in the tree, pick Bookmark — star appears, entry shows in the Bookmarks panel, survives app restart.
- [ ] Manual: Cmd/Ctrl+D on an active note toggles its bookmark from anywhere.
- [ ] Manual: drag bookmarks within the panel to reorder; right-click → Open in split moves the file to the right pane.
- [ ] Manual: rename a bookmarked file inside the app — panel entry updates; delete the file — panel entry renders dimmed with a Remove button.