### PR TITLE
fix(context-menu): right-click opens our menu instead of webview default (#47)

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -265,8 +265,29 @@
       toggleBookmark: () => { void toggleActiveBookmark(); },
     });
     document.addEventListener("keydown", handleKeydown, { capture: true });
-    return () => document.removeEventListener("keydown", handleKeydown, { capture: true });
+    document.addEventListener("contextmenu", handleContextMenu, { capture: true });
+    return () => {
+      document.removeEventListener("keydown", handleKeydown, { capture: true });
+      document.removeEventListener("contextmenu", handleContextMenu, { capture: true });
+    };
   });
+
+  // Issue #47: suppress the native webview context menu inside app chrome.
+  // Elements that still need the OS menu (e.g. inputs in modals) can opt out
+  // by attaching their own `oncontextmenu` that calls `e.stopPropagation()`.
+  // The sidebar tree and bookmarks panel render their own menus so they're
+  // unaffected here.
+  function handleContextMenu(e: MouseEvent) {
+    const target = e.target as Element | null;
+    if (target && typeof target.closest === "function") {
+      // Allow native menu inside real text entry (inputs, textareas,
+      // contenteditable) so copy/paste/spellcheck stay available.
+      if (target.closest('input, textarea, [contenteditable="true"], [contenteditable=""]')) {
+        return;
+      }
+    }
+    e.preventDefault();
+  }
 
   function handleKeydown(e: KeyboardEvent) {
     if (settingsOpen || inlineRenameActive()) return;

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -48,8 +48,11 @@
   let renaming = $state(false);
   let isNewEntry = $state(false);
 
-  // Context menu state
+  // Context menu state. When opened via right-click we position at the mouse
+  // coordinates; when opened via the three-dots button we leave `menuPos` null
+  // and fall back to the row-anchored CSS default.
   let showContextMenu = $state(false);
+  let menuPos = $state<{ x: number; y: number } | null>(null);
   let contextMenuRef: HTMLDivElement | null = null;
 
   // Delete confirmation state
@@ -206,11 +209,22 @@
   // Context menu
   function openContextMenu(e: MouseEvent) {
     e.stopPropagation();
+    menuPos = null;
+    showContextMenu = true;
+  }
+
+  // Issue #47: right-click handler on the row. Suppresses the webview default
+  // menu and anchors our menu at the cursor position.
+  function handleRowContextMenu(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    menuPos = { x: e.clientX, y: e.clientY };
     showContextMenu = true;
   }
 
   function closeContextMenu() {
     showContextMenu = false;
+    menuPos = null;
   }
 
   function startRename() {
@@ -483,6 +497,7 @@
     style="padding-left: calc({depth} * 16px + 8px)"
     bind:this={rowEl}
     onclick={handleClick}
+    oncontextmenu={handleRowContextMenu}
     role="button"
     tabindex="-1"
     title={entry.path}
@@ -561,7 +576,12 @@
       onclick={closeContextMenu}
       role="presentation"
     ></div>
-    <div class="vc-context-menu" bind:this={contextMenuRef}>
+    <div
+      class="vc-context-menu"
+      class:vc-context-menu--pointer={menuPos !== null}
+      style={menuPos ? `top: ${menuPos.y}px; left: ${menuPos.x}px` : undefined}
+      bind:this={contextMenuRef}
+    >
       <button class="vc-context-item" onclick={startRename}>Rename</button>
       {#if !entry.is_dir}
         <button class="vc-context-item" onclick={() => void toggleBookmark()}>
@@ -824,6 +844,11 @@
     border-radius: 6px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
     padding: 4px 0;
+  }
+
+  /* Right-click positioning uses viewport-relative clientX/clientY. */
+  .vc-context-menu--pointer {
+    position: fixed;
   }
 
   .vc-context-item {

--- a/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import TreeNode from "../TreeNode.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+const VAULT = "/tmp/test-vault";
+
+function fileEntry(overrides: Partial<DirEntry> = {}): DirEntry {
+  return {
+    name: "note.md",
+    path: `${VAULT}/note.md`,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+    ...overrides,
+  };
+}
+
+function makeProps(entry: DirEntry) {
+  return {
+    entry,
+    depth: 0,
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onRefreshParent: vi.fn(),
+    onPathChanged: vi.fn(),
+  };
+}
+
+describe("TreeNode right-click context menu (#47)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["note.md"], fileCount: 1 });
+  });
+
+  it("opens our custom menu on contextmenu and calls preventDefault()", async () => {
+    const { container } = render(TreeNode, { props: makeProps(fileEntry()) });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    expect(row).toBeTruthy();
+
+    // Menu is not in the DOM before right-click.
+    expect(container.querySelector(".vc-context-menu")).toBeNull();
+
+    const evt = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    });
+    const dispatched = row.dispatchEvent(evt);
+    // dispatchEvent returns false when preventDefault() was called on a
+    // cancelable event — which is the assertion we actually care about.
+    expect(dispatched).toBe(false);
+    expect(evt.defaultPrevented).toBe(true);
+
+    await tick();
+    const menu = container.querySelector(".vc-context-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+    // When opened via right-click, menu is positioned at the mouse coords
+    // (via inline style) and uses fixed positioning via the pointer modifier.
+    expect(menu.classList.contains("vc-context-menu--pointer")).toBe(true);
+    expect(menu.style.top).toBe("80px");
+    expect(menu.style.left).toBe("120px");
+  });
+
+  it("contains Rename / Bookmark / Move to Trash entries for a file", async () => {
+    const { container, getByText } = render(TreeNode, { props: makeProps(fileEntry()) });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });
+    await tick();
+
+    expect(getByText("Rename")).toBeTruthy();
+    expect(getByText("Bookmark")).toBeTruthy();
+    expect(getByText("Move to Trash")).toBeTruthy();
+  });
+
+  it("contains New file / New folder entries for a directory", async () => {
+    const dir = fileEntry({ name: "folder", path: `${VAULT}/folder`, is_dir: true, is_md: false });
+    const { container, getByText } = render(TreeNode, { props: makeProps(dir) });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });
+    await tick();
+
+    expect(getByText("New file here")).toBeTruthy();
+    expect(getByText("New folder here")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #47.

## Summary
- `TreeNode.svelte`: added an `oncontextmenu` handler on `.vc-tree-row` that calls `preventDefault()`, opens the existing custom menu, and anchors it at the mouse coordinates (`clientX` / `clientY`). The three-dots `MoreHorizontal` button keeps its row-anchored position via the existing CSS default.
- `VaultLayout.svelte`: registered a capture-phase `document.addEventListener("contextmenu", ...)` that mirrors the keydown capture trick from #13. Text-entry elements (`input`, `textarea`, `contenteditable`) opt out so copy / paste / spellcheck stay available where they actually belong.
- Added `src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts` covering the three invariants: right-click calls `preventDefault()`, the custom menu becomes visible with correct pointer-anchored positioning, and the menu items match the file vs. folder case.

## Test plan
- [x] `pnpm vitest run` — 307 / 307 pass (304 baseline + 3 new).
- [x] `pnpm typecheck` — no new errors beyond the pre-existing ones in `ui06Audit.test.ts` and `tabStore.ts`.
- [ ] Manual: right-click any file / folder in the sidebar tree and confirm our menu appears at the cursor with Rename / Bookmark / Move to Trash; no macOS "Suche nach …" appears.
- [ ] Manual: right-click a bookmark row (existing behaviour from #45) still works.
- [ ] Manual: right-click inside a text input in the Settings modal still shows the native spellcheck / copy / paste menu.