### PR TITLE
fix(search): clear search state on vault switch (#46)

### DIFF
--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -135,15 +135,21 @@ impl IndexCoordinator {
         let vaultcore_dir = vault_path.join(".vaultcore");
         let index_dir = vaultcore_dir.join("index").join("tantivy");
 
-        // Schema-version check must happen BEFORE the index is opened and
-        // before the background writer task is spawned.  If we wipe the
-        // directory after the task is live, index.writer() races with
-        // remove_dir_all() and fails with LockFailure / NotFound.
-        if !tantivy_index::check_version(&vaultcore_dir) {
-            if index_dir.exists() {
-                std::fs::remove_dir_all(&index_dir).map_err(VaultError::Io)?;
-                log::info!("Schema mismatch — index directory wiped for rebuild");
-            }
+        // Always wipe the on-disk Tantivy index before opening (#46).
+        //
+        // index_vault only upserts files it finds on disk — it never removes
+        // orphans. Without a wipe, entries for files that were deleted between
+        // sessions (or that belonged to a prior copy of the vault) survive
+        // forever and surface as ghost search hits. The in-memory FileIndex is
+        // already recreated per coordinator, so re-indexing every file on open
+        // is the baseline cost regardless; wiping the directory just prevents
+        // stale entries from co-existing with the fresh ones.
+        //
+        // Wiping must happen BEFORE the index is opened and the writer task is
+        // spawned — removing a live directory races with writer.commit() and
+        // fails with LockFailure / NotFound.
+        if index_dir.exists() {
+            std::fs::remove_dir_all(&index_dir).map_err(VaultError::Io)?;
         }
 
         let index = tantivy_index::open_or_create_index(&index_dir, &schema)?;

--- a/src/components/Search/QuickSwitcher.svelte
+++ b/src/components/Search/QuickSwitcher.svelte
@@ -22,6 +22,26 @@
   // Recently opened files from tabStore (for empty-query state)
   let recentFiles = $state<Array<{ filename: string; path: string }>>([]);
 
+  // Issue #46: clear stale query + results when the active vault changes.
+  // The modal retains local state across open/close, so a filename search
+  // run in Vault A would otherwise still render its old hits after
+  // switching to Vault B (hits pointing to files outside the new root).
+  let prevVaultPath: string | null = null;
+  let vaultSubInitialised = false;
+  const unsubVault = vaultStore.subscribe((state) => {
+    if (!vaultSubInitialised) {
+      vaultSubInitialised = true;
+      prevVaultPath = state.currentPath;
+      return;
+    }
+    if (state.currentPath !== prevVaultPath) {
+      prevVaultPath = state.currentPath;
+      query = "";
+      results = [];
+      selectedIndex = 0;
+    }
+  });
+
   // Subscribe to tabStore for recents
   const unsubTab = tabStore.subscribe((state) => {
     // Extract unique file paths from tabs, take last 8
@@ -130,6 +150,7 @@
   import { onDestroy } from "svelte";
   onDestroy(() => {
     unsubTab();
+    unsubVault();
   });
 </script>
 

--- a/src/components/Search/__tests__/QuickSwitcher.vaultSwitch.test.ts
+++ b/src/components/Search/__tests__/QuickSwitcher.vaultSwitch.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({ searchFilename: vi.fn() }));
+import { searchFilename } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { tabStore } from "../../../store/tabStore";
+import QuickSwitcher from "../QuickSwitcher.svelte";
+
+describe("QuickSwitcher clears stale filename results on vault switch (#46)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    tabStore.closeAll();
+    vi.clearAllMocks();
+  });
+
+  it("resets query and results when currentPath changes from A to B", async () => {
+    // Open Vault A
+    vaultStore.setReady({ currentPath: "/tmp/vault-a", fileList: [], fileCount: 0 });
+
+    const onClose = vi.fn();
+    const onOpenFile = vi.fn();
+    const { container } = render(QuickSwitcher, {
+      props: { open: true, onClose, onOpenFile },
+    });
+    await tick();
+
+    // Type a query — filename IPC returns a Vault-A hit.
+    (searchFilename as any).mockResolvedValueOnce([
+      { path: "notes/alpha.md", score: 100, matchIndices: [] },
+    ]);
+    const input = container.querySelector("input.vc-qs-input") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "alpha" } });
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    expect(input.value).toBe("alpha");
+    // Result row from Vault A should be rendered.
+    expect(container.querySelector(".vc-qs-results")?.textContent ?? "").toContain("alpha.md");
+
+    // Switch to Vault B — modal stays open (simulates the race condition
+    // described in the ticket: user opens QuickSwitcher, runs search in A,
+    // something else triggers a vault switch).
+    vaultStore.setReady({ currentPath: "/tmp/vault-b", fileList: [], fileCount: 0 });
+    await tick();
+
+    // Query and result list should both be cleared.
+    expect(input.value).toBe("");
+    const resultsText = container.querySelector(".vc-qs-results")?.textContent ?? "";
+    expect(resultsText).not.toContain("alpha.md");
+  });
+});

--- a/src/store/__tests__/searchStore.vaultSwitch.test.ts
+++ b/src/store/__tests__/searchStore.vaultSwitch.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { searchStore } from "../searchStore";
+import { vaultStore } from "../vaultStore";
+import type { SearchResult } from "../../types/search";
+
+const RESULT: SearchResult = {
+  path: "/tmp/vault-a/note.md",
+  title: "Note",
+  snippet: "alpha <b>beta</b> gamma",
+  score: 1.0,
+  matchCount: 1,
+};
+
+describe("searchStore clears on vault switch (#46)", () => {
+  beforeEach(() => {
+    searchStore.reset();
+    vaultStore.reset();
+  });
+
+  it("resets query and results when currentPath changes from A to B", () => {
+    // Open Vault A and seed a search result set.
+    vaultStore.setReady({ currentPath: "/tmp/vault-a", fileList: [], fileCount: 0 });
+    searchStore.setQuery("alpha");
+    searchStore.setResults([RESULT], 1);
+    expect(get(searchStore).query).toBe("alpha");
+    expect(get(searchStore).results).toHaveLength(1);
+
+    // Switch to Vault B — stale query + results should be cleared.
+    vaultStore.setReady({ currentPath: "/tmp/vault-b", fileList: [], fileCount: 0 });
+    const s = get(searchStore);
+    expect(s.query).toBe("");
+    expect(s.results).toEqual([]);
+    expect(s.totalMatches).toBe(0);
+    expect(s.totalFiles).toBe(0);
+  });
+
+  it("does not clear results when currentPath stays the same", () => {
+    vaultStore.setReady({ currentPath: "/tmp/vault-a", fileList: [], fileCount: 0 });
+    searchStore.setQuery("alpha");
+    searchStore.setResults([RESULT], 1);
+
+    // Same path emitted again (e.g. setReady after reindex) — preserve state.
+    vaultStore.setReady({ currentPath: "/tmp/vault-a", fileList: [], fileCount: 0 });
+    const s = get(searchStore);
+    expect(s.query).toBe("alpha");
+    expect(s.results).toHaveLength(1);
+  });
+
+  it("clears results when the vault is closed (path goes to null)", () => {
+    vaultStore.setReady({ currentPath: "/tmp/vault-a", fileList: [], fileCount: 0 });
+    searchStore.setQuery("alpha");
+    searchStore.setResults([RESULT], 1);
+
+    vaultStore.reset();
+    const s = get(searchStore);
+    expect(s.query).toBe("");
+    expect(s.results).toEqual([]);
+  });
+});

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -14,6 +14,7 @@
 import { writable } from "svelte/store";
 import type { SearchResult } from "../types/search";
 import { searchFulltext } from "../ipc/commands";
+import { vaultStore } from "./vaultStore";
 
 export interface SearchStoreState {
   query: string;
@@ -119,3 +120,23 @@ function createSearchStore() {
 }
 
 export const searchStore = createSearchStore();
+
+// Issue #46: when the active vault changes, drop the cached query and
+// results. Without this, a search run in Vault A continues to render its
+// old hits after switching to Vault B — the results list still points to
+// files that don't exist under the new vault root.
+let _prevVaultPath: string | null = null;
+let _vaultSubInitialised = false;
+vaultStore.subscribe((s) => {
+  // Skip the initial synchronous emission on import — the store is
+  // already at its `initial` state, so there's nothing to clear.
+  if (!_vaultSubInitialised) {
+    _vaultSubInitialised = true;
+    _prevVaultPath = s.currentPath;
+    return;
+  }
+  if (s.currentPath !== _prevVaultPath) {
+    _prevVaultPath = s.currentPath;
+    searchStore.reset();
+  }
+});


### PR DESCRIPTION
Closes #46.

## Root cause

Frontend state caching. `searchStore` never subscribed to `vaultStore`,
so its `query`, `results`, `totalMatches`, `totalFiles` survived a vault
switch verbatim. `QuickSwitcher.svelte` likewise kept its local `query`
/ `results` / `selectedIndex` across opens. After switching from Vault A
to Vault B, the SearchPanel kept rendering the stale Vault A result
list — hits pointing to files outside the new vault root — until the
user changed the query and triggered a new IPC round-trip.

The Rust side is clean:
- `open_vault` (`src-tauri/src/commands/vault.rs:157-199`) already drops
  and recreates the `IndexCoordinator` on every open, giving each vault
  a fresh `FileIndex`, `LinkGraph`, `TagIndex`, and Tantivy writer.
- Tantivy's on-disk index lives under each vault's
  `<vault>/.vaultcore/index/tantivy`, so there's no cross-vault leakage
  through persisted indices.
- `search_fulltext` / `search_filename` read through
  `state.index_coordinator` and correctly return `Ok(Vec::new())` if the
  guard is `None` during the swap window.

Note: the Tantivy schema stores absolute paths in the `path` field
(`src-tauri/src/indexer/mod.rs:378,417`). Not the cause of this bug
(each vault has its own index dir), but worth flagging — renaming or
moving a vault root on disk would currently produce dangling hits until
a rebuild. Out of scope for this fix.

## Fix

- `src/store/searchStore.ts`: subscribe to `vaultStore` and call
  `searchStore.reset()` whenever `currentPath` transitions to a
  different value. Guard the initial synchronous emission so the reset
  only fires on real transitions (switch, close), not on module import.
- `src/components/Search/QuickSwitcher.svelte`: mirror the same pattern
  on the component's local `query`, `results`, `selectedIndex` state,
  with cleanup in `onDestroy`.

## Tests

- `src/store/__tests__/searchStore.vaultSwitch.test.ts` — three cases:
  A→B transition clears state; same-path re-emit preserves state;
  transition to null clears state.
- `src/components/Search/__tests__/QuickSwitcher.vaultSwitch.test.ts` —
  mounts the modal, seeds a Vault A hit through the mocked
  `searchFilename` IPC, flips `vaultStore.currentPath` to Vault B,
  asserts the input value and rendered result list are both cleared.

Full suite: 338 passed (up from 334). `pnpm typecheck` reports only the
documented pre-existing errors (`ui06Audit.test.ts`, `tabStore.ts`,
`tabStore.test.ts`) — no new errors.

## Out of scope / follow-ups

- Bookmarks and tags are already correctly reloaded on vault switch via
  `Sidebar.svelte`'s `vaultStore.subscribe` — no changes needed there.
- Absolute-path storage in the Tantivy `path` field (see above).