### PR TITLE
fix: sidebar collapse — keep topbar visible and widen editor content (#112)

### DIFF
--- a/src/components/Editor/ReadingView.svelte
+++ b/src/components/Editor/ReadingView.svelte
@@ -149,7 +149,7 @@
   }
 
   .vc-reading-content {
-    max-width: 720px;
+    max-width: var(--vc-editor-max-width, 720px);
     margin: 0 auto;
   }
 

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -65,18 +65,25 @@ export const markdownTheme = EditorView.theme({
   // .cm-content = the centered "page". Surface-white background contrasts
   // gently with the gutter (--color-bg). Subtle border + shadow give it a
   // document-card feel without being heavy.
+  //
+  // Width is driven by `--vc-editor-max-width` (defaults to 720px for the
+  // book-like reading width when the sidebar is visible). VaultLayout raises
+  // it when the sidebar is collapsed so the freed space actually goes to
+  // the editor content (issue #112) instead of being absorbed by growing
+  // gutters — users who collapse the sidebar expect a wider writing area,
+  // not just a relocated one.
   // CSS variable defaults for each callout type. Themes may override these.
   ".cm-content": {
     padding: "32px 24px !important",
     width: "100% !important",
-    maxWidth: "720px !important",
+    maxWidth: "var(--vc-editor-max-width, 720px) !important",
     marginLeft: "auto !important",
     marginRight: "auto !important",
     marginTop: "24px !important",
     marginBottom: "24px !important",
     flexGrow: "0 !important",
     flexShrink: "1 !important",
-    flexBasis: "720px !important",
+    flexBasis: "var(--vc-editor-max-width, 720px) !important",
     backgroundColor: "var(--color-surface) !important",
     borderRadius: "8px !important",
     boxShadow: "0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06) !important",

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -578,7 +578,7 @@
 <div
   class="vc-vault-layout"
   class:vc-vault-layout--dragging={isDragging || isSplitDragging || isRightDragging}
-  style="--sidebar-width: {sidebarCollapsed ? 0 : sidebarWidth}px; --right-sidebar-width: {backlinksOpen ? backlinksWidth : 0}px"
+  style="--sidebar-width: {sidebarCollapsed ? 0 : sidebarWidth}px; --right-sidebar-width: {backlinksOpen ? backlinksWidth : 0}px; --vc-editor-max-width: {sidebarCollapsed ? 1100 : 720}px"
 >
   <!-- Sidebar column -->
   <div

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -593,8 +593,14 @@
     />
   </div>
 
-  <!-- Resize divider -->
-  {#if !sidebarCollapsed}
+  <!-- Resize divider (column 2). Always rendered — a missing element would
+       let CSS grid auto-placement slide every subsequent child one column
+       left, so the editor would land in the `auto` track (col 2) instead of
+       `1fr` (col 3). When collapsed we swap to a zero-width sibling that
+       keeps the placement anchored without showing a visible handle. -->
+  {#if sidebarCollapsed}
+    <div class="vc-layout-divider-hidden" aria-hidden="true"></div>
+  {:else}
     <div
       class="vc-layout-divider"
       class:vc-layout-divider--active={isDragging}
@@ -769,6 +775,10 @@
   .vc-layout-divider:hover,
   .vc-layout-divider--active {
     background: var(--color-accent-bg);
+  }
+
+  .vc-layout-divider-hidden {
+    width: 0;
   }
 
   .vc-layout-editor {

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -607,52 +607,41 @@
 
   <!-- Editor area (3rd column) -->
   <div class="vc-layout-editor" style="--split-ratio: {splitRatio}">
-    <!-- Sidebar collapse toggle (shown when collapsed) -->
-    {#if sidebarCollapsed}
+    <!-- Topbar: always rendered so its buttons (sidebar toggle, backlinks,
+         settings) don't vanish together with the sidebar (issue #112). The
+         sidebar toggle morphs between collapse / expand based on state. -->
+    <div class="vc-editor-topbar">
       <button
-        class="vc-sidebar-expand-btn"
+        class="vc-sidebar-toggle-btn"
         onclick={toggleSidebar}
-        aria-label="Expand sidebar"
-        title="Expand sidebar"
+        aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+        aria-expanded={!sidebarCollapsed}
+        title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
       >
-        &#9654;
+        {#if sidebarCollapsed}&#9654;{:else}&#9664;{/if}
       </button>
-    {/if}
-
-    <!-- Topbar with collapse toggle (shown when sidebar visible) -->
-    {#if !sidebarCollapsed}
-      <div class="vc-editor-topbar">
-        <button
-          class="vc-sidebar-toggle-btn"
-          onclick={toggleSidebar}
-          aria-label="Collapse sidebar"
-          title="Collapse sidebar"
-        >
-          &#9664;
-        </button>
-        <div class="vc-editor-topbar-spacer"></div>
-        <button
-          class="vc-sidebar-toggle-btn vc-backlinks-toggle-btn"
-          class:vc-backlinks-toggle-btn--active={backlinksOpen}
-          onclick={() => backlinksStore.toggle()}
-          aria-label="Backlinks-Panel umschalten"
-          aria-pressed={backlinksOpen}
-          title="Backlinks-Panel umschalten (Cmd/Ctrl+Shift+B)"
-        >
-          <PanelRight size={16} />
-        </button>
-        <button
-          class="vc-sidebar-toggle-btn"
-          class:vc-backlinks-toggle-btn--active={settingsOpen}
-          onclick={() => { settingsOpen = true; }}
-          aria-label="Einstellungen"
-          aria-haspopup="dialog"
-          title="Einstellungen"
-        >
-          <SettingsIcon size={16} />
-        </button>
-      </div>
-    {/if}
+      <div class="vc-editor-topbar-spacer"></div>
+      <button
+        class="vc-sidebar-toggle-btn vc-backlinks-toggle-btn"
+        class:vc-backlinks-toggle-btn--active={backlinksOpen}
+        onclick={() => backlinksStore.toggle()}
+        aria-label="Backlinks-Panel umschalten"
+        aria-pressed={backlinksOpen}
+        title="Backlinks-Panel umschalten (Cmd/Ctrl+Shift+B)"
+      >
+        <PanelRight size={16} />
+      </button>
+      <button
+        class="vc-sidebar-toggle-btn"
+        class:vc-backlinks-toggle-btn--active={settingsOpen}
+        onclick={() => { settingsOpen = true; }}
+        aria-label="Einstellungen"
+        aria-haspopup="dialog"
+        title="Einstellungen"
+      >
+        <SettingsIcon size={16} />
+      </button>
+    </div>
 
     <!-- Editor panes area -->
     <div class="vc-editor-panes">
@@ -843,8 +832,7 @@
     background: var(--color-accent-bg);
   }
 
-  .vc-sidebar-toggle-btn,
-  .vc-sidebar-expand-btn {
+  .vc-sidebar-toggle-btn {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -858,17 +846,9 @@
     font-size: 12px;
   }
 
-  .vc-sidebar-toggle-btn:hover,
-  .vc-sidebar-expand-btn:hover {
+  .vc-sidebar-toggle-btn:hover {
     background: var(--color-accent-bg);
     color: var(--color-accent);
-  }
-
-  .vc-sidebar-expand-btn {
-    position: absolute;
-    left: 8px;
-    top: 50%;
-    transform: translateY(-50%);
   }
 
   .vc-layout-divider-right {


### PR DESCRIPTION
## Summary

Closes #112. Three related fixes for the sidebar-collapse UX.

### 1. Topbar no longer vanishes on collapse

The topbar was gated on `!sidebarCollapsed`, so clicking collapse removed the whole row — taking the collapse button, Backlinks toggle and Settings button with it. Topbar is now rendered unconditionally; the sidebar toggle swaps its glyph (◀ ↔ ▶) and `aria-label` / `title`, so the button stays put across collapse cycles.

### 2. Editor stays anchored in grid column 3 when collapsing

The resize divider was conditionally rendered (`{#if !sidebarCollapsed}`), so collapsing removed the element from the DOM. CSS Grid auto-placement then slid every subsequent child one track to the left: editor landed in column 2 (`auto`) instead of column 3 (`1fr`), right divider landed in column 3, and the right sidebar in column 4. With the right sidebar closed the shift was invisible, but with it open the editor column was `auto`-sized and stopped growing into the freed space — the "editor just inherits the old left panel slot" symptom.

Render a zero-width `.vc-layout-divider-hidden` in place of the resize handle while collapsed so the grid columns stay anchored. The editor now reliably fills the freed left space, matching how collapsing the right sidebar already behaved.

### 3. Editor content card widens when sidebar is collapsed

Even with the grid fixed, `.cm-content` was pinned at `max-width: 720px` (centered). On wider editor columns the extra space became left/right gutter rather than writing area. Card width is now driven by a `--vc-editor-max-width` custom property (default 720 px). VaultLayout bumps it to 1100 px while `sidebarCollapsed`, and Reading view picks up the same variable so preview and edit modes stay in sync.

## Changes

- `src/components/Layout/VaultLayout.svelte` — topbar rendered unconditionally; toggle morphs glyph + aria-label; always-rendered left divider placeholder so grid columns don't shift; `--vc-editor-max-width` set to 1100 px when collapsed, 720 px otherwise.
- `src/components/Editor/theme.ts` — `.cm-content` `max-width` / `flex-basis` read `--vc-editor-max-width` with 720 px fallback.
- `src/components/Editor/ReadingView.svelte` — `.vc-reading-content` `max-width` reads the same var.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 463/463 passing

Existing e2e `sidebar-layout.spec.ts` targets the `aria-label="Collapse sidebar"` / `aria-label="Expand sidebar"` selectors that the new markup keeps, so the toggle behaviour is covered without changes.