### PR TITLE
fix: rename in edit mode silently fails and closes editor (#89)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -504,11 +504,20 @@
       // ERR-03: skip auto-save when vault is unreachable
       if (!vaultReachable) return;
 
+      // #89: Read the current filePath from the store at save time rather than
+      // using the mount-time capture. When a file is renamed while the editor
+      // is open, tabStore.updateFilePath updates the tab's filePath but the
+      // closure's captured `tab` object still holds the old path. Using the
+      // stale path causes the save to target the deleted old path, which
+      // silently fails and eventually closes the editor.
+      const currentTab = allTabs.find((t) => t.id === tab.id);
+      const filePath = currentTab?.filePath ?? tab.filePath;
+
       try {
         // EDIT-10: Hash-verify branch — detect external modifications before writing.
         let diskHash: string | null;
         try {
-          diskHash = await getFileHash(tab.filePath);
+          diskHash = await getFileHash(filePath);
         } catch (e) {
           // FileNotFound means the file was deleted externally → fall through to
           // write (create path). Any other error re-throws via existing toast plumbing.
@@ -525,8 +534,8 @@
 
         if (diskHash !== null && expected !== null && diskHash !== expected) {
           // MISMATCH: external edit detected — route through three-way merge engine.
-          const baseContent = tab.lastSavedContent;
-          const result = await mergeExternalChange(tab.filePath, text, baseContent);
+          const baseContent = currentTab?.lastSavedContent ?? tab.lastSavedContent;
+          const result = await mergeExternalChange(filePath, text, baseContent);
 
           // Apply merged content back to the CM6 view for this tab.
           const view = viewMap.get(tab.id);
@@ -537,7 +546,7 @@
           }
 
           // Write the merged content to disk so hash converges.
-          const newHash = await writeFile(tab.filePath, result.merged_content);
+          const newHash = await writeFile(filePath, result.merged_content);
           editorStore.setLastSavedHash(newHash);
           tabStore.setLastSavedHash(tab.id, newHash);
           tabStore.setLastSavedContent(tab.id, result.merged_content);
@@ -546,7 +555,7 @@
           void tagsStore.reload();
 
           // Toasts — reuse the exact Phase 2 German strings.
-          const filename = tab.filePath.split("/").pop() ?? tab.filePath;
+          const filename = filePath.split("/").pop() ?? filePath;
           if (result.outcome === "clean") {
             toastStore.push({ variant: "clean-merge", message: "Externe Änderungen wurden eingebunden" });
           } else {
@@ -556,7 +565,7 @@
         }
 
         // Hashes match (or file missing → create-path) — safe to write directly.
-        const hash = await writeFile(tab.filePath, text);
+        const hash = await writeFile(filePath, text);
         tabStore.setDirty(tab.id, false);
         tabStore.setLastSavedContent(tab.id, text);
         tabStore.setLastSavedHash(tab.id, hash);

--- a/src/components/Sidebar/InlineRename.svelte
+++ b/src/components/Sidebar/InlineRename.svelte
@@ -81,6 +81,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
+    e.stopPropagation();
     if (e.key === "Enter") {
       e.preventDefault();
       void handleConfirm();

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -278,7 +278,8 @@
     return null;
   }
 
-  function handlePathChanged(_oldPath: string, _newPath: string) {
+  function handlePathChanged(oldPath: string, newPath: string) {
+    tabStore.updateFilePath(oldPath, newPath);
     void loadRoot();
   }
 </script>


### PR DESCRIPTION
## Summary

- **Sidebar.handlePathChanged** now calls `tabStore.updateFilePath(oldPath, newPath)` so the open tab's file path is updated after a rename. Previously, the watcher event that would normally perform this update was suppressed by `write_ignore` (both old and new paths are recorded before the filesystem rename), leaving the tab pointing at the deleted old path.
- **EditorPane onSave closure** now resolves the current `filePath` from the reactive `allTabs` array at save time instead of using the mount-time capture. The stale path caused auto-save writes to target the old (deleted) file, which silently failed and eventually caused the editor to close.

## Test plan

- [ ] Open a note in edit mode, rename it via the sidebar context menu, verify the editor stays open and the tab title updates
- [ ] Type additional content after rename and verify auto-save writes to the new file path (check the file on disk)
- [ ] Rename a note that has backlinks, confirm the link-update dialog, verify the editor stays open
- [ ] Rename a note that is NOT open in the editor -- verify the existing rename flow still works
- [ ] Run `pnpm test` -- all 433 tests pass
- [ ] Run `npx tsc --noEmit` -- no type errors

Closes #89