### PR TITLE
feat(commands): daily notes open-today (#59)

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -14,13 +14,19 @@
   import { vaultStore } from "../../store/vaultStore";
   import { commandRegistry } from "../../lib/commands/registry";
   import { registerDefaultCommands } from "../../lib/commands/defaultCommands";
-  import { createFile } from "../../ipc/commands";
+  import { createFile, createFolder, listDirectory, readFile, writeFile } from "../../ipc/commands";
   import { toastStore } from "../../store/toastStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
   import { openFileAsTab } from "../../lib/openFileAsTab";
   import { resolveRevealRelPath } from "../../lib/activeTabReveal";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
+  import { settingsStore } from "../../store/settingsStore";
+  import {
+    DEFAULT_DAILY_DATE_FORMAT,
+    dailyNoteFilename,
+    splitFolderSegments,
+  } from "../../lib/dailyNotes";
 
   let { onSwitchVault }: { onSwitchVault: () => void } = $props();
 
@@ -245,6 +251,95 @@
     }
   }
 
+  /**
+   * Issue #59: open (or create) today's daily note.
+   *
+   * Resolution order:
+   *  1. Resolve the target folder from settingsStore.dailyNotesFolder. Each
+   *     segment is created if missing (listDirectory probe avoids the
+   *     createFolder auto-suffix that would make "Daily" turn into
+   *     "Daily 1").
+   *  2. Build the filename from today's local date using the configured
+   *     format (minimal YYYY/MM/DD token subset — see lib/dailyNotes.ts).
+   *  3. If the file already exists (detected by listing the parent),
+   *     reuse the existing absolute path so we never overwrite.
+   *  4. Otherwise createFile() writes an empty file; if a template path is
+   *     configured AND readable, its contents are then written into the
+   *     new file. Unreadable template silently falls back to empty.
+   */
+  async function openTodayNote() {
+    let vaultPath: string | null = null;
+    const unsubVault = vaultStore.subscribe((s) => { vaultPath = s.currentPath; });
+    unsubVault();
+    if (!vaultPath) return;
+
+    let folder = "";
+    let format = DEFAULT_DAILY_DATE_FORMAT;
+    let template = "";
+    const unsubSettings = settingsStore.subscribe((s) => {
+      folder = s.dailyNotesFolder;
+      format = s.dailyNotesDateFormat.trim().length > 0
+        ? s.dailyNotesDateFormat
+        : DEFAULT_DAILY_DATE_FORMAT;
+      template = s.dailyNotesTemplate.trim();
+    });
+    unsubSettings();
+
+    try {
+      // 1. Resolve / create folder chain.
+      const vault: string = vaultPath;
+      let parent: string = vault;
+      for (const segment of splitFolderSegments(folder)) {
+        const candidate = `${parent}/${segment}`;
+        try {
+          await listDirectory(candidate);
+          parent = candidate;
+        } catch {
+          // listDirectory throws for "doesn't exist" — create it.
+          parent = await createFolder(parent, segment);
+        }
+      }
+
+      // 2. Build filename from today's local date.
+      const filename = dailyNoteFilename(new Date(), format);
+
+      // 3. If the note already exists, open it without modifying.
+      let existingAbsPath: string | null = null;
+      try {
+        const entries = await listDirectory(parent);
+        const hit = entries.find((e) => !e.is_dir && e.name === filename);
+        if (hit) existingAbsPath = hit.path;
+      } catch {
+        // Listing a just-created folder can race — treat as "no existing file".
+      }
+      if (existingAbsPath) {
+        tabStore.openTab(existingAbsPath);
+        return;
+      }
+
+      // 4. Create the file (createFile auto-suffixes on collision, but step 3
+      //    already ruled collision out, so the returned path matches `filename`).
+      const newPath = await createFile(parent, filename);
+
+      // Seed with template contents if configured and readable.
+      if (template.length > 0) {
+        const templateAbs = `${vault}/${template.replace(/^[/\\]+/, "")}`;
+        try {
+          const contents = await readFile(templateAbs);
+          await writeFile(newPath, contents);
+        } catch {
+          // Missing/unreadable template — leave the note empty. No toast:
+          // AC explicitly says this must not block creation.
+        }
+      }
+
+      tabStore.openTab(newPath);
+      treeRefreshStore.requestRefresh();
+    } catch {
+      toastStore.push({ variant: "error", message: "Tagesnotiz konnte nicht geöffnet werden." });
+    }
+  }
+
   /** Issue #12: toggle bookmark on the active tab's file path. */
   async function toggleActiveBookmark() {
     let captured: string | null = null;
@@ -298,6 +393,7 @@
       openGraph: () => { tabStore.openGraphTab(); },
       openCommandPalette: () => { commandPaletteOpen = true; },
       toggleBookmark: () => { void toggleActiveBookmark(); },
+      openTodayNote: () => { void openTodayNote(); },
     });
     document.addEventListener("keydown", handleKeydown, { capture: true });
     document.addEventListener("contextmenu", handleContextMenu, { capture: true });

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -9,6 +9,7 @@
     type BodyFont,
     type MonoFont,
   } from "../../store/settingsStore";
+  import { DEFAULT_DAILY_DATE_FORMAT } from "../../lib/dailyNotes";
   import { vaultStore } from "../../store/vaultStore";
   import { formatShortcut } from "../../lib/shortcuts";
   import { commandRegistry, type Command } from "../../lib/commands/registry";
@@ -25,10 +26,18 @@
   let currentSize = $state<number>(14);
   let currentVaultPath = $state<string | null>(null);
   let shortcuts = $state<Command[]>([]);
+  let dailyFolder = $state<string>("");
+  let dailyFormat = $state<string>(DEFAULT_DAILY_DATE_FORMAT);
+  let dailyTemplate = $state<string>("");
 
   const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
   const unsubSettings = settingsStore.subscribe((s) => {
-    currentBody = s.fontBody; currentMono = s.fontMono; currentSize = s.fontSize;
+    currentBody = s.fontBody;
+    currentMono = s.fontMono;
+    currentSize = s.fontSize;
+    dailyFolder = s.dailyNotesFolder;
+    dailyFormat = s.dailyNotesDateFormat;
+    dailyTemplate = s.dailyNotesTemplate;
   });
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
   const unsubCommands = commandRegistry.subscribe((list) => {
@@ -55,6 +64,15 @@
   }
   function onSizeInput(e: Event) {
     settingsStore.setFontSize(Number((e.target as HTMLInputElement).value));
+  }
+  function onDailyFolderInput(e: Event) {
+    settingsStore.setDailyNotesFolder((e.target as HTMLInputElement).value);
+  }
+  function onDailyFormatInput(e: Event) {
+    settingsStore.setDailyNotesDateFormat((e.target as HTMLInputElement).value);
+  }
+  function onDailyTemplateInput(e: Event) {
+    settingsStore.setDailyNotesTemplate((e.target as HTMLInputElement).value);
   }
 
   onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); });
@@ -154,6 +172,51 @@
         />
       </section>
 
+      <!-- Section — Tagesnotizen (#59) -->
+      <section class="vc-settings-section" data-testid="settings-daily-notes">
+        <h3 class="vc-settings-section-title">TAGESNOTIZEN</h3>
+        <div class="vc-settings-row">
+          <label for="daily-folder-input">Ordner (relativ zum Vault)</label>
+          <input
+            id="daily-folder-input"
+            data-testid="settings-daily-folder"
+            type="text"
+            class="vc-settings-text"
+            placeholder="z. B. Daily"
+            value={dailyFolder}
+            oninput={onDailyFolderInput}
+          />
+        </div>
+        <div class="vc-settings-row">
+          <label for="daily-format-input">Datumsformat</label>
+          <input
+            id="daily-format-input"
+            data-testid="settings-daily-format"
+            type="text"
+            class="vc-settings-text"
+            placeholder={DEFAULT_DAILY_DATE_FORMAT}
+            value={dailyFormat}
+            oninput={onDailyFormatInput}
+          />
+        </div>
+        <div class="vc-settings-row">
+          <label for="daily-template-input">Vorlage (relativ zum Vault)</label>
+          <input
+            id="daily-template-input"
+            data-testid="settings-daily-template"
+            type="text"
+            class="vc-settings-text"
+            placeholder="z. B. Templates/Daily.md"
+            value={dailyTemplate}
+            oninput={onDailyTemplateInput}
+          />
+        </div>
+        <p class="vc-settings-hint">
+          Unterstützte Tokens: <code>YYYY</code>, <code>MM</code>, <code>DD</code>.
+          Fehlender Ordner wird beim ersten Öffnen erstellt.
+        </p>
+      </section>
+
       <!-- Section C — Tastaturkürzel (UI-05 / D-11) -->
       <section class="vc-settings-section" data-testid="settings-shortcuts">
         <h3 class="vc-settings-section-title">TASTATURKÜRZEL</h3>
@@ -248,6 +311,24 @@
     border: 1px solid var(--color-border); border-radius: 4px;
     background: var(--color-surface); color: var(--color-text);
     min-width: 180px;
+  }
+  .vc-settings-row :global(.vc-settings-text) {
+    font-size: 14px; padding: 4px 8px;
+    border: 1px solid var(--color-border); border-radius: 4px;
+    background: var(--color-surface); color: var(--color-text);
+    min-width: 240px;
+    font-family: var(--vc-font-mono);
+  }
+  .vc-settings-hint {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    margin: 4px 0 0;
+  }
+  .vc-settings-hint code {
+    font-family: var(--vc-font-mono);
+    padding: 0 4px;
+    background: var(--color-accent-bg);
+    border-radius: 3px;
   }
   .vc-settings-size-value { font-size: 14px; color: var(--color-text-muted); }
   .vc-settings-slider { width: 100%; }

--- a/src/lib/__tests__/dailyNotes.test.ts
+++ b/src/lib/__tests__/dailyNotes.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_DAILY_DATE_FORMAT,
+  dailyNoteFilename,
+  formatDailyNoteDate,
+  splitFolderSegments,
+} from "../dailyNotes";
+
+describe("dailyNotes helpers (#59)", () => {
+  it("formats YYYY-MM-DD with zero-padding from a local Date", () => {
+    // Use a local Date — getFullYear / getMonth / getDate are what the helper reads.
+    const d = new Date(2024, 0, 7); // 2024-01-07 local
+    expect(formatDailyNoteDate(d, DEFAULT_DAILY_DATE_FORMAT)).toBe("2024-01-07");
+  });
+
+  it("supports arbitrary placement of YYYY / MM / DD tokens", () => {
+    const d = new Date(2025, 11, 31); // 2025-12-31 local
+    expect(formatDailyNoteDate(d, "DD.MM.YYYY")).toBe("31.12.2025");
+    expect(formatDailyNoteDate(d, "YYYY/MM/DD")).toBe("2025/12/31");
+  });
+
+  it("copies unknown characters through verbatim", () => {
+    const d = new Date(2026, 3, 15);
+    expect(formatDailyNoteDate(d, "journal-YYYY-MM-DD")).toBe("journal-2026-04-15");
+  });
+
+  it("dailyNoteFilename appends .md when absent", () => {
+    const d = new Date(2026, 3, 15);
+    expect(dailyNoteFilename(d, "YYYY-MM-DD")).toBe("2026-04-15.md");
+  });
+
+  it("dailyNoteFilename keeps an explicit .md extension in the format string", () => {
+    const d = new Date(2026, 3, 15);
+    expect(dailyNoteFilename(d, "YYYY-MM-DD.md")).toBe("2026-04-15.md");
+  });
+
+  it("dailyNoteFilename falls back to default format when rendered stem is empty", () => {
+    const d = new Date(2026, 3, 15);
+    expect(dailyNoteFilename(d, "   ")).toBe("2026-04-15.md");
+  });
+
+  it("splitFolderSegments drops empty and whitespace segments", () => {
+    expect(splitFolderSegments("")).toEqual([]);
+    expect(splitFolderSegments("/")).toEqual([]);
+    expect(splitFolderSegments("Daily")).toEqual(["Daily"]);
+    expect(splitFolderSegments("/Daily/2026/")).toEqual(["Daily", "2026"]);
+    expect(splitFolderSegments("Daily\\Sub")).toEqual(["Daily", "Sub"]);
+    expect(splitFolderSegments("Daily//Sub")).toEqual(["Daily", "Sub"]);
+  });
+});

--- a/src/lib/__tests__/settingsStore.test.ts
+++ b/src/lib/__tests__/settingsStore.test.ts
@@ -84,4 +84,58 @@ describe("settingsStore", () => {
       document.documentElement.style.getPropertyValue("--vc-font-size")
     ).toBe("14px");
   });
+
+  // ─── Daily Notes fields (#59) ────────────────────────────────────────────
+  it("Test 9: defaults for daily-notes fields are empty folder/template + YYYY-MM-DD format", async () => {
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    const state = get(settingsStore);
+    expect(state.dailyNotesFolder).toBe("");
+    expect(state.dailyNotesDateFormat).toBe("YYYY-MM-DD");
+    expect(state.dailyNotesTemplate).toBe("");
+  });
+
+  it("Test 10: daily-notes setters persist via the K_* localStorage keys", async () => {
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    settingsStore.setDailyNotesFolder("Daily");
+    settingsStore.setDailyNotesDateFormat("DD.MM.YYYY");
+    settingsStore.setDailyNotesTemplate("Templates/Daily.md");
+    const state = get(settingsStore);
+    expect(state.dailyNotesFolder).toBe("Daily");
+    expect(state.dailyNotesDateFormat).toBe("DD.MM.YYYY");
+    expect(state.dailyNotesTemplate).toBe("Templates/Daily.md");
+    expect(localStorage.getItem("vaultcore-daily-notes-folder")).toBe("Daily");
+    expect(localStorage.getItem("vaultcore-daily-notes-date-format")).toBe("DD.MM.YYYY");
+    expect(localStorage.getItem("vaultcore-daily-notes-template")).toBe("Templates/Daily.md");
+  });
+
+  it("Test 11: init reads stored daily-notes strings on reload", async () => {
+    localStorage.setItem("vaultcore-daily-notes-folder", "Journal");
+    localStorage.setItem("vaultcore-daily-notes-date-format", "YYYY/MM/DD");
+    localStorage.setItem("vaultcore-daily-notes-template", "tpl.md");
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    const state = get(settingsStore);
+    expect(state.dailyNotesFolder).toBe("Journal");
+    expect(state.dailyNotesDateFormat).toBe("YYYY/MM/DD");
+    expect(state.dailyNotesTemplate).toBe("tpl.md");
+  });
+
+  it("Test 12: init rejects oversized tampered daily-notes entries and falls back to defaults", async () => {
+    const huge = "x".repeat(10_000);
+    localStorage.setItem("vaultcore-daily-notes-folder", huge);
+    localStorage.setItem("vaultcore-daily-notes-date-format", huge);
+    localStorage.setItem("vaultcore-daily-notes-template", huge);
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    const state = get(settingsStore);
+    expect(state.dailyNotesFolder).toBe("");
+    expect(state.dailyNotesDateFormat).toBe("YYYY-MM-DD");
+    expect(state.dailyNotesTemplate).toBe("");
+  });
 });

--- a/src/lib/commands/__tests__/defaultCommands.test.ts
+++ b/src/lib/commands/__tests__/defaultCommands.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { commandRegistry } from "../registry";
+import {
+  CMD_IDS,
+  DEFAULT_COMMAND_SPECS,
+  registerDefaultCommands,
+  type DefaultCommandContext,
+} from "../defaultCommands";
+
+function setupLocalStorage(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  });
+}
+
+function makeCtx(overrides: Partial<DefaultCommandContext> = {}): DefaultCommandContext {
+  const noop = () => {};
+  return {
+    openQuickSwitcher: noop,
+    toggleSidebar: noop,
+    openBacklinks: noop,
+    activateSearchTab: noop,
+    cycleTabNext: noop,
+    cycleTabPrev: noop,
+    closeActiveTab: noop,
+    createNewNote: noop,
+    openGraph: noop,
+    openCommandPalette: noop,
+    toggleBookmark: noop,
+    openTodayNote: noop,
+    ...overrides,
+  };
+}
+
+describe("defaultCommands — vault:open-today (#59)", () => {
+  beforeEach(() => {
+    setupLocalStorage();
+    commandRegistry._reset();
+  });
+
+  it("registers vault:open-today with a palette label and Cmd+Shift+D hotkey", () => {
+    const spec = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.OPEN_TODAY);
+    expect(spec).toBeTruthy();
+    expect(spec!.name.length).toBeGreaterThan(0);
+    expect(spec!.hotkey).toEqual({ meta: true, shift: true, key: "d" });
+  });
+
+  it("registerDefaultCommands wires openTodayNote callback and exposes it via execute()", () => {
+    const openTodayNote = vi.fn();
+    registerDefaultCommands(makeCtx({ openTodayNote }));
+    const cmd = commandRegistry.list().find((c) => c.id === CMD_IDS.OPEN_TODAY);
+    expect(cmd).toBeTruthy();
+    commandRegistry.execute(CMD_IDS.OPEN_TODAY);
+    expect(openTodayNote).toHaveBeenCalledOnce();
+  });
+
+  it("Cmd+Shift+D resolves to vault:open-today via findByHotkey", () => {
+    registerDefaultCommands(makeCtx());
+    const ev = new KeyboardEvent("keydown", { key: "d", metaKey: true, shiftKey: true });
+    expect(commandRegistry.findByHotkey(ev)?.id).toBe(CMD_IDS.OPEN_TODAY);
+    // Plain Cmd+D still resolves to the bookmark command — no collision.
+    const plainEv = new KeyboardEvent("keydown", { key: "d", metaKey: true });
+    expect(commandRegistry.findByHotkey(plainEv)?.id).toBe(CMD_IDS.TOGGLE_BOOKMARK);
+  });
+});

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -15,6 +15,7 @@ export interface DefaultCommandContext {
   openGraph: () => void;
   openCommandPalette: () => void;
   toggleBookmark: () => void;
+  openTodayNote: () => void;
 }
 
 /** Id constants — consumed by tests and anyone dispatching by id. */
@@ -31,6 +32,7 @@ export const CMD_IDS = {
   OPEN_GRAPH: "vault:open-graph",
   COMMAND_PALETTE: "app:command-palette",
   TOGGLE_BOOKMARK: "vault:toggle-bookmark",
+  OPEN_TODAY: "vault:open-today",
 } as const;
 
 export interface DefaultCommandSpec {
@@ -53,6 +55,7 @@ export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
   { id: CMD_IDS.OPEN_GRAPH, name: "Graph-Ansicht öffnen", hotkey: { meta: true, shift: true, key: "g" } },
   { id: CMD_IDS.COMMAND_PALETTE, name: "Befehlspalette", hotkey: { meta: true, key: "p" } },
   { id: CMD_IDS.TOGGLE_BOOKMARK, name: "Lesezeichen umschalten", hotkey: { meta: true, key: "d" } },
+  { id: CMD_IDS.OPEN_TODAY, name: "Tagesnotiz öffnen", hotkey: { meta: true, shift: true, key: "d" } },
 ] as const;
 
 /**
@@ -74,6 +77,7 @@ export function registerDefaultCommands(ctx: DefaultCommandContext): void {
     [CMD_IDS.OPEN_GRAPH]: ctx.openGraph,
     [CMD_IDS.COMMAND_PALETTE]: ctx.openCommandPalette,
     [CMD_IDS.TOGGLE_BOOKMARK]: ctx.toggleBookmark,
+    [CMD_IDS.OPEN_TODAY]: ctx.openTodayNote,
   };
 
   for (const spec of DEFAULT_COMMAND_SPECS) {

--- a/src/lib/dailyNotes.ts
+++ b/src/lib/dailyNotes.ts
@@ -1,0 +1,54 @@
+// Daily Notes helpers (#59).
+//
+// The date-format tokens supported here are intentionally a minimal subset of
+// the Obsidian convention:
+//   - YYYY — 4-digit local year
+//   - MM   — 2-digit local month (01-12)
+//   - DD   — 2-digit local day-of-month (01-31)
+// Anything else in the format string is copied through verbatim, so e.g.
+// "YYYY-MM-DD" and "DD.MM.YYYY" both work. Fancier tokens (day names, weeks,
+// locale formatting) are out of scope for this issue.
+
+export const DEFAULT_DAILY_DATE_FORMAT = "YYYY-MM-DD";
+
+/**
+ * Format a Date into a filename stem using the supported subset of tokens.
+ * Local time is used — the goal is "today's note" as the user perceives it,
+ * not a UTC rollover.
+ */
+export function formatDailyNoteDate(date: Date, format: string): string {
+  const yyyy = String(date.getFullYear()).padStart(4, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  // Longest tokens first so MM inside YYYY-MM never clobbers a stray M/D pair.
+  return format
+    .replace(/YYYY/g, yyyy)
+    .replace(/MM/g, mm)
+    .replace(/DD/g, dd);
+}
+
+/**
+ * Build the `.md` filename for `date` given a raw format string.
+ * If the rendered stem ends in `.md` (or `.markdown`) it is kept as-is;
+ * otherwise `.md` is appended. Empty/whitespace stems fall back to the
+ * default format so we never ask the IPC layer to create a nameless file.
+ */
+export function dailyNoteFilename(date: Date, format: string): string {
+  const raw = formatDailyNoteDate(date, format).trim();
+  const stem = raw.length > 0 ? raw : formatDailyNoteDate(date, DEFAULT_DAILY_DATE_FORMAT);
+  if (/\.md$/i.test(stem) || /\.markdown$/i.test(stem)) return stem;
+  return `${stem}.md`;
+}
+
+/**
+ * Split a vault-relative folder spec into its segments, dropping empty
+ * pieces and leading/trailing slashes. Returns `[]` for "", "/", or "  ".
+ * Backslashes are treated as separators so Windows-style input from a
+ * Settings field still parses cleanly.
+ */
+export function splitFolderSegments(folder: string): string[] {
+  return folder
+    .split(/[/\\]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -1,14 +1,21 @@
 /**
- * settingsStore — body/mono font family + editor font size (UI-02, D-08/D-09).
+ * settingsStore — body/mono font family + editor font size (UI-02, D-08/D-09)
+ * plus Daily Notes folder / date format / template (#59).
  *
  * Whitelist for font keys (T-05-02-02) maps safe tokens to full CSS stacks so
  * a tampered localStorage cannot inject `expression(...)` or `"; } body{…` into
  * the --vc-font-* custom properties.
  *
+ * Daily-notes strings are user-supplied but only ever handed to the IPC layer
+ * (which canonicalizes paths against the vault root) or the filename builder
+ * (which whitelists YYYY/MM/DD tokens). validate-on-read still caps length
+ * and strips non-strings so a tampered entry can't grow unbounded.
+ *
  * Pattern: classic writable factory (D-06/RC-01 locked). Do not refactor
  * to Svelte 5 $state runes.
  */
 import { writable } from "svelte/store";
+import { DEFAULT_DAILY_DATE_FORMAT } from "../lib/dailyNotes";
 
 export type BodyFont = "system" | "inter" | "lora";
 export type MonoFont = "system" | "jetbrains-mono" | "fira-code";
@@ -28,9 +35,17 @@ export const FONT_SIZE_MIN = 12;
 export const FONT_SIZE_MAX = 20;
 export const FONT_SIZE_DEFAULT = 14;
 
+/** Upper bound for persisted daily-notes strings — defensive against a
+ *  tampered localStorage entry growing without bound. Real paths/formats
+ *  fit in well under this. */
+const DAILY_STRING_MAX = 512;
+
 const K_BODY = "vaultcore-font-body";
 const K_MONO = "vaultcore-font-mono";
 const K_SIZE = "vaultcore-font-size";
+const K_DAILY_FOLDER = "vaultcore-daily-notes-folder";
+const K_DAILY_FORMAT = "vaultcore-daily-notes-date-format";
+const K_DAILY_TEMPLATE = "vaultcore-daily-notes-template";
 // Legacy key from the brief attachment-folder era (before embeds). Removed
 // during cleanup so stale entries don't linger in localStorage.
 const K_ATTACHMENT_FOLDER_LEGACY = "vaultcore-attachment-folder";
@@ -39,12 +54,21 @@ export interface SettingsState {
   fontBody: BodyFont;
   fontMono: MonoFont;
   fontSize: number;
+  /** Vault-relative folder for daily notes. Empty = vault root. */
+  dailyNotesFolder: string;
+  /** Token string understood by `formatDailyNoteDate` (YYYY / MM / DD). */
+  dailyNotesDateFormat: string;
+  /** Vault-relative path to a template file. Empty = no template. */
+  dailyNotesTemplate: string;
 }
 
 const initial: SettingsState = {
   fontBody: "system",
   fontMono: "system",
   fontSize: FONT_SIZE_DEFAULT,
+  dailyNotesFolder: "",
+  dailyNotesDateFormat: DEFAULT_DAILY_DATE_FORMAT,
+  dailyNotesTemplate: "",
 };
 
 function isBodyFont(v: unknown): v is BodyFont {
@@ -58,15 +82,29 @@ function clampSize(n: number): number {
   return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, Math.round(n)));
 }
 
+/** Validate-on-read for the three daily-notes strings: must be a string and
+ *  within a sensible length. Anything else falls back to the default. */
+function sanitizeDailyString(v: unknown, fallback: string): string {
+  if (typeof v !== "string") return fallback;
+  if (v.length > DAILY_STRING_MAX) return fallback;
+  return v;
+}
+
 function readInitial(): SettingsState {
   try {
     const b = localStorage.getItem(K_BODY);
     const m = localStorage.getItem(K_MONO);
     const s = Number(localStorage.getItem(K_SIZE));
+    const dFolder = localStorage.getItem(K_DAILY_FOLDER);
+    const dFormat = localStorage.getItem(K_DAILY_FORMAT);
+    const dTemplate = localStorage.getItem(K_DAILY_TEMPLATE);
     return {
       fontBody: isBodyFont(b) ? b : initial.fontBody,
       fontMono: isMonoFont(m) ? m : initial.fontMono,
       fontSize: Number.isFinite(s) && s > 0 ? clampSize(s) : FONT_SIZE_DEFAULT,
+      dailyNotesFolder: sanitizeDailyString(dFolder, initial.dailyNotesFolder),
+      dailyNotesDateFormat: sanitizeDailyString(dFormat, initial.dailyNotesDateFormat),
+      dailyNotesTemplate: sanitizeDailyString(dTemplate, initial.dailyNotesTemplate),
     };
   } catch { return { ...initial }; }
 }
@@ -110,6 +148,23 @@ function createSettingsStore() {
       _store.update((s) => ({ ...s, fontSize: clamped }));
       applySize(clamped);
       try { localStorage.setItem(K_SIZE, String(clamped)); } catch { /* */ }
+    },
+    setDailyNotesFolder(value: string): void {
+      const v = sanitizeDailyString(value, "");
+      _store.update((s) => ({ ...s, dailyNotesFolder: v }));
+      try { localStorage.setItem(K_DAILY_FOLDER, v); } catch { /* */ }
+    },
+    setDailyNotesDateFormat(value: string): void {
+      // Empty format falls back to the default on read/use; we still persist
+      // the literal empty string so the UI input can reflect it.
+      const v = sanitizeDailyString(value, "");
+      _store.update((s) => ({ ...s, dailyNotesDateFormat: v }));
+      try { localStorage.setItem(K_DAILY_FORMAT, v); } catch { /* */ }
+    },
+    setDailyNotesTemplate(value: string): void {
+      const v = sanitizeDailyString(value, "");
+      _store.update((s) => ({ ...s, dailyNotesTemplate: v }));
+      try { localStorage.setItem(K_DAILY_TEMPLATE, v); } catch { /* */ }
     },
   };
 }


### PR DESCRIPTION
Closes #59

## Summary
- Adds the `vault:open-today` command, labelled "Tagesnotiz öffnen", registered in `DEFAULT_COMMAND_SPECS` / `registerDefaultCommands` and wired in `VaultLayout`. It resolves today's note path from Settings, creates any missing folder segments, and either opens the existing file or creates a new one (optionally seeded from a configured template).
- Three new persisted fields on `settingsStore` — `dailyNotesFolder`, `dailyNotesDateFormat`, `dailyNotesTemplate` — using the same `K_*` localStorage + validate-on-read pattern already in use for fonts, plus a new "TAGESNOTIZEN" section in the Settings modal matching the existing inputs' style.
- Bound to `Cmd+Shift+D` — that slot was free (`Cmd+D` already toggles bookmarks, no other binding uses Shift+D). The palette still hosts the command regardless.
- Date-format support is intentionally the minimal Obsidian-compatible subset — `YYYY`, `MM`, `DD`. Other tokens (day names, weeks, locale) are out of scope for this issue; unknown characters pass through verbatim so e.g. `DD.MM.YYYY` and `journal-YYYY-MM-DD` work out of the box.

## Test plan
- [ ] `npm run typecheck` — no new errors introduced (pre-existing `tabStore.ts` / `ui06Audit.test.ts` issues remain on main).
- [ ] `npm run test` — all 371 tests pass, including new coverage for `dailyNotes` helpers, the three new `settingsStore` fields (defaults, persistence, init rehydration, oversized-entry rejection), and the new command spec / hotkey resolution.
- [ ] Command palette shows "Tagesnotiz öffnen".
- [ ] First invocation creates today's note at `<folder>/YYYY-MM-DD.md` (creating the folder if missing); second invocation opens the existing file without overwriting.
- [ ] Template path seeds the new file's contents when set; missing/unreadable template leaves the note empty without blocking creation.