### PR TITLE
fix: retry IndexWriter lock acquisition and surface IndexLocked (#108)

### DIFF
--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -174,16 +174,21 @@ pub async fn open_vault(
         *handle = None; // drops old debouncer, stops previous watch
     }
 
-    let coordinator = {
+    // Drop the previous coordinator before the lock guard goes out of scope so
+    // its `Drop`-time Shutdown is sent before we try to acquire a new writer
+    // on the same vault directory. The `acquire_writer_with_retry` inside the
+    // new `IndexCoordinator::new` will retry through the brief window where
+    // the old writer is still draining, but releasing earlier shortens it.
+    {
         let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
             std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
         ))?;
         *guard = None;
-        crate::indexer::IndexCoordinator::new(&canonical).map_err(|e| {
-            log::error!("Failed to create IndexCoordinator: {e:?}");
-            e
-        })?
-    };
+    }
+    let coordinator = crate::indexer::IndexCoordinator::new(&canonical).await.map_err(|e| {
+        log::error!("Failed to create IndexCoordinator: {e:?}");
+        e
+    })?;
 
     let vault_info = coordinator.index_vault(&canonical, &app).await.map_err(|e| {
         log::error!("index_vault failed: {e:?}");

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -22,6 +22,9 @@ pub enum VaultError {
     #[error("Index corrupt, rebuild needed")]
     IndexCorrupt,
 
+    #[error("Search index is locked by another process")]
+    IndexLocked,
+
     #[error("Vault unavailable: {path}")]
     VaultUnavailable { path: String },
 
@@ -42,6 +45,7 @@ impl VaultError {
             Self::PermissionDenied { .. } => "PermissionDenied",
             Self::DiskFull => "DiskFull",
             Self::IndexCorrupt => "IndexCorrupt",
+            Self::IndexLocked => "IndexLocked",
             Self::VaultUnavailable { .. } => "VaultUnavailable",
             Self::MergeConflict { .. } => "MergeConflict",
             Self::InvalidEncoding { .. } => "InvalidEncoding",

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -28,8 +28,9 @@ use link_graph::{LinkGraph, extract_links};
 use tag_index::TagIndex;
 use frontmatter::parse_frontmatter;
 
+use tantivy::directory::error::LockError;
 use tantivy::schema::Schema;
-use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, Term};
+use tantivy::{doc, Index, IndexReader, IndexWriter, ReloadPolicy, TantivyError, Term};
 use tokio::sync::mpsc;
 
 use crate::error::VaultError;
@@ -135,7 +136,12 @@ impl Drop for IndexCoordinator {
 
 impl IndexCoordinator {
     /// Create a new coordinator and spawn the background write-queue consumer.
-    pub fn new(vault_path: &Path) -> Result<Self, VaultError> {
+    ///
+    /// The Tantivy `IndexWriter` is acquired *eagerly* (with retry) before the
+    /// task is spawned. This is what surfaces `IndexLocked` / `IndexCorrupt`
+    /// errors back to the caller instead of letting the writer task die
+    /// silently after `new` already returned `Ok` (issue #108).
+    pub async fn new(vault_path: &Path) -> Result<Self, VaultError> {
         let (schema, path_field, title_field, body_field) = tantivy_index::build_schema();
 
         let vaultcore_dir = vault_path.join(".vaultcore");
@@ -159,6 +165,11 @@ impl IndexCoordinator {
             .try_into()
             .map_err(|_| VaultError::IndexCorrupt)?;
 
+        // Acquire the writer here so a `LockBusy` failure (issue #108) is
+        // visible to `open_vault` — and to the user — instead of being
+        // logged once and then silently swallowed by an exiting task.
+        let writer = acquire_writer_with_retry(&index).await?;
+
         let index = Arc::new(index);
         let reader = Arc::new(reader);
         let file_index = Arc::new(Mutex::new(FileIndex::new()));
@@ -171,15 +182,14 @@ impl IndexCoordinator {
         let (tx, rx) = mpsc::channel::<IndexCmd>(CHANNEL_CAPACITY);
 
         // Spawn the single writer task.
-        let index_clone = Arc::clone(&index);
         let reader_clone = Arc::clone(&reader);
         let file_index_clone = Arc::clone(&file_index);
         let link_graph_clone = Arc::clone(&link_graph);
         let tag_index_clone = Arc::clone(&tag_index);
         tokio::spawn(async move {
             run_queue_consumer(
+                writer,
                 rx,
-                index_clone,
                 reader_clone,
                 file_index_clone,
                 link_graph_clone,
@@ -369,8 +379,8 @@ impl IndexCoordinator {
 
 #[allow(clippy::too_many_arguments)]
 async fn run_queue_consumer(
+    mut writer: IndexWriter,
     mut rx: mpsc::Receiver<IndexCmd>,
-    index: Arc<Index>,
     reader: Arc<IndexReader>,
     file_index: Arc<Mutex<FileIndex>>,
     link_graph: Arc<Mutex<LinkGraph>>,
@@ -380,14 +390,6 @@ async fn run_queue_consumer(
     title_field: tantivy::schema::Field,
     body_field: tantivy::schema::Field,
 ) {
-    let mut writer: IndexWriter = match index.writer(WRITER_HEAP_BYTES) {
-        Ok(w) => w,
-        Err(e) => {
-            log::error!("Failed to create IndexWriter: {e}");
-            return;
-        }
-    };
-
     while let Some(cmd) = rx.recv().await {
         match cmd {
             IndexCmd::AddFile { path, title, body, .. } => {
@@ -513,6 +515,51 @@ async fn run_queue_consumer(
     }
     // `writer` drops here, releasing the write lock on the index directory.
     log::info!("IndexCoordinator write queue shut down");
+}
+
+// ── Writer acquisition with retry ────────────────────────────────────────────
+
+/// Backoff schedule for `acquire_writer_with_retry`. Total ≈ 1.55 s — long
+/// enough to outlast the previous coordinator's `Drop`-then-Shutdown drain on
+/// vault re-open, short enough that a real "another instance is running"
+/// failure surfaces to the user quickly.
+const ACQUIRE_BACKOFF_MS: &[u64] = &[50, 100, 200, 400, 800];
+
+/// Try to acquire the Tantivy `IndexWriter`, retrying on transient
+/// `LockBusy` failures.
+///
+/// On `LockBusy` after the full backoff is exhausted, returns
+/// `VaultError::IndexLocked` so `open_vault` can show a dedicated toast
+/// instead of degrading silently. Any other Tantivy error maps to
+/// `VaultError::IndexCorrupt`, matching the existing rebuild-recovery flow.
+async fn acquire_writer_with_retry(index: &Index) -> Result<IndexWriter, VaultError> {
+    let total = ACQUIRE_BACKOFF_MS.len() + 1;
+    for attempt in 0..total {
+        match index.writer(WRITER_HEAP_BYTES) {
+            Ok(w) => {
+                if attempt > 0 {
+                    log::info!("IndexWriter acquired on retry {attempt}");
+                }
+                return Ok(w);
+            }
+            Err(TantivyError::LockFailure(LockError::LockBusy, _)) => {
+                if let Some(&delay) = ACQUIRE_BACKOFF_MS.get(attempt) {
+                    log::warn!(
+                        "IndexWriter LockBusy (attempt {attempt}), retrying in {delay}ms"
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                } else {
+                    log::error!("IndexWriter LockBusy after {total} attempts — giving up");
+                    return Err(VaultError::IndexLocked);
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to create IndexWriter: {e}");
+                return Err(VaultError::IndexCorrupt);
+            }
+        }
+    }
+    unreachable!("loop body always either returns or sleeps before exiting");
 }
 
 // ── Walk helper ───────────────────────────────────────────────────────────────

--- a/src-tauri/src/tests/indexer.rs
+++ b/src-tauri/src/tests/indexer.rs
@@ -200,7 +200,7 @@ mod orphan_cleanup_tests {
 
         // ── Session 1: index both files ──
         {
-            let coord = IndexCoordinator::new(vault).expect("coordinator 1");
+            let coord = IndexCoordinator::new(vault).await.expect("coordinator 1");
             add_and_commit(&coord, &a_path, "A", "alpha body").await;
             add_and_commit(&coord, &b_path, "B", "bravo body").await;
             wait_for_drain(&coord).await;
@@ -223,13 +223,15 @@ mod orphan_cleanup_tests {
         // Simulate the vault mutation that happens between sessions.
         std::fs::remove_file(&b_path).unwrap();
 
-        // Give the previous writer task a moment to process Shutdown and drop
-        // its IndexWriter. In production, Drop + channel close already serialises
-        // this; the sleep just keeps the test deterministic across schedulers.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // The previous test sleep around Shutdown drain is now redundant —
+        // `IndexCoordinator::new` itself retries the writer acquisition for
+        // ~1.5 s (issue #108). Keeping a small sleep so the test still
+        // exercises the common path (writer acquired on first attempt) rather
+        // than the retry path.
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         // ── Session 2: new coordinator, only a.md gets re-added ──
-        let coord2 = IndexCoordinator::new(vault).expect("coordinator 2");
+        let coord2 = IndexCoordinator::new(vault).await.expect("coordinator 2");
         // IndexCoordinator::new already enqueued DeleteAll. Now mirror what
         // index_vault does when b.md is missing from disk: only a.md lands.
         add_and_commit(&coord2, &a_path, "A", "alpha body").await;
@@ -254,8 +256,89 @@ mod orphan_cleanup_tests {
         // guards against any regression where DeleteAll fails on an index
         // that has zero segments.
         let tmp = TempDir::new().unwrap();
-        let coord = IndexCoordinator::new(tmp.path()).expect("coordinator");
+        let coord = IndexCoordinator::new(tmp.path()).await.expect("coordinator");
         wait_for_drain(&coord).await;
         assert_eq!(total_docs(&coord.reader), 0);
+    }
+}
+
+// ─── Writer lock acquisition retry (issue #108) ──────────────────────────────
+//
+// `IndexCoordinator::new` must surface a writer-lock acquisition failure to
+// the caller instead of letting the background task die silently. These tests
+// hold a real `tantivy::Index::writer` on the would-be vault index directory
+// to simulate the two flavours of lock contention from issue #108:
+// - releases within the retry window (vault re-open race) → coordinator wins
+// - never releases (another process holds it) → coordinator returns IndexLocked
+#[cfg(test)]
+mod writer_lock_tests {
+    use std::time::Duration;
+
+    use tantivy::Index;
+    use tempfile::TempDir;
+
+    use crate::error::VaultError;
+    use crate::indexer::tantivy_index::{build_schema, open_or_create_index, write_version};
+    use crate::indexer::IndexCoordinator;
+
+    /// 50 MB heap budget — same value `IndexCoordinator` itself uses. The
+    /// actual budget doesn't matter for these tests; only that the writer
+    /// acquires the directory lock.
+    const HEAP: usize = 50_000_000;
+
+    fn vault_index_path(vault: &std::path::Path) -> std::path::PathBuf {
+        vault.join(".vaultcore").join("index").join("tantivy")
+    }
+
+    /// Pre-open a Tantivy index at the same location `IndexCoordinator::new`
+    /// will reach for, and return a live writer that holds the directory lock.
+    ///
+    /// Writes the schema-version stamp first so `IndexCoordinator::new` skips
+    /// its schema-mismatch path, which would `remove_dir_all` the index
+    /// directory (including our lockfile) before trying to open a writer.
+    fn lock_vault_index(vault: &std::path::Path) -> tantivy::IndexWriter {
+        write_version(&vault.join(".vaultcore")).expect("seed version stamp");
+        let (schema, _, _, _) = build_schema();
+        let dir = vault_index_path(vault);
+        let index: Index = open_or_create_index(&dir, &schema).expect("pre-open index");
+        index.writer(HEAP).expect("acquire holding writer")
+    }
+
+    #[tokio::test]
+    async fn coordinator_succeeds_when_lock_releases_within_retry_window() {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path().to_path_buf();
+
+        // Hold the directory lock, then release it after 150 ms — well inside
+        // the 1.55 s backoff schedule, so the third retry should succeed.
+        let holder = lock_vault_index(&vault);
+        let release_at = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            drop(holder);
+        });
+
+        let coord = IndexCoordinator::new(&vault)
+            .await
+            .expect("retry must eventually acquire writer once holder drops");
+        release_at.await.unwrap();
+
+        // Sanity-check the coordinator is actually functional, not just a
+        // half-initialised shell that happened to construct.
+        coord.tx.send(crate::indexer::IndexCmd::Commit).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn coordinator_returns_index_locked_when_lock_held_persistently() {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path().to_path_buf();
+
+        // Holder lives for the entire test — every retry attempt sees LockBusy.
+        let _holder = lock_vault_index(&vault);
+
+        match IndexCoordinator::new(&vault).await {
+            Ok(_) => panic!("expected IndexLocked, got Ok"),
+            Err(VaultError::IndexLocked) => {}
+            Err(other) => panic!("expected IndexLocked, got {other:?}"),
+        }
     }
 }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -8,6 +8,7 @@ export type VaultErrorKind =
   | "PermissionDenied"
   | "DiskFull"
   | "IndexCorrupt"
+  | "IndexLocked"
   | "VaultUnavailable"
   | "MergeConflict"
   | "InvalidEncoding"
@@ -51,6 +52,8 @@ export function vaultErrorCopy(err: VaultError): string {
       return "File system error. Check the folder and try again.";
     case "IndexCorrupt":
       return "Index corrupt. VaultCore will rebuild it.";
+    case "IndexLocked":
+      return "Search index is in use by another window or a stuck VaultCore process. Close other instances or restart VaultCore.";
     case "MergeConflict":
       return `Conflict in ${err.data ?? "file"} — local version kept.`;
     default: {


### PR DESCRIPTION
## Summary

Fixes #108. The Tantivy `IndexWriter` is now acquired eagerly inside `IndexCoordinator::new` with exponential backoff, so a `LockBusy` failure surfaces to `open_vault` as a real `VaultError` instead of being logged once and then silently swallowed by the exiting background task.

Before: when the writer task failed to acquire the lock, it logged the error and `return`ed. The coordinator's mpsc sender stayed alive but nothing drained it — search, live indexing, backlinks, tags all silently stopped, with no UI feedback.

After: failure is visible. The user sees a toast that points at the actual cause (other instance / stuck process) instead of the generic IndexCorrupt rebuild dialog.

## Changes

- **`acquire_writer_with_retry`** retries `index.writer()` on `LockBusy` with the schedule `50, 100, 200, 400, 800` ms (~1.55 s total). Long enough to outlast the vault re-open race where the previous coordinator's `Drop`-time Shutdown hasn't drained yet; short enough that a real "another instance" case surfaces quickly.
- **New `VaultError::IndexLocked`** variant + frontend mirror in `src/types/errors.ts`. Mapped to a dedicated toast: *"Search index is in use by another window or a stuck VaultCore process. Close other instances or restart VaultCore."* Other Tantivy errors still map to `IndexCorrupt`, preserving the existing rebuild-recovery flow.
- **`IndexCoordinator::new` is now `async`** so it can `tokio::time::sleep` between retries. The only production caller (`open_vault`) was already async; the pre-coordinator lock-guard is now dropped before the `.await` so the resulting future stays `Send`.
- **`run_queue_consumer`** receives the live `IndexWriter` as a parameter — the writer is no longer lazily created inside the spawned task.
- The test that previously needed a 200 ms sleep to outlast the race now needs only 50 ms (the new code's retry covers the rest).

## Tests

- New `writer_lock_tests::coordinator_succeeds_when_lock_releases_within_retry_window` — pre-opens a Tantivy writer on the would-be vault index dir, drops it after 150 ms, asserts the coordinator construction succeeds via the retry path.
- New `writer_lock_tests::coordinator_returns_index_locked_when_lock_held_persistently` — holds the writer for the full test, asserts `Err(IndexLocked)`.
- Both tests seed the schema-version stamp first so `IndexCoordinator::new` doesn't take its schema-mismatch wipe path (which would `remove_dir_all` the directory the holder is locking).

## Verification

- `cargo test --lib` — 189/189 passing in scope. (6 pre-existing `tests::files_ops::*` failures on macOS due to `/var` ↔ `/private/var` symlink canonicalization — exist on `main` without these changes, not touched here.)
- `pnpm typecheck` — clean
- `pnpm test` — 463/463 passing

## Out of scope

- Stale-lock detection (cleaning up a `.tantivy-writer.lock` whose holder PID no longer exists) — listed in #108 as a future direction. The retry handles the common race; explicit stale-lock cleanup would help the crash-recovery path and is worth its own change.
- Single-instance app lock to rule out the multi-instance cause — also from #108, separate concern.