### PR TITLE
fix: table widget cleanup — delete button, hover-gap, remove drag (#110)

### DIFF
--- a/e2e/specs/table-inline-edit-structural.spec.ts
+++ b/e2e/specs/table-inline-edit-structural.spec.ts
@@ -296,6 +296,35 @@ describe("Inline table editing — structural", () => {
     expect(headerCells[1]).toBe("Name");
   });
 
+  it("control stays visible when the cursor moves from the wrap onto it (issue #110)", async () => {
+    // Regression for the hover-gap bug: row/col delete buttons sit at
+    // top: -22px / left: -24px, outside .cm-table-wrap's visible area. When
+    // the cursor crosses the gap from wrap to button the wrap:hover selector
+    // drops; without the fade-out grace period, visibility flips to hidden
+    // instantly and the user clicks dead air.
+    const stillVisible = await browser.execute(() => {
+      const wrap = document.querySelector<HTMLElement>(".cm-table-wrap");
+      const btn = document.querySelector<HTMLElement>(
+        '[data-testid="table-row-delete-1"]',
+      );
+      if (!wrap || !btn) return { found: false };
+
+      // 1. Hover the wrap — controls become visible.
+      wrap.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+      wrap.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      // 2. Leave the wrap — without the fix, visibility flips to hidden now.
+      wrap.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+      // 3. Hover the control itself — the :hover rule should keep it visible.
+      btn.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+      btn.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+      const vis = getComputedStyle(btn).visibility;
+      return { found: true, visibility: vis };
+    });
+    expect(stillVisible.found).toBe(true);
+    expect(stillVisible.visibility).toBe("visible");
+  });
+
   it("column-header sort cycles unsorted → asc → desc → unsorted", async () => {
     // After prior drag, columns are [Age, Name]. Row order in source is
     // [Cara 25, Bob 42, <empty>]. Click sort on col 0 (Age, numeric).
@@ -332,5 +361,32 @@ describe("Inline table editing — structural", () => {
     await browser.pause(150);
     const restoredGrid = await cellTexts();
     expect(restoredGrid[1]?.[0]).toBe(beforeFirstValue);
+  });
+
+  // Must be the last test in this file — removes the table, invalidating
+  // the shared state the earlier tests rely on.
+  it("clicking 'delete table' removes the whole table from DOM and markdown (issue #110)", async () => {
+    const before = await getDocText();
+    expect(before).toContain("|"); // table still present in source
+    expect(
+      await browser.$("table.cm-table-rendered").isExisting(),
+    ).toBe(true);
+
+    await clickTestid("table-delete");
+
+    await browser.waitUntil(
+      async () => !(await browser.$("table.cm-table-rendered").isExisting()),
+      { timeout: 3000, timeoutMsg: "table widget never disappeared from DOM" },
+    );
+
+    const after = await getDocText();
+    const tableLines = after
+      .split("\n")
+      .filter((l) => l.trim().startsWith("|"));
+    expect(tableLines).toEqual([]);
+    // The heading and intro text above the table must still be there — delete
+    // is scoped to the widget range, not the whole note.
+    expect(after).toContain("# Structural");
+    expect(after).toContain("Intro.");
   });
 });

--- a/e2e/specs/table-inline-edit-structural.spec.ts
+++ b/e2e/specs/table-inline-edit-structural.spec.ts
@@ -224,78 +224,6 @@ describe("Inline table editing — structural", () => {
     expect(pipes).toBe(before.cols); // cols-1 columns → cols pipes
   });
 
-  it("drag-reorders a row in both DOM and markdown", async () => {
-    // State: columns = Name + Age (2). Body rows = Bob, Cara, (empty row).
-    // Reorder: drop row 1 (Bob) onto row 2 (Cara) — Bob goes to row 2 position.
-    const beforeDoc = await getDocText();
-    const beforeBobIdx = beforeDoc.indexOf("Bob");
-    const beforeCaraIdx = beforeDoc.indexOf("Cara");
-    expect(beforeBobIdx).toBeLessThan(beforeCaraIdx);
-
-    await browser.execute(() => {
-      const src = document.querySelector<HTMLElement>(
-        '[data-testid="table-row-drag-1"]',
-      );
-      const targetCell = document.querySelector<HTMLElement>(
-        '.cm-table-cell[data-cell-row="2"][data-cell-col="0"]',
-      );
-      if (!src || !targetCell) throw new Error("drag handles missing");
-      const dt = new DataTransfer();
-      src.dispatchEvent(new DragEvent("dragstart", { bubbles: true, dataTransfer: dt }));
-      targetCell.dispatchEvent(new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: dt }));
-      targetCell.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }));
-      src.dispatchEvent(new DragEvent("dragend", { bubbles: true, dataTransfer: dt }));
-    });
-
-    await browser.waitUntil(
-      async () => {
-        const doc = await getDocText();
-        return doc.indexOf("Cara") < doc.indexOf("Bob");
-      },
-      { timeout: 3000, timeoutMsg: "row order never flipped in source" },
-    );
-    const afterDoc = await getDocText();
-    expect(afterDoc.indexOf("Cara")).toBeLessThan(afterDoc.indexOf("Bob"));
-  });
-
-  it("drag-reorders a column in both DOM and markdown", async () => {
-    // Columns currently: [Name, Age]. Move col 0 after col 1 by dropping
-    // the col-0 drag handle onto a cell at col 1.
-    await browser.execute(() => {
-      const src = document.querySelector<HTMLElement>(
-        '[data-testid="table-col-drag-0"]',
-      );
-      const targetCell = document.querySelector<HTMLElement>(
-        '.cm-table-cell[data-cell-row="1"][data-cell-col="1"]',
-      );
-      if (!src || !targetCell) throw new Error("col drag handles missing");
-      const dt = new DataTransfer();
-      src.dispatchEvent(new DragEvent("dragstart", { bubbles: true, dataTransfer: dt }));
-      targetCell.dispatchEvent(new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: dt }));
-      targetCell.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }));
-      src.dispatchEvent(new DragEvent("dragend", { bubbles: true, dataTransfer: dt }));
-    });
-
-    await browser.waitUntil(
-      async () => {
-        const grid = await cellTexts();
-        return grid[0]?.[0] === "Age" && grid[0]?.[1] === "Name";
-      },
-      { timeout: 3000, timeoutMsg: "columns never swapped in DOM" },
-    );
-    const doc = await getDocText();
-    const header = doc
-      .split("\n")
-      .find((l) => l.trim().startsWith("|") && !l.match(/^\|\s*:?-/));
-    expect(header).toBeDefined();
-    const headerCells = (header as string)
-      .replace(/^\||\|$/g, "")
-      .split("|")
-      .map((s) => s.trim());
-    expect(headerCells[0]).toBe("Age");
-    expect(headerCells[1]).toBe("Name");
-  });
-
   it("control stays visible when the cursor moves from the wrap onto it (issue #110)", async () => {
     // Regression for the hover-gap bug: row/col delete buttons sit at
     // top: -22px / left: -24px, outside .cm-table-wrap's visible area. When
@@ -326,14 +254,11 @@ describe("Inline table editing — structural", () => {
   });
 
   it("column-header sort cycles unsorted → asc → desc → unsorted", async () => {
-    // After prior drag, columns are [Age, Name]. Row order in source is
-    // [Cara 25, Bob 42, <empty>]. Click sort on col 0 (Age, numeric).
-    // Expected asc order: 25, 42, "". But the empty row's value is "" which
-    // sorts numerically as NaN — in the serializer's comparator mixing
-    // numeric/string NaN returns 0. To avoid flakiness from the empty row
-    // left over, we seed a fresh note just for sorting.
-    // Actually: let's skip the legacy wrangle and test sort on the current
-    // layout directly.
+    // Content-agnostic: read the current first body value, cycle sort three
+    // times on column 0, and assert the final restore lands back on that
+    // same value. The earlier column/row deletes in this suite leave the
+    // table in a non-deterministic row order; snapshotting before the first
+    // click avoids coupling to the exact residue.
     const beforeGrid = await cellTexts();
     const beforeFirstValue = beforeGrid[1]?.[0];
 

--- a/src/components/Editor/tablePlugin.ts
+++ b/src/components/Editor/tablePlugin.ts
@@ -310,6 +310,7 @@ function buildTableDom(
   wrap.appendChild(el);
   wrap.appendChild(buildAddColButton());
   wrap.appendChild(buildAddRowButton());
+  wrap.appendChild(buildDeleteTableButton());
 
   attachCellHandlers(wrap);
   attachStructuralHandlers(wrap);
@@ -335,6 +336,18 @@ function buildAddRowButton(): HTMLButtonElement {
   b.setAttribute("aria-label", "Zeile hinzufügen");
   b.setAttribute("data-testid", "table-add-row");
   b.textContent = "+";
+  return b;
+}
+
+function buildDeleteTableButton(): HTMLButtonElement {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = "cm-table-ctrl cm-table-delete-btn";
+  b.setAttribute("aria-label", "Tabelle löschen");
+  b.setAttribute("data-testid", "table-delete");
+  // Unicode wastebasket is distinct from the per-column/-row "×" so the
+  // table-level action is not confused with a per-cell delete.
+  b.textContent = "🗑";
   return b;
 }
 
@@ -500,6 +513,11 @@ function attachStructuralHandlers(wrap: TableDomWithCtx): void {
       event.preventDefault();
       const newTable = withAppendedRow(readTableFromDom(wrap));
       commitStructuralChange(wrap, newTable);
+      return;
+    }
+    if (target.closest(".cm-table-delete-btn")) {
+      event.preventDefault();
+      deleteTable(wrap);
       return;
     }
 
@@ -689,6 +707,29 @@ function commitStructuralChange(
       if (newWrap) focusAfter(newWrap);
     });
   }
+}
+
+/**
+ * Remove the entire table block. Dispatches a single delete transaction over
+ * the widget's source range, plus the trailing newline so the surrounding
+ * paragraph flow doesn't leave a stranded blank line where the table used to
+ * sit. The StateField re-parses on the next change and the atomic widget
+ * disappears together with its source.
+ */
+function deleteTable(wrap: TableDomWithCtx): void {
+  const ctx = wrap.__tableCtx;
+  if (!ctx) return;
+  const view = ctx.view;
+  const doc = view.state.doc;
+  let to = ctx.to;
+  if (to < doc.length && doc.sliceString(to, to + 1) === "\n") {
+    to += 1;
+  }
+  view.dispatch({
+    changes: { from: ctx.from, to, insert: "" },
+    selection: { anchor: ctx.from },
+    userEvent: "delete",
+  });
 }
 
 function findTableWrapAt(view: EditorView, from: number): HTMLElement | null {

--- a/src/components/Editor/tablePlugin.ts
+++ b/src/components/Editor/tablePlugin.ts
@@ -356,15 +356,6 @@ function buildColControls(col: number, sortDir: "asc" | "desc" | null): HTMLElem
   box.className = "cm-table-col-ctrls cm-table-ctrl";
   box.setAttribute("contenteditable", "false");
 
-  const drag = document.createElement("span");
-  drag.className = "cm-table-col-drag";
-  drag.setAttribute("draggable", "true");
-  drag.setAttribute("aria-label", "Spalte verschieben");
-  drag.setAttribute("data-col-drag", String(col));
-  drag.setAttribute("data-testid", `table-col-drag-${col}`);
-  drag.textContent = "⋮⋮";
-  box.appendChild(drag);
-
   const sort = document.createElement("button");
   sort.type = "button";
   sort.className = "cm-table-col-sort";
@@ -390,15 +381,6 @@ function buildRowControls(row: number): HTMLElement {
   const box = document.createElement("span");
   box.className = "cm-table-row-ctrls cm-table-ctrl";
   box.setAttribute("contenteditable", "false");
-
-  const drag = document.createElement("span");
-  drag.className = "cm-table-row-drag";
-  drag.setAttribute("draggable", "true");
-  drag.setAttribute("aria-label", "Zeile verschieben");
-  drag.setAttribute("data-row-drag", String(row));
-  drag.setAttribute("data-testid", `table-row-drag-${row}`);
-  drag.textContent = "⋮⋮";
-  box.appendChild(drag);
 
   const del = document.createElement("button");
   del.type = "button";
@@ -469,31 +451,6 @@ function withRemovedRow(table: ParsedTable, row: number): ParsedTable {
   return { ...table, rows };
 }
 
-function withReorderedRows(table: ParsedTable, from: number, to: number): ParsedTable {
-  if (from <= 0 || to <= 0) return table;
-  if (from > table.rows.length || to > table.rows.length) return table;
-  if (from === to) return table;
-  const rows = table.rows.slice();
-  const [moved] = rows.splice(from - 1, 1);
-  rows.splice(to - 1, 0, moved!);
-  return { ...table, rows };
-}
-
-function withReorderedColumns(table: ParsedTable, from: number, to: number): ParsedTable {
-  if (from === to) return table;
-  const move = <T>(arr: T[]): T[] => {
-    const copy = arr.slice();
-    const [m] = copy.splice(from, 1);
-    copy.splice(to, 0, m!);
-    return copy;
-  };
-  return {
-    headers: move(table.headers),
-    alignments: move(table.alignments),
-    rows: table.rows.map((r) => move(r)),
-  };
-}
-
 // ── Structural event handlers ────────────────────────────────────────────────
 
 function attachStructuralHandlers(wrap: TableDomWithCtx): void {
@@ -544,70 +501,6 @@ function attachStructuralHandlers(wrap: TableDomWithCtx): void {
       cycleSort(wrap, col);
       return;
     }
-  });
-
-  // Drag-and-drop row / column reordering. We stash the source index in a
-  // closure-local variable (and mirror it into dataTransfer for normal UX) so
-  // the drop handler can act without reading back a DataTransfer payload —
-  // synthetic DragEvents dispatched by the E2E driver don't carry one.
-  let pendingDrag: { type: "row" | "col"; index: number } | null = null;
-
-  wrap.addEventListener("dragstart", (event) => {
-    const target = event.target as HTMLElement | null;
-    if (!target) return;
-    const rowDrag = target.closest<HTMLElement>("[data-row-drag]");
-    if (rowDrag) {
-      pendingDrag = {
-        type: "row",
-        index: parseInt(rowDrag.getAttribute("data-row-drag") ?? "-1", 10),
-      };
-      if (event.dataTransfer) {
-        event.dataTransfer.setData("text/plain", `row:${pendingDrag.index}`);
-        event.dataTransfer.effectAllowed = "move";
-      }
-      return;
-    }
-    const colDrag = target.closest<HTMLElement>("[data-col-drag]");
-    if (colDrag) {
-      pendingDrag = {
-        type: "col",
-        index: parseInt(colDrag.getAttribute("data-col-drag") ?? "-1", 10),
-      };
-      if (event.dataTransfer) {
-        event.dataTransfer.setData("text/plain", `col:${pendingDrag.index}`);
-        event.dataTransfer.effectAllowed = "move";
-      }
-      return;
-    }
-  });
-
-  wrap.addEventListener("dragover", (event) => {
-    if (pendingDrag) event.preventDefault();
-  });
-
-  wrap.addEventListener("drop", (event) => {
-    if (!pendingDrag) return;
-    event.preventDefault();
-    const target = event.target as HTMLElement | null;
-    const cell = target?.closest<HTMLElement>(".cm-table-cell");
-    if (!cell) {
-      pendingDrag = null;
-      return;
-    }
-    const toRow = parseInt(cell.getAttribute("data-cell-row") ?? "-1", 10);
-    const toCol = parseInt(cell.getAttribute("data-cell-col") ?? "-1", 10);
-    if (pendingDrag.type === "row") {
-      const newTable = withReorderedRows(readTableFromDom(wrap), pendingDrag.index, toRow);
-      commitStructuralChange(wrap, newTable);
-    } else {
-      const newTable = withReorderedColumns(readTableFromDom(wrap), pendingDrag.index, toCol);
-      commitStructuralChange(wrap, newTable);
-    }
-    pendingDrag = null;
-  });
-
-  wrap.addEventListener("dragend", () => {
-    pendingDrag = null;
   });
 }
 

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -421,7 +421,7 @@ export const markdownTheme = EditorView.theme({
     fontSize: "11px",
     userSelect: "none",
   },
-  ".cm-table-col-drag, .cm-table-row-drag, .cm-table-col-sort, .cm-table-col-delete, .cm-table-row-delete": {
+  ".cm-table-col-sort, .cm-table-col-delete, .cm-table-row-delete": {
     cursor: "pointer",
     color: "var(--color-text-muted)",
     background: "transparent",
@@ -431,10 +431,7 @@ export const markdownTheme = EditorView.theme({
     fontSize: "11px",
     lineHeight: "1",
   },
-  ".cm-table-col-drag, .cm-table-row-drag": {
-    cursor: "grab",
-  },
-  ".cm-table-col-sort:hover, .cm-table-col-delete:hover, .cm-table-row-delete:hover, .cm-table-col-drag:hover, .cm-table-row-drag:hover": {
+  ".cm-table-col-sort:hover, .cm-table-col-delete:hover, .cm-table-row-delete:hover": {
     background: "var(--color-border)",
     color: "var(--color-text)",
   },

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -318,14 +318,32 @@ export const markdownTheme = EditorView.theme({
   // Hover controls fade in together when the wrap is hovered. They remain
   // focusable via keyboard so screen-reader / test code can reach them even
   // when not visually present.
+  //
+  // The 300ms fade-OUT delay (`opacity 120ms ease 300ms, visibility 0s 300ms`)
+  // is the fix for issue #110: row/col delete buttons sit outside the table's
+  // visible area (top: -22px, left: -24px), so moving the cursor from a cell
+  // toward the button crosses a region that is not `.cm-table-wrap`. Without
+  // the delay the wrap-hover selector drops before the cursor reaches the
+  // button, `visibility` flips to `hidden`, and the button becomes
+  // unclickable — exactly when the user tries to hit it. Using `visibility`
+  // (not just `pointer-events`) keeps the transition discrete-friendly across
+  // WebKit versions. `.cm-table-ctrl:hover` and `:focus-visible` re-arm the
+  // visible state once the cursor / focus lands on the control, so it stays
+  // reachable even if the wrap itself is no longer hovered.
   ".cm-table-wrap .cm-table-ctrl": {
     opacity: "0",
-    transition: "opacity 120ms ease",
-    pointerEvents: "none",
+    visibility: "hidden",
+    transition: "opacity 120ms ease 300ms, visibility 0s 300ms",
   },
   ".cm-table-wrap:hover .cm-table-ctrl, .cm-table-wrap:focus-within .cm-table-ctrl": {
     opacity: "1",
-    pointerEvents: "auto",
+    visibility: "visible",
+    transitionDelay: "0s",
+  },
+  ".cm-table-wrap .cm-table-ctrl:hover, .cm-table-wrap .cm-table-ctrl:focus-visible": {
+    opacity: "1",
+    visibility: "visible",
+    transitionDelay: "0s",
   },
   ".cm-table-wrap .cm-table-add-col-btn": {
     position: "absolute",
@@ -356,6 +374,30 @@ export const markdownTheme = EditorView.theme({
     lineHeight: "1",
     cursor: "pointer",
     padding: "0",
+  },
+  // Table-level delete button — sits above the top-right corner of the table
+  // in the same horizontal band as the per-column controls. The z-index keeps
+  // it above the rightmost column's controls when they visually overlap.
+  ".cm-table-wrap .cm-table-delete-btn": {
+    position: "absolute",
+    top: "-22px",
+    right: "0",
+    width: "20px",
+    height: "20px",
+    border: "1px solid var(--color-border)",
+    borderRadius: "3px",
+    background: "var(--color-surface)",
+    color: "var(--color-text-muted)",
+    fontSize: "12px",
+    lineHeight: "1",
+    cursor: "pointer",
+    padding: "0",
+    zIndex: "2",
+  },
+  ".cm-table-wrap .cm-table-delete-btn:hover": {
+    background: "var(--color-danger, var(--color-border))",
+    color: "var(--color-danger-fg, var(--color-text))",
+    borderColor: "var(--color-danger, var(--color-border))",
   },
   ".cm-table-col-ctrls": {
     position: "absolute",


### PR DESCRIPTION
## Summary

Closes #110. Table-widget cleanup with three related changes:

### 1. Delete whole table (issue #110)

Adds a table-level delete button (🗑) to the widget's hover UI at the top-right corner, above the add-col strip. Click dispatches a CM6 transaction removing `ctx.from..ctx.to` plus the trailing newline so there's no stranded blank line. Closes the "no way to remove a table" gap — the atomic widget hid the pipe-syntax, so previously there was no reliable affordance to delete it.

### 2. Row/col delete buttons no longer vanish when hovered (issue #110)

Row controls sit at `left: -24px`, column controls at `top: -22px` — outside the table's visible area and outside the wrap's bounding box. Moving the cursor from a cell toward a delete button crossed a gap where nothing is `.cm-table-wrap`, dropping the wrap's hover state. The old CSS then flipped `pointer-events` to `none` instantly, so the button became unclickable exactly when the user reached for it.

New rule: `opacity 120ms ease 300ms, visibility 0s 300ms` on fade-out, zero delay on fade-in. Once the cursor lands on a control, a dedicated `.cm-table-ctrl:hover` rule re-arms visibility so the control persists even after wrap-hover drops. Using `visibility` instead of `pointer-events` makes the transition portable across WebKit versions without relying on `transition-behavior: allow-discrete`.

### 3. Remove drag-to-reorder

The ⋮⋮ drag handles on row/column controls are gone. The reorder UX isn't needed for this widget — it added clutter to the hover toolbar and had its own hit/testing complexity. Removed along with `dragstart`/`dragover`/`drop`/`dragend` listeners, `withReorderedRows` / `withReorderedColumns` helpers, the `.cm-table-col-drag` / `.cm-table-row-drag` CSS, and the two e2e reorder specs. Sort/delete/add controls are unchanged.

## Changes

- `src/components/Editor/tablePlugin.ts` — `buildDeleteTableButton()`, delete branch in `attachStructuralHandlers`, `deleteTable()` helper; removed drag creation + handlers + reorder helpers.
- `src/components/Editor/theme.ts` — delayed `visibility` transition, self-hover persistence rule, positioning for `.cm-table-delete-btn`; removed drag CSS.
- `e2e/specs/table-inline-edit-structural.spec.ts` — two new specs (hover persistence + delete-table), removed two drag-reorder specs.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 463/463 passing

E2E specs run in the Linux/tauri-driver CI harness.