### PR TITLE
feat: add 'Open in split' to file-tree context menu (#114)

### DIFF
--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -237,6 +237,12 @@
     isNewEntry = false;
   }
 
+  function handleOpenInSplit() {
+    closeContextMenu();
+    tabStore.openTab(entry.path);
+    tabStore.moveToPane("right");
+  }
+
   function getVaultRoot(): string | null {
     let v: string | null = null;
     const u = vaultStore.subscribe((s) => { v = s.currentPath; });
@@ -596,6 +602,9 @@
       style={menuPos ? `top: ${menuPos.y}px; left: ${menuPos.x}px` : undefined}
       bind:this={contextMenuRef}
     >
+      {#if !entry.is_dir}
+        <button class="vc-context-item" onclick={handleOpenInSplit}>Open in split</button>
+      {/if}
       <button class="vc-context-item" onclick={startRename}>Rename</button>
       {#if !entry.is_dir}
         <button class="vc-context-item" onclick={() => void toggleBookmark()}>


### PR DESCRIPTION
## Summary

Closes #114. The "Open in split" action was only offered from the Bookmarks panel's context menu, so opening a regular tree file in the right pane meant either dragging a tab across or bookmarking the file first. This adds the same item to the sidebar tree's context menu for files.

## Changes

- `src/components/Sidebar/TreeNode.svelte` — new `handleOpenInSplit` handler following the BookmarksPanel pattern: `tabStore.openTab(entry.path); tabStore.moveToPane("right")`. Menu item rendered only for files (`{#if !entry.is_dir}`), placed above `Rename` to mirror the action-first ordering from the bookmark menu.

No store changes — `entry.path` is already absolute so no `toAbsPath` conversion is needed.

Out of scope: split action for search / outline / backlinks / tags panels; none of those expose a context menu today.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 463/463 passing