### PR TITLE
chore: address accessibility warnings across components

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -601,6 +601,10 @@
   {#if sidebarCollapsed}
     <div class="vc-layout-divider-hidden" aria-hidden="true"></div>
   {:else}
+    <!-- role="separator" is the correct ARIA pattern for a drag-to-resize
+         handle; there is no standard keyboard activation for mouse-drag
+         resizing, so the mouse-only handler is intentional. -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div
       class="vc-layout-divider"
       class:vc-layout-divider--active={isDragging}
@@ -664,7 +668,11 @@
       </div>
 
       {#if isSplit}
-        <!-- Split divider -->
+        <!-- Split divider.
+             role="separator" is the correct ARIA pattern for a drag-to-resize
+             handle; no standard keyboard activation applies to mouse-drag
+             resizing. -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <div
           class="vc-split-divider"
           class:vc-split-divider--active={isSplitDragging}
@@ -685,8 +693,12 @@
     </div>
   </div>
 
-  <!-- Right resize divider (4th column) -->
+  <!-- Right resize divider (4th column).
+       role="separator" is the correct ARIA pattern for a drag-to-resize
+       handle; no standard keyboard activation applies to mouse-drag
+       resizing. -->
   {#if backlinksOpen}
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div
       class="vc-layout-divider-right"
       class:vc-layout-divider-right--active={isRightDragging}

--- a/src/components/Search/QuickSwitcherRow.svelte
+++ b/src/components/Search/QuickSwitcherRow.svelte
@@ -28,7 +28,12 @@
   );
 </script>
 
+<!-- Keyboard nav (ArrowUp/ArrowDown/Enter) is owned by the parent
+     QuickSwitcher's input handler — the row itself only needs to be a
+     click target; its tabindex={-1} keeps it out of the Tab sequence while
+     allowing programmatic focus if ever needed. -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   class="vc-qs-row"
   class:vc-qs-row--selected={selected}
@@ -36,6 +41,7 @@
   onmouseenter={onhover}
   role="option"
   aria-selected={selected}
+  tabindex={-1}
 >
   <!-- Filename line with per-char match highlighting -->
   <span class="vc-qs-row-filename">

--- a/src/components/Search/SearchInput.svelte
+++ b/src/components/Search/SearchInput.svelte
@@ -60,7 +60,6 @@
   <input
     bind:this={inputEl}
     type="search"
-    role="searchbox"
     aria-label="Volltextsuche"
     aria-busy={disabled}
     placeholder='Suchen... (AND, OR, NOT, "phrase")'

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -415,13 +415,13 @@
       <!-- Section C — Tastaturkürzel (UI-05 / D-11 / #65) -->
       <section class="vc-settings-section" data-testid="settings-shortcuts">
         <h3 class="vc-settings-section-title">TASTATURKÜRZEL</h3>
-        <table class="vc-shortcuts-table" role="table">
+        <table class="vc-shortcuts-table">
           <tbody>
             {#each shortcuts as s (s.id)}
               {@const isRecording = recordingFor === s.id}
               {@const def = defaultHotkey(s.id)}
               {@const isCustom = def ? !s.hotkey || !hotkeysEqual(def, s.hotkey) : Boolean(s.hotkey)}
-              <tr role="row">
+              <tr>
                 <td role="cell" class="vc-shortcut-action">{s.name}</td>
                 <td role="cell" class="vc-shortcut-keys">
                   {#if isRecording}

--- a/src/components/Tabs/Tab.svelte
+++ b/src/components/Tabs/Tab.svelte
@@ -43,9 +43,17 @@
     e.dataTransfer.setData("text/vaultcore-tab", tab.id);
     e.dataTransfer.effectAllowed = "move";
   }
+
+  // ARIA tab pattern: Enter or Space activates the focused tab. Space must
+  // preventDefault to stop the default page-scroll behavior.
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onactivate();
+    }
+  }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="vc-tab"
   class:vc-tab--active={isActive}
@@ -53,6 +61,7 @@
   draggable="true"
   onclick={handleClick}
   onmousedown={handleMiddleClick}
+  onkeydown={handleKeydown}
   ondragstart={handleDragStart}
   role="tab"
   aria-selected={isActive}

--- a/src/components/Tabs/TabBar.svelte
+++ b/src/components/Tabs/TabBar.svelte
@@ -74,6 +74,7 @@
   class="vc-tabbar"
   role="tablist"
   aria-label="{paneId} pane tabs"
+  tabindex="0"
   ondragover={handleDragover}
   ondragleave={handleDragleave}
   ondrop={handleDrop}

--- a/src/components/Tabs/__tests__/Tab.keyboard.test.ts
+++ b/src/components/Tabs/__tests__/Tab.keyboard.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import Tab from "../Tab.svelte";
+import type { Tab as TabType } from "../../../store/tabStore";
+
+/**
+ * Keyboard activation for tabs (#117).
+ *
+ * A tab must be activatable via Enter and Space to satisfy the ARIA tab
+ * pattern — clicking alone excludes keyboard-only users. Space must also
+ * preventDefault so the browser does not scroll the tablist container.
+ */
+
+function makeTab(id: string, path = "/vault/notes/a.md"): TabType {
+  return {
+    id,
+    filePath: path,
+    isDirty: false,
+    scrollPos: 0,
+    cursorPos: 0,
+    lastSaved: 0,
+    lastSavedContent: "",
+  };
+}
+
+describe("Tab keyboard activation (#117)", () => {
+  it("Enter on the tab fires onactivate", async () => {
+    const onactivate = vi.fn();
+    const onclose = vi.fn();
+    render(Tab, {
+      props: {
+        tab: makeTab("t1"),
+        isActive: true,
+        onactivate,
+        onclose,
+      },
+    });
+
+    const tabEl = screen.getByRole("tab");
+    await fireEvent.keyDown(tabEl, { key: "Enter" });
+    expect(onactivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Space on the tab fires onactivate and prevents default scroll", async () => {
+    const onactivate = vi.fn();
+    const onclose = vi.fn();
+    render(Tab, {
+      props: {
+        tab: makeTab("t2"),
+        isActive: true,
+        onactivate,
+        onclose,
+      },
+    });
+
+    const tabEl = screen.getByRole("tab");
+    // fireEvent.keyDown returns false if preventDefault was called.
+    const notDefaulted = await fireEvent.keyDown(tabEl, { key: " " });
+    expect(onactivate).toHaveBeenCalledTimes(1);
+    // The handler must call preventDefault on Space to stop the browser from
+    // scrolling the tablist container.
+    expect(notDefaulted).toBe(false);
+  });
+
+  it("other keys do not fire onactivate", async () => {
+    const onactivate = vi.fn();
+    const onclose = vi.fn();
+    render(Tab, {
+      props: {
+        tab: makeTab("t3"),
+        isActive: true,
+        onactivate,
+        onclose,
+      },
+    });
+
+    const tabEl = screen.getByRole("tab");
+    await fireEvent.keyDown(tabEl, { key: "a" });
+    await fireEvent.keyDown(tabEl, { key: "ArrowDown" });
+    await fireEvent.keyDown(tabEl, { key: "Escape" });
+    expect(onactivate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/TemplatePicker/TemplatePicker.svelte
+++ b/src/components/TemplatePicker/TemplatePicker.svelte
@@ -165,6 +165,7 @@
               class:vc-tp-row--selected={i === selectedIndex}
               role="option"
               aria-selected={i === selectedIndex}
+              tabindex={-1}
               onclick={() => void selectTemplate(tpl)}
               onmouseenter={() => { selectedIndex = i; }}
             >


### PR DESCRIPTION
Closes #117.

## Summary

Cleans up the a11y warnings Vite/Svelte emits for interactive widgets, without regressing mouse-only behavior.

### Dividers (VaultLayout)

Three resize handles (sidebar, split pane, right sidebar) keep their `onmousedown`-only handler with `role="separator"` — this is the spec-correct ARIA pattern for drag-to-resize, and there is no standard keyboard activation for mouse-drag resizing. The `a11y_no_noninteractive_element_interactions` warning is now suppressed via `svelte-ignore` with an inline rationale above each handle.

### `tabindex` on interactive roles

- `TemplatePicker` row: `role="option"` + `tabindex={-1}` (focus is driven by the parent's arrow-key handler).
- `QuickSwitcherRow`: `role="option"` + `tabindex={-1}` and a documented `a11y_click_events_have_key_events` ignore — keyboard navigation is owned by `QuickSwitcher.svelte`'s input handler (`ArrowUp`/`ArrowDown`/`Enter`).
- `TabBar` tablist: `role="tablist"` + `tabindex="0"` (ARIA tab pattern — the tablist itself is focusable; individual tabs already have the correct roving tabindex).

### Keyboard activation on `Tab.svelte`

Added an `onkeydown` handler that activates the tab on `Enter` / `Space` (Space `preventDefault`s to stop the default page scroll), covered by a new Vitest suite `src/components/Tabs/__tests__/Tab.keyboard.test.ts` (3 tests).

### Redundant roles removed

- `SettingsModal`: dropped `role="table"` on `<table>` and `role="row"` on `<tr>`.
- `SearchInput`: dropped `role="searchbox"` on `<input type="search">` — the implicit role keeps `SearchInput.test.ts`'s `getByRole("searchbox")` calls working (verified).

## Test plan

- [x] `pnpm run build` — zero a11y warnings from the touched files; build succeeds.
- [x] `pnpm test` — 465 pass, 1 pre-existing flaky perf test in `largeFile.test.ts` unrelated to this change; new Tab keyboard suite + existing `SearchInput.test.ts` pass.
- [ ] Manual UAT: Quick Switcher / Template Picker / Tabs still navigable by keyboard; resize handles still draggable by mouse.