### PR TITLE
feat: render inline HTML in editor with DOMPurify sanitization

### DIFF
--- a/src/components/Editor/__tests__/inlineHtml.test.ts
+++ b/src/components/Editor/__tests__/inlineHtml.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtml } from "../inlineHtml";
+
+describe("inlineHtml — sanitizer", () => {
+  it("strips <script> tags", () => {
+    expect(sanitizeHtml('<script>alert("xss")</script>')).toBe("");
+  });
+
+  it("strips onclick attributes", () => {
+    const result = sanitizeHtml('<div onclick="alert(1)">text</div>');
+    expect(result).not.toContain("onclick");
+    expect(result).toContain("text");
+  });
+
+  it("strips onerror attributes", () => {
+    const result = sanitizeHtml('<img src="x" onerror="alert(1)">');
+    expect(result).not.toContain("onerror");
+  });
+
+  it("strips javascript: URLs from href", () => {
+    const result = sanitizeHtml('<a href="javascript:alert(1)">click</a>');
+    expect(result).not.toContain("javascript:");
+  });
+
+  it("strips <iframe> tags", () => {
+    expect(sanitizeHtml('<iframe src="https://evil.com"></iframe>')).toBe("");
+  });
+
+  it("strips <foreignObject> from SVG", () => {
+    const result = sanitizeHtml(
+      '<svg><foreignObject><div onclick="alert(1)">x</div></foreignObject></svg>',
+    );
+    expect(result).not.toContain("foreignObject");
+  });
+
+  it("strips <object> and <embed> tags", () => {
+    expect(sanitizeHtml('<object data="evil.swf"></object>')).toBe("");
+    expect(sanitizeHtml('<embed src="evil.swf">')).toBe("");
+  });
+
+  // ── Allowed tags ────────────────────────────────────────────────────────────
+
+  it("renders <div> with content", () => {
+    const result = sanitizeHtml("<div>hello</div>");
+    expect(result).toBe("<div>hello</div>");
+  });
+
+  it("renders <span> with style", () => {
+    const result = sanitizeHtml('<span style="color: red">red text</span>');
+    expect(result).toContain("color: red");
+    expect(result).toContain("red text");
+  });
+
+  it("renders <details>/<summary>", () => {
+    const result = sanitizeHtml(
+      "<details><summary>Title</summary><p>Content</p></details>",
+    );
+    expect(result).toContain("<details>");
+    expect(result).toContain("<summary>");
+    expect(result).toContain("Title");
+    expect(result).toContain("Content");
+  });
+
+  it("renders <kbd>", () => {
+    const result = sanitizeHtml("<kbd>Ctrl</kbd>+<kbd>C</kbd>");
+    expect(result).toContain("<kbd>");
+    expect(result).toContain("Ctrl");
+  });
+
+  it("renders <sub> and <sup>", () => {
+    expect(sanitizeHtml("H<sub>2</sub>O")).toContain("<sub>2</sub>");
+    expect(sanitizeHtml("x<sup>2</sup>")).toContain("<sup>2</sup>");
+  });
+
+  it("renders <mark>", () => {
+    const result = sanitizeHtml("<mark>highlighted</mark>");
+    expect(result).toContain("<mark>");
+    expect(result).toContain("highlighted");
+  });
+
+  it("renders <br> and <hr>", () => {
+    expect(sanitizeHtml("line<br>break")).toContain("<br>");
+    expect(sanitizeHtml("<hr>")).toContain("<hr>");
+  });
+
+  it("renders <center>", () => {
+    const result = sanitizeHtml("<center>centered</center>");
+    expect(result).toContain("centered");
+  });
+
+  it("renders inline SVG", () => {
+    const svg = '<svg viewBox="0 0 24 24" width="16" height="16"><circle cx="12" cy="12" r="10"/></svg>';
+    const result = sanitizeHtml(svg);
+    expect(result).toContain("<svg");
+    expect(result).toContain("<circle");
+    expect(result).toContain('r="10"');
+  });
+
+  it("preserves class and id attributes", () => {
+    const result = sanitizeHtml('<div class="note" id="intro">text</div>');
+    expect(result).toContain('class="note"');
+    expect(result).toContain('id="intro"');
+  });
+
+  // ── Comments ────────────────────────────────────────────────────────────────
+
+  it("strips HTML comments (DOMPurify removes them)", () => {
+    const result = sanitizeHtml("<!-- this is a comment -->");
+    expect(result).not.toContain("<!--");
+    expect(result).not.toContain("this is a comment");
+  });
+});

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -35,6 +35,7 @@ import { countsPlugin } from "./countsPlugin";
 import type { PaneId } from "../../store/countsStore";
 import { activeViewStore } from "../../store/activeViewStore";
 import { imageAttachmentExtension } from "./imageAttachment";
+import { inlineHtmlPlugin } from "./inlineHtml";
 
 // Debounce sidebar panel re-renders during typing: rapid docChanged updates
 // otherwise flood PropertiesPanel and OutgoingLinksPanel with re-parses on
@@ -87,6 +88,7 @@ export function buildExtensions(
     frontmatterPlugin,
     calloutPlugin,
     taskListPlugin,
+    inlineHtmlPlugin,
     docVersionBumpListener,
     imageAttachmentExtension(),
   ];

--- a/src/components/Editor/inlineHtml.ts
+++ b/src/components/Editor/inlineHtml.ts
@@ -1,0 +1,214 @@
+// Inline HTML rendering CM6 plugin (#70).
+//
+// Walks the Lezer tree for `HTMLBlock` and `HTMLTag` nodes. When the cursor
+// is NOT on the same line(s), the raw HTML source is replaced with a
+// sanitized, rendered DOM widget. When the cursor is on the line, the raw
+// source is shown for editing (same live-preview pattern as livePreview.ts
+// and callouts.ts).
+//
+// HTML comments `<!-- … -->` are replaced with an empty widget so they
+// render as invisible.
+//
+// Security: DOMPurify strips `<script>`, `on*` attributes, `javascript:`
+// URLs, and dangerous SVG features before any HTML reaches the DOM.
+
+import {
+  ViewPlugin,
+  Decoration,
+  WidgetType,
+  type EditorView,
+  type DecorationSet,
+  type ViewUpdate,
+} from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+import DOMPurify from "dompurify";
+
+// ── Sanitizer config ─────────────────────────────────────────────────────────
+
+const PURIFY_CONFIG = {
+  // Allow common safe HTML tags
+  ALLOWED_TAGS: [
+    "div", "span", "p", "br", "hr",
+    "details", "summary",
+    "kbd", "sub", "sup", "mark", "abbr", "small",
+    "b", "i", "em", "strong", "u", "s", "del", "ins",
+    "center",
+    "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption", "colgroup", "col",
+    "ul", "ol", "li", "dl", "dt", "dd",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "blockquote", "pre", "code",
+    "a", "img",
+    // SVG subset
+    "svg", "path", "circle", "rect", "line", "polyline", "polygon",
+    "ellipse", "g", "text", "tspan", "defs", "use", "symbol",
+  ],
+  ALLOWED_ATTR: [
+    "style", "class", "id", "title", "alt", "src", "href", "target",
+    "width", "height", "colspan", "rowspan", "open",
+    // SVG attributes
+    "viewBox", "fill", "stroke", "stroke-width", "stroke-linecap",
+    "stroke-linejoin", "d", "cx", "cy", "r", "rx", "ry",
+    "x", "y", "x1", "y1", "x2", "y2", "points",
+    "xmlns", "transform", "opacity",
+  ],
+  // Block dangerous SVG elements
+  FORBID_TAGS: ["foreignObject", "script", "iframe", "object", "embed"],
+  // Strip all event handlers (on*)
+  FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
+  // Disallow javascript: URLs
+  ALLOW_UNKNOWN_PROTOCOLS: false,
+};
+
+/** Sanitize HTML string, returns safe HTML. Exported for testing. */
+export function sanitizeHtml(raw: string): string {
+  return DOMPurify.sanitize(raw, PURIFY_CONFIG) as unknown as string;
+}
+
+// ── Comment detection ────────────────────────────────────────────────────────
+
+const COMMENT_RE = /^<!--[\s\S]*?-->$/;
+
+function isHtmlComment(text: string): boolean {
+  return COMMENT_RE.test(text.trim());
+}
+
+// ── Widgets ──────────────────────────────────────────────────────────────────
+
+class HtmlBlockWidget extends WidgetType {
+  constructor(readonly html: string) {
+    super();
+  }
+
+  eq(other: HtmlBlockWidget): boolean {
+    return this.html === other.html;
+  }
+
+  toDOM(): HTMLElement {
+    const wrap = document.createElement("div");
+    wrap.className = "cm-html-rendered";
+    wrap.innerHTML = sanitizeHtml(this.html);
+    return wrap;
+  }
+
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+class HtmlInlineWidget extends WidgetType {
+  constructor(readonly html: string) {
+    super();
+  }
+
+  eq(other: HtmlInlineWidget): boolean {
+    return this.html === other.html;
+  }
+
+  toDOM(): HTMLElement {
+    const wrap = document.createElement("span");
+    wrap.className = "cm-html-rendered-inline";
+    wrap.innerHTML = sanitizeHtml(this.html);
+    return wrap;
+  }
+
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+// ── Decoration builder ───────────────────────────────────────────────────────
+
+interface HtmlRange {
+  from: number;
+  to: number;
+  isBlock: boolean;
+  text: string;
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const ranges: HtmlRange[] = [];
+
+  const head = view.state.selection.main.head;
+  const doc = view.state.doc;
+
+  syntaxTree(view.state).iterate({
+    from: view.viewport.from,
+    to: view.viewport.to,
+    enter(node) {
+      if (node.name !== "HTMLBlock" && node.name !== "HTMLTag") return;
+
+      const from = node.from;
+      const to = node.to;
+
+      // If cursor is on any line within this node, show raw source
+      const startLine = doc.lineAt(from).number;
+      const endLine = doc.lineAt(to).number;
+      const cursorLine = doc.lineAt(head).number;
+      if (cursorLine >= startLine && cursorLine <= endLine) return;
+
+      const text = doc.sliceString(from, to);
+
+      // Skip empty strings
+      if (text.trim().length === 0) return;
+
+      ranges.push({
+        from,
+        to,
+        isBlock: node.name === "HTMLBlock",
+        text,
+      });
+    },
+  });
+
+  // Sort by position
+  ranges.sort((a, b) => a.from - b.from);
+
+  for (const r of ranges) {
+    if (isHtmlComment(r.text)) {
+      // Comments become invisible
+      builder.add(r.from, r.to, Decoration.replace({}));
+    } else if (r.isBlock) {
+      builder.add(
+        r.from,
+        r.to,
+        Decoration.replace({
+          widget: new HtmlBlockWidget(r.text),
+          block: true,
+        }),
+      );
+    } else {
+      builder.add(
+        r.from,
+        r.to,
+        Decoration.replace({
+          widget: new HtmlInlineWidget(r.text),
+        }),
+      );
+    }
+  }
+
+  return builder.finish();
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+
+export const inlineHtmlPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged || update.selectionSet) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -240,4 +240,41 @@ export const markdownTheme = EditorView.theme({
     color: "var(--color-text-muted)",
     fontStyle: "italic",
   },
+
+  // ── Inline HTML rendering (#70) ──────────────────────────────────────────
+  ".cm-html-rendered": {
+    display: "block",
+    color: "var(--color-text)",
+    lineHeight: "1.6",
+  },
+  ".cm-html-rendered-inline": {
+    color: "var(--color-text)",
+  },
+  // <kbd> styling
+  ".cm-html-rendered kbd, .cm-html-rendered-inline kbd": {
+    fontFamily: "var(--vc-font-mono)",
+    fontSize: "0.85em",
+    padding: "2px 6px",
+    border: "1px solid var(--color-border)",
+    borderRadius: "3px",
+    backgroundColor: "var(--color-code-bg)",
+    boxShadow: "0 1px 0 rgba(0, 0, 0, 0.08)",
+  },
+  // <details> styling
+  ".cm-html-rendered details": {
+    border: "1px solid var(--color-border)",
+    borderRadius: "4px",
+    padding: "8px 12px",
+    margin: "4px 0",
+  },
+  ".cm-html-rendered details summary": {
+    cursor: "pointer",
+    fontWeight: "600",
+  },
+  // <mark> styling
+  ".cm-html-rendered mark, .cm-html-rendered-inline mark": {
+    backgroundColor: "rgba(255, 213, 79, 0.4)",
+    padding: "1px 2px",
+    borderRadius: "2px",
+  },
 });


### PR DESCRIPTION
## Summary

Closes #70.

- New CM6 `ViewPlugin` finds `HTMLBlock` and `HTMLTag` nodes in the Lezer tree and replaces them with sanitized, rendered DOM widgets
- When the cursor is on the HTML line(s), raw source is shown for editing (same live-preview pattern as callouts)
- HTML comments `<!-- … -->` render as invisible
- DOMPurify strips: `<script>`, `<iframe>`, `<object>`, `<embed>`, `<foreignObject>`, `on*` event handlers, `javascript:` URLs
- Allowed tags: `<div>`, `<span>`, `<details>/<summary>`, `<kbd>`, `<sub>`, `<sup>`, `<mark>`, `<br>`, `<hr>`, `<center>`, inline SVG, tables, and more
- Styles for `<kbd>`, `<details>`, `<mark>` in the CM6 theme
- 18 tests covering sanitizer allow/deny rules

## Test plan

- [ ] Type `<kbd>Ctrl</kbd>+<kbd>C</kbd>` — should render as styled keyboard keys
- [ ] Type `<details><summary>Click me</summary>Hidden content</details>` — should render collapsible
- [ ] Type `<span style="color: red">red</span>` — should render red text
- [ ] Type `<!-- comment -->` — should be invisible
- [ ] Type `<script>alert(1)</script>` — should render as nothing (stripped)
- [ ] Click on a rendered HTML widget — cursor should enter the line and show raw source
- [ ] Move cursor away — should re-render as widget
- [ ] Verify `H<sub>2</sub>O` renders subscript, `x<sup>2</sup>` renders superscript