### PR TITLE
feat(settings): hotkey rebinding ui (#65)

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -14,6 +14,7 @@
   import { vaultStore } from "../../store/vaultStore";
   import { commandRegistry } from "../../lib/commands/registry";
   import { registerDefaultCommands } from "../../lib/commands/defaultCommands";
+  import { initHotkeyOverrides } from "../../lib/commands/hotkeyOverrides";
   import { createFile, createFolder, listDirectory, readFile, writeFile } from "../../ipc/commands";
   import { toastStore } from "../../store/toastStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
@@ -395,6 +396,7 @@
       toggleBookmark: () => { void toggleActiveBookmark(); },
       openTodayNote: () => { void openTodayNote(); },
     });
+    initHotkeyOverrides();
     document.addEventListener("keydown", handleKeydown, { capture: true });
     document.addEventListener("contextmenu", handleContextMenu, { capture: true });
     return () => {

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
-  import { X, RefreshCw } from "lucide-svelte";
+  import { X, RefreshCw, Keyboard, RotateCcw } from "lucide-svelte";
   import { themeStore, type Theme } from "../../store/themeStore";
   import {
     settingsStore,
@@ -13,7 +13,14 @@
   import { vaultStore } from "../../store/vaultStore";
   import { snippetsStore } from "../../store/snippetsStore";
   import { formatShortcut } from "../../lib/shortcuts";
-  import { commandRegistry, type Command } from "../../lib/commands/registry";
+  import { commandRegistry, hotkeysEqual, type Command, type HotKey } from "../../lib/commands/registry";
+  import { DEFAULT_COMMAND_SPECS } from "../../lib/commands/defaultCommands";
+  import {
+    setHotkeyOverride,
+    resetHotkeyOverride,
+    hotkeyFromEvent,
+    validateHotKey,
+  } from "../../lib/commands/hotkeyOverrides";
 
   let { open, onClose, onSwitchVault }: {
     open: boolean;
@@ -27,6 +34,28 @@
   let currentSize = $state<number>(14);
   let currentVaultPath = $state<string | null>(null);
   let shortcuts = $state<Command[]>([]);
+  /** Command id currently listening for a new keydown, or null when idle. */
+  let recordingFor = $state<string | null>(null);
+  let recordError = $state<string | null>(null);
+  interface PendingConflict {
+    targetId: string;
+    newKey: HotKey;
+    conflictId: string;
+    conflictName: string;
+  }
+  let pendingConflict = $state<PendingConflict | null>(null);
+
+  const DEFAULTS_BY_ID: Record<string, HotKey | undefined> = Object.fromEntries(
+    DEFAULT_COMMAND_SPECS.map((s) => [s.id, s.hotkey])
+  );
+
+  function defaultHotkey(id: string): HotKey | undefined {
+    return DEFAULTS_BY_ID[id];
+  }
+
+  function hasDefault(id: string): boolean {
+    return Boolean(DEFAULTS_BY_ID[id]);
+  }
   let dailyFolder = $state<string>("");
   let dailyFormat = $state<string>(DEFAULT_DAILY_DATE_FORMAT);
   let dailyTemplate = $state<string>("");
@@ -46,7 +75,10 @@
   });
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
   const unsubCommands = commandRegistry.subscribe((list) => {
-    shortcuts = list.filter((c) => c.hotkey);
+    // Show every command that has either an effective hotkey or a spec
+    // default — disabled (override=null) commands remain listed so the
+    // user can rebind or reset them.
+    shortcuts = list.filter((c) => c.hotkey || hasDefault(c.id));
   });
   const unsubSnippets = snippetsStore.subscribe((s) => {
     snippetsAvailable = s.available;
@@ -55,11 +87,106 @@
   });
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape" && open) {
+    if (!open) return;
+    // While a conflict modal is up, intercept Escape for cancel only.
+    if (pendingConflict) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        pendingConflict = null;
+      }
+      return;
+    }
+    // While recording a new shortcut, capture the next keydown for it.
+    if (recordingFor) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        cancelRecording();
+        return;
+      }
+      handleRecordKeydown(e);
+      return;
+    }
+    if (e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation();
       onClose();
     }
+  }
+
+  function startRecording(id: string): void {
+    recordError = null;
+    recordingFor = id;
+  }
+
+  function cancelRecording(): void {
+    recordingFor = null;
+    recordError = null;
+  }
+
+  function handleRecordKeydown(e: KeyboardEvent): void {
+    e.preventDefault();
+    e.stopPropagation();
+    const id = recordingFor;
+    if (!id) return;
+    const candidate = hotkeyFromEvent(e);
+    // null => pure modifier press; keep listening.
+    if (!candidate) return;
+    const v = validateHotKey(candidate);
+    if (!v.ok) {
+      recordError = v.reason;
+      return;
+    }
+    commitBinding(id, candidate);
+  }
+
+  function commitBinding(id: string, newKey: HotKey): void {
+    // Conflict detection against every other command's effective hotkey.
+    const other = commandRegistry.getEffective().find((c) => {
+      if (c.id === id) return false;
+      if (!c.hotkey) return false;
+      return hotkeysEqual(c.hotkey, newKey);
+    });
+    if (other) {
+      pendingConflict = {
+        targetId: id,
+        newKey,
+        conflictId: other.id,
+        conflictName: other.name,
+      };
+      recordingFor = null;
+      recordError = null;
+      return;
+    }
+    setHotkeyOverride(id, newKey);
+    recordingFor = null;
+    recordError = null;
+  }
+
+  function resolveConflictUnbind(): void {
+    if (!pendingConflict) return;
+    const { targetId, newKey, conflictId } = pendingConflict;
+    // Disable the other binding first, then apply the new one.
+    setHotkeyOverride(conflictId, null);
+    setHotkeyOverride(targetId, newKey);
+    pendingConflict = null;
+  }
+
+  function resolveConflictCancel(): void {
+    pendingConflict = null;
+  }
+
+  function onResetShortcut(id: string): void {
+    resetHotkeyOverride(id);
+  }
+
+  function onBackdropClick(): void {
+    if (recordingFor) {
+      cancelRecording();
+      return;
+    }
+    onClose();
   }
 
   function onThemeChange(e: Event) {
@@ -107,7 +234,7 @@
 
 {#if open}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="vc-settings-backdrop" onclick={onClose} role="presentation"></div>
+  <div class="vc-settings-backdrop" onclick={onBackdropClick} role="presentation"></div>
   <div class="vc-settings-modal" role="dialog" aria-modal="true" aria-labelledby="settings-title" data-testid="settings-modal">
     <header class="vc-settings-header">
       <h2 id="settings-title" class="vc-settings-title">Einstellungen</h2>
@@ -285,22 +412,99 @@
         </p>
       </section>
 
-      <!-- Section C — Tastaturkürzel (UI-05 / D-11) -->
+      <!-- Section C — Tastaturkürzel (UI-05 / D-11 / #65) -->
       <section class="vc-settings-section" data-testid="settings-shortcuts">
         <h3 class="vc-settings-section-title">TASTATURKÜRZEL</h3>
         <table class="vc-shortcuts-table" role="table">
           <tbody>
             {#each shortcuts as s (s.id)}
+              {@const isRecording = recordingFor === s.id}
+              {@const def = defaultHotkey(s.id)}
+              {@const isCustom = def ? !s.hotkey || !hotkeysEqual(def, s.hotkey) : Boolean(s.hotkey)}
               <tr role="row">
                 <td role="cell" class="vc-shortcut-action">{s.name}</td>
-                <td role="cell" class="vc-shortcut-keys"><kbd>{s.hotkey ? formatShortcut(s.hotkey) : ""}</kbd></td>
+                <td role="cell" class="vc-shortcut-keys">
+                  {#if isRecording}
+                    <span class="vc-shortcut-recording" data-testid="shortcut-recording">
+                      Drücke eine Tastenkombination…
+                    </span>
+                  {:else if s.hotkey}
+                    <kbd>{formatShortcut(s.hotkey)}</kbd>
+                  {:else}
+                    <span class="vc-shortcut-disabled" title="Deaktiviert">—</span>
+                  {/if}
+                </td>
+                <td role="cell" class="vc-shortcut-controls">
+                  <button
+                    type="button"
+                    class="vc-shortcut-btn"
+                    class:vc-shortcut-btn--active={isRecording}
+                    onclick={() => (isRecording ? cancelRecording() : startRecording(s.id))}
+                    aria-label={isRecording ? "Aufnahme abbrechen" : "Kürzel neu aufnehmen"}
+                    title={isRecording ? "Aufnahme abbrechen" : "Kürzel neu aufnehmen"}
+                    data-testid="shortcut-record-btn"
+                    data-command-id={s.id}
+                  ><Keyboard size={14} /></button>
+                  <button
+                    type="button"
+                    class="vc-shortcut-btn"
+                    onclick={() => onResetShortcut(s.id)}
+                    disabled={!isCustom}
+                    aria-label="Auf Standard zurücksetzen"
+                    title="Auf Standard zurücksetzen"
+                    data-testid="shortcut-reset-btn"
+                    data-command-id={s.id}
+                  ><RotateCcw size={14} /></button>
+                </td>
               </tr>
             {/each}
           </tbody>
         </table>
+        {#if recordError}
+          <p class="vc-shortcut-error" role="alert" data-testid="shortcut-error">{recordError}</p>
+        {/if}
       </section>
     </div>
   </div>
+
+  {#if pendingConflict}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+      class="vc-conflict-backdrop"
+      role="presentation"
+      onclick={resolveConflictCancel}
+      data-testid="shortcut-conflict-backdrop"
+    ></div>
+    <div
+      class="vc-conflict-modal"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="shortcut-conflict-title"
+      data-testid="shortcut-conflict"
+    >
+      <h3 id="shortcut-conflict-title" class="vc-conflict-title">Tastenkürzel-Konflikt</h3>
+      <p class="vc-conflict-body">
+        <kbd>{formatShortcut(pendingConflict.newKey)}</kbd>
+        ist bereits
+        <strong>{pendingConflict.conflictName}</strong>
+        zugewiesen. Soll die andere Zuweisung aufgehoben werden?
+      </p>
+      <div class="vc-conflict-actions">
+        <button
+          type="button"
+          class="vc-conflict-btn"
+          onclick={resolveConflictCancel}
+          data-testid="shortcut-conflict-cancel"
+        >Abbrechen</button>
+        <button
+          type="button"
+          class="vc-conflict-btn vc-conflict-btn--primary"
+          onclick={resolveConflictUnbind}
+          data-testid="shortcut-conflict-unbind"
+        >Zuweisung aufheben</button>
+      </div>
+    </div>
+  {/if}
 {/if}
 
 <style>
@@ -541,5 +745,119 @@
     border-radius: 4px;
     color: var(--color-text);
     font-family: var(--vc-font-mono);
+  }
+  .vc-shortcut-recording {
+    font-size: 12px;
+    color: var(--color-accent);
+    font-style: italic;
+  }
+  .vc-shortcut-disabled {
+    font-size: 12px;
+    color: var(--color-text-muted);
+  }
+  .vc-shortcut-controls {
+    width: 72px;
+    text-align: right;
+    white-space: nowrap;
+    padding-right: 16px;
+  }
+  .vc-shortcut-btn {
+    width: 26px; height: 26px;
+    margin-left: 4px;
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+  }
+  .vc-shortcut-btn:hover:not(:disabled) {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+  .vc-shortcut-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .vc-shortcut-btn--active {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+  .vc-shortcut-error {
+    margin: 8px 16px 0;
+    font-size: 12px;
+    color: var(--color-danger, #c62828);
+  }
+
+  /* Conflict modal (#65) */
+  .vc-conflict-backdrop {
+    position: fixed; inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 310;
+  }
+  .vc-conflict-modal {
+    position: fixed; top: 50%; left: 50%;
+    transform: translate(-50%, -50%);
+    width: 420px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    padding: 20px;
+    z-index: 311;
+  }
+  .vc-conflict-title {
+    margin: 0 0 12px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .vc-conflict-body {
+    margin: 0 0 16px 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--color-text);
+  }
+  .vc-conflict-body kbd {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 6px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text);
+    font-family: var(--vc-font-mono);
+  }
+  .vc-conflict-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .vc-conflict-btn {
+    height: 30px;
+    padding: 0 12px;
+    font-size: 13px;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .vc-conflict-btn:hover {
+    background: var(--color-accent-bg);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+  .vc-conflict-btn--primary {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: var(--color-surface);
+  }
+  .vc-conflict-btn--primary:hover {
+    background: var(--color-accent);
+    color: var(--color-surface);
+    opacity: 0.9;
   }
 </style>

--- a/src/lib/commands/__tests__/hotkeyOverrides.test.ts
+++ b/src/lib/commands/__tests__/hotkeyOverrides.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { commandRegistry } from "../registry";
+import {
+  HOTKEY_OVERRIDES_KEY,
+  hotkeyFromEvent,
+  initHotkeyOverrides,
+  loadHotkeyOverrides,
+  resetHotkeyOverride,
+  setHotkeyOverride,
+  validateHotKey,
+} from "../hotkeyOverrides";
+
+function setupLocalStorage(): Map<string, string> {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  });
+  return store;
+}
+
+describe("hotkeyOverrides — validation", () => {
+  it("rejects bindings without Meta/Ctrl", () => {
+    expect(validateHotKey({ meta: false, key: "a" }).ok).toBe(false);
+  });
+
+  it("rejects bare Escape / Enter / Tab / modifiers", () => {
+    expect(validateHotKey({ meta: true, key: "Escape" }).ok).toBe(false);
+    expect(validateHotKey({ meta: true, key: "Enter" }).ok).toBe(false);
+    expect(validateHotKey({ meta: true, key: "Tab" }).ok).toBe(false);
+    expect(validateHotKey({ meta: true, key: "Meta" }).ok).toBe(false);
+    expect(validateHotKey({ meta: true, key: "Shift" }).ok).toBe(false);
+  });
+
+  it("accepts Meta+letter and Meta+Shift+letter", () => {
+    expect(validateHotKey({ meta: true, key: "k" }).ok).toBe(true);
+    expect(validateHotKey({ meta: true, shift: true, key: "f" }).ok).toBe(true);
+  });
+});
+
+describe("hotkeyFromEvent", () => {
+  it("returns null for pure modifier presses", () => {
+    const ev = new KeyboardEvent("keydown", { key: "Meta", metaKey: true });
+    expect(hotkeyFromEvent(ev)).toBeNull();
+  });
+
+  it("lowercases single-character keys and preserves named keys", () => {
+    const a = new KeyboardEvent("keydown", { key: "K", metaKey: true, shiftKey: true });
+    expect(hotkeyFromEvent(a)).toEqual({ meta: true, shift: true, key: "k" });
+    const b = new KeyboardEvent("keydown", { key: "ArrowLeft", ctrlKey: true });
+    expect(hotkeyFromEvent(b)).toEqual({ meta: true, key: "ArrowLeft" });
+  });
+});
+
+describe("hotkeyOverrides — persistence", () => {
+  beforeEach(() => {
+    setupLocalStorage();
+    commandRegistry._reset();
+  });
+
+  it("loadHotkeyOverrides returns {} for missing / malformed entries", () => {
+    expect(loadHotkeyOverrides()).toEqual({});
+    localStorage.setItem(HOTKEY_OVERRIDES_KEY, "not json");
+    expect(loadHotkeyOverrides()).toEqual({});
+    localStorage.setItem(HOTKEY_OVERRIDES_KEY, JSON.stringify({ version: 99, overrides: {} }));
+    expect(loadHotkeyOverrides()).toEqual({});
+    localStorage.setItem(
+      HOTKEY_OVERRIDES_KEY,
+      JSON.stringify({ version: 1, overrides: { foo: "bad" } })
+    );
+    expect(loadHotkeyOverrides()).toEqual({});
+  });
+
+  it("setHotkeyOverride persists a versioned envelope and updates the registry", () => {
+    commandRegistry.register({
+      id: "n",
+      name: "N",
+      callback: () => {},
+      hotkey: { meta: true, key: "n" },
+    });
+    setHotkeyOverride("n", { meta: true, key: "j" });
+    const raw = localStorage.getItem(HOTKEY_OVERRIDES_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.version).toBe(1);
+    expect(parsed.overrides.n).toEqual({ meta: true, key: "j" });
+    expect(commandRegistry.getEffectiveHotkey("n")).toEqual({ meta: true, key: "j" });
+  });
+
+  it("setHotkeyOverride with null persists a disabled state", () => {
+    commandRegistry.register({
+      id: "n",
+      name: "N",
+      callback: () => {},
+      hotkey: { meta: true, key: "n" },
+    });
+    setHotkeyOverride("n", null);
+    const parsed = JSON.parse(localStorage.getItem(HOTKEY_OVERRIDES_KEY)!);
+    expect(parsed.overrides.n).toBeNull();
+    expect(commandRegistry.getEffectiveHotkey("n")).toBeUndefined();
+  });
+
+  it("resetHotkeyOverride removes the entry from the persisted map", () => {
+    commandRegistry.register({
+      id: "n",
+      name: "N",
+      callback: () => {},
+      hotkey: { meta: true, key: "n" },
+    });
+    setHotkeyOverride("n", { meta: true, key: "j" });
+    resetHotkeyOverride("n");
+    const parsed = JSON.parse(localStorage.getItem(HOTKEY_OVERRIDES_KEY)!);
+    expect(parsed.overrides.n).toBeUndefined();
+    expect(commandRegistry.getEffectiveHotkey("n")).toEqual({ meta: true, key: "n" });
+  });
+
+  it("initHotkeyOverrides hydrates the registry from localStorage", () => {
+    localStorage.setItem(
+      HOTKEY_OVERRIDES_KEY,
+      JSON.stringify({
+        version: 1,
+        overrides: {
+          n: { meta: true, shift: true, key: "x" },
+          p: null,
+        },
+      })
+    );
+    commandRegistry.register({
+      id: "n",
+      name: "N",
+      callback: () => {},
+      hotkey: { meta: true, key: "n" },
+    });
+    commandRegistry.register({
+      id: "p",
+      name: "P",
+      callback: () => {},
+      hotkey: { meta: true, key: "p" },
+    });
+    initHotkeyOverrides();
+    expect(commandRegistry.getEffectiveHotkey("n")).toEqual({ meta: true, shift: true, key: "x" });
+    expect(commandRegistry.getEffectiveHotkey("p")).toBeUndefined();
+  });
+});

--- a/src/lib/commands/__tests__/registry.test.ts
+++ b/src/lib/commands/__tests__/registry.test.ts
@@ -124,4 +124,94 @@ describe("commandRegistry", () => {
     const ev = new KeyboardEvent("keydown", { key: "n" });
     expect(commandRegistry.findByHotkey(ev)).toBeNull();
   });
+
+  describe("hotkey overrides (#65)", () => {
+    it("setHotkeyOverride replaces the effective binding in findByHotkey", () => {
+      const cb = vi.fn();
+      commandRegistry.register({
+        id: "n",
+        name: "New",
+        callback: cb,
+        hotkey: { meta: true, key: "n" },
+      });
+      commandRegistry.setHotkeyOverride("n", { meta: true, key: "j" });
+      // Old binding no longer matches.
+      const oldEv = new KeyboardEvent("keydown", { key: "n", metaKey: true });
+      expect(commandRegistry.findByHotkey(oldEv)).toBeNull();
+      // New binding matches.
+      const newEv = new KeyboardEvent("keydown", { key: "j", metaKey: true });
+      expect(commandRegistry.findByHotkey(newEv)?.id).toBe("n");
+    });
+
+    it("override=null disables the default but keeps the command runnable", () => {
+      const cb = vi.fn();
+      commandRegistry.register({
+        id: "n",
+        name: "New",
+        callback: cb,
+        hotkey: { meta: true, key: "n" },
+      });
+      commandRegistry.setHotkeyOverride("n", null);
+      const ev = new KeyboardEvent("keydown", { key: "n", metaKey: true });
+      expect(commandRegistry.findByHotkey(ev)).toBeNull();
+      // execute still works.
+      commandRegistry.execute("n");
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it("clearHotkeyOverride restores the spec default", () => {
+      commandRegistry.register({
+        id: "n",
+        name: "New",
+        callback: () => {},
+        hotkey: { meta: true, key: "n" },
+      });
+      commandRegistry.setHotkeyOverride("n", { meta: true, key: "j" });
+      commandRegistry.clearHotkeyOverride("n");
+      const ev = new KeyboardEvent("keydown", { key: "n", metaKey: true });
+      expect(commandRegistry.findByHotkey(ev)?.id).toBe("n");
+    });
+
+    it("getEffective reflects overrides (replaces and strips disabled)", () => {
+      commandRegistry.register({
+        id: "a",
+        name: "A",
+        callback: () => {},
+        hotkey: { meta: true, key: "a" },
+      });
+      commandRegistry.register({
+        id: "b",
+        name: "B",
+        callback: () => {},
+        hotkey: { meta: true, key: "b" },
+      });
+      commandRegistry.setHotkeyOverride("a", { meta: true, shift: true, key: "x" });
+      commandRegistry.setHotkeyOverride("b", null);
+      const eff = commandRegistry.getEffective();
+      const a = eff.find((c) => c.id === "a");
+      const b = eff.find((c) => c.id === "b");
+      expect(a?.hotkey).toEqual({ meta: true, shift: true, key: "x" });
+      expect(b?.hotkey).toBeUndefined();
+    });
+
+    it("subscribe re-emits after override changes", () => {
+      commandRegistry.register({
+        id: "n",
+        name: "N",
+        callback: () => {},
+        hotkey: { meta: true, key: "n" },
+      });
+      const snapshots: Array<string | undefined> = [];
+      const unsub = commandRegistry.subscribe((list) => {
+        const c = list.find((x) => x.id === "n");
+        snapshots.push(c?.hotkey?.key);
+      });
+      commandRegistry.setHotkeyOverride("n", { meta: true, key: "j" });
+      commandRegistry.setHotkeyOverride("n", null);
+      commandRegistry.clearHotkeyOverride("n");
+      unsub();
+      // Initial emit, plus one per override change.
+      expect(snapshots).toEqual(["n", "j", undefined, "n"]);
+    });
+  });
 });

--- a/src/lib/commands/hotkeyOverrides.ts
+++ b/src/lib/commands/hotkeyOverrides.ts
@@ -1,0 +1,128 @@
+// Persistence + validation for user-configured hotkey overrides (#65).
+// Overrides live in localStorage under a versioned envelope so we have room
+// to migrate the schema later. The registry resolves them at lookup time —
+// see registry.ts.
+
+import { commandRegistry, type HotKey, type HotkeyOverrideMap } from "./registry";
+
+export const HOTKEY_OVERRIDES_KEY = "vaultcore-command-hotkey-overrides";
+const SCHEMA_VERSION = 1;
+
+interface Envelope {
+  version: number;
+  overrides: HotkeyOverrideMap;
+}
+
+/** Keys that must never be bound on their own — they'd swallow common UX. */
+const BLOCKED_BARE_KEYS = new Set(["escape", "enter", "tab", " ", "meta", "control", "shift", "alt"]);
+
+function isHotKey(v: unknown): v is HotKey {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.meta !== "boolean") return false;
+  if (o.shift !== undefined && typeof o.shift !== "boolean") return false;
+  if (typeof o.key !== "string" || o.key.length === 0) return false;
+  return true;
+}
+
+function isOverrideMap(v: unknown): v is HotkeyOverrideMap {
+  if (typeof v !== "object" || v === null) return false;
+  for (const [, val] of Object.entries(v as Record<string, unknown>)) {
+    if (val === null) continue;
+    if (!isHotKey(val)) return false;
+  }
+  return true;
+}
+
+/**
+ * Load overrides from localStorage, validate, install into the registry.
+ * Malformed data is dropped silently (after a single console.warn).
+ */
+export function loadHotkeyOverrides(): HotkeyOverrideMap {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(HOTKEY_OVERRIDES_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      (parsed as Envelope).version !== SCHEMA_VERSION ||
+      !isOverrideMap((parsed as Envelope).overrides)
+    ) {
+      console.warn("[hotkey-overrides] dropping malformed localStorage entry");
+      return {};
+    }
+    return (parsed as Envelope).overrides;
+  } catch (err) {
+    console.warn("[hotkey-overrides] parse failed, starting fresh", err);
+    return {};
+  }
+}
+
+function persist(overrides: HotkeyOverrideMap): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    const envelope: Envelope = { version: SCHEMA_VERSION, overrides };
+    localStorage.setItem(HOTKEY_OVERRIDES_KEY, JSON.stringify(envelope));
+  } catch {
+    // Best-effort.
+  }
+}
+
+/** Hydrate the registry from localStorage. Call once at app mount. */
+export function initHotkeyOverrides(): void {
+  const overrides = loadHotkeyOverrides();
+  commandRegistry.setHotkeyOverrides(overrides);
+}
+
+/**
+ * Validate a candidate binding recorded from a keydown event. Rejects bare
+ * keys (no modifier), the modifier-only case, and blocked bare keys.
+ */
+export function validateHotKey(candidate: HotKey): { ok: true } | { ok: false; reason: string } {
+  if (!candidate.meta) {
+    return { ok: false, reason: "Tastenkürzel muss Cmd/Ctrl enthalten." };
+  }
+  const key = candidate.key.toLowerCase();
+  if (key.length === 0) {
+    return { ok: false, reason: "Taste fehlt." };
+  }
+  if (BLOCKED_BARE_KEYS.has(key)) {
+    return { ok: false, reason: "Diese Taste kann nicht als Kürzel verwendet werden." };
+  }
+  return { ok: true };
+}
+
+/**
+ * Extract a HotKey from a keydown event. Returns null if no non-modifier
+ * key is pressed yet (i.e. user is still holding down modifiers).
+ */
+export function hotkeyFromEvent(e: KeyboardEvent): HotKey | null {
+  const key = e.key;
+  if (!key) return null;
+  const keyLower = key.toLowerCase();
+  // Ignore pure modifier presses — we only commit when a real key lands.
+  if (keyLower === "meta" || keyLower === "control" || keyLower === "shift" || keyLower === "alt") {
+    return null;
+  }
+  const meta = e.metaKey || e.ctrlKey;
+  const hk: HotKey = {
+    meta,
+    key: key.length === 1 ? key.toLowerCase() : key,
+  };
+  if (e.shiftKey) hk.shift = true;
+  return hk;
+}
+
+/** Set a user override and persist. Pass `null` to disable the spec default. */
+export function setHotkeyOverride(id: string, override: HotKey | null): void {
+  commandRegistry.setHotkeyOverride(id, override);
+  persist(commandRegistry.getHotkeyOverrides());
+}
+
+/** Revert a command to its spec default (drops the override entry). */
+export function resetHotkeyOverride(id: string): void {
+  commandRegistry.clearHotkeyOverride(id);
+  persist(commandRegistry.getHotkeyOverrides());
+}

--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -1,6 +1,8 @@
-// Extensible command registry (#13).
+// Extensible command registry (#13) with user-configurable hotkey overrides (#65).
 // Wraps a Map<id, Command> in a classic writable store so the palette and
-// settings table stay reactive.
+// settings table stay reactive. Overrides are resolved at lookup time — the
+// registered Command.hotkey stays as the spec default; findByHotkey and
+// getEffective consult the override map first.
 
 import { writable } from "svelte/store";
 
@@ -19,6 +21,10 @@ export interface Command {
   hotkey?: HotKey;
 }
 
+/** `null` means "user disabled this default binding". Missing key means
+ *  "use the spec default". */
+export type HotkeyOverrideMap = Record<string, HotKey | null>;
+
 export interface CommandRegistry {
   subscribe: ReturnType<typeof writable<Command[]>>["subscribe"];
   register(cmd: Command): void;
@@ -28,6 +34,17 @@ export interface CommandRegistry {
   findByHotkey(event: KeyboardEvent): Command | null;
   /** Ids ordered most-recently-executed first (capped at MRU_CAP). */
   getMru(): string[];
+  /** Resolve a command's currently-active hotkey (override || default || undefined). */
+  getEffectiveHotkey(id: string): HotKey | undefined;
+  /** Commands with their effective (override-applied) hotkey baked in. */
+  getEffective(): Command[];
+  /** Install a new override entry and re-emit. `null` disables the default. */
+  setHotkeyOverride(id: string, override: HotKey | null): void;
+  /** Remove a user override so the spec default takes over again. */
+  clearHotkeyOverride(id: string): void;
+  /** Bulk replace the override map (used on initial load). */
+  setHotkeyOverrides(map: HotkeyOverrideMap): void;
+  getHotkeyOverrides(): HotkeyOverrideMap;
   /** Clear the MRU list and in-memory map. Tests only. */
   _reset(): void;
 }
@@ -57,13 +74,40 @@ function persistMru(mru: string[]): void {
   }
 }
 
+function hotkeysEqual(a: HotKey, b: HotKey): boolean {
+  return (
+    a.meta === b.meta &&
+    (a.shift === true) === (b.shift === true) &&
+    a.key.toLowerCase() === b.key.toLowerCase()
+  );
+}
+
 function createRegistry(): CommandRegistry {
   const map = new Map<string, Command>();
   const store = writable<Command[]>([]);
   let mru: string[] = loadMru();
+  let overrides: HotkeyOverrideMap = {};
+
+  function resolveHotkey(id: string, specHotkey: HotKey | undefined): HotKey | undefined {
+    if (Object.prototype.hasOwnProperty.call(overrides, id)) {
+      const o = overrides[id];
+      // null => disabled; any hotkey => use override.
+      return o === null ? undefined : o;
+    }
+    return specHotkey;
+  }
+
+  function effective(cmd: Command): Command {
+    const h = resolveHotkey(cmd.id, cmd.hotkey);
+    if (h) return { ...cmd, hotkey: h };
+    // Strip hotkey when it's disabled or absent.
+    const { hotkey: _unused, ...rest } = cmd;
+    void _unused;
+    return rest;
+  }
 
   function emit(): void {
-    store.set(Array.from(map.values()));
+    store.set(Array.from(map.values()).map(effective));
   }
 
   function register(cmd: Command): void {
@@ -76,7 +120,7 @@ function createRegistry(): CommandRegistry {
   }
 
   function list(): Command[] {
-    return Array.from(map.values());
+    return Array.from(map.values()).map(effective);
   }
 
   function bumpMru(id: string): void {
@@ -100,7 +144,7 @@ function createRegistry(): CommandRegistry {
     if (!isMeta) return null;
     const keyLower = event.key.toLowerCase();
     for (const cmd of map.values()) {
-      const h = cmd.hotkey;
+      const h = resolveHotkey(cmd.id, cmd.hotkey);
       if (!h) continue;
       if (h.meta !== isMeta) continue;
       if (h.key.toLowerCase() !== keyLower) continue;
@@ -110,9 +154,41 @@ function createRegistry(): CommandRegistry {
         const shiftOk = h.shift === true ? event.shiftKey : !event.shiftKey;
         if (!shiftOk) continue;
       }
-      return cmd;
+      return effective(cmd);
     }
     return null;
+  }
+
+  function getEffectiveHotkey(id: string): HotKey | undefined {
+    const cmd = map.get(id);
+    if (!cmd) return undefined;
+    return resolveHotkey(id, cmd.hotkey);
+  }
+
+  function getEffective(): Command[] {
+    return list();
+  }
+
+  function setHotkeyOverride(id: string, override: HotKey | null): void {
+    overrides = { ...overrides, [id]: override };
+    emit();
+  }
+
+  function clearHotkeyOverride(id: string): void {
+    if (!(id in overrides)) return;
+    const next = { ...overrides };
+    delete next[id];
+    overrides = next;
+    emit();
+  }
+
+  function setHotkeyOverrides(next: HotkeyOverrideMap): void {
+    overrides = { ...next };
+    emit();
+  }
+
+  function getHotkeyOverrides(): HotkeyOverrideMap {
+    return { ...overrides };
   }
 
   return {
@@ -123,9 +199,16 @@ function createRegistry(): CommandRegistry {
     list,
     findByHotkey,
     getMru: () => [...mru],
+    getEffectiveHotkey,
+    getEffective,
+    setHotkeyOverride,
+    clearHotkeyOverride,
+    setHotkeyOverrides,
+    getHotkeyOverrides,
     _reset: () => {
       map.clear();
       mru = [];
+      overrides = {};
       persistMru(mru);
       emit();
     },
@@ -133,3 +216,6 @@ function createRegistry(): CommandRegistry {
 }
 
 export const commandRegistry = createRegistry();
+
+/** Exported for override-equality checks in the Settings UI. */
+export { hotkeysEqual };


### PR DESCRIPTION
Closes #65

## Summary
- Add a user-override layer on top of the command registry (`HotkeyOverrideMap` keyed by command id, `null` disables a default while keeping the command in the palette).
- Overrides resolve at lookup time inside `findByHotkey` / `getEffective` — commands stay registered with their spec defaults, so nothing needs to re-register when the user rebinds.
- Persist overrides in `localStorage` under `vaultcore-command-hotkey-overrides` in a versioned envelope (`{ version: 1, overrides: … }`) with validate-on-read fallback.
- Extend the shortcut table in the settings modal with per-row record / reset buttons, live capture widget, and a conflict-resolution dialog (unbind the other command or cancel — no silent overwrite).
- Validation rejects bindings without Cmd/Ctrl and bare Escape/Enter/Tab/modifier keys; Escape or backdrop-click cancels an active recording.

## Test plan
- [ ] Open Settings, hit the record icon on any shortcut, press a new Cmd/Ctrl combo — row updates, reset icon enables.
- [ ] Record a combo already used by another command — conflict dialog offers "unbind" (other row goes to `—`) or cancel.
- [ ] Press reset on a customised row — default returns, reset disables again.
- [ ] Record a combo, reload the app — override survives.
- [ ] Record a bare letter (no modifier) or Escape — inline error, row stays on previous value.
- [ ] Set a row to disabled (conflict-unbind), open Command Palette — command is still listed and runnable; its old hotkey no longer fires.
- [ ] `pnpm test` — all suites green (new coverage in `registry.test.ts` + `hotkeyOverrides.test.ts`).