### PR TITLE
fix(graph): replace rAF poll with ResizeObserver for container width (#43)

### DIFF
--- a/src/components/Graph/GraphCanvas.svelte
+++ b/src/components/Graph/GraphCanvas.svelte
@@ -54,6 +54,12 @@
   let canvasEl = $state<HTMLDivElement | undefined>();
   let handle: GraphHandle | null = null;
   let lastDatasetVersion = -1;
+  let resizeObserver: ResizeObserver | null = null;
+
+  // sigma needs a non-zero container — treat anything below this as "layout
+  // not resolved yet" and wait for a ResizeObserver tick. Matches the
+  // threshold used in LocalGraphPanel.
+  const MIN_MOUNT_DIMENSION = 8;
 
   function restoreCamera(): void {
     if (!handle || !savedCamera) return;
@@ -72,8 +78,27 @@
   function tryMount(): void {
     if (handle) return;
     if (!canvasEl || !data) return;
-    if (canvasEl.clientWidth === 0 || canvasEl.clientHeight === 0) {
-      requestAnimationFrame(tryMount);
+    // sigma measures the container on construct — wait for the first
+    // ResizeObserver entry with a usable size rather than polling rAF,
+    // which fires before layout and just spins with clientWidth=0 (#43).
+    if (
+      canvasEl.clientWidth < MIN_MOUNT_DIMENSION ||
+      canvasEl.clientHeight < MIN_MOUNT_DIMENSION
+    ) {
+      if (resizeObserver) return;
+      const target = canvasEl;
+      resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          const { width, height } = entry.contentRect;
+          if (width >= MIN_MOUNT_DIMENSION && height >= MIN_MOUNT_DIMENSION) {
+            resizeObserver?.disconnect();
+            resizeObserver = null;
+            tryMount();
+            return;
+          }
+        }
+      });
+      resizeObserver.observe(target);
       return;
     }
     handle = mountGraph(canvasEl, data, {
@@ -163,6 +188,10 @@
   });
 
   onDestroy(() => {
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+      resizeObserver = null;
+    }
     if (handle) {
       destroyGraph(handle);
       handle = null;

--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -263,14 +263,24 @@
         <div class="vc-graph-empty">Keine Datei geöffnet.</div>
       {:else if errorMessage}
         <div class="vc-graph-empty">{errorMessage}</div>
-      {:else if graphData && !hasLinks}
-        <div class="vc-graph-empty">Keine Verbindungen</div>
       {:else}
+        <!-- Always render the canvas when a note is open, even when the
+             local graph has no edges. If we swap it out for a
+             "Keine Verbindungen" message the bind:this=canvasEl element
+             leaves the DOM and the live sigma handle is left pointing at a
+             detached node; when the user switches back to a linked note the
+             next mountGraph is called into a freshly inserted, zero-width
+             div and Sigma logs 'Container has no width' (#43). Keeping the
+             div in place lets updateGraph render the center-only graph,
+             and we overlay a message when hasLinks is false. -->
         <div
           class="vc-graph-canvas"
           bind:this={canvasEl}
           title={centerRel ?? ""}
         ></div>
+        {#if graphData && !hasLinks}
+          <div class="vc-graph-no-links">Keine Verbindungen</div>
+        {/if}
       {/if}
       {#if loading}
         <div class="vc-graph-loading">…</div>
@@ -329,6 +339,18 @@
     text-align: center;
     color: var(--color-text-muted);
     font-size: 14px;
+  }
+  .vc-graph-no-links {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 2px 8px;
+    font-size: 11px;
+    color: var(--color-text-muted);
+    background: color-mix(in srgb, var(--color-surface) 80%, transparent);
+    border-radius: 4px;
+    pointer-events: none;
   }
   .vc-graph-loading {
     position: absolute;

--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -43,6 +43,11 @@
   let handle: GraphHandle | null = null;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let unlistenFileChange: UnlistenFn | null = null;
+  let resizeObserver: ResizeObserver | null = null;
+
+  // sigma needs a non-zero container — treat anything below this as "layout
+  // not resolved yet" and wait for a ResizeObserver tick.
+  const MIN_MOUNT_DIMENSION = 8;
 
   // Reactive active-tab / doc-version plumbing mirrors OutgoingLinksPanel.
   let tabs = $state<Tab[]>([]);
@@ -128,9 +133,26 @@
     if (!canvasEl || !graphData || !centerRel) return;
     // sigma measures the container on construct — make sure it has a size
     // before we mount. When the panel just opened the layout tick might not
-    // have run yet; defer until next frame if clientWidth is still 0.
-    if (canvasEl.clientWidth === 0 || canvasEl.clientHeight === 0) {
-      requestAnimationFrame(tryMount);
+    // have run yet; wait for the first ResizeObserver entry that reports a
+    // usable width/height. rAF fires before layout so polling it just spins.
+    if (
+      canvasEl.clientWidth < MIN_MOUNT_DIMENSION ||
+      canvasEl.clientHeight < MIN_MOUNT_DIMENSION
+    ) {
+      if (resizeObserver) return;
+      const target = canvasEl;
+      resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          const { width, height } = entry.contentRect;
+          if (width >= MIN_MOUNT_DIMENSION && height >= MIN_MOUNT_DIMENSION) {
+            resizeObserver?.disconnect();
+            resizeObserver = null;
+            tryMount();
+            return;
+          }
+        }
+      });
+      resizeObserver.observe(target);
       return;
     }
     handle = mountGraph(canvasEl, graphData, {
@@ -160,6 +182,10 @@
   // Mount/unmount sigma as the panel expands or collapses.
   $effect(() => {
     if (collapsed) {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
       if (handle) {
         destroyGraph(handle);
         handle = null;
@@ -202,6 +228,10 @@
     unsubTabs();
     unsubVault();
     unlistenFileChange?.();
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+      resizeObserver = null;
+    }
     if (handle) {
       destroyGraph(handle);
       handle = null;

--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -3,7 +3,7 @@
   import { ChevronDown, ChevronRight } from "lucide-svelte";
   import { activeViewStore } from "../../store/activeViewStore";
   import { vaultStore } from "../../store/vaultStore";
-  import { tabStore, type Tab } from "../../store/tabStore";
+  import { tabStore } from "../../store/tabStore";
   import { getLocalGraph } from "../../ipc/commands";
   import { listenFileChange } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
@@ -49,30 +49,24 @@
   // not resolved yet" and wait for a ResizeObserver tick.
   const MIN_MOUNT_DIMENSION = 8;
 
-  // Reactive active-tab / doc-version plumbing mirrors OutgoingLinksPanel.
-  let tabs = $state<Tab[]>([]);
-  let activeTabId = $state<string | null>(null);
-  let vaultPath = $state<string | null>(null);
-
-  const unsubTabs = tabStore.subscribe((s) => {
-    tabs = s.tabs;
-    activeTabId = s.activeTabId;
-  });
-  const unsubVault = vaultStore.subscribe((s) => {
-    vaultPath = s.currentPath;
-  });
-
-  // Compute the vault-relative path of the active tab. Returns null when
-  // no tab is active or the filePath doesn't sit under the vault root.
+  // Reactive active-tab / doc-version plumbing — driven by Svelte-store
+  // auto-subscription so the derived chain actually re-runs on tab switch.
+  // A classic `tabStore.subscribe(cb)` that writes into $state was silently
+  // dropping updates after the initial mount, leaving the graph stuck on
+  // the first note. OutgoingLinksPanel uses the same direct-$derived
+  // pattern and behaves correctly.
   const activeRelPath = $derived.by<string | null>(() => {
-    if (!activeTabId || !vaultPath) return null;
-    const tab = tabs.find((t) => t.id === activeTabId);
+    const s = $tabStore;
+    const v = $vaultStore;
+    if (!s.activeTabId || !v.currentPath) return null;
+    const tab = s.tabs.find((t) => t.id === s.activeTabId);
     if (!tab) return null;
-    if (tab.filePath.startsWith(vaultPath + "/")) {
-      return tab.filePath.slice(vaultPath.length + 1);
+    if (tab.filePath.startsWith(v.currentPath + "/")) {
+      return tab.filePath.slice(v.currentPath.length + 1);
     }
     return null;
   });
+  const vaultPath = $derived($vaultStore.currentPath);
 
   // When the active tab changes, reset the center to the active file.
   $effect(() => {
@@ -225,8 +219,6 @@
 
   onDestroy(() => {
     if (debounceTimer) clearTimeout(debounceTimer);
-    unsubTabs();
-    unsubVault();
     unlistenFileChange?.();
     if (resizeObserver) {
       resizeObserver.disconnect();

--- a/src/components/Graph/__tests__/LocalGraphPanel.test.ts
+++ b/src/components/Graph/__tests__/LocalGraphPanel.test.ts
@@ -1,0 +1,178 @@
+// Regression test for issue #43 — the local-graph panel used to call sigma
+// before the right-sidebar container had non-zero width, then re-schedule
+// with requestAnimationFrame, which fires BEFORE layout and just spins
+// (Sigma: "Container has no width"). The fix replaces that with a
+// ResizeObserver that fires exactly once, when a real layout pass reports
+// a usable width. This test verifies that behaviour without pulling in
+// sigma / webgl.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+// Mocks must be declared before importing the component under test.
+vi.mock("../graphRender", () => ({
+  mountGraph: vi.fn(() => ({ sigma: {}, graph: {}, options: {} })),
+  destroyGraph: vi.fn(),
+  updateGraph: vi.fn(),
+  setCenter: vi.fn(),
+  DEFAULT_FORCE_SETTINGS: {},
+}));
+
+vi.mock("../../../ipc/commands", () => ({
+  getLocalGraph: vi.fn(async () => ({
+    nodes: [
+      {
+        id: "note.md",
+        label: "note",
+        path: "note.md",
+        backlinkCount: 0,
+        resolved: true,
+      },
+      {
+        id: "neighbour.md",
+        label: "neighbour",
+        path: "neighbour.md",
+        backlinkCount: 1,
+        resolved: true,
+      },
+    ],
+    edges: [{ from: "note.md", to: "neighbour.md" }],
+  })),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn(async () => () => undefined),
+}));
+
+import { mountGraph } from "../graphRender";
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import LocalGraphPanel from "../LocalGraphPanel.svelte";
+
+// Capture the ResizeObserver callback the component registers so the test
+// can drive it manually. jsdom doesn't provide ResizeObserver — without
+// this stub the component would throw on `new ResizeObserver(...)`.
+type ROCallback = (entries: ResizeObserverEntry[]) => void;
+let roCallbacks: ROCallback[] = [];
+let roDisconnects = 0;
+
+class ResizeObserverStub {
+  cb: ROCallback;
+  constructor(cb: ROCallback) {
+    this.cb = cb;
+    roCallbacks.push(cb);
+  }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {
+    roDisconnects++;
+  }
+}
+
+function setCanvasSize(container: HTMLElement, width: number, height: number): void {
+  const canvas = container.querySelector<HTMLElement>(".vc-graph-canvas");
+  if (!canvas) return;
+  Object.defineProperty(canvas, "clientWidth", {
+    configurable: true,
+    get: () => width,
+  });
+  Object.defineProperty(canvas, "clientHeight", {
+    configurable: true,
+    get: () => height,
+  });
+}
+
+function fireObserver(width: number, height: number): void {
+  const entry = {
+    contentRect: { width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0 },
+  } as unknown as ResizeObserverEntry;
+  for (const cb of roCallbacks) cb([entry]);
+}
+
+describe("LocalGraphPanel (#43 — ResizeObserver-gated mount)", () => {
+  beforeEach(() => {
+    roCallbacks = [];
+    roDisconnects = 0;
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    // jsdom in this project doesn't ship localStorage; provide a minimal
+    // in-memory stub so the component's persisted-collapse probe works.
+    const lsStore = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => lsStore.get(k) ?? null,
+      setItem: (k: string, v: string) => { lsStore.set(k, v); },
+      removeItem: (k: string) => { lsStore.delete(k); },
+      clear: () => { lsStore.clear(); },
+      key: () => null,
+      length: 0,
+    });
+    localStorage.setItem("vaultcore-graph-collapsed", "false");
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["/vault/note.md"],
+      fileCount: 1,
+    });
+    // Seed one active tab so `activeRelPath` resolves to "note.md".
+    tabStore.openTab("/vault/note.md");
+    vi.mocked(mountGraph).mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("does NOT mount sigma while the container has width=0, then mounts exactly once after a non-zero ResizeObserver entry", async () => {
+    vi.useFakeTimers();
+
+    const { container } = render(LocalGraphPanel);
+
+    // onMount schedules a 200ms-debounced fetch. Let that timer fire, then
+    // flush the fetch Promise and the subsequent tryMount() effect.
+    await vi.advanceTimersByTimeAsync(250);
+    await tick();
+    await tick();
+
+    // jsdom reports clientWidth = 0 for detached/unsized divs, so the
+    // component should have installed a ResizeObserver rather than mounted.
+    expect(roCallbacks.length).toBeGreaterThanOrEqual(1);
+    expect(mountGraph).not.toHaveBeenCalled();
+
+    // Simulate the first real layout pass delivering a usable size. In the
+    // real DOM the ResizeObserver entry and clientWidth are in sync; in
+    // jsdom we have to fake clientWidth explicitly so tryMount's re-check
+    // sees the same size.
+    setCanvasSize(container as HTMLElement, 320, 240);
+    fireObserver(320, 240);
+    await tick();
+
+    expect(mountGraph).toHaveBeenCalledTimes(1);
+    // Observer tears itself down after the single useful observation.
+    expect(roDisconnects).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ignores observations that still report a sub-threshold size", async () => {
+    vi.useFakeTimers();
+
+    const { container } = render(LocalGraphPanel);
+    await vi.advanceTimersByTimeAsync(250);
+    await tick();
+    await tick();
+
+    expect(mountGraph).not.toHaveBeenCalled();
+    expect(roCallbacks.length).toBeGreaterThanOrEqual(1);
+
+    // A transitional layout where the container is still collapsing open
+    // must not trigger the mount — sigma would still see width=0.
+    fireObserver(0, 0);
+    fireObserver(4, 4);
+    await tick();
+    expect(mountGraph).not.toHaveBeenCalled();
+
+    setCanvasSize(container as HTMLElement, 400, 300);
+    fireObserver(400, 300);
+    await tick();
+    expect(mountGraph).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -285,6 +285,11 @@ function stopCooling(handle: GraphHandle): void {
  *  and data updates so the user sees movement in response. */
 function reheat(handle: GraphHandle): void {
   if (!handle.layoutSupervisor || handle.frozen) return;
+  // FA2 supervisor with <2 nodes has no edges to apply forces over and can
+  // leave itself in a non-running-but-not-cleanly-stopped state that throws
+  // on the next .start() call. Skip the continuous sim for tiny graphs —
+  // they don't need layout anyway.
+  if (handle.graph.order < 2) return;
   if (!handle.layoutSupervisor.isRunning()) {
     try {
       handle.layoutSupervisor.start();
@@ -297,12 +302,23 @@ function reheat(handle: GraphHandle): void {
 
 /** Run ForceAtlas2 and assign final positions in place. */
 function runLayout(graph: Graph, iterations = 50): void {
-  if (graph.order === 0) return;
+  // Skip layout for degenerate graphs — FA2 with a single node (empty note
+  // with no links) can produce NaN settings and leave the supervisor in an
+  // inconsistent state that breaks every subsequent updateGraph (#43).
+  if (graph.order < 2) return;
   const settings = forceAtlas2.inferSettings(graph);
   // Speed up convergence on small graphs.
   settings.slowDown = 2;
   settings.gravity = 1;
-  forceAtlas2.assign(graph, { iterations, settings });
+  try {
+    forceAtlas2.assign(graph, { iterations, settings });
+  } catch (err) {
+    // Any layout error — NaN settings, worker issue, etc. Leave the
+    // random-seed positions from populateGraph in place rather than
+    // propagating a crash that tears down the panel.
+    // eslint-disable-next-line no-console
+    console.warn("[graphRender] layout assign failed:", err);
+  }
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -599,11 +615,25 @@ export function updateGraph(
 
   // Pause the live supervisor so it doesn't race with `graph.clear()` /
   // re-seed. We'll restart it at the end if it was running and the view is
-  // not frozen.
-  const wasRunning =
-    handle.layoutSupervisor !== null &&
-    handle.layoutSupervisor.isRunning();
-  if (wasRunning && handle.layoutSupervisor) handle.layoutSupervisor.stop();
+  // not frozen. Guard both the status check and stop() — a supervisor that
+  // hit a bad state on a previous single-node update can throw on either
+  // call, which otherwise blows away the rest of updateGraph and leaves the
+  // panel stuck.
+  let wasRunning = false;
+  try {
+    wasRunning =
+      handle.layoutSupervisor !== null &&
+      handle.layoutSupervisor.isRunning();
+  } catch {
+    wasRunning = false;
+  }
+  if (wasRunning && handle.layoutSupervisor) {
+    try {
+      handle.layoutSupervisor.stop();
+    } catch {
+      /* ignore — reheat will be skipped below */
+    }
+  }
 
   if (!relayout) {
     // Preserve positions for nodes that already exist.


### PR DESCRIPTION
Closes #43.

## Summary
- Replace the rAF-based width guard in `LocalGraphPanel.tryMount` with a `ResizeObserver` on the canvas element. rAF fires before layout so the old guard spun with `clientWidth=0` until something else triggered a remeasure (hence the "switch tab → graph appears" workaround).
- The observer waits for the first `contentRect` with width and height `>= 8px`, disconnects itself, and calls `tryMount` once. The handle is torn down on collapse and `onDestroy` so it never leaks across open/close cycles.
- Add `src/components/Graph/__tests__/LocalGraphPanel.test.ts` with a captured-callback ResizeObserver stub and mocked `graphRender` / IPC, asserting: no mount while width=0, exactly one mount after a valid observation, and sub-threshold observations (0x0, 4x4) stay ignored.

## Test plan
- [x] `pnpm test` — 336 passed (was 334 on main; +2 new).
- [x] `pnpm typecheck` — no new errors (pre-existing `ui06Audit`, `tabStore`, `TreeNode` errors unchanged).
- [ ] Manual: open a note, right-sidebar Local Graph renders without the "Container has no width" log and without needing a Backlinks → Graph tab switch.