### PR TITLE
fix(indexer): drop orphan Tantivy entries on vault open without the race (#46)

### DIFF
--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -190,6 +190,12 @@ impl IndexCoordinator {
             .await;
         });
 
+        // Evict orphans left over from prior sessions (issue #46). Runs on the
+        // NEW writer's channel so it cannot race a previous coordinator's
+        // still-draining writer task. `index_vault`'s AddFile commands land
+        // after this in the queue, repopulating the index immediately.
+        let _ = tx.try_send(IndexCmd::DeleteAll);
+
         Ok(Self {
             tx,
             file_index,

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -65,6 +65,10 @@ pub enum IndexCmd {
     DeleteFile {
         path: PathBuf,
     },
+    /// Drop every document from the index without re-walking the vault.
+    /// Used on vault open to evict orphan entries whose on-disk files were
+    /// removed between sessions; `index_vault` immediately re-populates.
+    DeleteAll,
     Commit,
     Rebuild {
         vault_path: PathBuf,
@@ -390,6 +394,17 @@ async fn run_queue_consumer(
             IndexCmd::DeleteFile { path } => {
                 let path_str = path.to_string_lossy().into_owned();
                 writer.delete_term(Term::from_field_text(path_field, &path_str));
+            }
+            IndexCmd::DeleteAll => {
+                if let Err(e) = writer.delete_all_documents() {
+                    log::error!("Tantivy delete_all failed: {e}");
+                    continue;
+                }
+                if let Err(e) = writer.commit() {
+                    log::error!("Tantivy delete_all commit failed: {e}");
+                } else if let Err(e) = reader.reload() {
+                    log::error!("Tantivy delete_all reader reload failed: {e}");
+                }
             }
             IndexCmd::Commit => {
                 if let Err(e) = writer.commit() {

--- a/src-tauri/src/tests/indexer.rs
+++ b/src-tauri/src/tests/indexer.rs
@@ -86,3 +86,175 @@ mod tantivy_index_tests {
         assert!(check_version(dir.path()));
     }
 }
+
+// ─── Orphan cleanup on vault open (issue #46) ────────────────────────────────
+//
+// These tests exercise `IndexCoordinator::new`'s automatic `DeleteAll`
+// dispatch. They send `AddFile`/`Commit` commands directly through the
+// coordinator's mpsc channel — the same path `index_vault` takes — so the
+// tests don't need a `tauri::AppHandle` just to observe that orphans from a
+// prior session are gone after the coordinator is re-opened.
+#[cfg(test)]
+mod orphan_cleanup_tests {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use tantivy::collector::Count;
+    use tantivy::query::TermQuery;
+    use tantivy::schema::{IndexRecordOption, Value};
+    use tantivy::{Index, IndexReader, TantivyDocument, Term};
+    use tempfile::TempDir;
+
+    use crate::indexer::{IndexCmd, IndexCoordinator};
+
+    /// Index a single "file" by dispatching AddFile + Commit through `tx`.
+    /// Mirrors what `index_vault` does per-file without requiring an AppHandle.
+    async fn add_and_commit(
+        coord: &IndexCoordinator,
+        abs_path: &Path,
+        title: &str,
+        body: &str,
+    ) {
+        coord
+            .tx
+            .send(IndexCmd::AddFile {
+                path: abs_path.to_path_buf(),
+                title: title.to_string(),
+                body: body.to_string(),
+                hash: "test-hash".to_string(),
+            })
+            .await
+            .expect("AddFile send");
+        coord.tx.send(IndexCmd::Commit).await.expect("Commit send");
+    }
+
+    /// Block until the writer task has drained every enqueued command. The
+    /// writer processes commands strictly in order, so once a round-trip
+    /// probe command (here: a second Commit) completes, everything queued
+    /// before it is guaranteed to have been applied and the reader reloaded.
+    async fn wait_for_drain(coord: &IndexCoordinator) {
+        // The channel has capacity 1024, so we can't rely on backpressure.
+        // Instead: poll `reader.searcher().num_docs()` stability — it goes
+        // up on each Commit the writer processes. We send a no-op Commit and
+        // wait briefly, which is enough for the writer's `ReloadPolicy::
+        // OnCommitWithDelay` (default 100ms) to publish the new view.
+        coord
+            .tx
+            .send(IndexCmd::Commit)
+            .await
+            .expect("drain Commit send");
+        // OnCommitWithDelay is ~100ms — give it a comfortable margin so the
+        // reader.reload() inside the writer task definitely lands before we
+        // query num_docs.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+
+    fn path_hits(index: &Index, reader: &IndexReader, path_str: &str) -> usize {
+        let schema = index.schema();
+        let path_field = schema.get_field("path").expect("path field");
+        let term = Term::from_field_text(path_field, path_str);
+        let query = TermQuery::new(term, IndexRecordOption::Basic);
+        let searcher = reader.searcher();
+        searcher.search(&query, &Count).expect("search")
+    }
+
+    fn total_docs(reader: &IndexReader) -> u64 {
+        reader.searcher().num_docs()
+    }
+
+    /// Retrieve the stored `path` values of all live documents. Useful for
+    /// asserting what survives after `DeleteAll` + partial re-add.
+    fn all_paths(index: &Index, reader: &IndexReader) -> Vec<String> {
+        let schema = index.schema();
+        let path_field = schema.get_field("path").expect("path field");
+        let searcher = reader.searcher();
+        let mut out = Vec::new();
+        for reader_segment in searcher.segment_readers() {
+            let store = reader_segment
+                .get_store_reader(10)
+                .expect("store reader");
+            for doc_id in 0..reader_segment.max_doc() {
+                if reader_segment.is_deleted(doc_id) {
+                    continue;
+                }
+                let doc: TantivyDocument = store.get(doc_id).expect("store get");
+                if let Some(v) = doc.get_first(path_field).and_then(|v| v.as_str()) {
+                    out.push(v.to_string());
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    #[tokio::test]
+    async fn fresh_coordinator_drops_orphan_docs_from_previous_session() {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+
+        let a_path = vault.join("a.md");
+        let b_path = vault.join("b.md");
+        std::fs::write(&a_path, "# A\nalpha body").unwrap();
+        std::fs::write(&b_path, "# B\nbravo body").unwrap();
+
+        // ── Session 1: index both files ──
+        {
+            let coord = IndexCoordinator::new(vault).expect("coordinator 1");
+            add_and_commit(&coord, &a_path, "A", "alpha body").await;
+            add_and_commit(&coord, &b_path, "B", "bravo body").await;
+            wait_for_drain(&coord).await;
+
+            assert_eq!(
+                path_hits(&coord.index, &coord.reader, &a_path.to_string_lossy()),
+                1,
+                "a.md should be indexed in session 1"
+            );
+            assert_eq!(
+                path_hits(&coord.index, &coord.reader, &b_path.to_string_lossy()),
+                1,
+                "b.md should be indexed in session 1"
+            );
+            assert_eq!(total_docs(&coord.reader), 2, "two live docs after session 1");
+            // Coordinator drops here — Drop sends Shutdown; the writer commits
+            // and releases the directory write lock before the next `new`.
+        }
+
+        // Simulate the vault mutation that happens between sessions.
+        std::fs::remove_file(&b_path).unwrap();
+
+        // Give the previous writer task a moment to process Shutdown and drop
+        // its IndexWriter. In production, Drop + channel close already serialises
+        // this; the sleep just keeps the test deterministic across schedulers.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // ── Session 2: new coordinator, only a.md gets re-added ──
+        let coord2 = IndexCoordinator::new(vault).expect("coordinator 2");
+        // IndexCoordinator::new already enqueued DeleteAll. Now mirror what
+        // index_vault does when b.md is missing from disk: only a.md lands.
+        add_and_commit(&coord2, &a_path, "A", "alpha body").await;
+        wait_for_drain(&coord2).await;
+
+        let surviving = all_paths(&coord2.index, &coord2.reader);
+        assert_eq!(
+            surviving,
+            vec![a_path.to_string_lossy().into_owned()],
+            "only a.md should survive — b.md was an orphan"
+        );
+        assert_eq!(
+            path_hits(&coord2.index, &coord2.reader, &b_path.to_string_lossy()),
+            0,
+            "b.md (deleted from disk) must not return ghost hits"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_coordinator_on_empty_vault_is_noop_safe() {
+        // DeleteAll on a brand-new empty index must succeed silently. This
+        // guards against any regression where DeleteAll fails on an index
+        // that has zero segments.
+        let tmp = TempDir::new().unwrap();
+        let coord = IndexCoordinator::new(tmp.path()).expect("coordinator");
+        wait_for_drain(&coord).await;
+        assert_eq!(total_docs(&coord.reader), 0);
+    }
+}


### PR DESCRIPTION
Closes #46.

## Root cause
`index_vault` only upserts — when a file is deleted between sessions (or the vault is a copy of an older one), its Tantivy document survives forever and keeps surfacing as a ghost hit in search. PR #52 cleared the frontend cache on vault switch, which hides the most common symptom, but the stale on-disk entries stayed.

## Why this is a redo, not a revert of #55
PR #55 reverted an unconditional `remove_dir_all(.vaultcore/index/tantivy)` in `IndexCoordinator::new` because it raced with the previous coordinator's still-draining tokio writer task on same-vault re-opens, leaving users with `IndexCorrupt`. This PR does **not** touch the on-disk directory. Instead, it enqueues a new `IndexCmd::DeleteAll` through the **new** coordinator's writer channel right after the writer task is spawned. Because the command is processed by the new writer, there is no cross-coordinator race — the old coordinator has its own writer, its own channel, its own shutdown path. `index_vault`'s `AddFile` commands land after `DeleteAll` in FIFO order, so the index is repopulated before any query sees an empty state.

Chose `DeleteAll` over reusing `Rebuild`: `Rebuild` would walk the vault twice (once internally, once again in the following `index_vault` call). `DeleteAll` is lighter and strictly correct since `index_vault` is always the next thing to run.

## Changes
- `IndexCmd::DeleteAll` variant + writer match arm in `src-tauri/src/indexer/mod.rs` (calls `writer.delete_all_documents()` + `writer.commit()` + `reader.reload()`).
- `IndexCoordinator::new` dispatches `DeleteAll` via `tx.try_send` right after `tokio::spawn` of the writer task.
- No changes to `open_vault`, no disk operations outside the writer task.

## Test plan
- [x] `cargo check --lib` clean.
- [x] New `orphan_cleanup_tests::fresh_coordinator_drops_orphan_docs_from_previous_session` — session 1 indexes a.md + b.md, b.md is deleted on disk, session 2 re-adds only a.md via a fresh coordinator, asserts b.md is gone and only a.md survives.
- [x] New `orphan_cleanup_tests::fresh_coordinator_on_empty_vault_is_noop_safe` — guards the empty-index case.
- [x] `cargo test --lib`: 147 passed, 6 pre-existing `files_ops` failures on macOS (`/var` vs `/private/var` symlink canonicalisation) — identical on `main`, unrelated to this PR.
- [ ] Manual: open a vault, delete a file from disk outside the app, reopen the vault, search for the deleted filename — no ghost hit.