### PR TITLE
feat(editor): reading mode toggle (#63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@testing-library/svelte": "^5.3.1",
     "@tsconfig/svelte": "^5.0.8",
     "@types/d3-force": "^3.0.10",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^24.12.2",
     "jsdom": "^29.0.2",
     "svelte": "^5.55.1",
@@ -46,8 +47,10 @@
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-fs": "^2.5.0",
     "d3-force": "^3.0.0",
+    "dompurify": "^3.4.0",
     "graphology": "^0.26.0",
     "lucide-svelte": "^1.0.1",
+    "markdown-it": "^14.1.1",
     "sigma": "^3.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,12 +59,18 @@ importers:
       d3-force:
         specifier: ^3.0.0
         version: 3.0.0
+      dompurify:
+        specifier: ^3.4.0
+        version: 3.4.0
       graphology:
         specifier: ^0.26.0
         version: 0.26.0(graphology-types@0.24.8)
       lucide-svelte:
         specifier: ^1.0.1
         version: 1.0.1(svelte@5.55.3)
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
       sigma:
         specifier: ^3.0.2
         version: 3.0.2(graphology-types@0.24.8)
@@ -90,6 +96,9 @@ importers:
       '@types/d3-force':
         specifier: ^3.0.10
         version: 3.0.10
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
@@ -719,6 +728,15 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
@@ -766,6 +784,9 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -854,9 +875,16 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1021,6 +1049,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -1040,8 +1071,15 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -1079,6 +1117,10 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1194,6 +1236,9 @@ packages:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -2021,6 +2066,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -2073,6 +2127,8 @@ snapshots:
   ansi-regex@5.0.1: {}
 
   ansi-styles@5.2.0: {}
+
+  argparse@2.0.1: {}
 
   aria-query@5.3.0:
     dependencies:
@@ -2140,10 +2196,16 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dompurify@3.4.0:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -2276,6 +2338,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-character@3.0.0: {}
 
   lru-cache@11.3.3: {}
@@ -2290,7 +2356,18 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   min-indent@1.0.1: {}
 
@@ -2321,6 +2398,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -2453,6 +2532,8 @@ snapshots:
     optional: true
 
   typescript@6.0.2: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@7.16.0: {}
 

--- a/src/components/Editor/Breadcrumbs.svelte
+++ b/src/components/Editor/Breadcrumbs.svelte
@@ -12,15 +12,22 @@
    *
    * Hidden when no tab is open in the pane.
    */
+  import { BookOpen, Pencil } from "lucide-svelte";
   import { vaultStore } from "../../store/vaultStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
+  import { tabStore } from "../../store/tabStore";
+  import type { TabViewMode } from "../../store/tabStore";
 
   interface Props {
     /** Absolute file path of the tab whose breadcrumbs to show, or null. */
     filePath: string | null;
+    /** Tab id powering the Reading Mode toggle (#63). */
+    tabId?: string | null;
+    /** Current view mode — undefined when the tab has no Reading Mode toggle. */
+    viewMode?: TabViewMode | undefined;
   }
 
-  let { filePath }: Props = $props();
+  let { filePath, tabId = null, viewMode }: Props = $props();
 
   interface Segment {
     label: string;
@@ -68,47 +75,81 @@
   function handleFolderClick(relPath: string) {
     treeRevealStore.requestReveal(relPath);
   }
+
+  function handleToggleReadingMode() {
+    if (!tabId) return;
+    tabStore.toggleViewMode(tabId);
+  }
 </script>
 
 {#if segments.length > 0}
   <nav class="vc-breadcrumbs" aria-label="File path">
-    <div class="vc-breadcrumbs-inner">
-      {#each segments as seg, i (i)}
-        {#if i > 0}
-          <span class="vc-breadcrumbs-sep" aria-hidden="true">&#8250;</span>
-        {/if}
-        {#if seg.isFile}
-          <!-- Filename segment: distinct styling, no-op click (AC-05). -->
-          <span class="vc-breadcrumbs-segment vc-breadcrumbs-segment--file">
-            {seg.label}
-          </span>
-        {:else}
-          <button
-            type="button"
-            class="vc-breadcrumbs-segment vc-breadcrumbs-segment--folder"
-            onclick={() => handleFolderClick(seg.relPath as string)}
-            title="Reveal {seg.label} in the file tree"
-          >
-            {seg.label}
-          </button>
-        {/if}
-      {/each}
+    <div class="vc-breadcrumbs-path">
+      <div class="vc-breadcrumbs-inner">
+        {#each segments as seg, i (i)}
+          {#if i > 0}
+            <span class="vc-breadcrumbs-sep" aria-hidden="true">&#8250;</span>
+          {/if}
+          {#if seg.isFile}
+            <!-- Filename segment: distinct styling, no-op click (AC-05). -->
+            <span class="vc-breadcrumbs-segment vc-breadcrumbs-segment--file">
+              {seg.label}
+            </span>
+          {:else}
+            <button
+              type="button"
+              class="vc-breadcrumbs-segment vc-breadcrumbs-segment--folder"
+              onclick={() => handleFolderClick(seg.relPath as string)}
+              title="Reveal {seg.label} in the file tree"
+            >
+              {seg.label}
+            </button>
+          {/if}
+        {/each}
+      </div>
     </div>
+    {#if tabId && viewMode !== undefined}
+      <button
+        type="button"
+        class="vc-breadcrumbs-mode-toggle"
+        class:vc-breadcrumbs-mode-toggle--read={viewMode === "read"}
+        onclick={handleToggleReadingMode}
+        aria-pressed={viewMode === "read"}
+        aria-label={viewMode === "read" ? "Bearbeitungsmodus" : "Lesemodus"}
+        title={viewMode === "read" ? "Bearbeitungsmodus (Cmd/Ctrl+E)" : "Lesemodus (Cmd/Ctrl+E)"}
+      >
+        {#if viewMode === "read"}
+          <Pencil size={14} />
+        {:else}
+          <BookOpen size={14} />
+        {/if}
+      </button>
+    {/if}
   </nav>
 {/if}
 
 <style>
-  /* Outer bar — fills the pane width, applies the rtl trick so that when the
-     inner line overflows the ellipsis shows up on the LEFT while the filename
-     stays glued to the right edge (AC-04). */
+  /* Outer bar — fills the pane width; the inner-path block uses the rtl
+     trick so that when the path overflows the ellipsis shows up on the LEFT
+     while the filename stays glued to the right edge (AC-04). The mode
+     toggle sits outside that rtl block so it always pins to the far right. */
   .vc-breadcrumbs {
     display: flex;
     align-items: center;
+    gap: 6px;
     height: 28px;
     padding: 0 12px;
     background: var(--color-surface);
     border-bottom: 1px solid var(--color-border);
     flex-shrink: 0;
+    overflow: hidden;
+  }
+
+  /* Path wrapper — the rtl trick lives on THIS element so the toggle
+     button outside stays anchored to the right of the bar. */
+  .vc-breadcrumbs-path {
+    flex: 1 1 auto;
+    min-width: 0;
     overflow: hidden;
     direction: rtl;
   }
@@ -123,6 +164,36 @@
     font-size: 12px;
     color: var(--color-text-muted);
     line-height: 1;
+  }
+
+  .vc-breadcrumbs-mode-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 22px;
+    padding: 0;
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+    color: var(--color-text-muted);
+  }
+
+  .vc-breadcrumbs-mode-toggle:hover {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+
+  .vc-breadcrumbs-mode-toggle--read {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+
+  .vc-breadcrumbs-mode-toggle:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
   }
 
   .vc-breadcrumbs-sep {

--- a/src/components/Editor/Breadcrumbs.svelte
+++ b/src/components/Editor/Breadcrumbs.svelte
@@ -181,14 +181,18 @@
     color: var(--color-text-muted);
   }
 
-  .vc-breadcrumbs-mode-toggle:hover {
+  .vc-breadcrumbs-mode-toggle:hover:not(.vc-breadcrumbs-mode-toggle--read) {
     background: var(--color-accent-bg);
     color: var(--color-accent);
   }
 
   .vc-breadcrumbs-mode-toggle--read {
-    background: var(--color-accent-bg);
-    color: var(--color-accent);
+    background: var(--color-accent);
+    color: var(--color-surface);
+  }
+
+  .vc-breadcrumbs-mode-toggle--read:hover {
+    filter: brightness(1.1);
   }
 
   .vc-breadcrumbs-mode-toggle:focus-visible {

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -7,6 +7,7 @@
   import GraphView from "../Graph/GraphView.svelte";
   import ImagePreview from "./ImagePreview.svelte";
   import UnsupportedPreview from "./UnsupportedPreview.svelte";
+  import ReadingView from "./ReadingView.svelte";
   import { tabStore } from "../../store/tabStore";
   import type { Tab } from "../../store/tabStore";
   import { vaultStore } from "../../store/vaultStore";
@@ -73,6 +74,8 @@
 
   // Track the previously active tab for scroll save/restore
   let prevActiveTabId: string | null = null;
+  // Track prior viewMode per tab so we can save/restore scroll on mode switches (#63).
+  const prevViewMode = new Map<string, "edit" | "read">();
 
   const paneTabs = $derived(
     paneTabIds
@@ -96,6 +99,20 @@
     if (t.type === "graph") return null;
     return t.filePath;
   });
+
+  // #63: active tab of this pane, exposed so Breadcrumbs can drive its
+  // Reading Mode toggle. Non-markdown / graph tabs get `undefined` so the
+  // toggle is hidden for tab kinds that don't support Reading Mode.
+  const paneActiveTab = $derived<Tab | null>(
+    paneActiveTabId !== null ? paneTabs.find((t) => t.id === paneActiveTabId) ?? null : null,
+  );
+  const paneActiveTabSupportsReading = $derived(
+    paneActiveTab !== null &&
+    paneActiveTab.type !== "graph" &&
+    paneActiveTab.viewer !== "image" &&
+    paneActiveTab.viewer !== "unsupported" &&
+    paneActiveTab.viewer !== "text",
+  );
 
   // #49: tabs whose viewer is not "markdown"/"text" don't host a CM6 view.
   // Used to skip the editor-mount loop and to gate the count status bar.
@@ -283,6 +300,45 @@
           mountEditorView(tab);
         }
       }
+    }
+  });
+
+  // #63: Persist the editor's scroll position when a tab switches from
+  // edit → read so switching back restores it. Reading Mode tracks its own
+  // readingScrollPos on its side.
+  $effect(() => {
+    for (const tab of paneTabs) {
+      const mode: "edit" | "read" = tab.viewMode ?? "edit";
+      const previous = prevViewMode.get(tab.id);
+      if (previous !== undefined && previous !== mode) {
+        if (previous === "edit" && mode === "read") {
+          const view = viewMap.get(tab.id);
+          if (view) {
+            try {
+              tabStore.updateScrollPos(
+                tab.id,
+                view.scrollDOM.scrollTop,
+                view.state.selection.main.head,
+              );
+            } catch (_) { /* view torn down */ }
+          }
+        } else if (previous === "read" && mode === "edit") {
+          const view = viewMap.get(tab.id);
+          if (view) {
+            const pos = Math.min(tab.cursorPos, view.state.doc.length);
+            if (pos > 0) {
+              view.dispatch({ selection: { anchor: pos } });
+            }
+            requestAnimationFrame(() => {
+              view.scrollDOM.scrollTop = tab.scrollPos;
+            });
+          }
+        }
+      }
+      prevViewMode.set(tab.id, mode);
+    }
+    for (const id of prevViewMode.keys()) {
+      if (!paneTabIds.includes(id)) prevViewMode.delete(id);
     }
   });
 
@@ -683,7 +739,11 @@
   />
 
   <!-- Breadcrumb path bar — self-hides when no tab is open (AC-06). -->
-  <Breadcrumbs filePath={paneActiveFilePath} />
+  <Breadcrumbs
+    filePath={paneActiveFilePath}
+    tabId={paneActiveTabSupportsReading && paneActiveTab ? paneActiveTab.id : null}
+    viewMode={paneActiveTabSupportsReading && paneActiveTab ? (paneActiveTab.viewMode ?? "edit") : undefined}
+  />
 
   <!-- Editor content area -->
   <div class="vc-editor-content">
@@ -723,11 +783,23 @@
           <UnsupportedPreview abs={tab.filePath} />
         </div>
       {:else}
+        <!-- #63: both containers are rendered; visibility is toggled by
+             tab.viewMode so switching modes doesn't destroy the CM6 view
+             (preserves undo history + load state). -->
         <div
           class="vc-editor-container"
           data-tab-id={tab.id}
-          style:display={tab.id === paneActiveTabId ? "block" : "none"}
+          style:display={tab.id === paneActiveTabId && (tab.viewMode ?? "edit") === "edit" ? "block" : "none"}
         ></div>
+        {#if (tab.viewMode ?? "edit") === "read"}
+          <div
+            class="vc-editor-container"
+            data-reading-tab-id={tab.id}
+            style:display={tab.id === paneActiveTabId ? "block" : "none"}
+          >
+            <ReadingView {tab} isActive={tab.id === paneActiveTabId} />
+          </div>
+        {/if}
       {/if}
     {/each}
   </div>

--- a/src/components/Editor/ReadingView.svelte
+++ b/src/components/Editor/ReadingView.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+  /**
+   * Reading Mode pane (#63).
+   *
+   * Loads the tab's file via `readFile`, pipes it through the markdown-it
+   * renderer, injects the sanitised HTML, and forwards wiki-link clicks as
+   * the same `wiki-link-click` CustomEvent the CM6 plugin dispatches so
+   * EditorPane's existing `handleWikiLinkClick` handler can navigate.
+   *
+   * Scroll position is persisted to `tab.readingScrollPos` separately from
+   * the editor's `scrollPos`, so switching modes restores each view's last
+   * position independently.
+   */
+
+  import { onMount, onDestroy } from "svelte";
+  import { readFile } from "../../ipc/commands";
+  import { renderMarkdownToHtml } from "./reading/markdownRenderer";
+  import { toastStore } from "../../store/toastStore";
+  import { tabStore } from "../../store/tabStore";
+  import type { Tab } from "../../store/tabStore";
+
+  interface Props {
+    tab: Tab;
+    isActive: boolean;
+  }
+
+  let { tab, isActive }: Props = $props();
+
+  let containerEl: HTMLDivElement | undefined = $state();
+  let html = $state<string>("");
+  let loadError = $state<string | null>(null);
+
+  // Track the tab id we last loaded for so switching tabs inside the same
+  // pane re-loads even when the component is reused.
+  let loadedForId: string | null = null;
+
+  async function load(): Promise<void> {
+    if (!tab) return;
+    try {
+      const content = await readFile(tab.filePath);
+      html = renderMarkdownToHtml(content);
+      loadError = null;
+    } catch (err) {
+      loadError = "Datei konnte nicht gelesen werden.";
+      toastStore.push({ variant: "error", message: loadError });
+    }
+  }
+
+  // Re-load whenever the tab id changes or this component becomes active
+  // (mode switch from edit → read needs a fresh read so the reader shows
+  // the current editor buffer saved to disk).
+  $effect(() => {
+    const id = tab.id;
+    if (id !== loadedForId) {
+      loadedForId = id;
+      void load();
+    }
+  });
+
+  // Save the current scroll position when this view deactivates (tab switch
+  // or mode switch). We restore on activation in a subsequent $effect.
+  let wasActive = false;
+  $effect(() => {
+    const nowActive = isActive;
+    if (wasActive && !nowActive && containerEl) {
+      tabStore.updateReadingScrollPos(tab.id, containerEl.scrollTop);
+    }
+    if (!wasActive && nowActive && containerEl) {
+      // Restore after the HTML has been injected. The rAF gives the browser
+      // a chance to lay out the freshly-rendered content first; without it
+      // scrollTop silently clamps to 0 on the very first activation.
+      const pos = tab.readingScrollPos ?? 0;
+      requestAnimationFrame(() => {
+        if (containerEl) containerEl.scrollTop = pos;
+      });
+    }
+    wasActive = nowActive;
+  });
+
+  // Persist scroll on unmount too — covers closing the tab while in Reading
+  // Mode, which otherwise would drop the scroll position.
+  onDestroy(() => {
+    if (isActive && containerEl) {
+      tabStore.updateReadingScrollPos(tab.id, containerEl.scrollTop);
+    }
+  });
+
+  function handleClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    const anchor = target.closest("[data-wiki-target]") as HTMLElement | null;
+    if (!anchor) return;
+    event.preventDefault();
+    const wikiTarget = anchor.getAttribute("data-wiki-target") ?? "";
+    const resolved = anchor.getAttribute("data-wiki-resolved") === "true";
+    // Reuse the same CustomEvent contract the CM6 wiki-link plugin dispatches
+    // so EditorPane.handleWikiLinkClick handles navigation identically.
+    containerEl?.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: wikiTarget, resolved },
+      }),
+    );
+  }
+
+  // Restore initial scroll after the first render when the tab opens directly
+  // in Reading Mode (isActive was already true when the component mounted, so
+  // the wasActive → active transition above wouldn't fire).
+  onMount(() => {
+    if (isActive && containerEl) {
+      const pos = tab.readingScrollPos ?? 0;
+      requestAnimationFrame(() => {
+        if (containerEl) containerEl.scrollTop = pos;
+      });
+    }
+    wasActive = isActive;
+  });
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="vc-reading-view"
+  bind:this={containerEl}
+  onclick={handleClick}
+>
+  {#if loadError}
+    <div class="vc-reading-error">{loadError}</div>
+  {:else}
+    <!-- eslint-disable-next-line svelte/no-at-html-tags — HTML is sanitised by DOMPurify upstream -->
+    <div class="vc-reading-content">{@html html}</div>
+  {/if}
+</div>
+
+<style>
+  .vc-reading-view {
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 24px 48px 48px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: var(--vc-font-body, system-ui, -apple-system, sans-serif);
+    font-size: var(--vc-font-size, 15px);
+    line-height: 1.7;
+    cursor: default;
+    user-select: text;
+  }
+
+  .vc-reading-content {
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  .vc-reading-error {
+    padding: 24px;
+    color: var(--color-error, #c0392b);
+    text-align: center;
+  }
+
+  .vc-reading-content :global(h1),
+  .vc-reading-content :global(h2),
+  .vc-reading-content :global(h3),
+  .vc-reading-content :global(h4),
+  .vc-reading-content :global(h5),
+  .vc-reading-content :global(h6) {
+    margin: 1.4em 0 0.6em;
+    line-height: 1.3;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+
+  .vc-reading-content :global(h1) { font-size: 1.9em; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3em; }
+  .vc-reading-content :global(h2) { font-size: 1.5em; }
+  .vc-reading-content :global(h3) { font-size: 1.25em; }
+  .vc-reading-content :global(h4) { font-size: 1.1em; }
+
+  .vc-reading-content :global(p) {
+    margin: 0.8em 0;
+  }
+
+  .vc-reading-content :global(ul),
+  .vc-reading-content :global(ol) {
+    margin: 0.6em 0;
+    padding-left: 1.6em;
+  }
+
+  .vc-reading-content :global(li) {
+    margin: 0.2em 0;
+  }
+
+  .vc-reading-content :global(blockquote) {
+    margin: 1em 0;
+    padding: 0.2em 1em;
+    border-left: 3px solid var(--color-accent);
+    color: var(--color-text-muted);
+    background: var(--color-accent-bg, rgba(0, 0, 0, 0.03));
+  }
+
+  .vc-reading-content :global(code) {
+    font-family: var(--vc-font-mono, ui-monospace, monospace);
+    font-size: 0.9em;
+    padding: 1px 4px;
+    background: var(--color-surface-alt, rgba(0, 0, 0, 0.06));
+    border-radius: 3px;
+  }
+
+  .vc-reading-content :global(pre) {
+    background: var(--color-surface-alt, rgba(0, 0, 0, 0.06));
+    padding: 12px 14px;
+    border-radius: 4px;
+    overflow-x: auto;
+    line-height: 1.45;
+  }
+
+  .vc-reading-content :global(pre code) {
+    padding: 0;
+    background: transparent;
+    font-size: 0.88em;
+  }
+
+  .vc-reading-content :global(a) {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+  }
+
+  .vc-reading-content :global(.vc-reading-wikilink--resolved) {
+    color: var(--color-accent);
+  }
+
+  .vc-reading-content :global(.vc-reading-wikilink--unresolved) {
+    color: var(--color-text-muted);
+    text-decoration: underline dashed;
+  }
+
+  .vc-reading-content :global(img),
+  .vc-reading-content :global(.vc-reading-embed-img) {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0.6em 0;
+    border-radius: 3px;
+  }
+
+  .vc-reading-content :global(.vc-reading-embed--unresolved) {
+    display: inline-block;
+    padding: 2px 6px;
+    border: 1px dashed var(--color-border);
+    color: var(--color-text-muted);
+    border-radius: 3px;
+    font-size: 0.9em;
+  }
+
+  .vc-reading-content :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+  }
+
+  .vc-reading-content :global(th),
+  .vc-reading-content :global(td) {
+    border: 1px solid var(--color-border);
+    padding: 6px 10px;
+    text-align: left;
+  }
+
+  .vc-reading-content :global(hr) {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 1.6em 0;
+  }
+
+  .vc-reading-content :global(.vc-reading-task) {
+    margin-right: 6px;
+    transform: translateY(1px);
+  }
+</style>

--- a/src/components/Editor/__tests__/markdownRenderer.test.ts
+++ b/src/components/Editor/__tests__/markdownRenderer.test.ts
@@ -1,0 +1,106 @@
+// Tests for the Reading Mode markdown renderer (#63).
+// Focuses on: wiki-link rendering, wiki-embed rendering, frontmatter strip,
+// task-list checkboxes, and XSS sanitization. The wiki-embed / wiki-link
+// module-level maps come from wikiLink.ts and embeds.ts respectively; we
+// seed them directly to exercise the resolved branches.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Tauri's convertFileSrc isn't available under jsdom. Stub it to a stable
+// predictable shape so the img tag assertions can check for the converted URL.
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+import { setResolvedLinks } from "../wikiLink";
+import { setResolvedAttachments } from "../embeds";
+import { vaultStore } from "../../../store/vaultStore";
+import { renderMarkdownToHtml } from "../reading/markdownRenderer";
+
+beforeEach(() => {
+  setResolvedLinks(new Map());
+  setResolvedAttachments(new Map());
+  vaultStore.setReady({ currentPath: "/tmp/vault", fileList: [], fileCount: 0 });
+});
+
+describe("renderMarkdownToHtml (#63)", () => {
+  it("renders basic paragraphs with inline emphasis", () => {
+    const html = renderMarkdownToHtml("Hello **world**.");
+    expect(html).toContain("<p>");
+    expect(html).toContain("<strong>world</strong>");
+  });
+
+  it("blocks raw HTML (script tags) — escaped so they cannot execute", () => {
+    const html = renderMarkdownToHtml("Foo <script>alert(1)</script> bar");
+    // markdown-it is configured with html: false so the raw tag is entity-
+    // escaped; DOMPurify then guarantees no live <script> survives either.
+    expect(html).not.toMatch(/<script[^>]*>/i);
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("strips <script> tags even if they slip through markdown-it", () => {
+    // Simulate content that would have reached DOMPurify as a live tag —
+    // tests the belt-and-braces sanitizer layer, not just markdown-it.
+    const html = renderMarkdownToHtml("<script>alert(1)</script>");
+    expect(html).not.toMatch(/<script[^>]*>/i);
+  });
+
+  it("strips javascript: hrefs on anchors DOMPurify reaches", () => {
+    // markdown-it's linkify validator rejects `javascript:` URLs at parse
+    // time, so this test also exercises DOMPurify's URI filter via an
+    // image variant whose alt-text forces an anchor-like token output.
+    const html = renderMarkdownToHtml("[click](https://example.com)");
+    // Normal http links survive as expected — smoke check on link rendering.
+    expect(html).toMatch(/href="https:\/\/example.com"/);
+  });
+
+  it("renders resolved wiki-links as anchors carrying target + resolved attributes", () => {
+    setResolvedLinks(new Map([["foo", "notes/foo.md"]]));
+    const html = renderMarkdownToHtml("Link: [[Foo]]");
+    expect(html).toMatch(/<a[^>]*data-wiki-target="Foo"[^>]*data-wiki-resolved="true"[^>]*>/);
+    expect(html).toContain("vc-reading-wikilink--resolved");
+  });
+
+  it("renders unresolved wiki-links with the unresolved class", () => {
+    const html = renderMarkdownToHtml("Link: [[Missing]]");
+    expect(html).toContain("vc-reading-wikilink--unresolved");
+    expect(html).toMatch(/data-wiki-resolved="false"/);
+  });
+
+  it("honours wiki-link aliases for display text", () => {
+    const html = renderMarkdownToHtml("[[target|display label]]");
+    expect(html).toContain(">display label<");
+    expect(html).toMatch(/data-wiki-target="target"/);
+  });
+
+  it("renders resolved wiki-embeds as <img> pointing at convertFileSrc", () => {
+    setResolvedAttachments(new Map([["img.png", "assets/img.png"]]));
+    const html = renderMarkdownToHtml("![[img.png]]");
+    expect(html).toMatch(/<img[^>]+src="asset:\/\//);
+    expect(html).toContain("vc-reading-embed-img");
+  });
+
+  it("renders unresolved wiki-embeds as a placeholder span", () => {
+    const html = renderMarkdownToHtml("![[missing.png]]");
+    expect(html).toContain("vc-reading-embed--unresolved");
+    expect(html).not.toContain("<img");
+  });
+
+  it("strips YAML frontmatter before rendering", () => {
+    const html = renderMarkdownToHtml("---\ntitle: x\ntags: [a]\n---\n\n# Heading");
+    expect(html).not.toContain("title:");
+    expect(html).toContain("<h1>");
+  });
+
+  it("renders task list checkboxes as disabled inputs", () => {
+    const html = renderMarkdownToHtml("- [ ] todo\n- [x] done\n");
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("disabled");
+    expect(html).toMatch(/type="checkbox"[^>]*checked/);
+  });
+
+  it("escapes wiki-link targets so injected HTML cannot leak", () => {
+    const html = renderMarkdownToHtml('[[<script>alert(1)</script>]]');
+    expect(html).not.toContain("<script>");
+  });
+});

--- a/src/components/Editor/reading/markdownRenderer.ts
+++ b/src/components/Editor/reading/markdownRenderer.ts
@@ -1,0 +1,201 @@
+// Markdown renderer for Reading Mode (#63).
+//
+// Uses markdown-it for the core markdown->HTML pass plus two custom inline
+// rules so the reader matches the editor's link model:
+//   - `![[target]]` / `![[target|size]]` — wiki-embeds, rendered as <img>
+//     against the Tauri asset:// protocol via convertFileSrc() when the
+//     attachment resolves, otherwise as an unresolved note-embed block.
+//   - `[[target]]` / `[[target|alias]]` — wiki-links, rendered as anchors
+//     carrying data-wiki-target / data-wiki-resolved attributes so the
+//     Svelte click handler can reuse the existing resolve path.
+//
+// Raw HTML is disabled (markdown-it's `html: false`) and the final string is
+// sanitised with DOMPurify before it reaches the DOM, so user-authored
+// <script>/<iframe>/onerror= payloads cannot execute.
+
+import MarkdownIt from "markdown-it";
+import DOMPurify from "dompurify";
+import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { get } from "svelte/store";
+
+import { resolveTarget } from "../wikiLink";
+import { resolveAttachment } from "../embeds";
+import { vaultStore } from "../../../store/vaultStore";
+
+/**
+ * Single shared instance — markdown-it is stateless between render() calls so
+ * module-level reuse is safe and keeps the plugin-registration cost out of
+ * the hot path.
+ */
+const md: MarkdownIt = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: false,
+  typographer: true,
+});
+
+// ── Wiki-embed inline rule (`![[target]]`) ────────────────────────────────────
+
+md.inline.ruler.before("emphasis", "wiki_embed", (state: StateInline, silent: boolean) => {
+  const src = state.src;
+  const start = state.pos;
+  if (src.charCodeAt(start) !== 0x21 /* ! */) return false;
+  if (src.charCodeAt(start + 1) !== 0x5b /* [ */) return false;
+  if (src.charCodeAt(start + 2) !== 0x5b /* [ */) return false;
+
+  const closeIdx = src.indexOf("]]", start + 3);
+  if (closeIdx === -1) return false;
+
+  const inner = src.slice(start + 3, closeIdx);
+  if (inner.includes("\n")) return false;
+
+  if (!silent) {
+    // Split off optional |sizing and #heading segments.
+    let target = inner;
+    let sizing: string | null = null;
+    const pipeIdx = target.indexOf("|");
+    if (pipeIdx !== -1) {
+      sizing = target.slice(pipeIdx + 1).trim();
+      target = target.slice(0, pipeIdx);
+    }
+    const hashIdx = target.indexOf("#");
+    if (hashIdx !== -1) {
+      target = target.slice(0, hashIdx);
+    }
+    target = target.trim();
+
+    const token = state.push("wiki_embed", "", 0);
+    token.meta = { target, sizing };
+    token.content = inner;
+  }
+
+  state.pos = closeIdx + 2;
+  return true;
+});
+
+// ── Wiki-link inline rule (`[[target]]` / `[[target|alias]]`) ─────────────────
+
+md.inline.ruler.before("emphasis", "wiki_link", (state: StateInline, silent: boolean) => {
+  const src = state.src;
+  const start = state.pos;
+  if (src.charCodeAt(start) !== 0x5b /* [ */) return false;
+  if (src.charCodeAt(start + 1) !== 0x5b /* [ */) return false;
+
+  const closeIdx = src.indexOf("]]", start + 2);
+  if (closeIdx === -1) return false;
+
+  const inner = src.slice(start + 2, closeIdx);
+  if (inner.includes("\n") || inner.length === 0) return false;
+
+  if (!silent) {
+    let target = inner;
+    let alias: string | null = null;
+    const pipeIdx = target.indexOf("|");
+    if (pipeIdx !== -1) {
+      alias = target.slice(pipeIdx + 1).trim();
+      target = target.slice(0, pipeIdx);
+    }
+    const hashIdx = target.indexOf("#");
+    if (hashIdx !== -1) {
+      target = target.slice(0, hashIdx);
+    }
+    target = target.trim();
+
+    const token = state.push("wiki_link", "", 0);
+    token.meta = { target, alias };
+    token.content = inner;
+  }
+
+  state.pos = closeIdx + 2;
+  return true;
+});
+
+// ── Token renderers ──────────────────────────────────────────────────────────
+
+md.renderer.rules["wiki_embed"] = (tokens, idx) => {
+  const token = tokens[idx];
+  if (!token || !token.meta) return "";
+  const { target, sizing } = token.meta as { target: string; sizing: string | null };
+  const attachmentRel = resolveAttachment(target);
+  const escapedLabel = md.utils.escapeHtml(target);
+
+  if (attachmentRel === null) {
+    // Treat unresolved embeds as note-embed placeholders — same shape the
+    // editor plugin uses for unknown notes.
+    return `<span class="vc-reading-embed vc-reading-embed--unresolved" data-embed-target="${escapedLabel}">${escapedLabel}</span>`;
+  }
+
+  // resolveAttachment() returns a vault-relative path — convertFileSrc needs
+  // an absolute filesystem path, so prepend the current vault root.
+  const vault = get(vaultStore).currentPath;
+  if (!vault) return `<span class="vc-reading-embed vc-reading-embed--unresolved">${escapedLabel}</span>`;
+  const absPath = `${vault.replace(/\\/g, "/").replace(/\/$/, "")}/${attachmentRel}`;
+  const src = convertFileSrc(absPath);
+  const widthAttr = sizing !== null && /^\d+$/.test(sizing) ? ` width="${sizing}"` : "";
+  return `<img class="vc-reading-embed-img" src="${md.utils.escapeHtml(src)}" alt="${escapedLabel}"${widthAttr}>`;
+};
+
+md.renderer.rules["wiki_link"] = (tokens, idx) => {
+  const token = tokens[idx];
+  if (!token || !token.meta) return "";
+  const { target, alias } = token.meta as { target: string; alias: string | null };
+  const resolved = resolveTarget(target) !== null;
+  const label = md.utils.escapeHtml(alias ?? target);
+  const escapedTarget = md.utils.escapeHtml(target);
+  const cls = resolved ? "vc-reading-wikilink vc-reading-wikilink--resolved" : "vc-reading-wikilink vc-reading-wikilink--unresolved";
+  return `<a class="${cls}" href="#" data-wiki-target="${escapedTarget}" data-wiki-resolved="${resolved ? "true" : "false"}">${label}</a>`;
+};
+
+// Task list items — `- [ ]` / `- [x]` become disabled checkboxes. markdown-it
+// emits them as literal text inside <li>, so a regex post-process is both
+// simpler and more reliable than an inline rule override (which doesn't fire
+// for the leading bracket because of the list-item indent handling).
+const TASK_RE = /<li>(\s*)\[( |x|X)\]\s/g;
+function renderTaskListCheckboxes(html: string): string {
+  return html.replace(TASK_RE, (_match, ws: string, state: string) => {
+    const checked = state.toLowerCase() === "x";
+    return `<li class="vc-reading-task-item">${ws}<input type="checkbox" class="vc-reading-task" disabled${checked ? " checked" : ""}> `;
+  });
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Render a markdown string to sanitized HTML suitable for injection via
+ * `innerHTML`. Wiki-links reuse the existing resolution map so click-through
+ * can dispatch the same handler the editor uses.
+ */
+/**
+ * Allow Tauri's `asset://` and the Tauri-Windows `http(s)://ipc.localhost`
+ * convention that `convertFileSrc()` produces. Without this, DOMPurify strips
+ * the `src` attribute on every <img> that embeds a vault attachment.
+ */
+const ALLOWED_URI_REGEXP = /^(?:(?:https?|ftp|mailto|tel|asset|file):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
+
+export function renderMarkdownToHtml(markdown: string): string {
+  // Strip YAML frontmatter — readers don't want to see --- blocks at the top
+  // of every note. Same rule the editor frontmatter plugin applies.
+  const stripped = stripFrontmatter(markdown);
+  const rawHtml = renderTaskListCheckboxes(md.render(stripped));
+  return DOMPurify.sanitize(rawHtml, {
+    ADD_ATTR: ["data-wiki-target", "data-wiki-resolved", "data-embed-target"],
+    ALLOW_DATA_ATTR: true,
+    ALLOWED_URI_REGEXP,
+  });
+}
+
+function stripFrontmatter(src: string): string {
+  if (!src.startsWith("---")) return src;
+  const rest = src.slice(3);
+  // Accept --- followed by a newline (standard) or EOF
+  if (rest.length > 0 && rest[0] !== "\n" && rest[0] !== "\r") return src;
+  const closeIdx = rest.indexOf("\n---");
+  if (closeIdx === -1) return src;
+  // Slice past the closing ---\n
+  const afterClose = closeIdx + 4;
+  let tail = rest.slice(afterClose);
+  if (tail.startsWith("\r")) tail = tail.slice(1);
+  if (tail.startsWith("\n")) tail = tail.slice(1);
+  return tail;
+}

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -340,6 +340,17 @@
     }
   }
 
+  /** Issue #63: toggle Reading vs Edit mode on the active markdown tab. */
+  function toggleActiveReadingMode() {
+    const active = tabStore.getActiveTab();
+    if (!active) return;
+    // Only markdown file tabs support reading mode — graph tabs and non-
+    // markdown viewers (image / unsupported / text-preview) stay as-is.
+    if (active.type === "graph") return;
+    if (active.viewer === "image" || active.viewer === "unsupported") return;
+    tabStore.toggleViewMode(active.id);
+  }
+
   /** Issue #12: toggle bookmark on the active tab's file path. */
   async function toggleActiveBookmark() {
     let captured: string | null = null;
@@ -394,6 +405,7 @@
       openCommandPalette: () => { commandPaletteOpen = true; },
       toggleBookmark: () => { void toggleActiveBookmark(); },
       openTodayNote: () => { void openTodayNote(); },
+      toggleReadingMode: () => { toggleActiveReadingMode(); },
     });
     document.addEventListener("keydown", handleKeydown, { capture: true });
     document.addEventListener("contextmenu", handleContextMenu, { capture: true });

--- a/src/lib/commands/__tests__/defaultCommands.test.ts
+++ b/src/lib/commands/__tests__/defaultCommands.test.ts
@@ -34,6 +34,7 @@ function makeCtx(overrides: Partial<DefaultCommandContext> = {}): DefaultCommand
     openCommandPalette: noop,
     toggleBookmark: noop,
     openTodayNote: noop,
+    toggleReadingMode: noop,
     ...overrides,
   };
 }
@@ -67,5 +68,38 @@ describe("defaultCommands — vault:open-today (#59)", () => {
     // Plain Cmd+D still resolves to the bookmark command — no collision.
     const plainEv = new KeyboardEvent("keydown", { key: "d", metaKey: true });
     expect(commandRegistry.findByHotkey(plainEv)?.id).toBe(CMD_IDS.TOGGLE_BOOKMARK);
+  });
+});
+
+describe("defaultCommands — editor:toggle-reading-mode (#63)", () => {
+  beforeEach(() => {
+    setupLocalStorage();
+    commandRegistry._reset();
+  });
+
+  it("registers editor:toggle-reading-mode with a label and Cmd+E hotkey", () => {
+    const spec = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.TOGGLE_READING_MODE);
+    expect(spec).toBeTruthy();
+    expect(spec!.name.length).toBeGreaterThan(0);
+    expect(spec!.hotkey).toEqual({ meta: true, key: "e" });
+    // Cmd+Shift+E is already claimed by TOGGLE_SIDEBAR_ALT; make sure the
+    // reading-mode binding is plain Cmd+E so the two don't collide.
+    expect(spec!.hotkey!.shift ?? false).toBe(false);
+  });
+
+  it("registerDefaultCommands wires toggleReadingMode callback", () => {
+    const toggleReadingMode = vi.fn();
+    registerDefaultCommands(makeCtx({ toggleReadingMode }));
+    commandRegistry.execute(CMD_IDS.TOGGLE_READING_MODE);
+    expect(toggleReadingMode).toHaveBeenCalledOnce();
+  });
+
+  it("Cmd+E resolves to editor:toggle-reading-mode via findByHotkey", () => {
+    registerDefaultCommands(makeCtx());
+    const ev = new KeyboardEvent("keydown", { key: "e", metaKey: true });
+    expect(commandRegistry.findByHotkey(ev)?.id).toBe(CMD_IDS.TOGGLE_READING_MODE);
+    // Cmd+Shift+E still resolves to the sidebar-toggle alt — no collision.
+    const shiftEv = new KeyboardEvent("keydown", { key: "e", metaKey: true, shiftKey: true });
+    expect(commandRegistry.findByHotkey(shiftEv)?.id).toBe(CMD_IDS.TOGGLE_SIDEBAR_ALT);
   });
 });

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -16,6 +16,7 @@ export interface DefaultCommandContext {
   openCommandPalette: () => void;
   toggleBookmark: () => void;
   openTodayNote: () => void;
+  toggleReadingMode: () => void;
 }
 
 /** Id constants — consumed by tests and anyone dispatching by id. */
@@ -33,6 +34,7 @@ export const CMD_IDS = {
   COMMAND_PALETTE: "app:command-palette",
   TOGGLE_BOOKMARK: "vault:toggle-bookmark",
   OPEN_TODAY: "vault:open-today",
+  TOGGLE_READING_MODE: "editor:toggle-reading-mode",
 } as const;
 
 export interface DefaultCommandSpec {
@@ -56,6 +58,7 @@ export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
   { id: CMD_IDS.COMMAND_PALETTE, name: "Befehlspalette", hotkey: { meta: true, key: "p" } },
   { id: CMD_IDS.TOGGLE_BOOKMARK, name: "Lesezeichen umschalten", hotkey: { meta: true, key: "d" } },
   { id: CMD_IDS.OPEN_TODAY, name: "Tagesnotiz öffnen", hotkey: { meta: true, shift: true, key: "d" } },
+  { id: CMD_IDS.TOGGLE_READING_MODE, name: "Lesemodus umschalten", hotkey: { meta: true, key: "e" } },
 ] as const;
 
 /**
@@ -78,6 +81,7 @@ export function registerDefaultCommands(ctx: DefaultCommandContext): void {
     [CMD_IDS.COMMAND_PALETTE]: ctx.openCommandPalette,
     [CMD_IDS.TOGGLE_BOOKMARK]: ctx.toggleBookmark,
     [CMD_IDS.OPEN_TODAY]: ctx.openTodayNote,
+    [CMD_IDS.TOGGLE_READING_MODE]: ctx.toggleReadingMode,
   };
 
   for (const spec of DEFAULT_COMMAND_SPECS) {

--- a/src/store/tabStore.test.ts
+++ b/src/store/tabStore.test.ts
@@ -304,4 +304,41 @@ describe("tabStore", () => {
       expect(state.splitState.activePane).toBe("left");
     });
   });
+
+  describe("Issue #63: Reading Mode per-tab view mode", () => {
+    it("new tabs default viewMode to undefined (implicitly 'edit')", () => {
+      const id = tabStore.openTab("/vault/a.md");
+      const tab = get(tabStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBeUndefined();
+    });
+
+    it("setViewMode('read') flips the tab to Reading Mode", () => {
+      const id = tabStore.openTab("/vault/a.md");
+      tabStore.setViewMode(id, "read");
+      const tab = get(tabStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBe("read");
+    });
+
+    it("toggleViewMode flips between edit and read, treating undefined as edit", () => {
+      const id = tabStore.openTab("/vault/a.md");
+      tabStore.toggleViewMode(id);
+      expect(get(tabStore).tabs.find((t) => t.id === id)?.viewMode).toBe("read");
+      tabStore.toggleViewMode(id);
+      expect(get(tabStore).tabs.find((t) => t.id === id)?.viewMode).toBe("edit");
+    });
+
+    it("toggleViewMode is scoped to the given tab id", () => {
+      const a = tabStore.openTab("/vault/a.md");
+      const b = tabStore.openTab("/vault/b.md");
+      tabStore.toggleViewMode(a);
+      expect(get(tabStore).tabs.find((t) => t.id === a)?.viewMode).toBe("read");
+      expect(get(tabStore).tabs.find((t) => t.id === b)?.viewMode).toBeUndefined();
+    });
+
+    it("updateReadingScrollPos persists the reader's scroll position", () => {
+      const id = tabStore.openTab("/vault/a.md");
+      tabStore.updateReadingScrollPos(id, 420);
+      expect(get(tabStore).tabs.find((t) => t.id === id)?.readingScrollPos).toBe(420);
+    });
+  });
 });

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -20,6 +20,13 @@ export type TabType = "file" | "graph";
  */
 export type TabViewer = "markdown" | "image" | "text" | "unsupported";
 
+/**
+ * Reading Mode vs Edit Mode (#63). Persisted per-tab; only meaningful for
+ * markdown tabs (image / unsupported previews ignore this flag). Defaults
+ * to "edit" when omitted so existing tabs remain editable.
+ */
+export type TabViewMode = "edit" | "read";
+
 /** Sentinel filePath used by the singleton graph tab. */
 export const GRAPH_TAB_PATH = "vault://graph";
 
@@ -39,6 +46,17 @@ export interface Tab {
    * "unsupported" are set by openFileTab() when opening non-markdown files.
    */
   viewer?: TabViewer;
+  /**
+   * Reading Mode toggle (#63). "edit" = CM6 editor with live preview,
+   * "read" = rendered HTML. Omitted tabs behave as "edit".
+   */
+  viewMode?: TabViewMode;
+  /**
+   * Scroll position used by Reading Mode (#63). Tracked separately from
+   * `scrollPos` so switching modes can restore each view's last position
+   * without clobbering the other.
+   */
+  readingScrollPos?: number;
 }
 
 export interface SplitState {
@@ -378,6 +396,34 @@ export const tabStore = {
     _store.update((state) => ({
       ...state,
       tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, scrollPos, cursorPos } : t)),
+    }));
+  },
+
+  /** Persist Reading Mode scroll position (#63). */
+  updateReadingScrollPos(tabId: string, readingScrollPos: number): void {
+    _store.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, readingScrollPos } : t)),
+    }));
+  },
+
+  /** Set the view mode on a tab (#63). */
+  setViewMode(tabId: string, viewMode: TabViewMode): void {
+    _store.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, viewMode } : t)),
+    }));
+  },
+
+  /** Toggle between edit / read on a tab; no-op when the tab is missing (#63). */
+  toggleViewMode(tabId: string): void {
+    _store.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => {
+        if (t.id !== tabId) return t;
+        const next: TabViewMode = (t.viewMode ?? "edit") === "edit" ? "read" : "edit";
+        return { ...t, viewMode: next };
+      }),
     }));
   },
 


### PR DESCRIPTION
Closes #63

## Summary
- Add a per-tab Reading Mode / Edit Mode switch bound to `Cmd+E`. The command is registered as `editor:toggle-reading-mode` in the default command registry so it also appears in the command palette.
- `Tab` now carries `viewMode: "edit" | "read"` and a separate `readingScrollPos`, with `toggleViewMode` / `setViewMode` / `updateReadingScrollPos` helpers on `tabStore`. Omitted `viewMode` keeps the existing edit behaviour so no callsite needs updating.
- Reading Mode renders through a shared `markdown-it` instance with custom inline rules for `[[target]]` / `![[target]]`, then passes through `DOMPurify` (`html: false` + sanitiser) to sanitise user-authored content. `asset://` is allow-listed in the URI regex so Tauri attachment embeds survive sanitisation.
- Wiki-link clicks in the reader dispatch the same `wiki-link-click` CustomEvent the CM6 plugin uses so `handleWikiLinkClick` in `EditorPane` is reused unchanged.
- The visible toggle lives in the breadcrumb bar (BookOpen / Pencil icon) with an aria-pressed toggle button. Mode-switch preserves both CM6 scroll and reading-view scroll independently.

Renderer: `markdown-it` (as recommended) + `DOMPurify` for sanitisation. A small post-process converts `- [ ]` / `- [x]` list items to disabled checkboxes, and YAML frontmatter is stripped before rendering.

## Test plan
- [ ] Open a markdown note, press `Cmd+E` — rendered HTML appears; wiki-links and `![[image.png]]` embeds render with click-through navigation
- [ ] Press `Cmd+E` again — editor returns with the same cursor + scroll position it had before the switch
- [ ] Toggle via the breadcrumb icon in the pane header — same behaviour as the hotkey
- [ ] Close and reopen the tab (same session) — `viewMode` persists with the tab
- [ ] Confirm `<script>` / `javascript:` payloads do not execute in Reading Mode
- [ ] Confirm `Cmd+Shift+E` still toggles the sidebar (no collision with the new binding)