### PR TITLE
fix: close open tabs when their file is deleted from the sidebar (#102)

### DIFF
--- a/e2e/specs/delete.spec.ts
+++ b/e2e/specs/delete.spec.ts
@@ -91,12 +91,7 @@ describe("Delete file", () => {
     );
   });
 
-  // BUG #102: app-initiated deletes are filtered from the FS watcher by
-  // write_ignore, so the frontend never receives kind:"delete" and
-  // Sidebar.svelte:112 never calls tabStore.closeByPath(). Skip until the
-  // Rust side emits a dedicated delete notification (or stops recording
-  // the source path in write_ignore).
-  it.skip("closes the open tab when its backing file is deleted", async () => {
+  it("closes the open tab when its backing file is deleted", async () => {
     await openSidebarNote("Ideas.md");
     const activeLabel = await browser.$(".vc-tab--active .vc-tab-label");
     await activeLabel.waitForDisplayed({ timeout: 3000 });

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -424,10 +424,29 @@ pub fn delete_file_impl(state: &VaultState, path: String) -> Result<(), VaultErr
 
 #[tauri::command]
 pub async fn delete_file(
+    app: tauri::AppHandle,
     state: tauri::State<'_, VaultState>,
     path: String,
 ) -> Result<(), VaultError> {
-    delete_file_impl(&state, path)
+    use tauri::Emitter;
+    // Canonicalize before delete so the emitted path matches the form the
+    // watcher would have used (and matches how tabs/sidebar store paths).
+    let canonical_str = std::fs::canonicalize(&path)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.clone());
+    delete_file_impl(&state, path)?;
+    // Bug #102: the watcher suppresses this delete via write_ignore (D-12),
+    // so emit a synthetic file_changed event so tabs bound to the deleted
+    // path close.
+    let _ = app.emit(
+        crate::watcher::FILE_CHANGED_EVENT,
+        crate::watcher::FileChangePayload {
+            path: canonical_str,
+            kind: "delete".to_string(),
+            new_path: None,
+        },
+    );
+    Ok(())
 }
 
 // ─── move_file ───────────────────────────────────────────────────────────────

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -59,7 +59,7 @@ pub struct VaultStatusPayload {
 
 // ─── Event name constants ───────────────────────────────────────────────────────
 
-const FILE_CHANGED_EVENT: &str = "vault://file_changed";
+pub const FILE_CHANGED_EVENT: &str = "vault://file_changed";
 const BULK_CHANGE_START_EVENT: &str = "vault://bulk_change_start";
 const BULK_CHANGE_END_EVENT: &str = "vault://bulk_change_end";
 const VAULT_STATUS_EVENT: &str = "vault://vault_status";


### PR DESCRIPTION
## Summary

- Fixes #102: after `Move to Trash` from the sidebar, any tab backed by the deleted file stayed open and silently wrote to a stale path under `.trash/`.
- `delete_file` now emits a synthetic `vault://file_changed` event with `kind: "delete"` after the rename into `.trash/`, so `Sidebar.handleFileChange` can call `tabStore.closeByPath`. The watcher's `write_ignore` suppression stays in place — we don't want a double event.
- Unskipped the pre-existing E2E assertion that guards this flow.

## Implementation notes

- Event emission lives in the Tauri command wrapper, not in `delete_file_impl`, so unit tests that drive the `_impl` helper keep working without an `AppHandle`.
- Canonicalize the path before the delete so the emitted path matches the form the watcher would have used and the shape tabs/sidebar store (`${vaultPath}/${relPath}`).
- Exposed `FILE_CHANGED_EVENT` + reused the existing `FileChangePayload` struct so the frontend contract stays stable (no new event type).

## Test plan

- [x] `cargo test` — 193/193 pass
- [x] `pnpm test:e2e --spec ./e2e/specs/delete.spec.ts` — 3/3 pass (including the previously-skipped `closes the open tab when its backing file is deleted`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)