### PR TITLE
feat: add note templates with variable substitution

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub mod links;
 pub mod tags;
 pub mod bookmarks;
 pub mod snippets;
+pub mod templates;
 pub mod export;

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -1,0 +1,136 @@
+// Note templates IPC (#67). Users place `.md` files into
+// `<vault>/.vaultcore/templates/`. The "Insert template" command opens a
+// fuzzy picker listing those files; selecting one reads the content,
+// substitutes variables ({{date}}, {{time}}, {{title}}), and inserts it
+// at the current cursor position.
+//
+// Two read-only commands back the frontend:
+//   - `list_templates`   -> basenames of `*.md` files, sorted
+//   - `read_template`    -> markdown text for a single file
+//
+// Security: same T-02 scope guard as snippets.rs — vault_path must match
+// the currently-open vault, filenames are validated against traversal.
+
+use crate::error::VaultError;
+use crate::VaultState;
+use std::path::{Path, PathBuf};
+
+const VAULTCORE_DIR: &str = ".vaultcore";
+const TEMPLATES_DIR: &str = "templates";
+
+/// Resolve `<vault>/.vaultcore/templates/` after confirming `vault_path`
+/// matches the currently-open vault. Creates the directory if missing so
+/// first-run returns an empty list instead of FileNotFound.
+fn templates_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, VaultError> {
+    let canonical = std::fs::canonicalize(vault_path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: vault_path.to_string() },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: vault_path.to_string() },
+        _ => VaultError::Io(e),
+    })?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
+        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+    ))?;
+    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
+        path: vault_path.to_string(),
+    })?;
+    if canonical != *vault {
+        return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
+    }
+    let dir = canonical.join(VAULTCORE_DIR).join(TEMPLATES_DIR);
+    std::fs::create_dir_all(&dir).map_err(VaultError::Io)?;
+    Ok(dir)
+}
+
+/// Reject filenames that would escape the templates directory.
+/// Accept only a plain file basename ending in `.md` (case-insensitive),
+/// with no path separators, no traversal components, and no empty stem.
+fn validate_template_filename(filename: &str) -> Result<(), VaultError> {
+    if filename.is_empty()
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains('\0')
+        || filename == "."
+        || filename == ".."
+        || filename.contains("..")
+    {
+        return Err(VaultError::PermissionDenied { path: filename.to_string() });
+    }
+    if Path::new(filename).is_absolute() {
+        return Err(VaultError::PermissionDenied { path: filename.to_string() });
+    }
+    let lower = filename.to_lowercase();
+    if !lower.ends_with(".md") {
+        return Err(VaultError::PermissionDenied { path: filename.to_string() });
+    }
+    Ok(())
+}
+
+pub fn list_templates_impl(state: &VaultState, vault_path: String) -> Result<Vec<String>, VaultError> {
+    let dir = templates_dir_for(state, &vault_path)?;
+    let mut names: Vec<String> = Vec::new();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(it) => it,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(names),
+        Err(e) => return Err(VaultError::Io(e)),
+    };
+    for entry in entries {
+        let entry = entry.map_err(VaultError::Io)?;
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !ft.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = match name.to_str() {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        if name_str.to_lowercase().ends_with(".md") {
+            names.push(name_str);
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+#[tauri::command]
+pub async fn list_templates(
+    state: tauri::State<'_, VaultState>,
+    vault_path: String,
+) -> Result<Vec<String>, VaultError> {
+    list_templates_impl(&state, vault_path)
+}
+
+pub fn read_template_impl(
+    state: &VaultState,
+    vault_path: String,
+    filename: String,
+) -> Result<String, VaultError> {
+    validate_template_filename(&filename)?;
+    let dir = templates_dir_for(state, &vault_path)?;
+    let target = dir.join(&filename);
+
+    let canonical_target = std::fs::canonicalize(&target).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: filename.clone() },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: filename.clone() },
+        _ => VaultError::Io(e),
+    })?;
+    let canonical_dir = std::fs::canonicalize(&dir).map_err(VaultError::Io)?;
+    if !canonical_target.starts_with(&canonical_dir) {
+        return Err(VaultError::PermissionDenied { path: filename });
+    }
+
+    let bytes = std::fs::read(&canonical_target).map_err(VaultError::Io)?;
+    String::from_utf8(bytes).map_err(|_| VaultError::InvalidEncoding { path: filename })
+}
+
+#[tauri::command]
+pub async fn read_template(
+    state: tauri::State<'_, VaultState>,
+    vault_path: String,
+    filename: String,
+) -> Result<String, VaultError> {
+    read_template_impl(&state, vault_path, filename)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,8 @@ pub fn run() {
             commands::bookmarks::save_bookmarks,
             commands::snippets::list_snippets,
             commands::snippets::read_snippet,
+            commands::templates::list_templates,
+            commands::templates::read_template,
             commands::export::export_note_html,
             commands::export::render_note_html,
         ])

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -5,6 +5,7 @@
   import EditorPane from "../Editor/EditorPane.svelte";
   import QuickSwitcher from "../Search/QuickSwitcher.svelte";
   import CommandPalette from "../CommandPalette/CommandPalette.svelte";
+  import TemplatePicker from "../TemplatePicker/TemplatePicker.svelte";
   import RightSidebar from "./RightSidebar.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import { tabStore } from "../../store/tabStore";
@@ -52,6 +53,7 @@
   let isDragging = $state(false);
   let quickSwitcherOpen = $state(false);
   let commandPaletteOpen = $state(false);
+  let templatePickerOpen = $state(false);
   let settingsOpen = $state(false);
   let dragStartX = 0;
   let dragStartWidth = 0;
@@ -514,6 +516,7 @@
       exportActiveNoteHtml: () => { void exportActiveNoteHtml(); },
       exportActiveNotePdf: () => { void exportActiveNotePdf(); },
       toggleReadingMode: () => { toggleActiveReadingMode(); },
+      insertTemplate: () => { templatePickerOpen = true; },
     });
     initHotkeyOverrides();
     document.addEventListener("keydown", handleKeydown, { capture: true });
@@ -545,6 +548,7 @@
     if (settingsOpen || inlineRenameActive()) return;
     if (commandPaletteOpen) return; // palette handles its own keys
     if (quickSwitcherOpen) return; // quick switcher handles its own keys
+    if (templatePickerOpen) return; // template picker handles its own keys
 
     const cmd = commandRegistry.findByHotkey(e);
     if (!cmd) return;
@@ -719,6 +723,11 @@
 <CommandPalette
   open={commandPaletteOpen}
   onClose={() => { commandPaletteOpen = false; }}
+/>
+
+<TemplatePicker
+  open={templatePickerOpen}
+  onClose={() => { templatePickerOpen = false; }}
 />
 
 <SettingsModal

--- a/src/components/TemplatePicker/TemplatePicker.svelte
+++ b/src/components/TemplatePicker/TemplatePicker.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+  import { onDestroy, tick } from "svelte";
+  import { vaultStore } from "../../store/vaultStore";
+  import { activeViewStore } from "../../store/activeViewStore";
+  import { listTemplates, readTemplate } from "../../ipc/commands";
+  import { substituteTemplateVars } from "../../lib/templateSubstitution";
+  import { toastStore } from "../../store/toastStore";
+  import { tabStore } from "../../store/tabStore";
+  import type { EditorView } from "@codemirror/view";
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+  }
+
+  let { open, onClose }: Props = $props();
+
+  let query = $state("");
+  let templates = $state<string[]>([]);
+  let selectedIndex = $state(0);
+  let inputEl = $state<HTMLInputElement | undefined>();
+
+  let currentVaultPath: string | null = null;
+  const unsubVault = vaultStore.subscribe((s) => {
+    currentVaultPath = s.currentPath;
+  });
+
+  let activeView: EditorView | null = null;
+  const unsubView = activeViewStore.subscribe((s) => {
+    activeView = s.view;
+  });
+
+  onDestroy(() => {
+    unsubVault();
+    unsubView();
+  });
+
+  const filtered = $derived(
+    query.trim()
+      ? templates.filter((t) =>
+          t.toLowerCase().includes(query.toLowerCase()),
+        )
+      : templates,
+  );
+
+  $effect(() => {
+    if (open) {
+      query = "";
+      selectedIndex = 0;
+      void loadTemplates();
+      void tick().then(() => inputEl?.focus());
+    }
+  });
+
+  async function loadTemplates() {
+    if (!currentVaultPath) return;
+    try {
+      templates = await listTemplates(currentVaultPath);
+    } catch {
+      templates = [];
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    const count = filtered.length;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (count === 0) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      selectedIndex = (selectedIndex + 1) % count;
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      selectedIndex = (selectedIndex - 1 + count) % count;
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const selected = filtered[selectedIndex];
+      if (selected) void selectTemplate(selected);
+    } else if (e.key === "Tab") {
+      e.preventDefault();
+    }
+  }
+
+  function activeNoteTitle(): string {
+    const active = tabStore.getActiveTab();
+    if (!active) return "";
+    const filename = active.filePath.split("/").pop() ?? "";
+    return filename.replace(/\.md$/i, "");
+  }
+
+  async function selectTemplate(filename: string) {
+    if (!currentVaultPath) return;
+    try {
+      const raw = await readTemplate(currentVaultPath, filename);
+      const content = substituteTemplateVars(raw, activeNoteTitle());
+      insertAtCursor(content);
+      onClose();
+    } catch {
+      toastStore.push({
+        variant: "error",
+        message: `Vorlage "${filename}" konnte nicht geladen werden.`,
+      });
+    }
+  }
+
+  function insertAtCursor(text: string) {
+    if (!activeView) {
+      toastStore.push({
+        variant: "error",
+        message: "Kein Editor aktiv — öffne zuerst eine Notiz.",
+      });
+      return;
+    }
+    const pos = activeView.state.selection.main.head;
+    activeView.dispatch({
+      changes: { from: pos, insert: text },
+      selection: { anchor: pos + text.length },
+    });
+    activeView.focus();
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-tp-backdrop"
+    onclick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+  >
+    <div
+      class="vc-tp-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Vorlage einfügen"
+    >
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        onkeydown={handleKeydown}
+        type="text"
+        placeholder="Vorlage suchen..."
+        class="vc-tp-input"
+        aria-label="Vorlage suchen"
+        autocomplete="off"
+        spellcheck="false"
+      />
+
+      <div class="vc-tp-results" role="listbox" aria-label="Vorlagen">
+        {#if templates.length === 0}
+          <p class="vc-tp-empty">
+            Keine Vorlagen gefunden — lege <code>.md</code>-Dateien in
+            <code>.vaultcore/templates/</code> ab.
+          </p>
+        {:else if filtered.length === 0}
+          <p class="vc-tp-empty">Keine Treffer</p>
+        {:else}
+          {#each filtered as tpl, i (tpl)}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <div
+              class="vc-tp-row"
+              class:vc-tp-row--selected={i === selectedIndex}
+              role="option"
+              aria-selected={i === selectedIndex}
+              onclick={() => void selectTemplate(tpl)}
+              onmouseenter={() => { selectedIndex = i; }}
+            >
+              <span class="vc-tp-row-name">{tpl.replace(/\.md$/i, "")}</span>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-tp-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 200;
+  }
+
+  .vc-tp-modal {
+    width: 480px;
+    max-height: 400px;
+    position: fixed;
+    top: 15%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    z-index: 201;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .vc-tp-input {
+    width: 100%;
+    height: 44px;
+    padding: 0 16px;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 14px;
+    outline: none;
+    background: var(--color-surface);
+    color: var(--color-text);
+    flex-shrink: 0;
+    box-sizing: border-box;
+  }
+
+  .vc-tp-input::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  .vc-tp-results {
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .vc-tp-empty {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    text-align: center;
+    padding: 16px;
+    margin: 0;
+    line-height: 1.6;
+  }
+
+  .vc-tp-empty code {
+    font-family: var(--vc-font-mono);
+    font-size: 11px;
+    padding: 1px 4px;
+    background: var(--color-surface-alt, rgba(0, 0, 0, 0.06));
+    border-radius: 3px;
+  }
+
+  .vc-tp-row {
+    display: flex;
+    align-items: center;
+    padding: 6px 16px;
+    cursor: pointer;
+  }
+
+  .vc-tp-row:hover,
+  .vc-tp-row--selected {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-tp-row-name {
+    font-size: 13px;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -446,6 +446,32 @@ export async function readSnippet(vaultPath: string, filename: string): Promise<
   }
 }
 
+// ── Note templates (#67) ──────────────────────────────────────────────────────
+
+/**
+ * List `*.md` filenames in `<vault>/.vaultcore/templates/`. The directory is
+ * created on first call so the user has a stable drop-in path.
+ */
+export async function listTemplates(vaultPath: string): Promise<string[]> {
+  try {
+    return await invoke<string[]>("list_templates", { vaultPath });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Read the contents of a single template file. The Rust side vault-scope-
+ * guards the path and rejects traversal attempts.
+ */
+export async function readTemplate(vaultPath: string, filename: string): Promise<string> {
+  try {
+    return await invoke<string>("read_template", { vaultPath, filename });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 // ── HTML export (#61) ─────────────────────────────────────────────────────────
 
 /**

--- a/src/lib/commands/__tests__/defaultCommands.test.ts
+++ b/src/lib/commands/__tests__/defaultCommands.test.ts
@@ -37,6 +37,7 @@ function makeCtx(overrides: Partial<DefaultCommandContext> = {}): DefaultCommand
     exportActiveNoteHtml: noop,
     exportActiveNotePdf: noop,
     toggleReadingMode: noop,
+    insertTemplate: noop,
     ...overrides,
   };
 }

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -19,6 +19,7 @@ export interface DefaultCommandContext {
   exportActiveNoteHtml: () => void;
   exportActiveNotePdf: () => void;
   toggleReadingMode: () => void;
+  insertTemplate: () => void;
 }
 
 /** Id constants — consumed by tests and anyone dispatching by id. */
@@ -39,6 +40,7 @@ export const CMD_IDS = {
   EXPORT_HTML: "vault:export-html",
   EXPORT_PDF: "vault:export-pdf",
   TOGGLE_READING_MODE: "editor:toggle-reading-mode",
+  INSERT_TEMPLATE: "editor:insert-template",
 } as const;
 
 export interface DefaultCommandSpec {
@@ -65,6 +67,7 @@ export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
   { id: CMD_IDS.EXPORT_HTML, name: "Notiz als HTML exportieren" },
   { id: CMD_IDS.EXPORT_PDF, name: "Notiz als PDF exportieren" },
   { id: CMD_IDS.TOGGLE_READING_MODE, name: "Lesemodus umschalten", hotkey: { meta: true, key: "e" } },
+  { id: CMD_IDS.INSERT_TEMPLATE, name: "Vorlage einfügen", hotkey: { meta: true, shift: true, key: "t" } },
 ] as const;
 
 /**
@@ -90,6 +93,7 @@ export function registerDefaultCommands(ctx: DefaultCommandContext): void {
     [CMD_IDS.EXPORT_HTML]: ctx.exportActiveNoteHtml,
     [CMD_IDS.EXPORT_PDF]: ctx.exportActiveNotePdf,
     [CMD_IDS.TOGGLE_READING_MODE]: ctx.toggleReadingMode,
+    [CMD_IDS.INSERT_TEMPLATE]: ctx.insertTemplate,
   };
 
   for (const spec of DEFAULT_COMMAND_SPECS) {

--- a/src/lib/templateSubstitution.ts
+++ b/src/lib/templateSubstitution.ts
@@ -1,0 +1,28 @@
+/**
+ * Substitute template variables in a string.
+ *
+ * Supported variables:
+ *   {{date}}  → YYYY-MM-DD
+ *   {{time}}  → HH:mm
+ *   {{title}} → active note title (filename without .md extension)
+ */
+export function substituteTemplateVars(
+  content: string,
+  title: string,
+): string {
+  const now = new Date();
+
+  const yyyy = String(now.getFullYear());
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  const date = `${yyyy}-${mm}-${dd}`;
+
+  const hh = String(now.getHours()).padStart(2, "0");
+  const min = String(now.getMinutes()).padStart(2, "0");
+  const time = `${hh}:${min}`;
+
+  return content
+    .replaceAll("{{date}}", date)
+    .replaceAll("{{time}}", time)
+    .replaceAll("{{title}}", title);
+}


### PR DESCRIPTION
## Summary

Closes #67.

- Rust backend: `list_templates` + `read_template` commands (same scope-guard pattern as snippets)
- Frontend: `TemplatePicker` modal with fuzzy filtering, accessible via **Cmd+Shift+T** or command palette ("Vorlage einfügen")
- Variable substitution: `{{date}}` → YYYY-MM-DD, `{{time}}` → HH:mm, `{{title}}` → active note title
- Templates are `.md` files in `<vault>/.vaultcore/templates/`

## Test plan

- [ ] Create `.vaultcore/templates/` in a vault, add a `.md` template with `{{date}}`, `{{time}}`, `{{title}}`
- [ ] Open a note, press Cmd+Shift+T — picker should list the template
- [ ] Select it — content should be inserted at cursor with variables replaced
- [ ] Verify empty-state message when no templates exist
- [ ] Verify command palette lists "Vorlage einfügen"
- [ ] Verify Escape / backdrop click closes the picker