### PR TITLE
feat(export): html export command (#61)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4899,6 +4899,7 @@ dependencies = [
 name = "vaultcore"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "env_logger",
  "log",
  "notify-debouncer-full",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tantivy = "0.26"
 nucleo-matcher = "0.3"
 pulldown-cmark = "0.13"
 serde_yml = "0.0.12"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "dialog:default",
     "dialog:allow-open",
+    "dialog:allow-save",
     "fs:default",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,0 +1,546 @@
+// HTML export (#61).
+//
+// Renders a single note to a self-contained, offline-viewable HTML file:
+//   * `![[image.png]]` embeds are inlined as `data:` URLs so the output file
+//     can be moved anywhere (no external asset folder needed).
+//   * `[[Wiki-link]]` references become intra-document anchor fragments for
+//     resolvable headings inside the same note; everything else degrades to
+//     plain text so the reader still sees the linked title.
+//   * Theme CSS and readable-body styles are inlined in a `<style>` tag.
+//
+// The `note_path` is vault-scope-guarded like every other read; the
+// `output_path` is *not* — it's chosen by the user through the native save
+// dialog on the frontend and may legitimately sit outside the vault.
+
+use crate::error::VaultError;
+use crate::VaultState;
+use base64::Engine;
+use pulldown_cmark::{html, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "svg"];
+const SKIP_DIRS: &[&str] = &[".obsidian", ".git", ".vaultcore", ".trash"];
+
+// ── Path helpers ─────────────────────────────────────────────────────────────
+
+fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
+    let guard = state.current_vault.lock().map_err(|_| {
+        VaultError::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "vault lock poisoned",
+        ))
+    })?;
+    guard
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| VaultError::VaultUnavailable { path: String::from("<no vault>") })
+}
+
+fn ensure_inside_vault(vault: &Path, target: &Path) -> Result<PathBuf, VaultError> {
+    let canonical = std::fs::canonicalize(target).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound {
+            path: target.display().to_string(),
+        },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+            path: target.display().to_string(),
+        },
+        _ => VaultError::Io(e),
+    })?;
+    if !canonical.starts_with(vault) {
+        return Err(VaultError::PermissionDenied {
+            path: canonical.display().to_string(),
+        });
+    }
+    Ok(canonical)
+}
+
+// ── Slug helper ──────────────────────────────────────────────────────────────
+
+/// GitHub-flavoured slug: lowercase, spaces → `-`, strip chars that aren't
+/// alphanumeric / dash / underscore. Collisions are resolved with a numeric
+/// suffix by the caller.
+fn slugify(s: &str) -> String {
+    let lower = s.trim().to_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    for c in lower.chars() {
+        if c.is_alphanumeric() || c == '-' || c == '_' {
+            out.push(c);
+        } else if c.is_whitespace() {
+            out.push('-');
+        }
+    }
+    out
+}
+
+// ── Attachment map ───────────────────────────────────────────────────────────
+
+/// Walk the vault and return a `lowercased filename → absolute path` map for
+/// every image attachment. Mirrors `get_resolved_attachments` but keeps
+/// absolute paths so the exporter can read file bytes directly.
+fn build_attachment_map(vault: &Path) -> HashMap<String, PathBuf> {
+    let mut map = HashMap::new();
+    for entry in walkdir::WalkDir::new(vault)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            if e.depth() == 0 {
+                return true;
+            }
+            let name = e.file_name().to_str().unwrap_or("");
+            if name.starts_with('.') {
+                return false;
+            }
+            if e.file_type().is_dir() && SKIP_DIRS.iter().any(|d| name.eq_ignore_ascii_case(d)) {
+                return false;
+            }
+            true
+        })
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let ext = match entry.path().extension().and_then(|e| e.to_str()) {
+            Some(e) => e.to_ascii_lowercase(),
+            None => continue,
+        };
+        if !IMAGE_EXTENSIONS.iter().any(|e| *e == ext) {
+            continue;
+        }
+        if let Some(fname) = entry.path().file_name().and_then(|n| n.to_str()) {
+            map.entry(fname.to_ascii_lowercase())
+                .or_insert_with(|| entry.path().to_path_buf());
+        }
+    }
+    map
+}
+
+fn mime_for_ext(ext: &str) -> &'static str {
+    match ext.to_ascii_lowercase().as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        _ => "application/octet-stream",
+    }
+}
+
+// ── Embed / wiki-link preprocessing ──────────────────────────────────────────
+
+fn embed_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"!\[\[([^\]|]+?)(?:\|([^\]]*))?\]\]").expect("embed re"))
+}
+
+fn wikilink_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\[\[([^\]|]+?)(?:\|([^\]]*))?\]\]").expect("wikilink re"))
+}
+
+/// Replace `![[file.png]]` with a standard Markdown image whose `src` is a
+/// base64 `data:` URL. Unresolvable filenames fall back to the alias / raw
+/// target so the output still reads sensibly.
+fn inline_image_embeds(md: &str, attachments: &HashMap<String, PathBuf>) -> String {
+    let re = embed_regex();
+    re.replace_all(md, |caps: &regex::Captures| -> String {
+        let target = caps.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+        let alias = caps.get(2).map(|m| m.as_str().trim()).unwrap_or("");
+        let key = target.to_ascii_lowercase();
+        match attachments.get(&key) {
+            Some(abs) => match std::fs::read(abs) {
+                Ok(bytes) => {
+                    let ext = abs
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let mime = mime_for_ext(&ext);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                    let alt = if alias.is_empty() { target } else { alias };
+                    format!("![{}](data:{};base64,{})", alt.replace(']', ""), mime, encoded)
+                }
+                Err(_) => {
+                    if alias.is_empty() {
+                        target.to_string()
+                    } else {
+                        alias.to_string()
+                    }
+                }
+            },
+            None => {
+                if alias.is_empty() {
+                    target.to_string()
+                } else {
+                    alias.to_string()
+                }
+            }
+        }
+    })
+    .into_owned()
+}
+
+/// Convert `[[Heading]]` references into anchor-fragment links when the target
+/// matches a heading in the same note; otherwise drop to plain text so the
+/// reader still sees the linked phrase. Cross-note links are intentionally
+/// collapsed to plain text — HTML export is single-file.
+fn rewrite_wiki_links(md: &str, heading_slugs: &HashSet<String>) -> String {
+    let re = wikilink_regex();
+    re.replace_all(md, |caps: &regex::Captures| -> String {
+        let target = caps.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+        let alias = caps.get(2).map(|m| m.as_str().trim()).unwrap_or("");
+        let display = if alias.is_empty() { target } else { alias };
+
+        // Heading anchor lookup: "Note#Heading" or bare "Heading".
+        let heading_part = target.split_once('#').map(|(_, h)| h).unwrap_or(target);
+        let slug = slugify(heading_part);
+        if heading_slugs.contains(&slug) {
+            format!("[{}](#{})", display, slug)
+        } else {
+            display.to_string()
+        }
+    })
+    .into_owned()
+}
+
+/// First pass over the document: collect all heading slugs (with numeric
+/// disambiguation) so wiki-link rewriting can target them. Returns a set of
+/// slugs that actually exist in the rendered output.
+fn collect_heading_slugs(md: &str) -> HashSet<String> {
+    let parser = Parser::new_ext(md, Options::all());
+    let mut slugs: HashSet<String> = HashSet::new();
+    let mut current_text: Option<String> = None;
+    for event in parser {
+        match event {
+            Event::Start(Tag::Heading { .. }) => {
+                current_text = Some(String::new());
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if let Some(text) = current_text.take() {
+                    let base = slugify(&text);
+                    if base.is_empty() {
+                        continue;
+                    }
+                    if !slugs.contains(&base) {
+                        slugs.insert(base);
+                    } else {
+                        let mut n = 1u32;
+                        loop {
+                            let candidate = format!("{}-{}", base, n);
+                            if !slugs.contains(&candidate) {
+                                slugs.insert(candidate);
+                                break;
+                            }
+                            n += 1;
+                        }
+                    }
+                }
+            }
+            Event::Text(t) | Event::Code(t) => {
+                if let Some(buf) = current_text.as_mut() {
+                    buf.push_str(&t);
+                }
+            }
+            _ => {}
+        }
+    }
+    slugs
+}
+
+// ── Markdown → HTML ──────────────────────────────────────────────────────────
+
+/// Render Markdown to an HTML fragment. Headings are emitted with `id` attrs
+/// so wiki-link anchors resolve inside the exported page.
+fn render_markdown(md: &str) -> String {
+    let parser = Parser::new_ext(md, Options::all());
+
+    let mut assigned: HashSet<String> = HashSet::new();
+    let mut current_text: Option<String> = None;
+    let mut pending_level: Option<HeadingLevel> = None;
+    let mut events: Vec<Event> = Vec::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                pending_level = Some(level);
+                current_text = Some(String::new());
+                // Defer emission until End — we need the full heading text for the id.
+            }
+            Event::End(TagEnd::Heading(level)) => {
+                let text = current_text.take().unwrap_or_default();
+                let base = slugify(&text);
+                let mut slug = base.clone();
+                let mut n = 1u32;
+                while !slug.is_empty() && assigned.contains(&slug) {
+                    slug = format!("{}-{}", base, n);
+                    n += 1;
+                }
+                if !slug.is_empty() {
+                    assigned.insert(slug.clone());
+                }
+
+                let open_tag = format!(
+                    "<h{level} id=\"{slug}\">",
+                    level = heading_level_to_u8(level),
+                    slug = html_escape(&slug)
+                );
+                let close_tag = format!("</h{level}>", level = heading_level_to_u8(level));
+
+                events.push(Event::Html(open_tag.into()));
+                events.push(Event::Text(text.into()));
+                events.push(Event::Html(close_tag.into()));
+                pending_level = None;
+            }
+            Event::Text(t) | Event::Code(t) => {
+                if let Some(buf) = current_text.as_mut() {
+                    buf.push_str(&t);
+                } else {
+                    events.push(Event::Text(t));
+                }
+            }
+            other => {
+                if pending_level.is_some() {
+                    // Inside a heading — ignore decorative events; the text buffer
+                    // captures the user-visible content.
+                } else {
+                    events.push(other);
+                }
+            }
+        }
+    }
+
+    let mut out = String::new();
+    html::push_html(&mut out, events.into_iter());
+    out
+}
+
+fn heading_level_to_u8(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+// ── Document assembly ────────────────────────────────────────────────────────
+
+const READABLE_CSS: &str = r#"
+html, body { margin: 0; padding: 0; background: var(--color-bg, #F5F5F4); color: var(--color-text, #1C1C1A); }
+body { font-family: var(--vc-font-body, system-ui, -apple-system, sans-serif); font-size: 16px; line-height: 1.65; }
+main { max-width: 760px; margin: 0 auto; padding: 48px 24px; }
+h1, h2, h3, h4, h5, h6 { line-height: 1.25; margin-top: 1.6em; margin-bottom: 0.6em; }
+h1 { font-size: 2em; }
+h2 { font-size: 1.5em; border-bottom: 1px solid var(--color-border, #E5E5E4); padding-bottom: 0.2em; }
+h3 { font-size: 1.25em; }
+p { margin: 0.8em 0; }
+a { color: var(--color-accent, #6D28D9); text-decoration: none; }
+a:hover { text-decoration: underline; }
+img { max-width: 100%; height: auto; display: block; margin: 1em auto; border-radius: 4px; }
+code { font-family: var(--vc-font-mono, "JetBrains Mono", "Fira Code", monospace); background: var(--color-code-bg, #F3F4F6); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.92em; }
+pre { background: var(--color-code-bg, #F3F4F6); padding: 1em; border-radius: 6px; overflow-x: auto; }
+pre code { background: transparent; padding: 0; }
+blockquote { border-left: 3px solid var(--color-border, #E5E5E4); margin: 1em 0; padding: 0.2em 1em; color: var(--color-text-muted, #6B7280); }
+table { border-collapse: collapse; margin: 1em 0; }
+th, td { border: 1px solid var(--color-border, #E5E5E4); padding: 6px 10px; }
+hr { border: none; border-top: 1px solid var(--color-border, #E5E5E4); margin: 2em 0; }
+ul, ol { padding-left: 1.4em; }
+@media print { body { background: #fff; color: #000; } a { color: #000; text-decoration: underline; } main { max-width: 100%; padding: 0; } }
+"#;
+
+fn wrap_document(title: &str, theme_css: &str, body_html: &str) -> String {
+    let title_escaped = html_escape(title);
+    let mut doc = String::with_capacity(body_html.len() + theme_css.len() + READABLE_CSS.len() + 512);
+    doc.push_str("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
+    doc.push_str("<meta charset=\"utf-8\">\n");
+    doc.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    doc.push_str("<title>");
+    doc.push_str(&title_escaped);
+    doc.push_str("</title>\n<style>\n");
+    doc.push_str(theme_css);
+    doc.push_str("\n");
+    doc.push_str(READABLE_CSS);
+    doc.push_str("\n</style>\n</head>\n<body>\n<main>\n");
+    doc.push_str(body_html);
+    doc.push_str("\n</main>\n</body>\n</html>\n");
+    doc
+}
+
+// ── Public entry point (pure, testable) ──────────────────────────────────────
+
+/// Render a Markdown string to a self-contained HTML document. `vault_root`
+/// is used only to resolve `![[...]]` embeds — pass an empty map of
+/// attachments to skip image inlining entirely.
+pub fn build_export_html(
+    title: &str,
+    markdown: &str,
+    theme_css: &str,
+    attachments: &HashMap<String, PathBuf>,
+) -> String {
+    let with_images = inline_image_embeds(markdown, attachments);
+    let slugs = collect_heading_slugs(&with_images);
+    let rewritten = rewrite_wiki_links(&with_images, &slugs);
+    let body_html = render_markdown(&rewritten);
+    wrap_document(title, theme_css, &body_html)
+}
+
+// ── Tauri command ────────────────────────────────────────────────────────────
+
+/// Render the note at `note_path` to a fully-inlined HTML document and return
+/// it as a string. Shared between `export_note_html` (disk write) and the
+/// frontend PDF-print flow (feeds the string into a hidden iframe).
+///
+/// `note_path` must be inside the open vault (same guard as `read_file`).
+fn render_note(
+    state: &VaultState,
+    note_path: &str,
+    theme_css: &str,
+) -> Result<String, VaultError> {
+    let vault_root = get_vault_root(state)?;
+    let note_abs = ensure_inside_vault(&vault_root, &PathBuf::from(note_path))?;
+
+    let bytes = std::fs::read(&note_abs).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: note_path.to_string() },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: note_path.to_string() },
+        _ => VaultError::Io(e),
+    })?;
+    let markdown = String::from_utf8(bytes)
+        .map_err(|_| VaultError::InvalidEncoding { path: note_path.to_string() })?;
+
+    let title = note_abs
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("Export")
+        .to_string();
+
+    let attachments = build_attachment_map(&vault_root);
+    Ok(build_export_html(&title, &markdown, theme_css, &attachments))
+}
+
+/// Export the note at `note_path` to a self-contained HTML file at `output_path`.
+///
+/// `note_path` must be inside the open vault (same guard as `read_file`).
+/// `output_path` is user-chosen (native save dialog) and written directly;
+/// no vault-scope check — the dialog is the authority for where to write.
+#[tauri::command]
+pub async fn export_note_html(
+    state: tauri::State<'_, VaultState>,
+    note_path: String,
+    output_path: String,
+    theme_css: String,
+) -> Result<(), VaultError> {
+    let doc = render_note(&state, &note_path, &theme_css)?;
+
+    std::fs::write(PathBuf::from(&output_path), doc).map_err(|e| match e.kind() {
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: output_path.clone() },
+        std::io::ErrorKind::StorageFull => VaultError::DiskFull,
+        _ => VaultError::Io(e),
+    })?;
+    Ok(())
+}
+
+/// Return the rendered HTML document for the note at `note_path` as a string.
+///
+/// Used by the PDF-print flow — the frontend drops the string into a hidden
+/// iframe and invokes `window.print()`, which exposes the OS "Save as PDF"
+/// option without needing a Tauri print plugin.
+#[tauri::command]
+pub async fn render_note_html(
+    state: tauri::State<'_, VaultState>,
+    note_path: String,
+    theme_css: String,
+) -> Result<String, VaultError> {
+    render_note(&state, &note_path, &theme_css)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_basic() {
+        assert_eq!(slugify("Hello World"), "hello-world");
+        assert_eq!(slugify("  Mixed  Spaces  "), "mixed--spaces");
+        assert_eq!(slugify("Heading #1"), "heading-1");
+        assert_eq!(slugify("Über Größe"), "über-größe");
+    }
+
+    #[test]
+    fn heading_slugs_collected() {
+        let md = "# Intro\n\n## Details\n\n## Details\n";
+        let slugs = collect_heading_slugs(md);
+        assert!(slugs.contains("intro"));
+        assert!(slugs.contains("details"));
+        assert!(slugs.contains("details-1"));
+    }
+
+    #[test]
+    fn wiki_links_to_anchor_when_heading_matches() {
+        let md = "# Section A\n\nSee [[Section A]] for details.";
+        let slugs = collect_heading_slugs(md);
+        let out = rewrite_wiki_links(md, &slugs);
+        assert!(out.contains("(#section-a)"));
+    }
+
+    #[test]
+    fn wiki_links_degrade_when_unresolved() {
+        let md = "Refer to [[Other Note]].";
+        let slugs = HashSet::new();
+        let out = rewrite_wiki_links(md, &slugs);
+        assert!(!out.contains("[["));
+        assert!(out.contains("Other Note"));
+    }
+
+    #[test]
+    fn wiki_link_alias_used_for_display() {
+        let md = "# Target\n\n[[Target|click here]]";
+        let slugs = collect_heading_slugs(md);
+        let out = rewrite_wiki_links(md, &slugs);
+        assert!(out.contains("[click here](#target)"));
+    }
+
+    #[test]
+    fn image_embed_missing_falls_back_to_alias() {
+        let md = "![[nowhere.png|alt text]]";
+        let attachments: HashMap<String, PathBuf> = HashMap::new();
+        let out = inline_image_embeds(md, &attachments);
+        assert_eq!(out.trim(), "alt text");
+    }
+
+    #[test]
+    fn export_html_document_structure() {
+        let md = "# Title\n\nSome **bold** text.";
+        let doc = build_export_html("Test", md, ":root { --x: 1; }", &HashMap::new());
+        assert!(doc.starts_with("<!DOCTYPE html>"));
+        assert!(doc.contains("<title>Test</title>"));
+        assert!(doc.contains(":root { --x: 1; }"));
+        assert!(doc.contains("<h1 id=\"title\">Title</h1>"));
+        assert!(doc.contains("<strong>bold</strong>"));
+    }
+
+    #[test]
+    fn image_embed_inlines_as_data_url() {
+        use std::fs;
+        let tmp = tempfile::tempdir().unwrap();
+        let img_path = tmp.path().join("pic.png");
+        // Minimal PNG signature bytes (header only — enough to read as Vec<u8>).
+        fs::write(&img_path, [137u8, 80, 78, 71, 13, 10, 26, 10]).unwrap();
+        let mut map = HashMap::new();
+        map.insert("pic.png".to_string(), img_path);
+        let md = "![[pic.png]]";
+        let out = inline_image_embeds(md, &map);
+        assert!(out.contains("data:image/png;base64,"));
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod links;
 pub mod tags;
 pub mod bookmarks;
 pub mod snippets;
+pub mod export;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,8 @@ pub fn run() {
             commands::bookmarks::save_bookmarks,
             commands::snippets::list_snippets,
             commands::snippets::read_snippet,
+            commands::export::export_note_html,
+            commands::export::render_note_html,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -14,7 +14,17 @@
   import { vaultStore } from "../../store/vaultStore";
   import { commandRegistry } from "../../lib/commands/registry";
   import { registerDefaultCommands } from "../../lib/commands/defaultCommands";
-  import { createFile, createFolder, listDirectory, readFile, writeFile } from "../../ipc/commands";
+  import {
+    createFile,
+    createFolder,
+    exportNoteHtml,
+    listDirectory,
+    pickSavePath,
+    readFile,
+    renderNoteHtml,
+    writeFile,
+  } from "../../ipc/commands";
+  import { collectThemeCss, defaultExportFilename } from "../../lib/exportHtml";
   import { toastStore } from "../../store/toastStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
@@ -340,6 +350,101 @@
     }
   }
 
+  /**
+   * Issue #61: export the active note as a self-contained HTML file.
+   *
+   * Flow:
+   *  1. Resolve the active markdown tab; abort silently for non-file tabs
+   *     (graph, image, etc.) — export doesn't apply.
+   *  2. Pop the native save dialog so the user picks any location (not vault-
+   *     scoped; the HTML file is meant to be shared outside the vault).
+   *  3. Snapshot the applied theme's CSS variables and hand them to Rust
+   *     alongside the note path; Rust reads the markdown, inlines
+   *     `![[image.png]]` embeds as base64 `data:` URLs, rewrites resolvable
+   *     `[[heading]]` wiki-links into `#slug` anchors, and writes the final
+   *     document.
+   */
+  async function exportActiveNoteHtml() {
+    const active = tabStore.getActiveTab();
+    if (!active || active.type === "graph") {
+      toastStore.push({ variant: "error", message: "Keine Notiz aktiv." });
+      return;
+    }
+    if (active.viewer !== undefined && active.viewer !== "markdown") {
+      toastStore.push({ variant: "error", message: "Nur Markdown-Notizen können exportiert werden." });
+      return;
+    }
+    const defaultName = defaultExportFilename(active.filePath, "html");
+    let chosen: string | null;
+    try {
+      chosen = await pickSavePath(defaultName, [
+        { name: "HTML", extensions: ["html", "htm"] },
+      ]);
+    } catch (err) {
+      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+      return;
+    }
+    if (chosen === null) return;
+    try {
+      const themeCss = collectThemeCss();
+      await exportNoteHtml(active.filePath, chosen, themeCss);
+      const filename = chosen.split(/[\\/]/).pop() ?? chosen;
+      toastStore.push({ variant: "clean-merge", message: `Notiz als HTML exportiert — ${filename}` });
+    } catch (err) {
+      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
+  /**
+   * Issue #61 stretch: render the active note via the same Rust pipeline used
+   * by HTML export, then drop the result into a hidden iframe and call
+   * `window.print()`. The native dialog exposes "Save as PDF" on every major
+   * platform — no Tauri print plugin required.
+   */
+  async function exportActiveNotePdf() {
+    const active = tabStore.getActiveTab();
+    if (!active || active.type === "graph") {
+      toastStore.push({ variant: "error", message: "Keine Notiz aktiv." });
+      return;
+    }
+    if (active.viewer !== undefined && active.viewer !== "markdown") {
+      toastStore.push({ variant: "error", message: "Nur Markdown-Notizen können exportiert werden." });
+      return;
+    }
+    try {
+      const themeCss = collectThemeCss();
+      const html = await renderNoteHtml(active.filePath, themeCss);
+      const iframe = document.createElement("iframe");
+      iframe.setAttribute("aria-hidden", "true");
+      iframe.style.position = "fixed";
+      iframe.style.right = "0";
+      iframe.style.bottom = "0";
+      iframe.style.width = "0";
+      iframe.style.height = "0";
+      iframe.style.border = "0";
+      // srcdoc keeps the document in-memory (no blob URL to revoke) so cleanup
+      // is simple and there is no same-origin / CSP surprise for the print hook.
+      iframe.srcdoc = html;
+      iframe.onload = () => {
+        try {
+          iframe.contentWindow?.focus();
+          iframe.contentWindow?.print();
+        } finally {
+          // Give the webview a moment to surface the print dialog before we
+          // tear down the iframe.
+          setTimeout(() => iframe.remove(), 1000);
+        }
+      };
+      document.body.appendChild(iframe);
+      toastStore.push({ variant: "clean-merge", message: "Druckdialog geöffnet — wähle »Als PDF speichern«." });
+    } catch (err) {
+      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
   /** Issue #12: toggle bookmark on the active tab's file path. */
   async function toggleActiveBookmark() {
     let captured: string | null = null;
@@ -394,6 +499,8 @@
       openCommandPalette: () => { commandPaletteOpen = true; },
       toggleBookmark: () => { void toggleActiveBookmark(); },
       openTodayNote: () => { void openTodayNote(); },
+      exportActiveNoteHtml: () => { void exportActiveNoteHtml(); },
+      exportActiveNotePdf: () => { void exportActiveNotePdf(); },
     });
     document.addEventListener("keydown", handleKeydown, { capture: true });
     document.addEventListener("contextmenu", handleContextMenu, { capture: true });

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -5,7 +5,7 @@
 //      component calling `invoke` directly with an arbitrary path (T-02-01).
 
 import { invoke } from "@tauri-apps/api/core";
-import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import type { VaultError } from "../types/errors";
 import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
@@ -441,6 +441,53 @@ export async function listSnippets(vaultPath: string): Promise<string[]> {
 export async function readSnippet(vaultPath: string, filename: string): Promise<string> {
   try {
     return await invoke<string>("read_snippet", { vaultPath, filename });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+// ── HTML export (#61) ─────────────────────────────────────────────────────────
+
+/**
+ * Native save-as dialog. Returns the user-chosen absolute path, or `null` when
+ * the dialog is cancelled. `defaultPath` suggests the starting filename.
+ */
+export async function pickSavePath(
+  defaultPath: string,
+  filters: { name: string; extensions: string[] }[] = [],
+): Promise<string | null> {
+  const picked = await saveDialog({ defaultPath, filters });
+  return picked ?? null;
+}
+
+/**
+ * Render the note at `notePath` to a self-contained HTML file at `outputPath`.
+ * `themeCss` is inlined into a `<style>` tag in the exported document so it
+ * renders correctly offline without the vault.
+ */
+export async function exportNoteHtml(
+  notePath: string,
+  outputPath: string,
+  themeCss: string,
+): Promise<void> {
+  try {
+    await invoke<void>("export_note_html", { notePath, outputPath, themeCss });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Same rendering pipeline as `exportNoteHtml`, but returns the HTML string
+ * instead of writing a file. The PDF-export flow feeds this into a hidden
+ * iframe and calls `window.print()`.
+ */
+export async function renderNoteHtml(
+  notePath: string,
+  themeCss: string,
+): Promise<string> {
+  try {
+    return await invoke<string>("render_note_html", { notePath, themeCss });
   } catch (e) {
     throw normalizeError(e);
   }

--- a/src/lib/commands/__tests__/defaultCommands.test.ts
+++ b/src/lib/commands/__tests__/defaultCommands.test.ts
@@ -34,6 +34,8 @@ function makeCtx(overrides: Partial<DefaultCommandContext> = {}): DefaultCommand
     openCommandPalette: noop,
     toggleBookmark: noop,
     openTodayNote: noop,
+    exportActiveNoteHtml: noop,
+    exportActiveNotePdf: noop,
     ...overrides,
   };
 }
@@ -67,5 +69,37 @@ describe("defaultCommands — vault:open-today (#59)", () => {
     // Plain Cmd+D still resolves to the bookmark command — no collision.
     const plainEv = new KeyboardEvent("keydown", { key: "d", metaKey: true });
     expect(commandRegistry.findByHotkey(plainEv)?.id).toBe(CMD_IDS.TOGGLE_BOOKMARK);
+  });
+});
+
+describe("defaultCommands — vault:export-html / vault:export-pdf (#61)", () => {
+  beforeEach(() => {
+    setupLocalStorage();
+    commandRegistry._reset();
+  });
+
+  it("registers export-html without a default hotkey", () => {
+    const spec = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.EXPORT_HTML);
+    expect(spec).toBeTruthy();
+    expect(spec!.hotkey).toBeUndefined();
+    expect(spec!.name.length).toBeGreaterThan(0);
+  });
+
+  it("registers export-pdf without a default hotkey", () => {
+    const spec = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.EXPORT_PDF);
+    expect(spec).toBeTruthy();
+    expect(spec!.hotkey).toBeUndefined();
+  });
+
+  it("execute wires the exportActiveNoteHtml / exportActiveNotePdf callbacks", () => {
+    const exportHtml = vi.fn();
+    const exportPdf = vi.fn();
+    registerDefaultCommands(
+      makeCtx({ exportActiveNoteHtml: exportHtml, exportActiveNotePdf: exportPdf }),
+    );
+    commandRegistry.execute(CMD_IDS.EXPORT_HTML);
+    commandRegistry.execute(CMD_IDS.EXPORT_PDF);
+    expect(exportHtml).toHaveBeenCalledOnce();
+    expect(exportPdf).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -16,6 +16,8 @@ export interface DefaultCommandContext {
   openCommandPalette: () => void;
   toggleBookmark: () => void;
   openTodayNote: () => void;
+  exportActiveNoteHtml: () => void;
+  exportActiveNotePdf: () => void;
 }
 
 /** Id constants — consumed by tests and anyone dispatching by id. */
@@ -33,6 +35,8 @@ export const CMD_IDS = {
   COMMAND_PALETTE: "app:command-palette",
   TOGGLE_BOOKMARK: "vault:toggle-bookmark",
   OPEN_TODAY: "vault:open-today",
+  EXPORT_HTML: "vault:export-html",
+  EXPORT_PDF: "vault:export-pdf",
 } as const;
 
 export interface DefaultCommandSpec {
@@ -56,6 +60,8 @@ export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
   { id: CMD_IDS.COMMAND_PALETTE, name: "Befehlspalette", hotkey: { meta: true, key: "p" } },
   { id: CMD_IDS.TOGGLE_BOOKMARK, name: "Lesezeichen umschalten", hotkey: { meta: true, key: "d" } },
   { id: CMD_IDS.OPEN_TODAY, name: "Tagesnotiz öffnen", hotkey: { meta: true, shift: true, key: "d" } },
+  { id: CMD_IDS.EXPORT_HTML, name: "Notiz als HTML exportieren" },
+  { id: CMD_IDS.EXPORT_PDF, name: "Notiz als PDF exportieren" },
 ] as const;
 
 /**
@@ -78,6 +84,8 @@ export function registerDefaultCommands(ctx: DefaultCommandContext): void {
     [CMD_IDS.COMMAND_PALETTE]: ctx.openCommandPalette,
     [CMD_IDS.TOGGLE_BOOKMARK]: ctx.toggleBookmark,
     [CMD_IDS.OPEN_TODAY]: ctx.openTodayNote,
+    [CMD_IDS.EXPORT_HTML]: ctx.exportActiveNoteHtml,
+    [CMD_IDS.EXPORT_PDF]: ctx.exportActiveNotePdf,
   };
 
   for (const spec of DEFAULT_COMMAND_SPECS) {

--- a/src/lib/exportHtml.ts
+++ b/src/lib/exportHtml.ts
@@ -1,0 +1,56 @@
+// HTML export helpers (#61).
+//
+// Pulls the currently applied theme's CSS custom properties off
+// `document.documentElement` and serialises them into a `:root { … }` block
+// that the Rust exporter inlines into the <head>. Only the tokens the
+// readable-body stylesheet references are emitted — user snippets stay in the
+// app, not the export (deliberately out of scope per issue #61).
+
+const THEME_VARS = [
+  "--color-bg",
+  "--color-surface",
+  "--color-border",
+  "--color-text",
+  "--color-text-muted",
+  "--color-accent",
+  "--color-accent-bg",
+  "--color-selection",
+  "--color-error",
+  "--color-warning",
+  "--color-success",
+  "--color-code-bg",
+  "--vc-font-body",
+  "--vc-font-mono",
+  "--vc-font-size",
+] as const;
+
+/**
+ * Read the computed value of each known theme token on `<html>` and return a
+ * `:root { --key: value; ... }` CSS string suitable for inlining. Empty /
+ * unset properties are skipped. Safe to call under jsdom — unresolved
+ * properties simply return empty strings.
+ */
+export function collectThemeCss(): string {
+  if (typeof document === "undefined") return "";
+  const root = document.documentElement;
+  const computed = window.getComputedStyle(root);
+  const lines: string[] = [];
+  for (const name of THEME_VARS) {
+    const value = computed.getPropertyValue(name).trim();
+    if (value.length > 0) {
+      lines.push(`  ${name}: ${value};`);
+    }
+  }
+  if (lines.length === 0) return "";
+  return `:root {\n${lines.join("\n")}\n}\n`;
+}
+
+/**
+ * Strip any extension and trailing directory slashes from an absolute path to
+ * produce a sensible default-filename stem for the save dialog.
+ */
+export function defaultExportFilename(notePath: string, ext: string): string {
+  const last = notePath.split(/[\\/]/).pop() ?? "note";
+  const stem = last.replace(/\.md$/i, "");
+  return `${stem}.${ext}`;
+}


### PR DESCRIPTION
Closes #61

## Summary
- Add `export_note_html` Rust command: reads the active note, inlines `![[image.png]]` embeds as base64 data-URLs, rewrites resolvable `[[Heading]]` wiki-links into `#slug` anchor fragments (cross-note links degrade to plain text), renders via `pulldown-cmark`, and wraps the result in a self-contained HTML document with inlined theme CSS + a readable-body stylesheet.
- Add `render_note_html` companion command that returns the rendered string so the PDF flow can feed it into a hidden iframe without a disk round-trip.
- Register `vault:export-html` and `vault:export-pdf` commands; HTML export pops the native save dialog and surfaces a success toast after the file is written, PDF export renders to an iframe and calls `window.print()` (user picks "Save as PDF" from the OS dialog — no new Tauri plugin).
- Theme CSS is collected from `document.documentElement` computed styles on the frontend and inlined into the exported `<head>` so output renders correctly offline.
- Added `dialog:allow-save` permission and pulled in `base64` as a direct Rust dep.

## Test plan
- [ ] Open a note with `![[image.png]]` embeds and `[[Heading]]` links, run "Notiz als HTML exportieren", confirm the written HTML file opens standalone with images rendered and in-document anchors working
- [ ] Export a note whose wiki-link targets a missing heading — link degrades to plain text
- [ ] Run "Notiz als PDF exportieren" and confirm the print dialog appears with Save-as-PDF available
- [ ] Try export with no active tab (should surface a "Keine Notiz aktiv" toast)
- [ ] `cargo test --lib commands::export` — 8 unit tests cover slug generation, heading-slug collection, wiki-link rewriting, image-embed fallback + inlining, and document assembly
- [ ] `pnpm test` passes (386 tests)