### PR TITLE
chore: remove unused CSS and replace deprecated svelte:self

### DIFF
--- a/src/components/Search/SearchPanel.svelte
+++ b/src/components/Search/SearchPanel.svelte
@@ -99,7 +99,7 @@
       disabled={$searchStore.isRebuilding}
     >
       {#if $searchStore.indexStale}
-        <AlertTriangle size={16} strokeWidth={1.5} class="vc-index-stale-icon" />
+        <AlertTriangle size={16} strokeWidth={1.5} />
       {:else}
         <RefreshCw
           size={16}
@@ -184,10 +184,6 @@
   }
 
   .vc-search-rebuild-btn.index-stale {
-    color: var(--color-error, #e53e3e);
-  }
-
-  .vc-index-stale-icon {
     color: var(--color-error, #e53e3e);
   }
 

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -457,10 +457,6 @@
     color: var(--color-accent);
   }
 
-  .vc-sidebar-action-btn--active {
-    color: var(--color-accent);
-  }
-
   /* Bulk-change progress strip — replaces vault name + action buttons */
   .vc-sidebar-bulk-progress {
     display: flex;

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -6,6 +6,7 @@
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import type { DirEntry } from "../../types/tree";
   import InlineRename from "./InlineRename.svelte";
+  import TreeNode from "./TreeNode.svelte";
   import { vaultStore } from "../../store/vaultStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { tabStore } from "../../store/tabStore";
@@ -686,7 +687,7 @@
   {#if entry.is_dir && expanded && childrenLoaded}
     <ul class="vc-tree-children" role="group">
       {#each children as child (child.path)}
-        <svelte:self
+        <TreeNode
           entry={child}
           depth={depth + 1}
           {selectedPath}
@@ -970,16 +971,6 @@
   }
 
   .vc-confirm-btn--danger:hover {
-    opacity: 0.9;
-  }
-
-  .vc-confirm-btn--primary {
-    background: var(--color-accent);
-    color: #fff;
-    border-color: var(--color-accent);
-  }
-
-  .vc-confirm-btn--primary:hover {
     opacity: 0.9;
   }
 

--- a/src/components/Sidebar/__tests__/TreeNodeRecursion.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeRecursion.test.ts
@@ -1,0 +1,114 @@
+// Regression test for issue #118: `<svelte:self>` was replaced with a
+// self-import in Svelte 5. The recursive tree must still render nested
+// subfolders correctly — otherwise the entire tree collapses to a single
+// level without any build/runtime warning.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import TreeNode from "../TreeNode.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+const VAULT = "/tmp/test-vault";
+
+function dirEntry(name: string, path: string): DirEntry {
+  return {
+    name,
+    path,
+    is_dir: true,
+    is_symlink: false,
+    is_md: false,
+    modified: null,
+    created: null,
+  };
+}
+
+function fileEntry(name: string, path: string): DirEntry {
+  return {
+    name,
+    path,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+  };
+}
+
+describe("TreeNode recursion (#118)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+  });
+
+  it("renders nested subfolders across multiple levels via self-import", async () => {
+    // Tree layout:
+    //   outer/            (root, rendered via TreeNode)
+    //     inner/          (subfolder, must render via recursive self-import)
+    //       deep.md       (leaf in the nested subfolder)
+    const outer = dirEntry("outer", `${VAULT}/outer`);
+    const inner = dirEntry("inner", `${VAULT}/outer/inner`);
+    const deep = fileEntry("deep.md", `${VAULT}/outer/inner/deep.md`);
+
+    // Children of outer -> [inner]; children of inner -> [deep].
+    (listDirectory as any).mockImplementation(async (path: string) => {
+      if (path === outer.path) return [inner];
+      if (path === inner.path) return [deep];
+      return [];
+    });
+
+    const { container } = render(TreeNode, {
+      props: {
+        entry: outer,
+        depth: 0,
+        selectedPath: null,
+        onSelect: vi.fn(),
+        onOpenFile: vi.fn(),
+        onRefreshParent: vi.fn(),
+        onPathChanged: vi.fn(),
+        initiallyExpanded: true,
+        // Persisted-expanded paths — relative to vault root — so the nested
+        // `inner` folder auto-expands on mount and its child becomes visible.
+        expandedPaths: ["outer/inner"],
+      },
+    });
+
+    // Allow onMount + nested loadChildren to settle. Multiple ticks needed
+    // because each recursion level mounts asynchronously.
+    for (let i = 0; i < 6; i++) await tick();
+
+    // Outer folder row is rendered.
+    expect(container.textContent).toContain("outer");
+
+    // Inner folder row — rendered via the recursive TreeNode self-import.
+    // If `<TreeNode>` (ex `<svelte:self>`) did not recurse, "inner" would be
+    // absent from the DOM.
+    expect(container.textContent).toContain("inner");
+
+    // Leaf two levels deep — confirms recursion descended past level 1.
+    expect(container.textContent).toContain("deep.md");
+
+    // There must be at least two tree-children groups nested inside one
+    // another (outer > inner), proving the recursion structurally.
+    const groups = container.querySelectorAll("ul.vc-tree-children");
+    expect(groups.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Closes #118

## Summary

Resolves Svelte 5 build warnings (`css_unused_selector`, `svelte_self_deprecated`) surfaced in the tree/sidebar/search components.

### Unused CSS removed
- `src/components/Sidebar/Sidebar.svelte` — `.vc-sidebar-action-btn--active` (orphaned after commit `bc23c92` dropped the SortMenu button that set it; grep confirms zero remaining references).
- `src/components/Sidebar/TreeNode.svelte` — `.vc-confirm-btn--primary` + `:hover` (template only uses the `--cancel`, `--danger`, `--accent` variants; grep confirms the `--primary` class is never set).
- `src/components/Search/SearchPanel.svelte` — `.vc-index-stale-icon`. The class was applied to a Lucide `<AlertTriangle>` child component at line ~102, but Svelte scoped CSS cannot reach into a child component's DOM, so the rule was unreachable. The parent `.vc-search-rebuild-btn.index-stale` already sets `color: var(--color-error)`, which `<AlertTriangle>` inherits via `currentColor`. The dead `class="vc-index-stale-icon"` attribute was removed as well — visual behaviour unchanged.

### Deprecated API replaced
- `src/components/Sidebar/TreeNode.svelte` — `<svelte:self>` replaced with a self-import (`import TreeNode from "./TreeNode.svelte"`) per Svelte 5 guidance. Props flow unchanged (still self-closing).

## Verification

- `pnpm run build` — no `css_unused_selector` / `svelte_self_deprecated` warnings remain. Only unrelated pre-existing a11y / state warnings in other files, none touched here.
- `pnpm run test` — 464 tests pass across 59 files (was 463/58 on main).
- Added `src/components/Sidebar/__tests__/TreeNodeRecursion.test.ts`: renders a nested folder tree (`outer → inner → deep.md`) and asserts both recursion levels appear in the DOM, guarding against silent breakage of the `<svelte:self>` → self-import swap.

## Test plan

- [x] Unit tests pass (`pnpm run test`)
- [x] Production build clean for target warnings (`pnpm run build`)
- [ ] Manual: open a vault with nested folders; expand/collapse 2+ levels; confirm confirm-dialog styling (danger + accent variants); confirm stale-index triangle icon still appears red.