### PR TITLE
feat(indexer): note aliases via frontmatter (#60)

### DIFF
--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -125,7 +125,11 @@ pub async fn get_unresolved_links(
 
 /// Fuzzy filename search for `[[` autocomplete — delegates to nucleo matcher.
 ///
-/// Reuses the same FileIndex + Matcher as search_filename (Phase 3).
+/// Candidate set: filenames AND frontmatter aliases (issue #60). Alias hits
+/// carry the matched alias text in `matched_alias` so the popup can render
+/// `alias → filename`. When the same file surfaces from both a filename and
+/// an alias haystack, the higher-scoring row wins (filename hits take the
+/// tiebreak so ranking stays consistent with pure-filename search).
 #[tauri::command]
 pub async fn suggest_links(
     query: String,
@@ -145,49 +149,103 @@ pub async fn suggest_links(
         }
     };
 
-    let paths: Vec<String> = {
+    // Snapshot paths + per-file aliases under a single lock so the subsequent
+    // matcher work runs without holding the FileIndex mutex.
+    let (paths, file_aliases): (Vec<String>, Vec<(String, Vec<String>)>) = {
         let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
-        fi.all_relative_paths()
+        let paths = fi.all_relative_paths();
+        let aliases: Vec<(String, Vec<String>)> = fi
+            .all_entries()
+            .map(|(_, m)| (m.relative_path.clone(), m.aliases.clone()))
+            .filter(|(_, a)| !a.is_empty())
+            .collect();
+        (paths, aliases)
     };
 
     // Empty query: return the first N files sorted alphabetically (Obsidian-style
     // "browse" mode for [[|]]). Skip nucleo ranking — there's no pattern to rank by.
+    // Aliases are not surfaced in browse mode; alias surfacing requires a query.
     if query.trim().is_empty() {
         let mut sorted = paths;
         sorted.sort_unstable();
         sorted.truncate(effective_limit);
         return Ok(sorted
             .into_iter()
-            .map(|path| FileMatch { path, score: 0, match_indices: Vec::new() })
+            .map(|path| FileMatch {
+                path,
+                score: 0,
+                match_indices: Vec::new(),
+                matched_alias: None,
+            })
             .collect());
     }
 
     let pattern = Pattern::parse(&query, CaseMatching::Ignore, Normalization::Smart);
 
     let mut buf: Vec<char> = Vec::new();
-    let mut matches: Vec<(String, u32, Vec<u32>)> = {
+    let mut matches: Vec<FileMatch> = {
         let mut matcher = matcher_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
-        paths
-            .into_iter()
+
+        // Filename haystack
+        let mut out: Vec<FileMatch> = paths
+            .iter()
             .filter_map(|path| {
                 buf.clear();
-                let haystack = Utf32Str::new(&path, &mut buf);
+                let haystack = Utf32Str::new(path, &mut buf);
                 let mut indices: Vec<u32> = Vec::new();
                 let score = pattern.indices(haystack, &mut *matcher, &mut indices)?;
                 indices.sort_unstable();
                 indices.dedup();
-                Some((path, score, indices))
+                Some(FileMatch {
+                    path: path.clone(),
+                    score,
+                    match_indices: indices,
+                    matched_alias: None,
+                })
             })
-            .collect()
+            .collect();
+
+        // Alias haystack — one nucleo pass per (file, alias) pair. Alias
+        // matches carry empty `match_indices` because the indices would point
+        // into the alias string, not the path shown in the popup.
+        for (rel_path, aliases) in &file_aliases {
+            for alias in aliases {
+                buf.clear();
+                let haystack = Utf32Str::new(alias, &mut buf);
+                let mut indices: Vec<u32> = Vec::new();
+                if let Some(score) = pattern.indices(haystack, &mut *matcher, &mut indices) {
+                    out.push(FileMatch {
+                        path: rel_path.clone(),
+                        score,
+                        match_indices: Vec::new(),
+                        matched_alias: Some(alias.clone()),
+                    });
+                }
+            }
+        }
+
+        out
     };
 
-    matches.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    // Per-path dedupe: keep the best row per file. Tie-break prefers filename
+    // hits (matched_alias=None) over alias hits so ranking stays predictable
+    // when a note's filename and alias both score equally.
+    matches.sort_unstable_by(|a, b| {
+        b.score.cmp(&a.score).then_with(|| {
+            // alias None sorts before alias Some at equal score
+            match (&a.matched_alias, &b.matched_alias) {
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                _ => std::cmp::Ordering::Equal,
+            }
+        })
+    });
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    matches.retain(|m| seen.insert(m.path.clone()));
     matches.truncate(effective_limit);
 
-    Ok(matches
-        .into_iter()
-        .map(|(path, score, match_indices)| FileMatch { path, score, match_indices })
-        .collect())
+    Ok(matches)
 }
 
 // ── update_links_after_rename ──────────────────────────────────────────────────
@@ -372,10 +430,17 @@ pub async fn update_links_after_rename(
 
 // ── get_resolved_links ─────────────────────────────────────────────────────────
 
-/// Return a stem → vault-relative-path map for all files in the vault.
+/// Return a (stem OR alias) → vault-relative-path map for all files in the vault.
 ///
-/// Keys are lowercased stems; values are vault-relative paths.
-/// The frontend converts this to `Map<string, string>` for zero-IPC click handling.
+/// Keys are lowercased — stems come from filenames, aliases come from YAML
+/// frontmatter (issue #60). Values are vault-relative paths. The frontend
+/// converts this to `Map<string, string>` for zero-IPC click handling.
+///
+/// Collision priority (also documented at the call site in `link_graph::
+/// resolved_map_with_aliases`):
+///   1. Filename-stem match wins over alias match.
+///   2. Between two aliases on different notes, first-indexed wins; the loser
+///      is logged.
 #[tauri::command]
 pub async fn get_resolved_links(
     state: tauri::State<'_, VaultState>,
@@ -391,12 +456,17 @@ pub async fn get_resolved_links(
         }
     };
 
-    let paths = {
+    let (paths, file_aliases) = {
         let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
-        fi.all_relative_paths()
+        let paths = fi.all_relative_paths();
+        let file_aliases: Vec<(String, Vec<String>)> = fi
+            .all_entries()
+            .map(|(_, m)| (m.relative_path.clone(), m.aliases.clone()))
+            .collect();
+        (paths, file_aliases)
     };
 
-    Ok(link_graph::resolved_map(&paths))
+    Ok(link_graph::resolved_map_with_aliases(&paths, &file_aliases))
 }
 
 // ── get_resolved_attachments ───────────────────────────────────────────────────

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -52,6 +52,14 @@ pub struct FileMatch {
     pub score: u32,
     /// Character positions in `path` that matched the query (sorted, deduplicated).
     pub match_indices: Vec<u32>,
+    /// Matched alias text (from frontmatter `aliases:`) when the nucleo hit
+    /// came from an alias haystack rather than the filename. `None` for
+    /// path-based matches. Issue #60: the Quick Switcher and `[[` popup
+    /// render this as `alias → filename` so the user sees why the row
+    /// surfaced. `default` makes older callers (search_filename) continue to
+    /// serialize a `matchedAlias: null` field, which the TS types tolerate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matched_alias: Option<String>,
 }
 
 // ── search_fulltext ───────────────────────────────────────────────────────────
@@ -157,6 +165,12 @@ pub async fn search_fulltext(
 
 /// Fuzzy filename search using the pre-warmed nucleo Matcher.
 ///
+/// Candidate set: filenames AND frontmatter aliases (issue #60). Alias hits
+/// carry the matched alias text in `matched_alias` so Quick Switcher rows
+/// render as `alias → filename`. Per-path dedupe keeps the best row per
+/// file; filename hits win at equal score so ranking is consistent with
+/// pre-alias behaviour.
+///
 /// Results are sorted by composite score descending and capped at `limit`.
 #[tauri::command]
 pub async fn search_filename(
@@ -183,53 +197,84 @@ pub async fn search_filename(
         }
     };
 
-    // Gather all relative paths from the in-memory file index.
-    let paths: Vec<String> = {
+    // Gather paths + per-file aliases in a single lock hold.
+    let (paths, file_aliases): (Vec<String>, Vec<(String, Vec<String>)>) = {
         let fi = file_index_arc
             .lock()
             .map_err(|_| VaultError::IndexCorrupt)?;
-        fi.all_relative_paths()
+        let paths = fi.all_relative_paths();
+        let aliases: Vec<(String, Vec<String>)> = fi
+            .all_entries()
+            .map(|(_, m)| (m.relative_path.clone(), m.aliases.clone()))
+            .filter(|(_, a)| !a.is_empty())
+            .collect();
+        (paths, aliases)
     };
 
     // Build nucleo pattern with special syntax support.
     let pattern = Pattern::parse(&query, CaseMatching::Ignore, Normalization::Smart);
 
-    // Score and collect matches using the pre-warmed Matcher.
+    // Score filenames + aliases.
     let mut buf: Vec<char> = Vec::new();
-    let mut matches: Vec<(String, u32, Vec<u32>)> = {
+    let mut matches: Vec<FileMatch> = {
         let mut matcher = matcher_arc
             .lock()
             .map_err(|_| VaultError::IndexCorrupt)?;
 
-        paths
-            .into_iter()
+        let mut out: Vec<FileMatch> = paths
+            .iter()
             .filter_map(|path| {
                 buf.clear();
-                let haystack = Utf32Str::new(&path, &mut buf);
+                let haystack = Utf32Str::new(path, &mut buf);
                 let mut indices: Vec<u32> = Vec::new();
                 let score = pattern.indices(haystack, &mut *matcher, &mut indices)?;
                 // Sort + dedup per nucleo docs — multiple atoms append independently.
                 indices.sort_unstable();
                 indices.dedup();
-                Some((path, score, indices))
+                Some(FileMatch {
+                    path: path.clone(),
+                    score,
+                    match_indices: indices,
+                    matched_alias: None,
+                })
             })
-            .collect()
+            .collect();
+
+        for (rel_path, aliases) in &file_aliases {
+            for alias in aliases {
+                buf.clear();
+                let haystack = Utf32Str::new(alias, &mut buf);
+                let mut indices: Vec<u32> = Vec::new();
+                if let Some(score) = pattern.indices(haystack, &mut *matcher, &mut indices) {
+                    out.push(FileMatch {
+                        path: rel_path.clone(),
+                        score,
+                        match_indices: Vec::new(),
+                        matched_alias: Some(alias.clone()),
+                    });
+                }
+            }
+        }
+
+        out
     };
 
-    // Sort by score descending, cap at limit.
-    matches.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    // Sort by score desc; at equal score, filename hits beat alias hits.
+    matches.sort_unstable_by(|a, b| {
+        b.score.cmp(&a.score).then_with(|| {
+            match (&a.matched_alias, &b.matched_alias) {
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                _ => std::cmp::Ordering::Equal,
+            }
+        })
+    });
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    matches.retain(|m| seen.insert(m.path.clone()));
     matches.truncate(limit);
 
-    let results = matches
-        .into_iter()
-        .map(|(path, score, match_indices)| FileMatch {
-            path,
-            score,
-            match_indices,
-        })
-        .collect();
-
-    Ok(results)
+    Ok(matches)
 }
 
 // ── rebuild_index ─────────────────────────────────────────────────────────────

--- a/src-tauri/src/indexer/frontmatter.rs
+++ b/src-tauri/src/indexer/frontmatter.rs
@@ -72,9 +72,14 @@ pub fn parse_frontmatter(content: &str) -> Frontmatter {
         return Frontmatter::default();
     };
 
+    let mut aliases = read_string_seq_or_scalar(&value, "aliases");
+    if aliases.is_empty() {
+        aliases = read_string_seq_or_scalar(&value, "alias");
+    }
+
     Frontmatter {
         tags: read_string_seq_or_scalar(&value, "tags"),
-        aliases: read_string_seq_or_scalar(&value, "aliases"),
+        aliases,
     }
 }
 
@@ -157,6 +162,24 @@ mod tests {
         let fm = parse_frontmatter(content);
         assert_eq!(fm.tags, vec!["rust"]);
         assert_eq!(fm.aliases, vec!["ui", "interface"]);
+    }
+
+    #[test]
+    fn alias_singular_list_form() {
+        let content = "---\nalias: [UI, User Interface]\n---\nbody";
+        assert_eq!(extract_yaml_aliases(content), vec!["ui", "user interface"]);
+    }
+
+    #[test]
+    fn alias_singular_scalar_form() {
+        let content = "---\nalias: UI\n---\nbody";
+        assert_eq!(extract_yaml_aliases(content), vec!["ui"]);
+    }
+
+    #[test]
+    fn aliases_plural_takes_priority_over_singular() {
+        let content = "---\naliases: [plural]\nalias: [singular]\n---\nbody";
+        assert_eq!(extract_yaml_aliases(content), vec!["plural"]);
     }
 
     #[test]

--- a/src-tauri/src/indexer/frontmatter.rs
+++ b/src-tauri/src/indexer/frontmatter.rs
@@ -1,0 +1,177 @@
+// Shared YAML frontmatter reader.
+//
+// Extracted from `tag_index.rs`'s original `extract_yaml_tags` so that the
+// same parser can service the `tags:` key and the new `aliases:` key without
+// duplicating the `---` delimiter logic, the empty-frontmatter guard, or the
+// malformed-YAML fallback.
+//
+// Behaviour (unchanged from the original):
+// - Returns `None` for any document without a leading `---\n…\n---` block.
+// - Returns `None` (i.e. the key was absent) and an empty vector for malformed
+//   YAML so the caller degrades gracefully. Tests cover this explicitly.
+// - Both list form (`tags: [a, b]`) and scalar form (`tags: a`) are accepted.
+//
+// Serde behaviour mirrors the `serde_yml` 0.0.12 semantics already in use by
+// `tag_index.rs` — see the original pitfall note about version selection.
+
+use serde_yml::Value;
+
+/// Parsed frontmatter keys the indexer cares about.
+///
+/// Only surfaces the *recognised* keys; the parser is not a full `serde_yml`
+/// roundtrip. Keys absent from the source file collapse to empty `Vec`s so
+/// the caller doesn't have to distinguish missing-vs-empty.
+///
+/// Strings inside each vector are lowercased for case-insensitive matching
+/// (same contract as `extract_yaml_tags` / `extract_inline_tags`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Frontmatter {
+    pub tags: Vec<String>,
+    pub aliases: Vec<String>,
+}
+
+/// Extract the raw YAML text between the leading `---` delimiters of a
+/// frontmatter block. Returns `None` if no well-formed delimiter pair exists.
+///
+/// Splitting out this step (vs. running the full YAML parse first) keeps the
+/// fast-path free — 99% of Markdown files have no frontmatter and can be
+/// rejected after one `starts_with` check and one `find`.
+fn frontmatter_yaml_block(content: &str) -> Option<&str> {
+    let stripped = content.trim_start();
+    if !stripped.starts_with("---") {
+        return None;
+    }
+    let after_first = &stripped[3..];
+    let end_rel = after_first.find("\n---")?;
+    Some(&after_first[..end_rel])
+}
+
+/// Read a single key from a parsed YAML value, accepting either a list of
+/// scalars or a single scalar string. Other node shapes (maps, nested seqs,
+/// booleans, …) collapse to an empty vector — same contract as the original
+/// `extract_yaml_tags`.
+fn read_string_seq_or_scalar(value: &Value, key: &str) -> Vec<String> {
+    match value.get(key) {
+        Some(Value::Sequence(seq)) => seq
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+            .collect(),
+        Some(Value::String(s)) => vec![s.to_lowercase()],
+        _ => Vec::new(),
+    }
+}
+
+/// Parse a Markdown document's YAML frontmatter and return the recognised
+/// keys. Returns `Frontmatter::default()` (all empty) when there is no
+/// frontmatter block or the YAML fails to parse.
+pub fn parse_frontmatter(content: &str) -> Frontmatter {
+    let Some(yaml_block) = frontmatter_yaml_block(content) else {
+        return Frontmatter::default();
+    };
+    let Ok(value): Result<Value, _> = serde_yml::from_str(yaml_block) else {
+        return Frontmatter::default();
+    };
+
+    Frontmatter {
+        tags: read_string_seq_or_scalar(&value, "tags"),
+        aliases: read_string_seq_or_scalar(&value, "aliases"),
+    }
+}
+
+/// Back-compat helper matching the original `extract_yaml_tags` signature —
+/// kept so `tag_index.rs` can delegate without touching its public API.
+pub fn extract_yaml_tags(content: &str) -> Vec<String> {
+    parse_frontmatter(content).tags
+}
+
+/// Frontmatter `aliases:` helper (list or scalar form).
+///
+/// Order is preserved, values are lowercased; duplicates are NOT deduped here
+/// because callers may want to surface the raw list verbatim.
+pub fn extract_yaml_aliases(content: &str) -> Vec<String> {
+    parse_frontmatter(content).aliases
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Tag back-compat — mirrors the original tag_index.rs tests ──────────────
+
+    #[test]
+    fn tags_list_form() {
+        let content = "---\ntags: [a, b, nested/tag]\n---\nbody";
+        assert_eq!(extract_yaml_tags(content), vec!["a", "b", "nested/tag"]);
+    }
+
+    #[test]
+    fn tags_scalar_form() {
+        let content = "---\ntags: single\n---\n...";
+        assert_eq!(extract_yaml_tags(content), vec!["single"]);
+    }
+
+    #[test]
+    fn tags_absent_key() {
+        let content = "---\ntitle: foo\n---\n...";
+        assert!(extract_yaml_tags(content).is_empty());
+    }
+
+    #[test]
+    fn tags_no_frontmatter() {
+        let content = "no dashes\ntags: [a]";
+        assert!(extract_yaml_tags(content).is_empty());
+    }
+
+    // ── Alias behaviour ────────────────────────────────────────────────────────
+
+    #[test]
+    fn aliases_list_form() {
+        let content = "---\naliases: [UI, User Interface]\n---\nbody";
+        assert_eq!(extract_yaml_aliases(content), vec!["ui", "user interface"]);
+    }
+
+    #[test]
+    fn aliases_scalar_form() {
+        let content = "---\naliases: UI\n---\nbody";
+        assert_eq!(extract_yaml_aliases(content), vec!["ui"]);
+    }
+
+    #[test]
+    fn aliases_absent_key_returns_empty() {
+        let content = "---\ntitle: foo\n---\nbody";
+        assert!(extract_yaml_aliases(content).is_empty());
+    }
+
+    #[test]
+    fn malformed_yaml_degrades_to_empty() {
+        // Unbalanced bracket — serde_yml::from_str returns Err → default.
+        let content = "---\naliases: [UI, User Interface\n---\nbody";
+        let fm = parse_frontmatter(content);
+        assert!(fm.aliases.is_empty());
+        assert!(fm.tags.is_empty());
+    }
+
+    #[test]
+    fn combined_keys_are_both_parsed() {
+        let content = "---\ntags: [rust]\naliases: [UI, Interface]\n---\nbody";
+        let fm = parse_frontmatter(content);
+        assert_eq!(fm.tags, vec!["rust"]);
+        assert_eq!(fm.aliases, vec!["ui", "interface"]);
+    }
+
+    #[test]
+    fn aliases_non_string_node_is_empty() {
+        // A nested mapping is not a scalar/sequence of strings.
+        let content = "---\naliases:\n  nested: value\n---\nbody";
+        let fm = parse_frontmatter(content);
+        assert!(fm.aliases.is_empty());
+    }
+
+    #[test]
+    fn empty_frontmatter_block_is_empty() {
+        let content = "---\n---\nbody";
+        let fm = parse_frontmatter(content);
+        assert!(fm.tags.is_empty());
+        assert!(fm.aliases.is_empty());
+    }
+}

--- a/src-tauri/src/indexer/link_graph.rs
+++ b/src-tauri/src/indexer/link_graph.rs
@@ -399,3 +399,59 @@ pub fn resolved_map(all_rel_paths: &[String]) -> HashMap<String, String> {
 
     map
 }
+
+/// Build a `key (lowercased) → vault-relative path` map that includes both
+/// filename stems AND frontmatter aliases (issue #60).
+///
+/// Collision priority (document in code — do not change without updating
+/// acceptance criteria in issue #60):
+///   1. Exact filename-stem match wins over alias match. If an alias string
+///      is also the stem of a different file, the stem's file is authoritative
+///      and the alias never reaches the map.
+///   2. Between two aliases on different notes, first-indexed wins. The loser
+///      is logged at `info` — same structured-logging strategy used by
+///      `resolve_link`'s stem-collision path.
+///
+/// `file_aliases` is a slice of `(rel_path, aliases)` pairs in whatever order
+/// the `FileIndex` iterator produced. Iteration order drives alias-collision
+/// resolution, matching the "first-indexed wins" rule.
+pub fn resolved_map_with_aliases(
+    all_rel_paths: &[String],
+    file_aliases: &[(String, Vec<String>)],
+) -> HashMap<String, String> {
+    let stem_map = resolved_map(all_rel_paths);
+
+    // Start from the stem map so stems always beat aliases (priority rule #1).
+    let mut map = stem_map.clone();
+
+    for (rel_path, aliases) in file_aliases {
+        for alias in aliases {
+            let key = alias.to_lowercase();
+
+            // Priority 1: stem always wins. If the key is already a stem,
+            // skip — stems are authoritative.
+            if stem_map.contains_key(&key) {
+                continue;
+            }
+
+            // Priority 2: first-indexed alias wins. Log the loser so
+            // vault-health checks can surface duplicate-alias configurations
+            // (same pattern as stem-collision logging in `resolve_link`).
+            if let Some(existing) = map.get(&key) {
+                if existing != rel_path {
+                    log::info!(
+                        "alias collision: '{}' already points to {}, ignoring duplicate from {}",
+                        alias,
+                        existing,
+                        rel_path
+                    );
+                }
+                continue;
+            }
+
+            map.insert(key, rel_path.clone());
+        }
+    }
+
+    map
+}

--- a/src-tauri/src/indexer/memory.rs
+++ b/src-tauri/src/indexer/memory.rs
@@ -17,6 +17,9 @@ pub struct FileMeta {
     pub hash: String,
     /// First `# ` heading text, or the filename stem as fallback.
     pub title: String,
+    /// YAML frontmatter `aliases:` values (lowercased, order preserved).
+    /// Issue #60 — empty when the file has no frontmatter or no aliases key.
+    pub aliases: Vec<String>,
 }
 
 /// In-memory index of vault files keyed by canonical absolute path.
@@ -62,6 +65,28 @@ impl FileIndex {
     pub fn all_entries(&self) -> impl Iterator<Item = (&PathBuf, &FileMeta)> {
         self.entries.iter()
     }
+
+    /// Update the aliases slot for the entry matching `rel_path`. No-op when
+    /// the rel_path is not in the index (aliases are populated as part of
+    /// `AddFile`; this is only used for in-place refreshes from `UpdateLinks`).
+    pub fn set_aliases_for_rel(&mut self, rel_path: &str, aliases: Vec<String>) {
+        for meta in self.entries.values_mut() {
+            if meta.relative_path == rel_path {
+                meta.aliases = aliases;
+                return;
+            }
+        }
+    }
+
+    /// Return the aliases stored for `rel_path`, or an empty vector.
+    pub fn aliases_for_rel(&self, rel_path: &str) -> Vec<String> {
+        for meta in self.entries.values() {
+            if meta.relative_path == rel_path {
+                return meta.aliases.clone();
+            }
+        }
+        Vec::new()
+    }
 }
 
 #[cfg(test)]
@@ -73,6 +98,7 @@ mod tests {
             relative_path: rel.to_string(),
             hash: "abc123".to_string(),
             title: "Test".to_string(),
+            aliases: Vec::new(),
         }
     }
 

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -18,6 +18,7 @@ pub mod memory;
 pub mod parser;
 pub mod link_graph;
 pub mod tag_index;
+pub mod frontmatter;
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -25,6 +26,7 @@ use std::time::{Duration, Instant};
 
 use link_graph::{LinkGraph, extract_links};
 use tag_index::TagIndex;
+use frontmatter::parse_frontmatter;
 
 use tantivy::schema::Schema;
 use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, Term};
@@ -278,6 +280,9 @@ impl IndexCoordinator {
             if !already_current {
                 let body = parser::strip_markdown(&content);
                 let title = tantivy_index::extract_title(&content, &stem);
+                // Issue #60: parse frontmatter once per add so aliases land
+                // in FileMeta at the same time the file enters the index.
+                let aliases = parse_frontmatter(&content).aliases;
 
                 // Update in-memory index before sending to queue.
                 {
@@ -290,6 +295,7 @@ impl IndexCoordinator {
                             relative_path: relative_path.clone(),
                             hash: hash.clone(),
                             title: title.clone(),
+                            aliases,
                         },
                     );
                 }
@@ -465,12 +471,25 @@ async fn run_queue_consumer(
                 if let Ok(mut lg) = link_graph.lock() {
                     lg.update_file(&rel_path, links, &all_paths);
                 }
+                // Issue #60: keep FileMeta.aliases in sync on every file edit.
+                // UpdateLinks fires after every save/rename/external modify, so
+                // piggy-backing alias refresh here avoids introducing another
+                // command channel for a single metadata slot.
+                let aliases = parse_frontmatter(&content).aliases;
+                if let Ok(mut fi) = file_index.lock() {
+                    fi.set_aliases_for_rel(&rel_path, aliases);
+                }
             }
             IndexCmd::RemoveLinks { rel_path } => {
                 // Remove link-graph entries for a deleted file (LINK-08).
                 if let Ok(mut lg) = link_graph.lock() {
                     lg.remove_file(&rel_path);
                 }
+                // Issue #60: aliases hang off FileMeta; when DeleteFile drops the
+                // FileIndex entry the aliases die with it, so nothing extra to
+                // clear here. RemoveLinks fires on rename-old too — the rename's
+                // new-side UpdateLinks command repopulates aliases under the new
+                // rel_path.
             }
             IndexCmd::UpdateTags { rel_path, content } => {
                 // Incrementally update tag-index entries for a file (TAG-01/02).

--- a/src-tauri/src/indexer/tag_index.rs
+++ b/src-tauri/src/indexer/tag_index.rs
@@ -96,31 +96,11 @@ pub fn extract_inline_tag_occurrences(content: &str) -> Vec<String> {
 /// - Frontmatter has no `tags` key
 /// - The YAML is malformed (T-05-01-01 mitigation: `from_str` returns Err → `[]`)
 ///
-/// Uses serde_yml 0.0.12 per RESEARCH Pitfall 1.
+/// Delegates to the shared frontmatter reader (`super::frontmatter`). Public
+/// contract is semantically identical to the pre-refactor implementation —
+/// existing tag tests still exercise this code path.
 pub fn extract_yaml_tags(content: &str) -> Vec<String> {
-    let stripped = content.trim_start();
-    if !stripped.starts_with("---") {
-        return Vec::new();
-    }
-    let after_first = &stripped[3..];
-    let Some(end_rel) = after_first.find("\n---") else {
-        return Vec::new();
-    };
-    let yaml_block = &after_first[..end_rel];
-    let Ok(value): Result<serde_yml::Value, _> = serde_yml::from_str(yaml_block) else {
-        return Vec::new();
-    };
-    let Some(tags_val) = value.get("tags") else {
-        return Vec::new();
-    };
-    match tags_val {
-        serde_yml::Value::Sequence(seq) => seq
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
-            .collect(),
-        serde_yml::Value::String(s) => vec![s.to_lowercase()],
-        _ => Vec::new(),
-    }
+    super::frontmatter::extract_yaml_tags(content)
 }
 
 // ── TagIndex ───────────────────────────────────────────────────────────────────

--- a/src-tauri/src/tests/aliases.rs
+++ b/src-tauri/src/tests/aliases.rs
@@ -1,0 +1,170 @@
+// Unit tests for note aliases (issue #60).
+//
+// Covers:
+//   - Frontmatter reader: list form, scalar form, missing key, malformed YAML.
+//   - Resolution map: alias lookup, stem-vs-alias collision, alias-vs-alias
+//     collision with first-indexed-wins ordering.
+
+use std::path::PathBuf;
+
+use crate::indexer::frontmatter::{extract_yaml_aliases, extract_yaml_tags, parse_frontmatter};
+use crate::indexer::link_graph::resolved_map_with_aliases;
+use crate::indexer::memory::{FileIndex, FileMeta};
+
+// ── Frontmatter reader ─────────────────────────────────────────────────────────
+
+#[test]
+fn aliases_list_form_parses() {
+    let content = "---\naliases: [UI, User Interface]\n---\nbody";
+    assert_eq!(
+        extract_yaml_aliases(content),
+        vec!["ui".to_string(), "user interface".to_string()]
+    );
+}
+
+#[test]
+fn aliases_scalar_form_parses() {
+    let content = "---\naliases: UI\n---\nbody";
+    assert_eq!(extract_yaml_aliases(content), vec!["ui".to_string()]);
+}
+
+#[test]
+fn aliases_missing_returns_empty() {
+    let content = "---\ntitle: foo\n---\nbody";
+    assert!(extract_yaml_aliases(content).is_empty());
+}
+
+#[test]
+fn aliases_malformed_yaml_graceful_noop() {
+    // Unterminated list — serde_yml::from_str returns Err, reader must not panic.
+    let content = "---\naliases: [UI, Interface\n---\nbody";
+    let fm = parse_frontmatter(content);
+    assert!(fm.aliases.is_empty());
+    assert!(fm.tags.is_empty());
+}
+
+#[test]
+fn existing_tag_behaviour_unchanged() {
+    // Regression guard — the shared reader must return the same shape for
+    // the tag path that `tag_index` originally produced.
+    let content = "---\ntags: [rust, work/meeting]\n---\nbody";
+    assert_eq!(
+        extract_yaml_tags(content),
+        vec!["rust".to_string(), "work/meeting".to_string()]
+    );
+    let content = "---\ntags: single\n---\nbody";
+    assert_eq!(extract_yaml_tags(content), vec!["single".to_string()]);
+}
+
+// ── Resolution map collision handling ──────────────────────────────────────────
+
+fn make_file(idx: &mut FileIndex, rel: &str, aliases: Vec<String>) {
+    idx.insert(
+        PathBuf::from(format!("/vault/{}", rel)),
+        FileMeta {
+            relative_path: rel.to_string(),
+            hash: "h".to_string(),
+            title: rel.to_string(),
+            aliases,
+        },
+    );
+}
+
+/// Build the `(rel_path, aliases)` slice in a deterministic order — used by the
+/// collision tests to assert first-indexed-wins ordering.
+fn file_alias_list(order: &[(&str, &[&str])]) -> Vec<(String, Vec<String>)> {
+    order
+        .iter()
+        .map(|(rel, aliases)| {
+            (
+                (*rel).to_string(),
+                aliases.iter().map(|s| s.to_string()).collect(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn alias_resolves_to_target_file() {
+    let all_paths = vec!["notes/uinote.md".to_string()];
+    let aliases = file_alias_list(&[("notes/uinote.md", &["ui", "user interface"])]);
+
+    let map = resolved_map_with_aliases(&all_paths, &aliases);
+
+    assert_eq!(
+        map.get("ui").map(|s| s.as_str()),
+        Some("notes/uinote.md"),
+        "alias 'ui' should resolve to notes/uinote.md"
+    );
+    assert_eq!(
+        map.get("user interface").map(|s| s.as_str()),
+        Some("notes/uinote.md")
+    );
+    // Filename stem key is unaffected.
+    assert_eq!(
+        map.get("uinote").map(|s| s.as_str()),
+        Some("notes/uinote.md")
+    );
+}
+
+#[test]
+fn stem_beats_alias_on_collision() {
+    // File A is named `ui.md`, file B has alias 'UI'. Resolving `[[ui]]`
+    // must pick A (stem) — alias never reaches the map for that key.
+    let all_paths = vec!["a/ui.md".to_string(), "b/other.md".to_string()];
+    let aliases = file_alias_list(&[("b/other.md", &["ui"])]);
+
+    let map = resolved_map_with_aliases(&all_paths, &aliases);
+
+    assert_eq!(
+        map.get("ui").map(|s| s.as_str()),
+        Some("a/ui.md"),
+        "stem must win over alias"
+    );
+}
+
+#[test]
+fn alias_vs_alias_first_indexed_wins() {
+    // Two files both declare alias 'ui'. The first-indexed file (order of the
+    // file_aliases slice) wins; loser is ignored (log::info emitted but not
+    // asserted here because the test harness doesn't capture log output).
+    let all_paths = vec!["a/first.md".to_string(), "b/second.md".to_string()];
+    let aliases = file_alias_list(&[
+        ("a/first.md", &["ui"]),
+        ("b/second.md", &["ui"]),
+    ]);
+
+    let map = resolved_map_with_aliases(&all_paths, &aliases);
+
+    assert_eq!(
+        map.get("ui").map(|s| s.as_str()),
+        Some("a/first.md"),
+        "first-indexed alias must win"
+    );
+}
+
+#[test]
+fn alias_stable_when_no_collision() {
+    // Sanity: distinct aliases on distinct files both resolve.
+    let all_paths = vec!["a/first.md".to_string(), "b/second.md".to_string()];
+    let aliases = file_alias_list(&[
+        ("a/first.md", &["alpha"]),
+        ("b/second.md", &["beta"]),
+    ]);
+
+    let map = resolved_map_with_aliases(&all_paths, &aliases);
+
+    assert_eq!(map.get("alpha").map(|s| s.as_str()), Some("a/first.md"));
+    assert_eq!(map.get("beta").map(|s| s.as_str()), Some("b/second.md"));
+}
+
+#[test]
+fn aliases_populated_into_file_meta_via_helper() {
+    // Smoke test for the FileIndex mutator used by `IndexCmd::UpdateLinks`.
+    let mut fi = FileIndex::new();
+    make_file(&mut fi, "note.md", Vec::new());
+    fi.set_aliases_for_rel("note.md", vec!["ui".to_string()]);
+
+    let got = fi.aliases_for_rel("note.md");
+    assert_eq!(got, vec!["ui".to_string()]);
+}

--- a/src-tauri/src/tests/global_graph.rs
+++ b/src-tauri/src/tests/global_graph.rs
@@ -18,6 +18,7 @@ fn make_file_index(entries: &[(&str, &str)]) -> FileIndex {
                 relative_path: rel.to_string(),
                 hash: "abc".to_string(),
                 title: title.to_string(),
+                aliases: Vec::new(),
             },
         );
     }

--- a/src-tauri/src/tests/indexer.rs
+++ b/src-tauri/src/tests/indexer.rs
@@ -34,6 +34,7 @@ mod memory_tests {
             relative_path: rel.to_string(),
             hash: "deadbeef".to_string(),
             title: rel.to_string(),
+            aliases: Vec::new(),
         }
     }
 

--- a/src-tauri/src/tests/link_graph.rs
+++ b/src-tauri/src/tests/link_graph.rs
@@ -21,6 +21,7 @@ fn make_file_index(entries: &[(&str, &str)]) -> FileIndex {
                 relative_path: rel.to_string(),
                 hash: "abc".to_string(),
                 title: title.to_string(),
+                aliases: Vec::new(),
             },
         );
     }

--- a/src-tauri/src/tests/local_graph.rs
+++ b/src-tauri/src/tests/local_graph.rs
@@ -17,6 +17,7 @@ fn make_file_index(entries: &[(&str, &str)]) -> FileIndex {
                 relative_path: rel.to_string(),
                 hash: "abc".to_string(),
                 title: title.to_string(),
+                aliases: Vec::new(),
             },
         );
     }

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -12,3 +12,4 @@ mod global_graph;
 pub mod tag_index;
 mod hash_verify;
 mod bookmarks;
+mod aliases;

--- a/src/components/Editor/wikiLinkAutocomplete.ts
+++ b/src/components/Editor/wikiLinkAutocomplete.ts
@@ -82,8 +82,13 @@ export async function wikiLinkCompletionSource(
     from: match.from + 2, // from is after the [[
     options: results.map((r) => {
       const name = basename(r.path);
+      // Issue #60: surface alias hits as `alias → filename` in the label so
+      // users understand why a note with a non-matching filename surfaced.
+      // The inserted wiki-link target stays the filename — Obsidian-compatible
+      // resolution lives on the backend (`resolved_map_with_aliases`).
+      const label = r.matchedAlias ? `${r.matchedAlias} \u2192 ${name}` : name;
       return {
-        label: name,
+        label,
         detail: r.path, // relative path shown in grey (D-04)
         // apply as function: consume existing `]` chars after the cursor so the
         // final result has exactly `[[Name]]` regardless of closeBrackets state.

--- a/src/components/Search/QuickSwitcher.svelte
+++ b/src/components/Search/QuickSwitcher.svelte
@@ -195,11 +195,12 @@
           {#if !query.trim()}
             <p class="vc-qs-section-label">Zuletzt geöffnet</p>
           {/if}
-          {#each activeResults as result, i (result.path)}
+          {#each activeResults as result, i (result.matchedAlias ? `${result.path}|${result.matchedAlias}` : result.path)}
             <QuickSwitcherRow
               filename={getFilename(result.path)}
               relativePath={result.path}
               matchIndices={result.matchIndices}
+              matchedAlias={result.matchedAlias}
               selected={i === selectedIndex}
               onclick={() => openResult(result)}
               onhover={() => { selectedIndex = i; }}

--- a/src/components/Search/QuickSwitcherRow.svelte
+++ b/src/components/Search/QuickSwitcherRow.svelte
@@ -6,9 +6,13 @@
     selected: boolean;
     onclick: () => void;
     onhover: () => void;
+    /** Issue #60: matched frontmatter alias (when the row surfaced because of
+     *  an `aliases:` hit rather than a filename hit). Rendered as
+     *  `alias → filename` in front of the filename. */
+    matchedAlias?: string;
   }
 
-  let { filename, relativePath, matchIndices, selected, onclick, onhover }: Props = $props();
+  let { filename, relativePath, matchIndices, selected, onclick, onhover, matchedAlias }: Props = $props();
 
   // Build character array for the filename with matched-char highlighting
   // matchIndices are indices into `relativePath` (the full path returned by nucleo),
@@ -35,6 +39,13 @@
 >
   <!-- Filename line with per-char match highlighting -->
   <span class="vc-qs-row-filename">
+    {#if matchedAlias}
+      <!-- Issue #60: alias hit — render `alias → filename` so users see why
+           a note with a non-matching filename surfaced. The alias is shown
+           with accent weight because it's the string the query actually hit. -->
+      <span class="vc-qs-row-alias">{matchedAlias}</span>
+      <span class="vc-qs-row-alias-arrow">&nbsp;&rarr;&nbsp;</span>
+    {/if}
     {#each filenameChars as { char, highlighted }, i (i)}
       {#if highlighted}
         <span style="font-weight: 700; color: var(--color-accent)">{char}</span>
@@ -76,5 +87,14 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .vc-qs-row-alias {
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+
+  .vc-qs-row-alias-arrow {
+    color: var(--color-text-muted);
   }
 </style>

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -23,4 +23,9 @@ export interface FileMatch {
   score: number;
   /** Character positions in `path` that matched the query (sorted, deduplicated). */
   matchIndices: number[];
+  /** Frontmatter alias that scored this match (issue #60). Present only when
+   *  the nucleo hit came from the alias haystack — the popup should render
+   *  `matchedAlias → filename` to explain why the row surfaced. Absent (or
+   *  `undefined`) for regular filename hits. */
+  matchedAlias?: string;
 }


### PR DESCRIPTION
Closes #60

## Summary
- Parse YAML frontmatter `aliases:` (list form and scalar) via a new shared `indexer::frontmatter` module. `tag_index::extract_yaml_tags` delegates to the same reader so existing tag behaviour is untouched.
- `FileMeta` gains `aliases: Vec<String>`, populated on `AddFile` and refreshed on every `UpdateLinks`. `RemoveLinks` is a no-op (aliases hang off the FileIndex entry which the existing `DeleteFile` drops wholesale); the rename old-side `RemoveLinks` is followed by a new-side `UpdateLinks` that repopulates under the new rel_path.
- `[[alias]]` resolves via an extended `resolved_map_with_aliases`. Collision priority is documented in-code at the merge site: (1) filename-stem match always wins over alias match; (2) between two aliases on different notes the first-indexed wins and the loser is logged at `info` (mirrors `resolve_link`'s stem-collision logging).
- `suggest_links` and `search_filename` add an alias nucleo pass; alias hits carry the matched alias text in a new `FileMatch.matched_alias` field. Per-path dedupe keeps the best row per file; filename hits beat alias hits at equal score so ranking stays consistent with pre-alias behaviour.
- Quick Switcher rows and the `[[` autocomplete render alias hits as `alias → filename` so it's obvious why a note with a non-matching filename surfaced.

## Test plan
- [ ] cargo test + cargo check pass
- [ ] typecheck + vitest pass
- [ ] `[[alias]]` resolves to target note in editor
- [ ] Quick Switcher surfaces notes by alias with hint
- [ ] Stem vs alias collision resolves to stem
- [ ] Alias vs alias collision: first-indexed wins, loser logged