### PR TITLE
feat: bundle example templates seeded on first use

### DIFF
--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -37,8 +37,33 @@ fn templates_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, Va
         return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
     }
     let dir = canonical.join(VAULTCORE_DIR).join(TEMPLATES_DIR);
+    let fresh = !dir.exists();
     std::fs::create_dir_all(&dir).map_err(VaultError::Io)?;
+    if fresh {
+        seed_default_templates(&dir);
+    }
     Ok(dir)
+}
+
+/// Write bundled example templates into a freshly created templates directory.
+/// Failures are silently ignored — missing examples are not worth blocking the
+/// user. Files that already exist (e.g. from a previous partial seed) are not
+/// overwritten.
+fn seed_default_templates(dir: &Path) {
+    const DEFAULTS: &[(&str, &str)] = &[
+        ("Meeting Notes.md", include_str!("../default_templates/Meeting Notes.md")),
+        ("Daily Journal.md", include_str!("../default_templates/Daily Journal.md")),
+        ("Project Brief.md", include_str!("../default_templates/Project Brief.md")),
+        ("Weekly Review.md", include_str!("../default_templates/Weekly Review.md")),
+        ("Book Notes.md", include_str!("../default_templates/Book Notes.md")),
+        ("Bug Report.md", include_str!("../default_templates/Bug Report.md")),
+    ];
+    for (name, content) in DEFAULTS {
+        let path = dir.join(name);
+        if !path.exists() {
+            let _ = std::fs::write(&path, content);
+        }
+    }
 }
 
 /// Reject filenames that would escape the templates directory.

--- a/src-tauri/src/default_templates/Book Notes.md
+++ b/src-tauri/src/default_templates/Book Notes.md
@@ -1,0 +1,31 @@
+---
+tags: [book]
+date: {{date}}
+author:
+rating:
+---
+
+# {{title}}
+
+## Key takeaways
+
+1.
+2.
+3.
+
+## Favorite quotes
+
+>
+
+>
+
+## Summary
+
+
+
+## How it connects
+
+Related notes: [[]]
+
+## Would I recommend it?
+

--- a/src-tauri/src/default_templates/Bug Report.md
+++ b/src-tauri/src/default_templates/Bug Report.md
@@ -1,0 +1,38 @@
+---
+tags: [bug]
+date: {{date}}
+status: open
+severity:
+---
+
+# {{title}}
+
+## Description
+
+> What happened?
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+
+
+## Actual behavior
+
+
+
+## Environment
+
+- OS:
+- Version:
+
+## Screenshots / logs
+
+
+
+## Notes
+

--- a/src-tauri/src/default_templates/Daily Journal.md
+++ b/src-tauri/src/default_templates/Daily Journal.md
@@ -1,0 +1,28 @@
+---
+tags: [journal, daily]
+date: {{date}}
+---
+
+# Journal — {{date}}
+
+## Grateful for
+
+-
+
+## Today's focus
+
+- [ ]
+- [ ]
+- [ ]
+
+## Notes
+
+
+
+## End-of-day reflection
+
+*What went well?*
+
+
+*What could be better?*
+

--- a/src-tauri/src/default_templates/Meeting Notes.md
+++ b/src-tauri/src/default_templates/Meeting Notes.md
@@ -1,0 +1,26 @@
+---
+tags: [meeting]
+date: {{date}}
+---
+
+# {{title}}
+
+**Date:** {{date}}
+**Time:** {{time}}
+**Attendees:**
+
+-
+
+## Agenda
+
+1.
+
+## Notes
+
+
+
+## Action Items
+
+- [ ]
+- [ ]
+- [ ]

--- a/src-tauri/src/default_templates/Project Brief.md
+++ b/src-tauri/src/default_templates/Project Brief.md
@@ -1,0 +1,46 @@
+---
+tags: [project]
+date: {{date}}
+---
+
+# {{title}}
+
+## Goal
+
+> One sentence: what does success look like?
+
+## Context
+
+Why are we doing this? Link to relevant notes: [[]]
+
+## Scope
+
+### In scope
+
+-
+
+### Out of scope
+
+-
+
+## Stakeholders
+
+| Role | Name |
+|------|------|
+| Lead | |
+| Reviewer | |
+
+## Timeline
+
+| Milestone | Date |
+|-----------|------|
+| Kickoff | {{date}} |
+| | |
+
+## Risks
+
+-
+
+## Open questions
+
+- [ ]

--- a/src-tauri/src/default_templates/Weekly Review.md
+++ b/src-tauri/src/default_templates/Weekly Review.md
@@ -1,0 +1,27 @@
+---
+tags: [review, weekly]
+date: {{date}}
+---
+
+# Weekly Review — {{date}}
+
+## Accomplishments
+
+-
+
+## Blockers
+
+-
+
+## Lessons learned
+
+-
+
+## Next week
+
+- [ ]
+- [ ]
+- [ ]
+
+## Notes
+


### PR DESCRIPTION
## Summary

Closes #95.

Six example templates are embedded in the binary via `include_str!` and automatically written into `.vaultcore/templates/` when the directory is first created. Existing files are never overwritten.

**Templates:**
- Meeting Notes — date, time, attendees, agenda, action items
- Daily Journal — gratitude, focus, reflection
- Project Brief — goal, scope, stakeholders, timeline, risks
- Weekly Review — accomplishments, blockers, next week
- Book Notes — takeaways, quotes, summary, connections
- Bug Report — steps to reproduce, expected/actual, environment

All templates demonstrate `{{date}}`, `{{time}}`, `{{title}}` variables, frontmatter with tags, headings, checklists, tables, and `[[wiki-links]]`.

## Test plan

- [ ] Delete `.vaultcore/templates/` in a test vault, reopen — examples should appear
- [ ] Verify existing user templates are not overwritten on subsequent opens
- [ ] Open template picker (Cmd+Shift+T) — all six should be listed
- [ ] Insert each template — variables should be substituted correctly