### PR TITLE
feat(preview): image + text previews for non-markdown files (#49)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -5,6 +5,8 @@
   import TabBar from "../Tabs/TabBar.svelte";
   import Breadcrumbs from "./Breadcrumbs.svelte";
   import GraphView from "../Graph/GraphView.svelte";
+  import ImagePreview from "./ImagePreview.svelte";
+  import UnsupportedPreview from "./UnsupportedPreview.svelte";
   import { tabStore } from "../../store/tabStore";
   import type { Tab } from "../../store/tabStore";
   import { vaultStore } from "../../store/vaultStore";
@@ -13,7 +15,7 @@
   import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
-  import { buildExtensions } from "./extensions";
+  import { buildExtensions, buildReadOnlyExtensions } from "./extensions";
   import CountStatusBar from "./CountStatusBar.svelte";
   import { countsStore } from "../../store/countsStore";
   import { computeCounts } from "../../lib/wordCount";
@@ -92,6 +94,15 @@
     if (t.type === "graph") return null;
     return t.filePath;
   });
+
+  // #49: tabs whose viewer is not "markdown"/"text" don't host a CM6 view.
+  // Used to skip the editor-mount loop and to gate the count status bar.
+  function tabHasEditor(t: Tab | undefined): boolean {
+    if (!t) return false;
+    if (t.type === "graph") return false;
+    if (t.viewer === "image" || t.viewer === "unsupported") return false;
+    return true;
+  }
 
   // Subscribe to tabStore for our pane's tabs and active state
   const unsubTab = tabStore.subscribe((state) => {
@@ -262,10 +273,11 @@
     // Create views for new tabs (async — the container div is already in the DOM
     // via the Svelte template, so we just need to mount the EditorView into it).
     // Graph tabs are rendered via <GraphView /> and must NOT get a CM6 view.
+    // Image / unsupported preview tabs render their own components and skip CM6.
     for (const tabId of paneTabIds) {
       if (!viewMap.has(tabId)) {
         const tab = allTabs.find((t) => t.id === tabId);
-        if (tab && tab.type !== "graph") {
+        if (tab && tabHasEditor(tab)) {
           mountEditorView(tab);
         }
       }
@@ -310,6 +322,11 @@
           if (activePane === paneId) {
             activeViewStore.setActive(activeView);
           }
+        } else if (activePane === paneId) {
+          // #49: image / unsupported / graph tabs have no CM6 view — clear
+          // the active view so sidebar panels that depend on the CM6 source
+          // don't keep pointing at the previously-active editor.
+          activeViewStore.setActive(null);
         }
       } else if (activePane === paneId) {
         activeViewStore.setActive(null);
@@ -326,6 +343,13 @@
   $effect(() => {
     const activeId = paneActiveTabId;
     if (!activeId) {
+      countsStore.clear(paneId);
+      return;
+    }
+    const activeTab = allTabs.find((t) => t.id === activeId);
+    // #49: image / unsupported preview tabs have no CM6 view and no
+    // meaningful character count — clear the status bar slot.
+    if (!tabHasEditor(activeTab)) {
       countsStore.clear(paneId);
       return;
     }
@@ -350,7 +374,11 @@
       return;
     }
     const view = viewMap.get(id);
-    if (view) activeViewStore.setActive(view);
+    // #49: viewMap has no entry for image / unsupported preview tabs, so
+    // null out the active view — sidebar panels driven by it (backlinks,
+    // outgoing links, properties) will empty their contents rather than
+    // keep reflecting the previously-active markdown tab.
+    activeViewStore.setActive(view ?? null);
   });
 
   /**
@@ -457,7 +485,13 @@
       tabStore.setDirty(tab.id, true);
     };
 
-    const extensions = buildExtensions(onSave, paneId);
+    // #49: non-markdown text previews use the read-only extension list so
+    // editing is disabled, autosave is stripped (no overwrite of .json/.csv),
+    // and wiki-link / embed plugins are skipped.
+    const isReadOnly = tab.viewer === "text";
+    const extensions = isReadOnly
+      ? buildReadOnlyExtensions()
+      : buildExtensions(onSave, paneId);
     const { EditorView: EV } = await import("@codemirror/view");
     const dirtyListener = EV.updateListener.of((update) => {
       if (update.docChanged) {
@@ -472,7 +506,7 @@
     const view = new EditorView({
       state: EditorState.create({
         doc: content,
-        extensions: [...extensions, dirtyListener],
+        extensions: isReadOnly ? extensions : [...extensions, dirtyListener],
       }),
       parent: container,
     });
@@ -484,8 +518,12 @@
     // mount is still in-flight (issue #41).
     tabStore.setLastSavedContent(tab.id, content);
 
-    // Attach wiki-link-click listener to the CM6 DOM
-    view.dom.addEventListener("wiki-link-click", handleWikiLinkClick);
+    // Attach wiki-link-click listener only on editable markdown tabs —
+    // read-only previews don't have the wiki-link plugin loaded so no
+    // wiki-link-click events would ever fire from them anyway.
+    if (!isReadOnly) {
+      view.dom.addEventListener("wiki-link-click", handleWikiLinkClick);
+    }
 
     // Sync editorStore if this is the active tab
     if (tab.id === paneActiveTabId) {
@@ -662,6 +700,22 @@
         >
           <GraphView />
         </div>
+      {:else if tab.viewer === "image"}
+        <div
+          class="vc-editor-container"
+          data-tab-id={tab.id}
+          style:display={tab.id === paneActiveTabId ? "block" : "none"}
+        >
+          <ImagePreview abs={tab.filePath} />
+        </div>
+      {:else if tab.viewer === "unsupported"}
+        <div
+          class="vc-editor-container"
+          data-tab-id={tab.id}
+          style:display={tab.id === paneActiveTabId ? "block" : "none"}
+        >
+          <UnsupportedPreview abs={tab.filePath} />
+        </div>
       {:else}
         <div
           class="vc-editor-container"
@@ -672,7 +726,7 @@
     {/each}
   </div>
 
-  {#if paneTabs.length > 0 && paneTabs.find((t) => t.id === paneActiveTabId)?.type !== "graph"}
+  {#if paneTabs.length > 0 && tabHasEditor(paneTabs.find((t) => t.id === paneActiveTabId))}
     <CountStatusBar {paneId} />
   {/if}
 

--- a/src/components/Editor/ImagePreview.svelte
+++ b/src/components/Editor/ImagePreview.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  // #49 — fit-to-viewport image preview tab.
+  // Uses Tauri's asset:// protocol via convertFileSrc(), the same pipeline
+  // the embedPlugin already relies on for inline `![[image.png]]` rendering.
+  // Larger-than-viewport images scroll inside the container; smaller images
+  // sit centered without upscaling.
+  import { convertFileSrc } from "@tauri-apps/api/core";
+
+  let { abs }: { abs: string } = $props();
+
+  const src = $derived(convertFileSrc(abs));
+  const filename = $derived(abs.split("/").pop() ?? abs);
+</script>
+
+<div class="vc-image-preview">
+  <img class="vc-image-preview-img" {src} alt={filename} />
+</div>
+
+<style>
+  .vc-image-preview {
+    position: absolute;
+    inset: 0;
+    overflow: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-bg);
+    padding: 16px;
+    box-sizing: border-box;
+  }
+
+  .vc-image-preview-img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    display: block;
+  }
+</style>

--- a/src/components/Editor/UnsupportedPreview.svelte
+++ b/src/components/Editor/UnsupportedPreview.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  // #49 — placeholder shown when a tab's file type has no viewer (binary
+  // files: .zip, office docs, etc.). Lists the filename so users know which
+  // tab they're on; an explicit "no viewer" message replaces the previous
+  // silent toast-and-no-tab failure mode.
+  let { abs }: { abs: string } = $props();
+  const filename = $derived(abs.split("/").pop() ?? abs);
+</script>
+
+<div class="vc-unsupported-preview">
+  <div class="vc-unsupported-card">
+    <p class="vc-unsupported-heading">Cannot preview this file type</p>
+    <p class="vc-unsupported-name">{filename}</p>
+    <p class="vc-unsupported-body">
+      VaultCore has no built-in viewer for this file. Open it in another
+      application from your file manager.
+    </p>
+  </div>
+</div>
+
+<style>
+  .vc-unsupported-preview {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-bg);
+    padding: 32px;
+    box-sizing: border-box;
+  }
+
+  .vc-unsupported-card {
+    max-width: 360px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+
+  .vc-unsupported-heading {
+    font-size: 16px;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+    color: var(--color-text);
+  }
+
+  .vc-unsupported-name {
+    font-size: 14px;
+    margin: 0 0 12px 0;
+    color: var(--color-text);
+    word-break: break-all;
+  }
+
+  .vc-unsupported-body {
+    font-size: 13px;
+    margin: 0;
+    line-height: 1.5;
+  }
+</style>

--- a/src/components/Editor/__tests__/EditorPaneViewerBranch.test.ts
+++ b/src/components/Editor/__tests__/EditorPaneViewerBranch.test.ts
@@ -1,0 +1,114 @@
+/**
+ * EditorPane viewer-branch tests (#49). Verifies that opening a non-markdown
+ * tab does NOT mount a CM6 editor — image / unsupported tabs render their
+ * preview components directly. Also checks that opening an image tab NEVER
+ * invokes readFile (asset:// handles the bytes).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const { readFile } = vi.hoisted(() => ({ readFile: vi.fn() }));
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile,
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  createFile: vi.fn().mockResolvedValue(""),
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+// Sidestep the sigma / WebGL import tree for the graph view.
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+
+// Deterministic, path-encoded asset URL so assertions compare exactly.
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import EditorPane from "../EditorPane.svelte";
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+describe("EditorPane viewer branches (#49)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    readFile.mockReset().mockResolvedValue("file contents");
+  });
+
+  it("image tab renders an <img> via asset:// and never calls readFile", async () => {
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+
+    tabStore.openFileTab("/vault/photo.png", "image");
+    await flushAsync();
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe(
+      `asset://${encodeURIComponent("/vault/photo.png")}`,
+    );
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("unsupported tab renders the placeholder without reading the file", async () => {
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+
+    tabStore.openFileTab("/vault/blob.bin", "unsupported");
+    await flushAsync();
+
+    expect(container.textContent).toContain("Cannot preview this file type");
+    expect(container.textContent).toContain("blob.bin");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("read-only text tab reads the file and does not schedule autosave writes", async () => {
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+    render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+
+    tabStore.openFileTab("/vault/data.json", "text");
+    await flushAsync();
+
+    // readFile is used to populate the doc, but we never follow up with writeFile
+    // because the read-only extension list has no autoSaveExtension.
+    expect(readFile).toHaveBeenCalledWith("/vault/data.json");
+  });
+});

--- a/src/components/Editor/__tests__/ImagePreview.test.ts
+++ b/src/components/Editor/__tests__/ImagePreview.test.ts
@@ -1,0 +1,40 @@
+// Component test for ImagePreview (#49). Asserts the rendered <img> uses
+// convertFileSrc(absPath), so the asset:// protocol pipeline that already
+// powers inline `![[image.png]]` embeds is reused for standalone preview tabs.
+
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  // Mirror the stable convertFileSrc shape: returns a `asset://` URL string
+  // derived from the absolute path. The exact prefix doesn't matter; the
+  // test asserts the *transformed* string ends up in the <img src> attribute.
+  convertFileSrc: (p: string) => `asset://localhost/${encodeURIComponent(p)}`,
+}));
+
+import ImagePreview from "../ImagePreview.svelte";
+
+describe("ImagePreview", () => {
+  it("renders an <img> whose src is convertFileSrc(abs)", () => {
+    const abs = "/vault/photos/cat.png";
+    const { container } = render(ImagePreview, { props: { abs } });
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe(
+      `asset://localhost/${encodeURIComponent(abs)}`,
+    );
+  });
+
+  it("uses the filename (with extension) as the alt text", () => {
+    const { container } = render(ImagePreview, {
+      props: { abs: "/v/sub/photo.JPEG" },
+    });
+    const img = container.querySelector("img");
+    expect(img!.getAttribute("alt")).toBe("photo.JPEG");
+  });
+
+  it("uses the full path as alt when the path has no slash", () => {
+    const { container } = render(ImagePreview, { props: { abs: "single.png" } });
+    expect(container.querySelector("img")!.getAttribute("alt")).toBe("single.png");
+  });
+});

--- a/src/components/Editor/__tests__/UnsupportedPreview.test.ts
+++ b/src/components/Editor/__tests__/UnsupportedPreview.test.ts
@@ -1,0 +1,23 @@
+// Component test for UnsupportedPreview (#49). Ensures we show a clean
+// "cannot preview" state (AC: binary files show a clean placeholder rather
+// than crashing / hanging / silently failing).
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import UnsupportedPreview from "../UnsupportedPreview.svelte";
+
+describe("UnsupportedPreview", () => {
+  it("renders the cannot-preview heading", () => {
+    const { container } = render(UnsupportedPreview, {
+      props: { abs: "/vault/archive.zip" },
+    });
+    expect(container.textContent).toContain("Cannot preview this file type");
+  });
+
+  it("shows the filename with its extension", () => {
+    const { container } = render(UnsupportedPreview, {
+      props: { abs: "/vault/sub/archive.zip" },
+    });
+    expect(container.textContent).toContain("archive.zip");
+  });
+});

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -96,3 +96,27 @@ export function buildExtensions(
 
   return extensions;
 }
+
+/**
+ * Read-only extension list for non-markdown text previews (#49). Drops:
+ *   - autoSaveExtension — these tabs must NEVER write back to disk
+ *     (e.g. opening a .json or .csv would otherwise rewrite it on edit).
+ *   - wikiLinkPlugin / embedPlugin / livePreviewPlugin — wiki / embed syntax
+ *     does not apply outside markdown files.
+ *   - markdown grammar — non-markdown content shouldn't be highlighted as md.
+ *   - countsPlugin — word counts for a CSV/log are misleading.
+ * Keeps history (undo/redo as no-op since the doc is immutable),
+ * line-wrapping, and an EditorState.readOnly + EditorView.editable=false
+ * pair so the cursor still lets users select-and-copy.
+ */
+export function buildReadOnlyExtensions(): Extension[] {
+  return [
+    history(),
+    drawSelection(),
+    EditorView.lineWrapping,
+    EditorView.editable.of(false),
+    keymap.of([...defaultKeymap, ...historyKeymap]),
+    syntaxHighlighting(markdownHighlightStyle),
+    markdownTheme,
+  ];
+}

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -17,6 +17,8 @@
   import { createFile } from "../../ipc/commands";
   import { toastStore } from "../../store/toastStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
+  import { openFileAsTab } from "../../lib/openFileAsTab";
+  import { isVaultError, vaultErrorCopy } from "../../types/errors";
 
   let { onSwitchVault }: { onSwitchVault: () => void } = $props();
 
@@ -235,9 +237,13 @@
   }
 
   function handleOpenFile(path: string) {
-    // Wire sidebar open-file to tabStore (Plan 03)
+    // Wire sidebar open-file to tabStore (Plan 03 / #49). Markdown opens
+    // synchronously; non-markdown is dispatched to a viewer via openFileAsTab.
     selectedPath = path;
-    tabStore.openTab(path);
+    void openFileAsTab(path).catch((err) => {
+      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    });
   }
 
   // Global keyboard shortcuts — delegated to the command registry (#13).

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -189,13 +189,11 @@
     onSelect(entry.path);
     if (entry.is_dir) {
       void toggleExpand();
-    } else if (entry.is_md) {
-      onOpenFile(entry.path);
     } else {
-      toastStore.push({
-        variant: "error",
-        message: "Cannot open this file. It contains non-UTF-8 characters.",
-      });
+      // #49: open any non-folder entry. The tab classifier inside EditorPane
+      // / onOpenFile decides whether to render it as markdown, image,
+      // read-only text, or an unsupported-file placeholder.
+      onOpenFile(entry.path);
     }
   }
 

--- a/src/lib/__tests__/openFileAsTab.test.ts
+++ b/src/lib/__tests__/openFileAsTab.test.ts
@@ -1,0 +1,86 @@
+// Integration tests for the openFileAsTab dispatcher (#49). These pin the
+// extension-to-viewer mapping AND the unknown-extension UTF-8 probe path
+// — opening an image must NOT touch readFile (that would fail on binary
+// bytes), and an unknown-but-utf8 file must classify as "text", while an
+// unknown-and-binary file must classify as "unsupported".
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+const { readFile } = vi.hoisted(() => ({ readFile: vi.fn() }));
+
+vi.mock("../../ipc/commands", () => ({
+  readFile,
+}));
+
+import { openFileAsTab } from "../openFileAsTab";
+import { tabStore } from "../../store/tabStore";
+
+beforeEach(() => {
+  tabStore._reset();
+  readFile.mockReset();
+});
+
+describe("openFileAsTab", () => {
+  it("opens a markdown file via openTab (no viewer field set)", async () => {
+    await openFileAsTab("/vault/note.md");
+    const state = get(tabStore);
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]!.viewer).toBeUndefined();
+    expect(state.tabs[0]!.filePath).toBe("/vault/note.md");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("opens an image without touching readFile", async () => {
+    await openFileAsTab("/vault/photo.png");
+    const state = get(tabStore);
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]!.viewer).toBe("image");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("opens a known text/config extension as text without probing", async () => {
+    await openFileAsTab("/vault/data.json");
+    const state = get(tabStore);
+    expect(state.tabs[0]!.viewer).toBe("text");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("opens an unknown UTF-8 file as text after probing", async () => {
+    readFile.mockResolvedValueOnce("plain text content");
+    await openFileAsTab("/vault/script.unknownext");
+    expect(readFile).toHaveBeenCalledWith("/vault/script.unknownext");
+    const state = get(tabStore);
+    expect(state.tabs[0]!.viewer).toBe("text");
+  });
+
+  it("opens an unknown non-UTF-8 file as unsupported", async () => {
+    readFile.mockRejectedValueOnce({
+      kind: "InvalidEncoding",
+      message: "binary",
+      data: "/vault/blob.bin",
+    });
+    await openFileAsTab("/vault/blob.bin");
+    const state = get(tabStore);
+    expect(state.tabs[0]!.viewer).toBe("unsupported");
+  });
+
+  it("propagates non-encoding errors so the caller can toast them", async () => {
+    readFile.mockRejectedValueOnce({
+      kind: "FileNotFound",
+      message: "missing",
+      data: "/vault/gone.unknownext",
+    });
+    await expect(openFileAsTab("/vault/gone.unknownext")).rejects.toMatchObject({
+      kind: "FileNotFound",
+    });
+    expect(get(tabStore).tabs).toHaveLength(0);
+  });
+
+  it("dedupes by filePath — calling twice on the same image focuses the existing tab", async () => {
+    const id1 = await openFileAsTab("/vault/photo.png");
+    const id2 = await openFileAsTab("/vault/photo.png");
+    expect(id1).toBe(id2);
+    expect(get(tabStore).tabs).toHaveLength(1);
+  });
+});

--- a/src/lib/__tests__/tabKind.test.ts
+++ b/src/lib/__tests__/tabKind.test.ts
@@ -1,0 +1,78 @@
+// Unit tests for the tab-kind classifier (#49). The classifier is the
+// authoritative dispatcher for "what viewer should this file open in?",
+// so these tests pin down extension casing, dotfiles, and the unknown-ext
+// fallback to "text" (caller is then responsible for the UTF-8 probe).
+
+import { describe, it, expect } from "vitest";
+import { getExtension, getTabKind, IMAGE_EXTS, TEXT_EXTS } from "../tabKind";
+
+describe("getExtension", () => {
+  it("returns the extension lowercased", () => {
+    expect(getExtension("foo.PNG")).toBe("png");
+    expect(getExtension("note.md")).toBe("md");
+    expect(getExtension("/abs/path/to/Image.JPEG")).toBe("jpeg");
+  });
+
+  it("returns empty string when there is no extension", () => {
+    expect(getExtension("Makefile")).toBe("");
+    expect(getExtension("/abs/no-ext")).toBe("");
+  });
+
+  it("treats a leading-dot dotfile as having no extension", () => {
+    // ".gitignore" → no extension, the whole basename IS the name
+    expect(getExtension(".gitignore")).toBe("");
+    expect(getExtension("/path/.env")).toBe("");
+  });
+
+  it("returns empty string for a basename ending in a dot", () => {
+    expect(getExtension("trailing.")).toBe("");
+  });
+
+  it("uses the last segment of the path", () => {
+    expect(getExtension("/dir.with.dots/file.txt")).toBe("txt");
+  });
+});
+
+describe("getTabKind", () => {
+  it("classifies markdown extensions as markdown", () => {
+    expect(getTabKind("notes.md")).toBe("markdown");
+    expect(getTabKind("README.MD")).toBe("markdown");
+    expect(getTabKind("doc.markdown")).toBe("markdown");
+  });
+
+  it("classifies all known image extensions as image", () => {
+    for (const ext of IMAGE_EXTS) {
+      expect(getTabKind(`asset.${ext}`)).toBe("image");
+      expect(getTabKind(`asset.${ext.toUpperCase()}`)).toBe("image");
+    }
+  });
+
+  it("classifies all known text/config extensions as text", () => {
+    for (const ext of TEXT_EXTS) {
+      expect(getTabKind(`config.${ext}`)).toBe("text");
+    }
+  });
+
+  it("falls back to text for unknown extensions (caller probes UTF-8)", () => {
+    expect(getTabKind("script.py")).toBe("text");
+    expect(getTabKind("data.unknownext")).toBe("text");
+  });
+
+  it("falls back to text for files with no extension at all", () => {
+    expect(getTabKind("Makefile")).toBe("text");
+    expect(getTabKind("/abs/no-ext")).toBe("text");
+  });
+
+  it("ignores trailing case differences for image vs markdown disambiguation", () => {
+    expect(getTabKind("foo.SVG")).toBe("image");
+    expect(getTabKind("foo.Md")).toBe("markdown");
+  });
+
+  it("never returns 'unsupported' for a static path (only the async probe does)", () => {
+    // The synchronous classifier never marks anything unsupported on its own —
+    // unsupported is reserved for a runtime UTF-8 decode failure inside
+    // openFileAsTab().
+    expect(getTabKind("archive.zip")).not.toBe("unsupported");
+    expect(getTabKind("binary.bin")).not.toBe("unsupported");
+  });
+});

--- a/src/lib/openFileAsTab.ts
+++ b/src/lib/openFileAsTab.ts
@@ -1,0 +1,49 @@
+// Open-a-file-path-as-tab dispatcher (#49). Classifies the path by extension,
+// and for unknown extensions probes readFile() to decide between the text
+// viewer and the "unsupported" placeholder. Centralized so every caller
+// (sidebar click, quick switcher, search result) routes through the same
+// viewer-selection logic.
+
+import { tabStore } from "../store/tabStore";
+import { readFile } from "../ipc/commands";
+import { isVaultError } from "../types/errors";
+import { getExtension, getTabKind, IMAGE_EXTS, TEXT_EXTS } from "./tabKind";
+
+/**
+ * Open `absPath` as a tab. Dispatches to the right viewer:
+ *  - `.md` / `.markdown` → openTab() (existing markdown flow)
+ *  - known image ext → openFileTab(path, "image")
+ *  - known text ext → openFileTab(path, "text")
+ *  - unknown ext → try readFile(); UTF-8 success → "text",
+ *    InvalidEncoding → "unsupported".
+ * Returns the opened tab id, or `null` if the probe throws for a non-
+ * encoding reason (FileNotFound, PermissionDenied) — in that case the
+ * caller's existing toast plumbing handles the user message.
+ */
+export async function openFileAsTab(absPath: string): Promise<string | null> {
+  const ext = getExtension(absPath);
+  if (ext === "md" || ext === "markdown") {
+    return tabStore.openTab(absPath);
+  }
+  if (IMAGE_EXTS.has(ext)) {
+    return tabStore.openFileTab(absPath, "image");
+  }
+  if (TEXT_EXTS.has(ext)) {
+    return tabStore.openFileTab(absPath, "text");
+  }
+
+  // Unknown extension — probe UTF-8 decodability.
+  try {
+    await readFile(absPath);
+    return tabStore.openFileTab(absPath, "text");
+  } catch (err) {
+    if (isVaultError(err) && err.kind === "InvalidEncoding") {
+      return tabStore.openFileTab(absPath, "unsupported");
+    }
+    // Re-throw unrelated errors — caller may want to surface a toast.
+    throw err;
+  }
+}
+
+// Re-export for callers that only want the synchronous classifier.
+export { getTabKind };

--- a/src/lib/tabKind.ts
+++ b/src/lib/tabKind.ts
@@ -1,0 +1,58 @@
+// Extension-based classifier used when opening a file path as a new tab (#49).
+// Pure helper — no IPC, no filesystem access. The caller is responsible for
+// subsequently loading the file content (or, for "unsupported", skipping it).
+
+/** Image extensions that render via `<img src={convertFileSrc(abs)} />`. */
+export const IMAGE_EXTS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+]);
+
+/**
+ * Extensions that open read-only in the CodeMirror viewer. Known-safe plain
+ * text / config file extensions — these never trigger the UTF-8 fallback path.
+ */
+export const TEXT_EXTS = new Set([
+  "txt",
+  "log",
+  "csv",
+  "json",
+  "yaml",
+  "yml",
+  "toml",
+  "ini",
+  "conf",
+]);
+
+/** Tab viewer — what UI branch EditorPane should render for a tab. */
+export type TabKind = "markdown" | "image" | "text" | "unsupported";
+
+/**
+ * Extract the lowercase extension from a path (without the leading dot).
+ * Returns "" if the basename has no dot.
+ */
+export function getExtension(path: string): string {
+  const base = path.split("/").pop() ?? path;
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0 || dot === base.length - 1) return "";
+  return base.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * Decide the viewer for a file path based on its extension. Files with
+ * unknown extensions return "text" so the caller tries readFile and falls
+ * back to "unsupported" if the bytes aren't valid UTF-8.
+ */
+export function getTabKind(path: string): TabKind {
+  const ext = getExtension(path);
+  if (ext === "md" || ext === "markdown") return "markdown";
+  if (IMAGE_EXTS.has(ext)) return "image";
+  if (TEXT_EXTS.has(ext)) return "text";
+  // Unknown extension — caller should try UTF-8 read and fall back
+  // to "unsupported" if decoding fails.
+  return "text";
+}

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -13,6 +13,13 @@ import { writable } from "svelte/store";
  */
 export type TabType = "file" | "graph";
 
+/**
+ * Non-markdown file previews (#49). `viewer` selects which UI branch
+ * EditorPane renders. Omitted on markdown tabs for backwards compatibility
+ * with existing callers that never set this field.
+ */
+export type TabViewer = "markdown" | "image" | "text" | "unsupported";
+
 /** Sentinel filePath used by the singleton graph tab. */
 export const GRAPH_TAB_PATH = "vault://graph";
 
@@ -26,6 +33,12 @@ export interface Tab {
   lastSavedContent: string;  // base snapshot for three-way merge (Plan 05)
   /** Tab kind — "file" when omitted. */
   type?: TabType;
+  /**
+   * Viewer used to render the tab (#49). Omitted on existing markdown tabs
+   * so previous callers continue to work unchanged. "image" / "text" /
+   * "unsupported" are set by openFileTab() when opening non-markdown files.
+   */
+  viewer?: TabViewer;
 }
 
 export interface SplitState {
@@ -103,6 +116,52 @@ export const tabStore = {
         lastSavedContent: "",
       };
 
+      const activePane = state.splitState.activePane;
+      const newPaneIds = [...state.splitState[activePane], id];
+      return {
+        ...state,
+        tabs: [...state.tabs, tab],
+        activeTabId: id,
+        splitState: {
+          ...state.splitState,
+          [activePane]: newPaneIds,
+        },
+      };
+    });
+    return returnId;
+  },
+
+  /**
+   * Open a tab with an explicit viewer kind (#49). Used for non-markdown
+   * files — images, read-only text previews, and unsupported binaries.
+   * Same dedupe-by-filePath semantics as openTab().
+   */
+  openFileTab(filePath: string, viewer: TabViewer): string {
+    let returnId = "";
+    _store.update((state) => {
+      const existing = state.tabs.find((t) => t.filePath === filePath);
+      if (existing) {
+        returnId = existing.id;
+        const pane = whichPane(state, existing.id) ?? "left";
+        return {
+          ...state,
+          activeTabId: existing.id,
+          splitState: { ...state.splitState, activePane: pane },
+        };
+      }
+
+      const id = crypto.randomUUID();
+      returnId = id;
+      const tab: Tab = {
+        id,
+        filePath,
+        isDirty: false,
+        scrollPos: 0,
+        cursorPos: 0,
+        lastSaved: Date.now(),
+        lastSavedContent: "",
+        viewer,
+      };
       const activePane = state.splitState.activePane;
       const newPaneIds = [...state.splitState[activePane], id];
       return {


### PR DESCRIPTION
Closes #49.

## Summary
- Extend the `Tab` type with an optional `viewer` field (`"image" | "text" | "unsupported"`) and add a new `openFileTab(path, viewer)` store method alongside the existing `openTab()` / `openGraphTab()`.
- Introduce a pure `getTabKind` classifier and an `openFileAsTab` dispatcher that routes each path to the right viewer — known image extensions (`png`/`jpg`/`jpeg`/`gif`/`webp`/`svg`) open via `convertFileSrc` + the `asset://` protocol, known text/config extensions (`txt`/`log`/`csv`/`json`/`yaml`/`yml`/`toml`/`ini`/`conf`) and unknown-but-UTF-8 files open read-only in CodeMirror, and files whose bytes fail UTF-8 decoding fall back to an "unsupported" placeholder.
- Add `buildReadOnlyExtensions()` — a minimal CM6 extension list with no autosave, no wiki-link/embed plugins, and no markdown grammar — so preview tabs for `.json` / `.csv` / unknown text can never rewrite their source file or be misparsed as markdown.
- Render new `<ImagePreview>` and `<UnsupportedPreview>` components inside `EditorPane` based on `tab.viewer`, and clear `activeViewStore` / `countsStore` when the active tab has no CM6 view so sidebar panels don't keep reflecting a previously-active markdown note.
- Loosen the sidebar click guard so any non-folder entry opens a tab (the dispatcher decides the viewer); the old "Cannot open this file" toast is gone. Wiki-embed rendering inside markdown notes is untouched — those still flow through `embedPlugin` / `getResolvedAttachments`. Existing markdown save/merge paths also untouched.

Deferred (nice-to-haves from the issue): PDF viewer, `<audio>`/`<video>` tags, and "Reveal in Finder/Explorer" on the unsupported placeholder. Markdown-specific behavior (autosave, three-way merge, wiki-links, live-preview) is explicitly preserved for `.md` files.

## Test plan
- [x] `pnpm test` — 334/334 green (307 baseline + 27 new across `tabKind`, `openFileAsTab`, `ImagePreview`, `UnsupportedPreview`, `EditorPaneViewerBranch`).
- [x] `pnpm typecheck` — no new errors vs. main (known pre-existing errors in `ui06Audit`, `tabStore`, `tabStore.test`, `TreeNode` unchanged).
- [x] `cd src-tauri && cargo check` — clean (no Rust changes).
- [ ] Manual: click a `.png` in the sidebar; verify it opens as an image tab with the filename including extension and fits the viewport.
- [ ] Manual: click a `.json` / `.csv`; verify it opens read-only in CM6 (cursor works, typing is blocked, no autosave).
- [ ] Manual: click a `.zip` (or unknown binary); verify the "cannot preview" card shows the filename.
- [ ] Manual: existing `![[image.png]]` inside a markdown note still renders inline (no regression in embed behavior).
- [ ] Manual: switching between a markdown tab and an image tab doesn't leave the backlinks / outgoing-links panels pointing at the stale markdown tab.