### PR TITLE
feat(appearance): custom CSS snippets (#64)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod search;
 pub mod links;
 pub mod tags;
 pub mod bookmarks;
+pub mod snippets;

--- a/src-tauri/src/commands/snippets.rs
+++ b/src-tauri/src/commands/snippets.rs
@@ -1,0 +1,142 @@
+// Custom CSS snippets IPC (#64). Users drop `.css` files into
+// `<vault>/.vaultcore/snippets/` and toggle them from Settings. Two read-only
+// commands back the frontend:
+//   - `list_snippets`   -> basenames of `*.css` files, sorted
+//   - `read_snippet`    -> CSS text for a single file
+//
+// Security: both commands use the same T-02 scope guard as bookmarks.rs —
+// the `vault_path` argument is canonicalized and must match the currently-
+// open vault root. `read_snippet` additionally rejects any filename that
+// could escape the snippets directory (`..`, path separators, absolute
+// paths, or a resolved path outside the snippets dir).
+
+use crate::error::VaultError;
+use crate::VaultState;
+use std::path::{Path, PathBuf};
+
+const VAULTCORE_DIR: &str = ".vaultcore";
+const SNIPPETS_DIR: &str = "snippets";
+
+/// Resolve `<vault>/.vaultcore/snippets/` after confirming `vault_path`
+/// matches the currently-open vault. Creates the directory if missing so
+/// first-run returns an empty list instead of FileNotFound.
+fn snippets_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, VaultError> {
+    let canonical = std::fs::canonicalize(vault_path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: vault_path.to_string() },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: vault_path.to_string() },
+        _ => VaultError::Io(e),
+    })?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
+        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+    ))?;
+    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
+        path: vault_path.to_string(),
+    })?;
+    if canonical != *vault {
+        return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
+    }
+    let dir = canonical.join(VAULTCORE_DIR).join(SNIPPETS_DIR);
+    std::fs::create_dir_all(&dir).map_err(VaultError::Io)?;
+    Ok(dir)
+}
+
+/// Reject filenames that would escape the snippets directory.
+/// We accept only a plain file basename ending in `.css` (case-insensitive),
+/// with no path separators, no traversal components, and no empty stem.
+fn validate_snippet_filename(filename: &str) -> Result<(), VaultError> {
+    if filename.is_empty()
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains('\0')
+        || filename == "."
+        || filename == ".."
+        || filename.contains("..")
+    {
+        return Err(VaultError::PermissionDenied { path: filename.to_string() });
+    }
+    // Absolute-path heuristic (Windows drive letter / UNC, or POSIX absolute
+    // that already failed the `/` check above but keep belt-and-suspenders).
+    if Path::new(filename).is_absolute() {
+        return Err(VaultError::PermissionDenied { path: filename.to_string() });
+    }
+    let lower = filename.to_lowercase();
+    if !lower.ends_with(".css") {
+        return Err(VaultError::PermissionDenied { path: filename.to_string() });
+    }
+    Ok(())
+}
+
+pub fn list_snippets_impl(state: &VaultState, vault_path: String) -> Result<Vec<String>, VaultError> {
+    let dir = snippets_dir_for(state, &vault_path)?;
+    let mut names: Vec<String> = Vec::new();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(it) => it,
+        // Directory was just created above, so this shouldn't fire, but
+        // tolerate NotFound for races and return an empty list.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(names),
+        Err(e) => return Err(VaultError::Io(e)),
+    };
+    for entry in entries {
+        let entry = entry.map_err(VaultError::Io)?;
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !ft.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = match name.to_str() {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        if name_str.to_lowercase().ends_with(".css") {
+            names.push(name_str);
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+#[tauri::command]
+pub async fn list_snippets(
+    state: tauri::State<'_, VaultState>,
+    vault_path: String,
+) -> Result<Vec<String>, VaultError> {
+    list_snippets_impl(&state, vault_path)
+}
+
+pub fn read_snippet_impl(
+    state: &VaultState,
+    vault_path: String,
+    filename: String,
+) -> Result<String, VaultError> {
+    validate_snippet_filename(&filename)?;
+    let dir = snippets_dir_for(state, &vault_path)?;
+    let target = dir.join(&filename);
+
+    // Canonicalize the final path and re-confirm it lives inside the
+    // snippets dir. Defends against symlinks or unicode-normalization
+    // tricks that slip past the string-level check above.
+    let canonical_target = std::fs::canonicalize(&target).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: filename.clone() },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: filename.clone() },
+        _ => VaultError::Io(e),
+    })?;
+    let canonical_dir = std::fs::canonicalize(&dir).map_err(VaultError::Io)?;
+    if !canonical_target.starts_with(&canonical_dir) {
+        return Err(VaultError::PermissionDenied { path: filename });
+    }
+
+    let bytes = std::fs::read(&canonical_target).map_err(VaultError::Io)?;
+    String::from_utf8(bytes).map_err(|_| VaultError::InvalidEncoding { path: filename })
+}
+
+#[tauri::command]
+pub async fn read_snippet(
+    state: tauri::State<'_, VaultState>,
+    vault_path: String,
+    filename: String,
+) -> Result<String, VaultError> {
+    read_snippet_impl(&state, vault_path, filename)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,8 @@ pub fn run() {
             commands::tags::get_tag_occurrences,
             commands::bookmarks::load_bookmarks,
             commands::bookmarks::save_bookmarks,
+            commands::snippets::list_snippets,
+            commands::snippets::read_snippet,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -12,3 +12,4 @@ mod global_graph;
 pub mod tag_index;
 mod hash_verify;
 mod bookmarks;
+mod snippets;

--- a/src-tauri/src/tests/snippets.rs
+++ b/src-tauri/src/tests/snippets.rs
@@ -1,0 +1,142 @@
+// Tests for snippet commands (#64). Mirrors the `_impl` test pattern used
+// in bookmarks.rs and files_ops.rs.
+
+use crate::commands::snippets::{list_snippets_impl, read_snippet_impl};
+use crate::VaultState;
+use std::fs;
+use tempfile::tempdir;
+
+fn state_with_vault(root: &std::path::Path) -> VaultState {
+    let canonical = fs::canonicalize(root).unwrap();
+    let s = VaultState::default();
+    *s.current_vault.lock().unwrap() = Some(canonical);
+    s
+}
+
+#[test]
+fn list_creates_dir_and_returns_empty_on_first_run() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let result = list_snippets_impl(&state, dir.path().to_string_lossy().into_owned()).unwrap();
+    assert_eq!(result, Vec::<String>::new());
+    assert!(
+        dir.path().join(".vaultcore").join("snippets").is_dir(),
+        ".vaultcore/snippets/ should be created on first list"
+    );
+}
+
+#[test]
+fn list_returns_only_css_basenames_sorted() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let snippets = dir.path().join(".vaultcore").join("snippets");
+    fs::create_dir_all(&snippets).unwrap();
+    fs::write(snippets.join("zeta.css"), "body {}").unwrap();
+    fs::write(snippets.join("alpha.css"), "body {}").unwrap();
+    fs::write(snippets.join("README.md"), "ignore me").unwrap();
+    fs::write(snippets.join("no-ext"), "ignore me").unwrap();
+
+    let result = list_snippets_impl(&state, dir.path().to_string_lossy().into_owned()).unwrap();
+    assert_eq!(result, vec!["alpha.css".to_string(), "zeta.css".to_string()]);
+}
+
+#[test]
+fn read_returns_file_contents() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let snippets = dir.path().join(".vaultcore").join("snippets");
+    fs::create_dir_all(&snippets).unwrap();
+    let css = "body { background: rebeccapurple; }";
+    fs::write(snippets.join("theme.css"), css).unwrap();
+
+    let result = read_snippet_impl(
+        &state,
+        dir.path().to_string_lossy().into_owned(),
+        "theme.css".to_string(),
+    )
+    .unwrap();
+    assert_eq!(result, css);
+}
+
+#[test]
+fn read_rejects_path_traversal() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let snippets = dir.path().join(".vaultcore").join("snippets");
+    fs::create_dir_all(&snippets).unwrap();
+    // A file planted outside the snippets dir that a traversal would reach.
+    fs::write(dir.path().join("secret.css"), "leaked").unwrap();
+
+    for bad in [
+        "../secret.css",
+        "../../etc/passwd",
+        "./a.css",
+        "sub/nested.css",
+        "",
+        "..",
+        ".",
+    ] {
+        let result = read_snippet_impl(
+            &state,
+            dir.path().to_string_lossy().into_owned(),
+            bad.to_string(),
+        );
+        assert!(result.is_err(), "expected rejection for {bad:?}");
+    }
+}
+
+#[test]
+fn read_rejects_absolute_paths() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+
+    #[cfg(unix)]
+    let abs = "/etc/passwd".to_string();
+    #[cfg(windows)]
+    let abs = "C:\\Windows\\System32\\drivers\\etc\\hosts".to_string();
+
+    let result = read_snippet_impl(
+        &state,
+        dir.path().to_string_lossy().into_owned(),
+        abs,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_rejects_non_css_extension() {
+    let dir = tempdir().unwrap();
+    let state = state_with_vault(dir.path());
+    let snippets = dir.path().join(".vaultcore").join("snippets");
+    fs::create_dir_all(&snippets).unwrap();
+    fs::write(snippets.join("data.json"), "{}").unwrap();
+
+    let result = read_snippet_impl(
+        &state,
+        dir.path().to_string_lossy().into_owned(),
+        "data.json".to_string(),
+    );
+    assert!(result.is_err(), "non-.css filenames must be rejected");
+}
+
+#[test]
+fn list_rejects_vault_path_not_matching_current_vault() {
+    let vault_dir = tempdir().unwrap();
+    let other_dir = tempdir().unwrap();
+    let state = state_with_vault(vault_dir.path());
+    let result = list_snippets_impl(&state, other_dir.path().to_string_lossy().into_owned());
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_rejects_vault_path_not_matching_current_vault() {
+    let vault_dir = tempdir().unwrap();
+    let other_dir = tempdir().unwrap();
+    let state = state_with_vault(vault_dir.path());
+    let result = read_snippet_impl(
+        &state,
+        other_dir.path().to_string_lossy().into_owned(),
+        "anything.css".to_string(),
+    );
+    assert!(result.is_err());
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,6 +6,7 @@
   import { tabStore } from "./store/tabStore";
   import { toastStore } from "./store/toastStore";
   import { progressStore } from "./store/progressStore";
+  import { snippetsStore } from "./store/snippetsStore";
   import {
     getRecentVaults,
     openVault,
@@ -22,6 +23,42 @@
 
   let recent: RecentVault[] = $state([]);
   let unlistenProgress: (() => void) | null = null;
+
+  // Custom CSS snippets (#64): keep one HTMLStyleElement per enabled snippet
+  // mounted at the top of document.head, tagged with data-snippet="<filename>".
+  // We manage these imperatively because Svelte template style blocks are
+  // compiler-scoped — inline CSS text can't be piped into them at runtime.
+  // Reacting to the store keeps toggling instant (no restart, no remount).
+  const SNIPPET_ATTR = "data-snippet";
+  const unsubSnippets = snippetsStore.subscribe((s) => {
+    // Run after Svelte finishes mounting so document.head exists during SSR-like
+    // early ticks (unit tests / jsdom). Defer to a microtask if head isn't ready.
+    if (typeof document === "undefined") return;
+    const head = document.head;
+    if (!head) return;
+    const active = s.enabled.filter((name) => s.contents[name] !== undefined);
+    const activeSet = new Set(active);
+    // Remove tags for snippets that are no longer enabled or whose contents
+    // disappeared (e.g. the file was deleted on disk).
+    const existing = head.querySelectorAll(`style[${SNIPPET_ATTR}]`);
+    for (const el of Array.from(existing)) {
+      const name = el.getAttribute(SNIPPET_ATTR) ?? "";
+      if (!activeSet.has(name)) el.remove();
+    }
+    // Add / update tags for everything that should be active now.
+    for (const name of active) {
+      const css = s.contents[name] ?? "";
+      let el = head.querySelector<HTMLStyleElement>(
+        `style[${SNIPPET_ATTR}="${CSS.escape(name)}"]`,
+      );
+      if (!el) {
+        el = document.createElement("style");
+        el.setAttribute(SNIPPET_ATTR, name);
+        head.appendChild(el);
+      }
+      if (el.textContent !== css) el.textContent = css;
+    }
+  });
 
   // Index-corrupt recovery dialog — shown when openVault fails with
   // IndexCorrupt. Confirming wipes .vaultcore/index/tantivy + the version
@@ -50,6 +87,9 @@
       // Refresh recent-vaults list so the just-opened entry floats to the top
       // next time the Welcome card is shown.
       recent = await getRecentVaults();
+      // Snippets are per-vault — reload the enabled set and CSS text now
+      // that we know which vault is active.
+      void snippetsStore.load(info.path);
     } catch (err) {
       progressStore.finish();
       const ve = toVaultError(err);
@@ -152,6 +192,7 @@
 
   onDestroy(() => {
     unlistenProgress?.();
+    unsubSnippets();
   });
 </script>
 

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
-  import { X } from "lucide-svelte";
+  import { X, RefreshCw } from "lucide-svelte";
   import { themeStore, type Theme } from "../../store/themeStore";
   import {
     settingsStore,
@@ -11,6 +11,7 @@
   } from "../../store/settingsStore";
   import { DEFAULT_DAILY_DATE_FORMAT } from "../../lib/dailyNotes";
   import { vaultStore } from "../../store/vaultStore";
+  import { snippetsStore } from "../../store/snippetsStore";
   import { formatShortcut } from "../../lib/shortcuts";
   import { commandRegistry, type Command } from "../../lib/commands/registry";
 
@@ -29,6 +30,10 @@
   let dailyFolder = $state<string>("");
   let dailyFormat = $state<string>(DEFAULT_DAILY_DATE_FORMAT);
   let dailyTemplate = $state<string>("");
+  let snippetsAvailable = $state<string[]>([]);
+  let snippetsEnabled = $state<string[]>([]);
+  let snippetsLoaded = $state<boolean>(false);
+  let refreshingSnippets = $state<boolean>(false);
 
   const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
   const unsubSettings = settingsStore.subscribe((s) => {
@@ -42,6 +47,11 @@
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
   const unsubCommands = commandRegistry.subscribe((list) => {
     shortcuts = list.filter((c) => c.hotkey);
+  });
+  const unsubSnippets = snippetsStore.subscribe((s) => {
+    snippetsAvailable = s.available;
+    snippetsEnabled = s.enabled;
+    snippetsLoaded = s.loaded;
   });
 
   function handleKeydown(e: KeyboardEvent) {
@@ -75,7 +85,22 @@
     settingsStore.setDailyNotesTemplate((e.target as HTMLInputElement).value);
   }
 
-  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); });
+  async function onToggleSnippet(name: string): Promise<void> {
+    if (!currentVaultPath) return;
+    await snippetsStore.toggle(name, currentVaultPath);
+  }
+
+  async function onRefreshSnippets(): Promise<void> {
+    if (!currentVaultPath || refreshingSnippets) return;
+    refreshingSnippets = true;
+    try {
+      await snippetsStore.load(currentVaultPath);
+    } finally {
+      refreshingSnippets = false;
+    }
+  }
+
+  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -131,6 +156,49 @@
             </label>
           {/each}
         </div>
+      </section>
+
+      <!-- Section — CSS-Snippets (#64) -->
+      <section class="vc-settings-section" data-testid="settings-snippets">
+        <div class="vc-snippets-head">
+          <h3 class="vc-settings-section-title">CSS-SNIPPETS</h3>
+          <button
+            type="button"
+            class="vc-snippets-refresh"
+            onclick={onRefreshSnippets}
+            disabled={!currentVaultPath || refreshingSnippets}
+            aria-label="Snippets neu laden"
+            title="Snippets neu laden"
+          ><RefreshCw size={14} /></button>
+        </div>
+        <p class="vc-snippets-hint">
+          Lege <code>.css</code>-Dateien in <code>&lt;Vault&gt;/.vaultcore/snippets/</code> ab,
+          um das Aussehen pro Vault anzupassen.
+        </p>
+        {#if !currentVaultPath}
+          <p class="vc-snippets-empty">Öffne zuerst einen Vault.</p>
+        {:else if snippetsLoaded && snippetsAvailable.length === 0}
+          <p class="vc-snippets-empty">Keine Snippets gefunden.</p>
+        {:else}
+          <ul class="vc-snippets-list" role="list">
+            {#each snippetsAvailable as name (name)}
+              <li class="vc-snippets-item">
+                <span class="vc-snippets-name" title={name}>{name}</span>
+                <label class="vc-snippets-toggle">
+                  <input
+                    type="checkbox"
+                    checked={snippetsEnabled.includes(name)}
+                    onchange={() => onToggleSnippet(name)}
+                    aria-label={`Snippet ${name} aktivieren`}
+                  />
+                  <span class="vc-snippets-toggle-track" aria-hidden="true">
+                    <span class="vc-snippets-toggle-thumb"></span>
+                  </span>
+                </label>
+              </li>
+            {/each}
+          </ul>
+        {/if}
       </section>
 
       <!-- Section B — Schrift -->
@@ -359,6 +427,104 @@
     background: var(--color-accent-bg);
     border-color: var(--color-accent);
     color: var(--color-accent);
+  }
+
+  /* Section — CSS-Snippets */
+  .vc-snippets-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .vc-snippets-head .vc-settings-section-title { margin: 0; }
+  .vc-snippets-refresh {
+    width: 28px; height: 28px;
+    background: none; border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    border-radius: 4px; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .vc-snippets-refresh:hover:not(:disabled) {
+    background: var(--color-accent-bg); color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+  .vc-snippets-refresh:disabled { opacity: 0.5; cursor: not-allowed; }
+  .vc-snippets-hint {
+    margin: 0 0 12px 0;
+    font-size: 12px; line-height: 1.5;
+    color: var(--color-text-muted);
+  }
+  .vc-snippets-hint code {
+    font-family: var(--vc-font-mono);
+    font-size: 11px;
+    padding: 1px 4px;
+    background: var(--color-surface-alt, rgba(0,0,0,0.06));
+    border-radius: 3px;
+  }
+  .vc-snippets-empty {
+    margin: 0;
+    font-size: 13px;
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+  .vc-snippets-list {
+    list-style: none; padding: 0; margin: 0;
+    display: flex; flex-direction: column;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .vc-snippets-item {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 8px 12px;
+    font-size: 13px; color: var(--color-text);
+  }
+  .vc-snippets-item + .vc-snippets-item {
+    border-top: 1px solid var(--color-border);
+  }
+  .vc-snippets-name {
+    font-family: var(--vc-font-mono);
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1 1 0; min-width: 0;
+    margin-right: 12px;
+  }
+  .vc-snippets-toggle {
+    position: relative;
+    flex-shrink: 0;
+    cursor: pointer;
+  }
+  .vc-snippets-toggle input {
+    position: absolute; inset: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+  .vc-snippets-toggle-track {
+    display: inline-block;
+    width: 32px; height: 18px;
+    background: var(--color-border);
+    border-radius: 999px;
+    position: relative;
+    transition: background 120ms ease;
+  }
+  .vc-snippets-toggle-thumb {
+    position: absolute;
+    top: 2px; left: 2px;
+    width: 14px; height: 14px;
+    background: var(--color-surface);
+    border-radius: 50%;
+    transition: transform 120ms ease;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  }
+  .vc-snippets-toggle input:checked + .vc-snippets-toggle-track {
+    background: var(--color-accent);
+  }
+  .vc-snippets-toggle input:checked + .vc-snippets-toggle-track .vc-snippets-toggle-thumb {
+    transform: translateX(14px);
+  }
+  .vc-snippets-toggle input:focus-visible + .vc-snippets-toggle-track {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
   }
 
   /* Section C — Tastaturkürzel */

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -417,3 +417,31 @@ export async function saveBookmarks(vaultPath: string, bookmarks: string[]): Pro
     throw normalizeError(e);
   }
 }
+
+// ── Custom CSS snippets (#64) ──────────────────────────────────────────────────
+
+/**
+ * List `*.css` filenames in `<vault>/.vaultcore/snippets/`. The directory is
+ * created on first call so the user has a stable drop-in path, and an empty
+ * list is returned when nothing is present.
+ */
+export async function listSnippets(vaultPath: string): Promise<string[]> {
+  try {
+    return await invoke<string[]>("list_snippets", { vaultPath });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Read the contents of a single snippet file. The Rust side vault-scope-
+ * guards the path and rejects traversal attempts (`..`, absolute paths,
+ * anything outside the snippets dir).
+ */
+export async function readSnippet(vaultPath: string, filename: string): Promise<string> {
+  try {
+    return await invoke<string>("read_snippet", { vaultPath, filename });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}

--- a/src/store/snippetsStore.ts
+++ b/src/store/snippetsStore.ts
@@ -1,0 +1,136 @@
+// snippetsStore — custom CSS snippets (#64).
+//
+// Holds the list of snippet filenames available in the current vault, the
+// per-vault enabled set, and the CSS text of enabled snippets (lazy-loaded).
+// Classic `writable` factory per D-06 / RC-01 — no `$state` runes.
+//
+// Persistence: the enabled set is keyed per vault in localStorage using a
+// SHA-256 prefix of the vault path, identical to treeState (FILE-06/07).
+// This keeps the "enabled here" choice local to each vault — opening a
+// different vault doesn't silently inherit a previous vault's CSS.
+
+import { writable, get } from "svelte/store";
+import { listSnippets, readSnippet } from "../ipc/commands";
+import { toastStore } from "./toastStore";
+import { isVaultError, vaultErrorCopy } from "../types/errors";
+import { vaultHashKey } from "../lib/treeState";
+
+export interface SnippetsState {
+  /** All `*.css` filenames found in `<vault>/.vaultcore/snippets/`, sorted. */
+  available: string[];
+  /** Filenames the user has toggled on for this vault. */
+  enabled: string[];
+  /** CSS text keyed by filename. Populated lazily when a snippet is enabled. */
+  contents: Record<string, string>;
+  loaded: boolean;
+}
+
+const initial: SnippetsState = {
+  available: [],
+  enabled: [],
+  contents: {},
+  loaded: false,
+};
+
+const _store = writable<SnippetsState>({ ...initial });
+
+function pushError(e: unknown): void {
+  const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
+  toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+}
+
+async function enabledStorageKey(vaultPath: string): Promise<string> {
+  // Reuse the vault-hash prefix helper so all per-vault keys share a common
+  // scheme. `vaultHashKey` returns `vaultcore-tree-state:<hex>` — we swap
+  // the namespace to `vaultcore-snippets-enabled:<hex>`.
+  const treeKey = await vaultHashKey(vaultPath);
+  return treeKey.replace(/^vaultcore-tree-state:/, "vaultcore-snippets-enabled:");
+}
+
+async function readEnabled(vaultPath: string): Promise<string[]> {
+  try {
+    const key = await enabledStorageKey(vaultPath);
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) {
+      return parsed;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeEnabled(vaultPath: string, enabled: string[]): Promise<void> {
+  try {
+    const key = await enabledStorageKey(vaultPath);
+    localStorage.setItem(key, JSON.stringify(enabled));
+  } catch {
+    /* private mode / quota — fall through silently */
+  }
+}
+
+async function ensureLoaded(vaultPath: string, filename: string): Promise<void> {
+  const cur = get(_store);
+  if (cur.contents[filename] !== undefined) return;
+  try {
+    const css = await readSnippet(vaultPath, filename);
+    _store.update((s) => ({ ...s, contents: { ...s.contents, [filename]: css } }));
+  } catch (e) {
+    // If read fails, strip it from the enabled set so we don't leave a
+    // ghost style tag with empty content and keep retrying forever.
+    _store.update((s) => ({ ...s, enabled: s.enabled.filter((n) => n !== filename) }));
+    void writeEnabled(vaultPath, get(_store).enabled);
+    pushError(e);
+  }
+}
+
+export const snippetsStore = {
+  subscribe: _store.subscribe,
+
+  /**
+   * Refresh `available` by re-scanning the vault, then preload any enabled
+   * snippet whose text isn't cached yet. Called on vault open and whenever
+   * the user hits "Reload" in Settings.
+   */
+  async load(vaultPath: string): Promise<void> {
+    let available: string[] = [];
+    try {
+      available = await listSnippets(vaultPath);
+    } catch (e) {
+      pushError(e);
+    }
+    const persistedEnabled = await readEnabled(vaultPath);
+    // Drop enabled entries whose files have vanished since last run.
+    const enabled = persistedEnabled.filter((n) => available.includes(n));
+    if (enabled.length !== persistedEnabled.length) {
+      void writeEnabled(vaultPath, enabled);
+    }
+    _store.set({ available, enabled, contents: {}, loaded: true });
+    // Lazily fetch CSS text for the currently-enabled ones so the DOM
+    // <style> tags can render immediately.
+    for (const name of enabled) {
+      void ensureLoaded(vaultPath, name);
+    }
+  },
+
+  async toggle(filename: string, vaultPath: string): Promise<void> {
+    if (!filename) return;
+    const current = get(_store);
+    if (!current.available.includes(filename)) return;
+    const isOn = current.enabled.includes(filename);
+    const next = isOn
+      ? current.enabled.filter((n) => n !== filename)
+      : [...current.enabled, filename];
+    _store.update((s) => ({ ...s, enabled: next }));
+    await writeEnabled(vaultPath, next);
+    if (!isOn) {
+      await ensureLoaded(vaultPath, filename);
+    }
+  },
+
+  reset(): void {
+    _store.set({ ...initial });
+  },
+};


### PR DESCRIPTION
Closes #64

## Summary
- New `list_snippets` / `read_snippet` Tauri commands in `src-tauri/src/commands/snippets.rs`, both vault-scope-guarded (same pattern as bookmarks) with an extra canonicalised path check on read so symlinks or unicode tricks can't escape `<vault>/.vaultcore/snippets/`.
- `snippetsStore` loads the available list on vault open, persists the enabled set per-vault in localStorage via a SHA-256-hashed key (same scheme as treeState), and lazy-loads CSS text on enable.
- Settings modal gets a new CSS-Snippets section near Appearance with a toggle per snippet, empty state, and a refresh button.
- `App.svelte` mounts one `<style data-snippet="<filename>">` tag per active snippet in `document.head` and reacts to store changes, so toggling takes effect without a restart.

## Test plan
- [ ] typecheck + tests + cargo check pass
- [ ] Dropping a .css file into <vault>/.vaultcore/snippets/ shows it in Settings
- [ ] Toggling applies immediately (DOM `<style data-snippet>` appears/disappears)
- [ ] Enabled set survives app restart per vault
- [ ] Path traversal attempts (`..`, absolute paths) rejected