### PR TITLE
fix(sidebar): reveal and select active editor tab in the tree (#50)

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -17,7 +17,9 @@
   import { createFile } from "../../ipc/commands";
   import { toastStore } from "../../store/toastStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
+  import { treeRevealStore } from "../../store/treeRevealStore";
   import { openFileAsTab } from "../../lib/openFileAsTab";
+  import { resolveRevealRelPath } from "../../lib/activeTabReveal";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
 
   let { onSwitchVault }: { onSwitchVault: () => void } = $props();
@@ -184,9 +186,36 @@
     });
   });
 
+  // Issue #50: reveal + select the active editor tab in the sidebar tree.
+  // Any tab activation (tree click, Quick Switcher, wiki-link, backlinks,
+  // bookmarks, Cmd+N, cycle, close) flows through tabStore.activeTabId,
+  // so a single subscription here covers every entry point. We guard by
+  // the computed rel path so per-keystroke mutations (setDirty, scroll)
+  // don't re-issue the same reveal on every tabStore emission.
+  let unsubActiveTabReveal: (() => void) | null = null;
+  let lastRevealedRelPath: string | null | undefined = undefined;
+  onMount(() => {
+    unsubActiveTabReveal = tabStore.subscribe((state) => {
+      const activeTab = state.tabs.find((t) => t.id === state.activeTabId) ?? null;
+      let vault: string | null = null;
+      const u = vaultStore.subscribe((s) => { vault = s.currentPath; });
+      u();
+      const relPath = resolveRevealRelPath(activeTab, vault);
+      if (relPath === lastRevealedRelPath) return;
+      lastRevealedRelPath = relPath;
+      selectedPath = relPath !== null && vault !== null
+        ? `${vault}/${relPath}`
+        : null;
+      if (relPath !== null) {
+        treeRevealStore.requestReveal(relPath);
+      }
+    });
+  });
+
   onDestroy(() => {
     unsubTab();
     unsubBacklinksTab?.();
+    unsubActiveTabReveal?.();
     document.removeEventListener("mousemove", handleMousemove);
     document.removeEventListener("mouseup", handleMouseup);
   });

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -388,6 +388,7 @@
             onPathChanged={handlePathChanged}
             {onExpandToggle}
             initiallyExpanded={treeState.expanded.includes(vaultRel(entry.path))}
+            expandedPaths={treeState.expanded}
             sortBy={treeState.sortBy}
           />
         {/each}

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -24,6 +24,10 @@
     onPathChanged: (oldPath: string, newPath: string) => void;
     onExpandToggle?: (relPath: string, isExpanded: boolean) => void;
     initiallyExpanded?: boolean;
+    /** Vault-relative folder paths persisted as expanded — propagated through
+     *  the recursive tree so deeply nested descendants can restore their
+     *  open/closed state on mount instead of always starting collapsed. */
+    expandedPaths?: readonly string[];
     sortBy?: SortBy;
   }
 
@@ -37,6 +41,7 @@
     onPathChanged,
     onExpandToggle,
     initiallyExpanded = false,
+    expandedPaths = [],
     sortBy = "name",
   }: Props = $props();
 
@@ -678,7 +683,13 @@
           onRefreshParent={refreshChildren}
           {onPathChanged}
           {onExpandToggle}
-          initiallyExpanded={false}
+          initiallyExpanded={(() => {
+            const vault = getVaultRoot();
+            if (!vault) return false;
+            const rel = toRelPath(child.path, vault);
+            return child.is_dir && rel !== null && expandedPaths.includes(rel);
+          })()}
+          {expandedPaths}
           {sortBy}
         />
       {/each}

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -8,6 +8,7 @@
   import InlineRename from "./InlineRename.svelte";
   import { vaultStore } from "../../store/vaultStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
+  import { tabStore } from "../../store/tabStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
   import { bookmarksStore } from "../../store/bookmarksStore";
   import { sortEntries, type SortBy } from "../../lib/treeState";
@@ -323,22 +324,33 @@
     showDeleteConfirm = false;
   }
 
+  /**
+   * Persist this folder as expanded in the Sidebar's TreeState so later
+   * re-mounts (e.g. triggered by a tree refresh) start expanded too.
+   */
+  function persistExpanded() {
+    if (!entry.is_dir) return;
+    const vault = getVaultRoot();
+    const rel = vault ? toRelPath(entry.path, vault) : entry.path;
+    onExpandToggle?.(rel, true);
+  }
+
   async function handleNewFileHere() {
     closeContextMenu();
     try {
       const newPath = await createFile(entry.path, "");
-      if (!expanded) {
-        expanded = true;
-        await loadChildren();
-      } else {
-        await loadChildren();
-      }
-      // Find the newly created entry and trigger inline rename
-      const newEntry = children.find((c) => c.path === newPath);
-      if (newEntry) {
-        // Trigger rename on the new entry — handled via child component
-        // The child will receive isNewFile=true
-      }
+      // Issue #50: keep the containing folder expanded after a create.
+      // The assignments are intentional even when `expanded` was already
+      // true — a simultaneous watcher-driven tree refresh can otherwise
+      // race with the local state flip. Persist the expanded flag so a
+      // full re-mount of this subtree restores it.
+      expanded = true;
+      persistExpanded();
+      await loadChildren();
+      expanded = true;
+      // Open the new note so the active-tab reveal hook (VaultLayout)
+      // selects it in the tree automatically.
+      tabStore.openTab(newPath);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
@@ -349,12 +361,11 @@
     closeContextMenu();
     try {
       await createFolder(entry.path, "");
-      if (!expanded) {
-        expanded = true;
-        await loadChildren();
-      } else {
-        await loadChildren();
-      }
+      // Issue #50: same expanded-state protection as handleNewFileHere.
+      expanded = true;
+      persistExpanded();
+      await loadChildren();
+      expanded = true;
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });

--- a/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
@@ -1,0 +1,142 @@
+// Regression test for issue #50: creating a new file inside an expanded folder
+// via the "New file here" context-menu entry must keep the folder expanded and
+// show the freshly created child row.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { listDirectory, createFile } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { tabStore } from "../../../store/tabStore";
+import TreeNode from "../TreeNode.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+const VAULT = "/tmp/test-vault";
+
+function dirEntry(overrides: Partial<DirEntry> = {}): DirEntry {
+  return {
+    name: "folder",
+    path: `${VAULT}/folder`,
+    is_dir: true,
+    is_symlink: false,
+    is_md: false,
+    modified: null,
+    created: null,
+    ...overrides,
+  };
+}
+
+function fileEntry(overrides: Partial<DirEntry> = {}): DirEntry {
+  return {
+    name: "existing.md",
+    path: `${VAULT}/folder/existing.md`,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+    ...overrides,
+  };
+}
+
+function makeProps(entry: DirEntry, initiallyExpanded = true) {
+  return {
+    entry,
+    depth: 0,
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onRefreshParent: vi.fn(),
+    onPathChanged: vi.fn(),
+    initiallyExpanded,
+  };
+}
+
+describe("TreeNode 'New file here' keeps folder expanded (#50)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    tabStore._reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+  });
+
+  it("leaves the folder expanded and renders the new child after creation", async () => {
+    const existing = fileEntry();
+    const newFile = fileEntry({ name: "Unbenannte Notiz.md", path: `${VAULT}/folder/Unbenannte Notiz.md` });
+
+    (listDirectory as any).mockResolvedValueOnce([existing]);
+    (createFile as any).mockResolvedValueOnce(newFile.path);
+    (listDirectory as any).mockResolvedValueOnce([existing, newFile]);
+
+    const { container } = render(TreeNode, { props: makeProps(dirEntry(), true) });
+
+    // Let onMount + initial loadChildren resolve.
+    await tick();
+    await tick();
+
+    // Folder is expanded and the existing child is rendered.
+    const nodeEl = container.querySelector(".vc-tree-node") as HTMLElement;
+    expect(nodeEl.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("existing.md");
+
+    // Open context menu via right-click and pick "New file here".
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    await fireEvent.contextMenu(row, { clientX: 0, clientY: 0 });
+    await tick();
+    const newFileItem = Array.from(container.querySelectorAll<HTMLButtonElement>(".vc-context-item"))
+      .find((b) => b.textContent?.trim() === "New file here");
+    expect(newFileItem).toBeTruthy();
+    await fireEvent.click(newFileItem!);
+
+    // Flush the create + reload.
+    await tick();
+    await tick();
+    await tick();
+
+    expect(createFile).toHaveBeenCalledWith(`${VAULT}/folder`, "");
+
+    const nodeAfter = container.querySelector(".vc-tree-node") as HTMLElement;
+    expect(nodeAfter.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("Unbenannte Notiz.md");
+    expect(container.textContent).toContain("existing.md");
+  });
+
+  it("opens the newly created file in a tab so the active-tab reveal hook can sync the tree", async () => {
+    const newFile = fileEntry({ name: "Unbenannte Notiz.md", path: `${VAULT}/folder/Unbenannte Notiz.md` });
+
+    (listDirectory as any).mockResolvedValue([]);
+    (createFile as any).mockResolvedValueOnce(newFile.path);
+
+    const openSpy = vi.spyOn(tabStore, "openTab");
+
+    const { container } = render(TreeNode, { props: makeProps(dirEntry(), true) });
+    await tick();
+    await tick();
+
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    await fireEvent.contextMenu(row, { clientX: 0, clientY: 0 });
+    await tick();
+    const newFileItem = Array.from(container.querySelectorAll<HTMLButtonElement>(".vc-context-item"))
+      .find((b) => b.textContent?.trim() === "New file here");
+    await fireEvent.click(newFileItem!);
+    await tick();
+    await tick();
+
+    expect(openSpy).toHaveBeenCalledWith(newFile.path);
+  });
+});

--- a/src/lib/__tests__/activeTabReveal.test.ts
+++ b/src/lib/__tests__/activeTabReveal.test.ts
@@ -1,0 +1,100 @@
+// Unit tests for the active-tab → tree reveal resolver (#50).
+
+import { describe, it, expect } from "vitest";
+import { resolveRevealRelPath } from "../activeTabReveal";
+import { GRAPH_TAB_PATH, type Tab } from "../../store/tabStore";
+
+function tab(overrides: Partial<Tab> & Pick<Tab, "filePath">): Tab {
+  return {
+    id: "t1",
+    isDirty: false,
+    scrollPos: 0,
+    cursorPos: 0,
+    lastSaved: 0,
+    lastSavedContent: "",
+    ...overrides,
+  };
+}
+
+describe("resolveRevealRelPath (#50)", () => {
+  it("returns null when there is no active tab", () => {
+    expect(resolveRevealRelPath(null, "/vault")).toBeNull();
+    expect(resolveRevealRelPath(undefined, "/vault")).toBeNull();
+  });
+
+  it("returns null when the vault path is null", () => {
+    expect(resolveRevealRelPath(tab({ filePath: "/vault/notes/a.md" }), null)).toBeNull();
+  });
+
+  it("returns null for graph tabs via type discriminant", () => {
+    expect(
+      resolveRevealRelPath(
+        tab({ filePath: GRAPH_TAB_PATH, type: "graph" }),
+        "/vault",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for graph tabs even if only the sentinel path is set", () => {
+    expect(
+      resolveRevealRelPath(tab({ filePath: GRAPH_TAB_PATH }), "/vault"),
+    ).toBeNull();
+  });
+
+  it("returns null when the tab's file lives outside the vault", () => {
+    expect(
+      resolveRevealRelPath(tab({ filePath: "/other/foo.md" }), "/vault"),
+    ).toBeNull();
+  });
+
+  it("returns the vault-relative path for a top-level file", () => {
+    expect(
+      resolveRevealRelPath(tab({ filePath: "/vault/foo.md" }), "/vault"),
+    ).toBe("foo.md");
+  });
+
+  it("returns the vault-relative path for a nested file", () => {
+    expect(
+      resolveRevealRelPath(
+        tab({ filePath: "/vault/notes/daily/today.md" }),
+        "/vault",
+      ),
+    ).toBe("notes/daily/today.md");
+  });
+
+  it("returns rel paths for non-markdown viewer tabs too", () => {
+    expect(
+      resolveRevealRelPath(
+        tab({ filePath: "/vault/images/logo.png", viewer: "image" }),
+        "/vault",
+      ),
+    ).toBe("images/logo.png");
+  });
+
+  it("strips trailing slashes from the vault path before comparing", () => {
+    expect(
+      resolveRevealRelPath(
+        tab({ filePath: "/vault/notes/a.md" }),
+        "/vault/",
+      ),
+    ).toBe("notes/a.md");
+  });
+
+  it("normalises backslashes to forward slashes in the tab's absolute path", () => {
+    // The vault path is forward-slash form; backslash separators in the
+    // tab's absolute path (defensive on Windows-shaped inputs) should
+    // still match.
+    expect(
+      resolveRevealRelPath(
+        tab({ filePath: "/vault\\notes\\a.md" }),
+        "/vault",
+      ),
+    ).toBe("notes/a.md");
+  });
+
+  it("returns null for a file whose absolute path equals the vault itself", () => {
+    expect(
+      resolveRevealRelPath(tab({ filePath: "/vault" }), "/vault"),
+    ).toBeNull();
+  });
+});

--- a/src/lib/activeTabReveal.ts
+++ b/src/lib/activeTabReveal.ts
@@ -1,0 +1,43 @@
+// Active-tab → tree reveal bridge (#50).
+//
+// The sidebar's file tree should always follow whichever tab the user
+// has active in the editor — mirroring Obsidian. Tabs can be activated
+// from many places (tree click, Quick Switcher, wiki-link, backlinks,
+// bookmarks, Cmd+N, tab cycling, tab close, …) and we don't want to
+// scatter reveal calls through all of them. Instead, a single subscription
+// on tabStore routes every activation through treeRevealStore.
+//
+// This module contains the pure decision logic — turning an active tab
+// plus the current vault root into the reveal payload — so it can be
+// unit-tested without spinning up the Svelte component.
+//
+// Rules:
+//   - No reveal when there is no active tab.
+//   - No reveal when the vault path is null.
+//   - No reveal for graph tabs (sentinel filePath "vault://graph").
+//   - No reveal when the tab's absolute path is outside the vault.
+//   - Otherwise, return the vault-relative path (forward slashes,
+//     no leading slash).
+
+import { GRAPH_TAB_PATH, type Tab } from "../store/tabStore";
+
+/**
+ * Compute the vault-relative path that should be revealed in the tree for
+ * a given active tab. Returns `null` when no reveal is appropriate.
+ */
+export function resolveRevealRelPath(
+  activeTab: Tab | null | undefined,
+  vaultPath: string | null,
+): string | null {
+  if (!activeTab) return null;
+  if (!vaultPath) return null;
+  if (activeTab.type === "graph") return null;
+  if (activeTab.filePath === GRAPH_TAB_PATH) return null;
+
+  const abs = activeTab.filePath.replace(/\\/g, "/");
+  const root = vaultPath.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!abs.startsWith(root + "/")) return null;
+
+  const rel = abs.slice(root.length + 1);
+  return rel.length > 0 ? rel : null;
+}


### PR DESCRIPTION
Closes #50.

## Summary

Two related sidebar UX fixes.

1. **Tree now follows the active editor tab.** Tab activations from Quick Switcher, wiki-links, backlinks, bookmarks, `Cmd+N`, tab cycling and tab close all flow through `tabStore.activeTabId`, so a single subscription in `VaultLayout.svelte` routes every activation through `treeRevealStore.requestReveal` and drives the sidebar's `selectedPath`. Previously only the breadcrumb bar revealed anything; the tree selection was stuck on whatever row was clicked last.

2. **Creating a note inside a folder no longer collapses it.** `TreeNode.handleNewFileHere` / `handleNewFolderHere` now re-assert `expanded = true` both before and after `loadChildren()` to survive a racing watcher-driven tree refresh, and persist the expanded flag via `onExpandToggle` so subtree re-mounts restore it. The "New file here" flow also opens the fresh note via `tabStore.openTab`, which lets the active-tab reveal hook in (1) select and scroll to it automatically.

The reveal decision lives in a pure `resolveRevealRelPath` helper (`src/lib/activeTabReveal.ts`) so it can be unit-tested without a component harness — covering null tab, null vault, graph-sentinel (`vault://graph`), outside-vault paths, trailing slashes, backslash normalisation, nested paths, non-markdown viewer tabs, and vault-equals-path.

## Test plan

- [x] `pnpm test` — 347 tests pass (up from 334; 11 new resolver cases + 2 new folder-collapse component cases).
- [x] `pnpm typecheck` — no new errors beyond the pre-existing ones in `ui06Audit.test.ts` / `tabStore.ts` / `tabStore.test.ts`.
- [ ] Manual: open two vault files, switch tabs, confirm the sidebar selection follows. Repeat via Quick Switcher and a wiki-link click.
- [ ] Manual: right-click a collapsed folder → "New file here" → folder expands, new note opens in a tab, tree row for the new note is selected and scrolled into view.
- [ ] Manual: right-click an already-expanded folder → "New file here" → folder stays expanded.