### PR TITLE
fix: prevent orphan closing tags from disappearing in inline HTML

### DIFF
--- a/src/components/Editor/inlineHtml.ts
+++ b/src/components/Editor/inlineHtml.ts
@@ -3,31 +3,31 @@
 // Walks the Lezer tree for `HTMLBlock` and `HTMLTag` nodes. When the cursor
 // is NOT on the same line(s), the raw HTML source is replaced with a
 // sanitized, rendered DOM widget. When the cursor is on the line, the raw
-// source is shown for editing (same live-preview pattern as livePreview.ts
-// and callouts.ts).
+// source is shown for editing (same live-preview pattern as callouts.ts).
 //
-// HTML comments `<!-- … -->` are replaced with an empty widget so they
+// HTML comments `<!-- … -->` are replaced with an empty decoration so they
 // render as invisible.
+//
+// Uses a StateField (not ViewPlugin) because CM6 requires block-level
+// replace decorations to come from a StateField.
 //
 // Security: DOMPurify strips `<script>`, `on*` attributes, `javascript:`
 // URLs, and dangerous SVG features before any HTML reaches the DOM.
 
 import {
-  ViewPlugin,
   Decoration,
+  EditorView,
   WidgetType,
-  type EditorView,
-  type DecorationSet,
-  type ViewUpdate,
 } from "@codemirror/view";
-import { RangeSetBuilder } from "@codemirror/state";
+import type { DecorationSet } from "@codemirror/view";
+import { EditorState, StateField } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import DOMPurify from "dompurify";
+import type { Extension } from "@codemirror/state";
 
 // ── Sanitizer config ─────────────────────────────────────────────────────────
 
 const PURIFY_CONFIG = {
-  // Allow common safe HTML tags
   ALLOWED_TAGS: [
     "div", "span", "p", "br", "hr",
     "details", "summary",
@@ -52,11 +52,8 @@ const PURIFY_CONFIG = {
     "x", "y", "x1", "y1", "x2", "y2", "points",
     "xmlns", "transform", "opacity",
   ],
-  // Block dangerous SVG elements
   FORBID_TAGS: ["foreignObject", "script", "iframe", "object", "embed"],
-  // Strip all event handlers (on*)
   FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
-  // Disallow javascript: URLs
   ALLOW_UNKNOWN_PROTOCOLS: false,
 };
 
@@ -119,23 +116,13 @@ class HtmlInlineWidget extends WidgetType {
 
 // ── Decoration builder ───────────────────────────────────────────────────────
 
-interface HtmlRange {
-  from: number;
-  to: number;
-  isBlock: boolean;
-  text: string;
-}
+function buildDecorations(state: EditorState): DecorationSet {
+  const ranges: Array<{ from: number; to: number; decoration: Decoration }> = [];
 
-function buildDecorations(view: EditorView): DecorationSet {
-  const builder = new RangeSetBuilder<Decoration>();
-  const ranges: HtmlRange[] = [];
+  const head = state.selection.main.head;
+  const doc = state.doc;
 
-  const head = view.state.selection.main.head;
-  const doc = view.state.doc;
-
-  syntaxTree(view.state).iterate({
-    from: view.viewport.from,
-    to: view.viewport.to,
+  syntaxTree(state).iterate({
     enter(node) {
       if (node.name !== "HTMLBlock" && node.name !== "HTMLTag") return;
 
@@ -149,66 +136,67 @@ function buildDecorations(view: EditorView): DecorationSet {
       if (cursorLine >= startLine && cursorLine <= endLine) return;
 
       const text = doc.sliceString(from, to);
-
-      // Skip empty strings
       if (text.trim().length === 0) return;
 
-      ranges.push({
-        from,
-        to,
-        isBlock: node.name === "HTMLBlock",
-        text,
-      });
+      if (isHtmlComment(text)) {
+        ranges.push({
+          from,
+          to,
+          decoration: Decoration.replace({}),
+        });
+      } else {
+        // Don't replace HTML fragments whose sanitized output is empty
+        // (e.g. a lone `</div>` after a blank line — CommonMark splits
+        // multi-line HTML blocks at blank lines, producing orphan closing
+        // tags that DOMPurify strips entirely).
+        const sanitized = sanitizeHtml(text);
+        if (sanitized.trim().length === 0) return;
+
+        if (node.name === "HTMLBlock") {
+          ranges.push({
+            from,
+            to,
+            decoration: Decoration.replace({
+              widget: new HtmlBlockWidget(text),
+              block: true,
+            }),
+          });
+        } else {
+          ranges.push({
+            from,
+            to,
+            decoration: Decoration.replace({
+              widget: new HtmlInlineWidget(text),
+            }),
+          });
+        }
+      }
     },
   });
 
-  // Sort by position
   ranges.sort((a, b) => a.from - b.from);
 
-  for (const r of ranges) {
-    if (isHtmlComment(r.text)) {
-      // Comments become invisible
-      builder.add(r.from, r.to, Decoration.replace({}));
-    } else if (r.isBlock) {
-      builder.add(
-        r.from,
-        r.to,
-        Decoration.replace({
-          widget: new HtmlBlockWidget(r.text),
-          block: true,
-        }),
-      );
-    } else {
-      builder.add(
-        r.from,
-        r.to,
-        Decoration.replace({
-          widget: new HtmlInlineWidget(r.text),
-        }),
-      );
-    }
-  }
-
-  return builder.finish();
+  return Decoration.set(
+    ranges.map((r) => r.decoration.range(r.from, r.to)),
+    true,
+  );
 }
 
-// ── Plugin ───────────────────────────────────────────────────────────────────
+// ── StateField ───────────────────────────────────────────────────────────────
 
-export const inlineHtmlPlugin = ViewPlugin.fromClass(
-  class {
-    decorations: DecorationSet;
-
-    constructor(view: EditorView) {
-      this.decorations = buildDecorations(view);
-    }
-
-    update(update: ViewUpdate) {
-      if (update.docChanged || update.viewportChanged || update.selectionSet) {
-        this.decorations = buildDecorations(update.view);
-      }
-    }
+const inlineHtmlField = StateField.define<DecorationSet>({
+  create(state) {
+    return buildDecorations(state);
   },
-  {
-    decorations: (v) => v.decorations,
+  update(value, tr) {
+    if (tr.docChanged || tr.selection) {
+      return buildDecorations(tr.state);
+    }
+    return value;
   },
-);
+  provide(f) {
+    return EditorView.decorations.from(f);
+  },
+});
+
+export const inlineHtmlPlugin: Extension = inlineHtmlField;


### PR DESCRIPTION
## Summary

Follow-up fix for #70.

- Migrates `inlineHtmlPlugin` from `ViewPlugin` to `StateField` — CM6 forbids `block: true` decorations in ViewPlugins (`RangeError: Block decorations may not be specified via plugins`)
- Skips replacing HTML fragments whose sanitized output is empty (e.g. a lone `</div>` after a blank line) — CommonMark splits multi-line HTML blocks at blank lines, producing orphan closing tags that DOMPurify strips entirely

## Test plan

- [x] `<div style="color:red">HALLO</div>` on a single line renders correctly
- [x] Multi-line HTML with blank lines: closing `</div>` stays visible
- [x] All 451 tests pass