### PR TITLE
feat(editor): tag autocomplete on # (#68)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -22,6 +22,7 @@
   import { scrollToMatch } from "./flashHighlight";
   import { scrollStore } from "../../store/scrollStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
+  import { tagsStore } from "../../store/tagsStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { setResolvedLinks, resolveTarget, refreshWikiLinks } from "./wikiLink";
   import { setResolvedAttachments } from "./embeds";
@@ -447,6 +448,7 @@
           editorStore.setLastSavedHash(newHash);
           tabStore.setLastSavedContent(tab.id, result.merged_content);
           tabStore.setDirty(tab.id, false);
+          void tagsStore.reload();
 
           // Toasts — reuse the exact Phase 2 German strings.
           const filename = tab.filePath.split("/").pop() ?? tab.filePath;
@@ -463,6 +465,7 @@
         tabStore.setDirty(tab.id, false);
         tabStore.setLastSavedContent(tab.id, text);
         editorStore.setLastSavedHash(hash);
+        void tagsStore.reload();
       } catch (err: unknown) {
         // ERR-04: disk-full error — preserve buffer, debounce toast
         const isVaultErr = err && typeof err === "object" && "kind" in err;

--- a/src/components/Editor/__tests__/tagAutocomplete.test.ts
+++ b/src/components/Editor/__tests__/tagAutocomplete.test.ts
@@ -1,0 +1,175 @@
+// Unit tests for the #tag CompletionSource (#68).
+//
+// We exercise the source directly with a real EditorState + CompletionContext
+// (no EditorView or Tauri runtime needed). The tagsStore is driven by calling
+// its internal subscribe with a mocked `listTags` IPC.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { CompletionContext } from "@codemirror/autocomplete";
+import { markdown } from "@codemirror/lang-markdown";
+import { GFM } from "@lezer/markdown";
+import { writable } from "svelte/store";
+
+// Mock the tagsStore before importing the source under test.
+vi.mock("../../../store/tagsStore", () => {
+  const _store = writable({
+    tags: [
+      { tag: "project", count: 5 },
+      { tag: "projects/active", count: 2 },
+      { tag: "productivity", count: 1 },
+      { tag: "todo", count: 9 },
+    ],
+    loading: false,
+    error: null,
+  });
+  return {
+    tagsStore: {
+      subscribe: _store.subscribe,
+      reload: vi.fn(),
+      reset: vi.fn(),
+      // Exposed for tests — not part of the real store surface.
+      _set: _store.set,
+    },
+  };
+});
+
+// Import after the mock so the source picks up the mocked store.
+import { tagCompletionSource } from "../tagAutocomplete";
+import { tagsStore } from "../../../store/tagsStore";
+
+function makeState(doc: string): EditorState {
+  return EditorState.create({
+    doc,
+    extensions: [markdown({ extensions: [GFM] })],
+  });
+}
+
+/**
+ * Build a CompletionContext anchored at `pos` (end of doc by default).
+ * `explicit=false` mimics typing; `true` mimics Ctrl-Space.
+ */
+function makeCtx(
+  doc: string,
+  pos: number = doc.length,
+  explicit = false,
+): CompletionContext {
+  const state = makeState(doc);
+  return new CompletionContext(state, pos, explicit);
+}
+
+beforeEach(() => {
+  // Reset store to default fixture before each test.
+  (tagsStore as unknown as { _set: (v: unknown) => void })._set({
+    tags: [
+      { tag: "project", count: 5 },
+      { tag: "projects/active", count: 2 },
+      { tag: "productivity", count: 1 },
+      { tag: "todo", count: 9 },
+    ],
+    loading: false,
+    error: null,
+  });
+});
+
+describe("tagCompletionSource", () => {
+  it("returns all tags when user types `#` at line start (explicit)", () => {
+    const ctx = makeCtx("#", 1, true);
+    const result = tagCompletionSource(ctx);
+    expect(result).not.toBeNull();
+    expect(result!.from).toBe(1);
+    expect(result!.options.map((o) => o.label)).toEqual([
+      "project",
+      "projects/active",
+      "productivity",
+      "todo",
+    ]);
+  });
+
+  it("does not fire on bare `#` during typing (non-explicit) — avoids markdown headings", () => {
+    const ctx = makeCtx("#", 1, false);
+    expect(tagCompletionSource(ctx)).toBeNull();
+  });
+
+  it("returns candidates when a prefix is typed — CM6 filters the visible list", () => {
+    const ctx = makeCtx("#proj");
+    const result = tagCompletionSource(ctx);
+    expect(result).not.toBeNull();
+    // `from` points after the `#`, so CM6's built-in prefix filter matches
+    // `proj` against each label (project, projects/active, productivity…).
+    expect(result!.from).toBe(1);
+    // We hand back the full set; CM6 narrows it — verify our labels are there.
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("project");
+    expect(labels).toContain("projects/active");
+  });
+
+  it("inserts the bare tag text via the `apply` string (Enter behaviour)", () => {
+    const ctx = makeCtx("#proj");
+    const result = tagCompletionSource(ctx)!;
+    const opt = result.options.find((o) => o.label === "project")!;
+    expect(opt.apply).toBe("project");
+  });
+
+  it("triggers after whitespace — `hello #t` is a valid tag-start", () => {
+    const ctx = makeCtx("hello #t");
+    const result = tagCompletionSource(ctx);
+    expect(result).not.toBeNull();
+    expect(result!.from).toBe("hello #".length);
+  });
+
+  it("does NOT trigger inside a URL fragment (`example.com/page#frag`)", () => {
+    const ctx = makeCtx("see example.com/page#frag");
+    expect(tagCompletionSource(ctx)).toBeNull();
+  });
+
+  it("does NOT trigger when `#` follows a word character (`abc#def`)", () => {
+    const ctx = makeCtx("abc#def");
+    expect(tagCompletionSource(ctx)).toBeNull();
+  });
+
+  it("does NOT trigger inside a fenced code block", () => {
+    const doc = "```\n#proj\n```\n";
+    // Cursor just after `#proj` inside the fence.
+    const pos = doc.indexOf("#proj") + "#proj".length;
+    const ctx = makeCtx(doc, pos);
+    expect(tagCompletionSource(ctx)).toBeNull();
+  });
+
+  it("does NOT trigger inside inline code (`` `#proj` ``)", () => {
+    const doc = "text `#proj` more";
+    const pos = doc.indexOf("#proj") + "#proj".length;
+    const ctx = makeCtx(doc, pos);
+    expect(tagCompletionSource(ctx)).toBeNull();
+  });
+
+  it("returns null when the tags store is empty", () => {
+    (tagsStore as unknown as { _set: (v: unknown) => void })._set({
+      tags: [],
+      loading: false,
+      error: null,
+    });
+    const ctx = makeCtx("#t");
+    expect(tagCompletionSource(ctx)).toBeNull();
+  });
+
+  it("reflects newly added tags reactively — next firing picks them up", () => {
+    (tagsStore as unknown as { _set: (v: unknown) => void })._set({
+      tags: [{ tag: "fresh", count: 1 }],
+      loading: false,
+      error: null,
+    });
+    const ctx = makeCtx("#f");
+    const result = tagCompletionSource(ctx);
+    expect(result).not.toBeNull();
+    expect(result!.options.map((o) => o.label)).toEqual(["fresh"]);
+  });
+
+  it("supports nested tag segments (`#projects/a`)", () => {
+    const ctx = makeCtx("#projects/a");
+    const result = tagCompletionSource(ctx);
+    expect(result).not.toBeNull();
+    expect(result!.from).toBe(1);
+    expect(result!.options.map((o) => o.label)).toContain("projects/active");
+  });
+});

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -16,6 +16,7 @@ import { history, historyKeymap, defaultKeymap, indentWithTab } from "@codemirro
 import { bracketMatching, indentOnInput, syntaxHighlighting } from "@codemirror/language";
 import { autocompletion, closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
 import { wikiLinkCompletionSource } from "./wikiLinkAutocomplete";
+import { tagCompletionSource } from "./tagAutocomplete";
 import { markdown } from "@codemirror/lang-markdown";
 import { GFM } from "@lezer/markdown";
 import { languages } from "@codemirror/language-data";
@@ -62,7 +63,7 @@ export function buildExtensions(
     bracketMatching(),
     closeBrackets(),
     autocompletion({
-      override: [wikiLinkCompletionSource],
+      override: [wikiLinkCompletionSource, tagCompletionSource],
       activateOnTyping: true,
       defaultKeymap: true,
     }),

--- a/src/components/Editor/tagAutocomplete.ts
+++ b/src/components/Editor/tagAutocomplete.ts
@@ -1,0 +1,103 @@
+// Tag `#` autocomplete CompletionSource (#68).
+//
+// Sibling of wikiLinkAutocomplete.ts. Triggers when the user types `#` at a
+// word boundary and offers the current vault tag set (from tagsStore). Tag
+// list is read synchronously via `get(tagsStore)` each time the source fires,
+// so newly created tags appear without needing a restart.
+//
+// Design decisions:
+//   - filter: true (CM6 default) — the tag set is small and local, so we let
+//     CodeMirror's prefix filter narrow as the user types. No fuzzy backend.
+//   - Trigger only at a word boundary: the character before `#` must be
+//     whitespace, punctuation, or line-start (mirrors the Rust inline tag
+//     regex in src-tauri/src/indexer/tag_index.rs — filters out URL fragments
+//     like `example.com/page#section` and CSS hex colors like `#abc`).
+//   - Skip inside code fences / inline code — same syntax-tree guard pattern
+//     used by wikiLink.ts and embedPlugin.ts (FencedCode / CodeBlock /
+//     InlineCode / Code nodes).
+//   - Enter inserts the tag (CM6 default apply just inserts the label), and
+//     Escape dismisses the popup (CM6 default keymap).
+
+import type { CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+import { syntaxTree } from "@codemirror/language";
+import type { EditorState } from "@codemirror/state";
+import { get } from "svelte/store";
+import { tagsStore } from "../../store/tagsStore";
+
+/**
+ * Returns true if `pos` sits inside a fenced code block, plain code block,
+ * or inline code span. Mirrors wikiLink.ts / embedPlugin.ts — a false
+ * positive here is always safe (we just suppress the popup).
+ */
+function isInsideCodeBlock(state: EditorState, pos: number): boolean {
+  const node = syntaxTree(state).resolve(pos, 1);
+  let cur: typeof node | null = node;
+  while (cur) {
+    const name = cur.type.name;
+    if (
+      name === "FencedCode" ||
+      name === "CodeBlock" ||
+      name === "InlineCode" ||
+      name === "Code"
+    ) {
+      return true;
+    }
+    cur = cur.parent;
+  }
+  return false;
+}
+
+/**
+ * CM6 CompletionSource for `#tag` autocomplete.
+ *
+ * Matches a `#` at a word boundary followed by optional tag-prefix characters
+ * (letters/digits/underscore/hyphen/slash for nested tags). Offers candidates
+ * from the tags store; CM6 handles prefix filtering as the user keeps typing.
+ */
+export function tagCompletionSource(
+  ctx: CompletionContext,
+): CompletionResult | null {
+  // Match `#` + the partial tag text typed so far. Allow letters, digits,
+  // `_`, `-`, `/` in the prefix (nested tags). We don't require a letter as
+  // the first char here (unlike the Rust indexer) — the user may be mid-type
+  // and we rank against the stored tag set anyway.
+  const match = ctx.matchBefore(/#[\w\-/]*/);
+  if (!match) return null;
+
+  // Boundary check: the character BEFORE the `#` must be whitespace,
+  // punctuation, or line-start. Otherwise we're inside a URL fragment,
+  // CSS hex color, or similar — do not fire the popup.
+  if (match.from > 0) {
+    const prev = ctx.state.doc.sliceString(match.from - 1, match.from);
+    if (!/[\s(,!?;:]/.test(prev)) return null;
+  }
+
+  // Skip inside fenced/inline code — tags there aren't real vault tags.
+  if (isInsideCodeBlock(ctx.state, match.from)) return null;
+
+  // If the user only typed `#` with nothing after, do not fire unless
+  // explicitly requested (clicking / Ctrl-Space). This matches Obsidian
+  // and avoids the popup blocking every line that starts with `#`
+  // (markdown headings).
+  const query = match.text.slice(1); // strip leading `#`
+  if (query.length === 0 && !ctx.explicit) return null;
+
+  // Pull the current tag list synchronously. Reactivity is covered because
+  // this source runs on every keystroke — if tagsStore updated between
+  // firings, the next popup uses the fresh list.
+  const { tags } = get(tagsStore);
+  if (tags.length === 0) return null;
+
+  return {
+    // `from` is after the `#` so CM6's prefix filter matches against the
+    // bare tag text (without the `#`). `apply` re-adds the `#`.
+    from: match.from + 1,
+    options: tags.map((t) => ({
+      label: t.tag,
+      apply: t.tag,
+      detail: String(t.count),
+      type: "constant",
+      boost: t.count, // more-used tags rank higher when prefixes tie
+    })),
+  };
+}


### PR DESCRIPTION
Closes #68

## Summary
- New CM6 `CompletionSource` (`tagAutocomplete.ts`) that fires on `#` at a word boundary, sourced reactively from `tagsStore` so newly created tags appear without restart.
- Guards against firing inside fenced code / inline code (syntax-tree check mirroring `wikiLink.ts`), URL fragments, and bare `#` at line start (avoids hijacking markdown headings).
- Registered alongside the existing wiki-link source in `extensions.ts`; prefix filtering handled by CM6, Enter inserts the tag, Escape dismisses (both via CM6 defaults).

## Test plan
- [ ] typecheck passes
- [ ] tests pass
- [ ] `#` autocomplete appears in editor, filters on prefix, Enter inserts, Escape dismisses