### PR TITLE
revert(indexer): stop wiping Tantivy dir on every open (#46 regression)

### DIFF
--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -135,21 +135,15 @@ impl IndexCoordinator {
         let vaultcore_dir = vault_path.join(".vaultcore");
         let index_dir = vaultcore_dir.join("index").join("tantivy");
 
-        // Always wipe the on-disk Tantivy index before opening (#46).
-        //
-        // index_vault only upserts files it finds on disk — it never removes
-        // orphans. Without a wipe, entries for files that were deleted between
-        // sessions (or that belonged to a prior copy of the vault) survive
-        // forever and surface as ghost search hits. The in-memory FileIndex is
-        // already recreated per coordinator, so re-indexing every file on open
-        // is the baseline cost regardless; wiping the directory just prevents
-        // stale entries from co-existing with the fresh ones.
-        //
-        // Wiping must happen BEFORE the index is opened and the writer task is
-        // spawned — removing a live directory races with writer.commit() and
-        // fails with LockFailure / NotFound.
-        if index_dir.exists() {
-            std::fs::remove_dir_all(&index_dir).map_err(VaultError::Io)?;
+        // Schema-version check must happen BEFORE the index is opened and
+        // before the background writer task is spawned.  If we wipe the
+        // directory after the task is live, index.writer() races with
+        // remove_dir_all() and fails with LockFailure / NotFound.
+        if !tantivy_index::check_version(&vaultcore_dir) {
+            if index_dir.exists() {
+                std::fs::remove_dir_all(&index_dir).map_err(VaultError::Io)?;
+                log::info!("Schema mismatch — index directory wiped for rebuild");
+            }
         }
 
         let index = tantivy_index::open_or_create_index(&index_dir, &schema)?;


### PR DESCRIPTION
Reverts the unconditional \`remove_dir_all\` added in 89a0ecb.

## Why
That wipe raced with the prior coordinator's writer task on same-vault re-opens. \`*guard = None\` in \`open_vault\` drops the old coordinator and queues \`Shutdown\` to its writer, but the tokio task keeps draining pending commits asynchronously. The new \`remove_dir_all\` could then delete files out from under the still-live writer, leaving the Tantivy directory in an inconsistent state.

Users reported 'Index corrupt. VaultCore will rebuild it' on both of their vaults after vault-switch sequences.

## What this PR does
Restores the schema-mismatch-only wipe. The frontend cache clear from e2e2218 (PR #52, still on main) remains in place — it addresses the most common user-visible manifestation of #46 (stale results rendering after vault switch).

## Followup
The backend orphan-entry cleanup (true fix for #46: deleting Tantivy entries for files that no longer exist) needs to be redone without the race. Two safe approaches:
1. Dispatch \`IndexCmd::Rebuild\` on the NEW coordinator's writer channel — clears + re-walks in the new writer's context, no cross-coordinator race.
2. At the end of \`index_vault\`, enumerate all Tantivy docs and queue \`DeleteFile\` for paths not present in the walk's \`file_list\`.

Will track as a follow-up issue after this revert lands.

## Manual recovery for affected users
Quit VaultCore, delete \`<vault>/.vaultcore/index/tantivy\` (and \`<vault>/.vaultcore/index_version.json\` if present) in each affected vault, relaunch — the app will rebuild the index from scratch on next open.