### PR TITLE
feat(vault): in-app repair dialog for IndexCorrupt errors (#46)

### DIFF
--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -233,6 +233,30 @@ pub async fn get_recent_vaults(app: AppHandle) -> Result<Vec<RecentVault>, Vault
     read_recent_vaults_at(&file)
 }
 
+/// Delete the on-disk Tantivy index and version stamp for `vault_path` so
+/// that the next `open_vault` call rebuilds them from scratch.
+///
+/// Called by the frontend after an `IndexCorrupt` error — the UI shows a
+/// confirmation dialog, then calls this command, then retries `open_vault`.
+/// The coordinator for this vault is never kept across the error (the failed
+/// `IndexCoordinator::new` never stored anything in `state.index_coordinator`),
+/// so this is safe to call without touching the coordinator mutex.
+#[tauri::command]
+pub async fn repair_vault_index(vault_path: String) -> Result<(), VaultError> {
+    let root = PathBuf::from(&vault_path);
+    let root = root.canonicalize().map_err(VaultError::Io)?;
+    let vaultcore = root.join(".vaultcore");
+    let index_dir = vaultcore.join("index").join("tantivy");
+    let version_file = vaultcore.join("index_version.json");
+    if index_dir.exists() {
+        std::fs::remove_dir_all(&index_dir).map_err(VaultError::Io)?;
+    }
+    if version_file.exists() {
+        let _ = std::fs::remove_file(&version_file);
+    }
+    Ok(())
+}
+
 // --- recent-vaults.json persistence -----------------------------------------
 
 fn recent_vaults_path(app: &AppHandle) -> Result<PathBuf, VaultError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
             commands::vault::open_vault,
             commands::vault::get_recent_vaults,
             commands::vault::get_vault_stats,
+            commands::vault::repair_vault_index,
             commands::files::read_file,
             commands::files::write_file,
             commands::files::create_file,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
     getRecentVaults,
     openVault,
     pickVaultFolder,
+    repairVaultIndex,
   } from "./ipc/commands";
   import { listenIndexProgress } from "./ipc/events";
   import { isVaultError, vaultErrorCopy } from "./types/errors";
@@ -21,6 +22,12 @@
 
   let recent: RecentVault[] = $state([]);
   let unlistenProgress: (() => void) | null = null;
+
+  // Index-corrupt recovery dialog — shown when openVault fails with
+  // IndexCorrupt. Confirming wipes .vaultcore/index/tantivy + the version
+  // stamp and retries openVault, which rebuilds from scratch.
+  let repairPrompt = $state<{ vaultPath: string } | null>(null);
+  let repairing = $state(false);
 
   function toVaultError(err: unknown) {
     if (isVaultError(err)) {
@@ -46,10 +53,39 @@
     } catch (err) {
       progressStore.finish();
       const ve = toVaultError(err);
-      const copy = vaultErrorCopy(ve);
-      vaultStore.setError(copy);
-      toastStore.push({ variant: "error", message: copy });
+      if (ve.kind === "IndexCorrupt") {
+        // Offer the user an in-app repair rather than making them delete
+        // .vaultcore/index by hand.
+        repairPrompt = { vaultPath: path };
+        vaultStore.setError(vaultErrorCopy(ve));
+        return;
+      }
+      vaultStore.setError(vaultErrorCopy(ve));
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
     }
+  }
+
+  async function confirmRepair(): Promise<void> {
+    if (!repairPrompt || repairing) return;
+    repairing = true;
+    const path = repairPrompt.vaultPath;
+    try {
+      await repairVaultIndex(path);
+      repairPrompt = null;
+      repairing = false;
+      await loadVault(path);
+    } catch (err) {
+      repairing = false;
+      const ve = toVaultError(err);
+      toastStore.push({
+        variant: "error",
+        message: `Repair failed: ${vaultErrorCopy(ve)}`,
+      });
+    }
+  }
+
+  function cancelRepair(): void {
+    repairPrompt = null;
   }
 
   async function handlePickVault(): Promise<void> {
@@ -131,3 +167,89 @@
 
 <ProgressBar />
 <ToastContainer />
+
+{#if repairPrompt}
+  <div class="vc-repair-backdrop" role="dialog" aria-modal="true" aria-labelledby="vc-repair-title">
+    <div class="vc-repair-modal">
+      <h2 id="vc-repair-title" class="vc-repair-title">Index corrupt</h2>
+      <p class="vc-repair-body">
+        The search index for this vault can't be opened. VaultCore can wipe
+        <code>.vaultcore/index/tantivy</code> and rebuild it from scratch —
+        your notes are not touched.
+      </p>
+      <div class="vc-repair-actions">
+        <button type="button" class="vc-repair-cancel" onclick={cancelRepair} disabled={repairing}>
+          Cancel
+        </button>
+        <button type="button" class="vc-repair-confirm" onclick={confirmRepair} disabled={repairing}>
+          {repairing ? "Rebuilding…" : "Rebuild index"}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-repair-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 300;
+  }
+  .vc-repair-modal {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    padding: 20px 24px;
+    max-width: 440px;
+    width: calc(100% - 48px);
+  }
+  .vc-repair-title {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+  .vc-repair-body {
+    margin: 0 0 20px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--color-text);
+  }
+  .vc-repair-body code {
+    font-family: var(--vc-font-mono);
+    font-size: 12px;
+    padding: 1px 4px;
+    background: var(--color-surface-alt, rgba(0, 0, 0, 0.06));
+    border-radius: 3px;
+  }
+  .vc-repair-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .vc-repair-cancel,
+  .vc-repair-confirm {
+    padding: 6px 14px;
+    border-radius: 4px;
+    font-size: 13px;
+    cursor: pointer;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .vc-repair-confirm {
+    background: var(--color-accent);
+    color: white;
+    border-color: var(--color-accent);
+  }
+  .vc-repair-cancel:disabled,
+  .vc-repair-confirm:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -55,6 +55,14 @@ export async function getRecentVaults(): Promise<RecentVault[]> {
   }
 }
 
+export async function repairVaultIndex(vaultPath: string): Promise<void> {
+  try {
+    await invoke<void>("repair_vault_index", { vaultPath });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function getVaultStats(path: string): Promise<VaultStats> {
   try {
     return await invoke<VaultStats>("get_vault_stats", { path });


### PR DESCRIPTION
Partial fix for #46.

## Why
After PR #55 reverted the racy unconditional wipe, users who hit \`IndexCorrupt\` (for any reason — a truncated Tantivy segment, a previous aborted session, a leftover from the racy wipe) were stuck: the toast said "VaultCore will rebuild it" but nothing rebuilt. They had to delete \`.vaultcore/index\` by hand.

## What
- New Tauri command \`repair_vault_index(vault_path)\` removes \`<vault>/.vaultcore/index/tantivy\` and the version stamp. Notes are untouched — only the cached index.
- \`App.svelte\` catches the IndexCorrupt variant, shows a confirmation dialog, calls repair on confirm, then retries \`openVault\`. Rebuilding runs through the normal \`index_vault\` path on the fresh coordinator, so no race with a prior writer task.
- No auto-wipe: the user always sees the dialog. That keeps the Tantivy cache intact across normal app restarts.

## Test plan
- [ ] Trigger IndexCorrupt (e.g. manually truncate \`.meta.json\` inside \`<vault>/.vaultcore/index/tantivy\`, re-open) → dialog appears
- [ ] Click "Rebuild index" → Tantivy dir + version file are deleted, vault reopens successfully, indexing progress bar runs, search works
- [ ] Click "Cancel" → vault stays in error state, user stays on Welcome screen
- [ ] Repeat open on a healthy vault → no dialog, normal open
- [ ] Notes on disk remain untouched