### PR TITLE
fix: align isNewFile prop name between TreeNode and InlineRename

### DIFF
--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -58,7 +58,7 @@
 
   // Rename/inline edit state
   let renaming = $state(false);
-  let isNewEntry = $state(false);
+  let isNewFile = $state(false);
 
   // Context menu state. When opened via right-click we position at the mouse
   // coordinates; when opened via the three-dots button we leave `menuPos` null
@@ -239,7 +239,7 @@
   function startRename() {
     closeContextMenu();
     renaming = true;
-    isNewEntry = false;
+    isNewFile = false;
   }
 
   function handleOpenInSplit() {
@@ -562,7 +562,7 @@
       <InlineRename
         currentName={entry.name}
         oldPath={entry.path}
-        {isNewEntry}
+        {isNewFile}
         onConfirm={handleRenameConfirm}
         onCancel={handleRenameCancel}
       />

--- a/src/components/Sidebar/__tests__/InlineRename.test.ts
+++ b/src/components/Sidebar/__tests__/InlineRename.test.ts
@@ -1,0 +1,107 @@
+// Regression test for issue #121: the prop that tells InlineRename this is
+// a freshly-created file must flow from TreeNode so the cleanup branches
+// (delete the empty file on Escape/rename error) can actually fire. Before
+// the fix, TreeNode passed `isNewEntry` while InlineRename declared
+// `isNewFile`, leaving `isNewFile` permanently `false`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  renameFile: vi.fn(),
+  deleteFile: vi.fn(),
+}));
+
+import { renameFile, deleteFile } from "../../../ipc/commands";
+import InlineRename from "../InlineRename.svelte";
+
+const OLD_PATH = "/tmp/vault/Untitled.md";
+
+function baseProps(overrides: { isNewFile?: boolean } = {}) {
+  return {
+    currentName: "Untitled.md",
+    oldPath: OLD_PATH,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("InlineRename cleanup for new files (#121)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes the pending file when Escape is pressed with isNewFile=true", async () => {
+    const onCancel = vi.fn();
+    const { container } = render(InlineRename, {
+      props: { ...baseProps({ isNewFile: true }), onCancel },
+    });
+
+    const input = container.querySelector(".vc-rename-input") as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: "Escape" });
+    await tick();
+    await tick();
+
+    expect(deleteFile).toHaveBeenCalledWith(OLD_PATH);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT delete the file when Escape is pressed with isNewFile=false", async () => {
+    const onCancel = vi.fn();
+    const { container } = render(InlineRename, {
+      props: { ...baseProps({ isNewFile: false }), onCancel },
+    });
+
+    const input = container.querySelector(".vc-rename-input") as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: "Escape" });
+    await tick();
+
+    expect(deleteFile).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the pending file when renameFile throws with isNewFile=true", async () => {
+    (renameFile as any).mockRejectedValueOnce(new Error("boom"));
+
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    const { container } = render(InlineRename, {
+      props: { ...baseProps({ isNewFile: true }), onConfirm, onCancel },
+    });
+
+    const input = container.querySelector(".vc-rename-input") as HTMLInputElement;
+    input.value = "my-note.md";
+    await fireEvent.input(input);
+    await fireEvent.keyDown(input, { key: "Enter" });
+    // Let the async renameFile rejection and cleanup settle.
+    await tick();
+    await tick();
+    await tick();
+
+    expect(renameFile).toHaveBeenCalled();
+    expect(deleteFile).toHaveBeenCalledWith(OLD_PATH);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("does NOT delete the file when renameFile throws with isNewFile=false", async () => {
+    (renameFile as any).mockRejectedValueOnce(new Error("boom"));
+
+    const { container } = render(InlineRename, {
+      props: baseProps({ isNewFile: false }),
+    });
+
+    const input = container.querySelector(".vc-rename-input") as HTMLInputElement;
+    input.value = "renamed.md";
+    await fireEvent.input(input);
+    await fireEvent.keyDown(input, { key: "Enter" });
+    await tick();
+    await tick();
+    await tick();
+
+    expect(renameFile).toHaveBeenCalled();
+    expect(deleteFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`TreeNode.svelte` passed `{isNewEntry}` (shorthand for `isNewEntry={isNewEntry}`), but `InlineRename.svelte`'s `Props` interface declares the prop as `isNewFile`. The prop never landed, so `isNewFile` stayed at its default `false` and the two cleanup branches in `InlineRename` — delete the pending empty file when the user presses Escape or when `renameFile` throws — never fired.

Renames the state in `TreeNode` from `isNewEntry` to `isNewFile` (3 call sites) so both sides of the component boundary agree.

## Why this was latent, not observable

The rename dialog is **not** currently auto-opened after creating a new file. `handleNewFileHere`/`handleNewFile` call `createFile` with an empty name, reload the tree, and open the resulting tab — the rename dialog is only reachable via the `Rename` context-menu entry on an existing entry, and `startRename` explicitly sets `isNewFile = false`. A grep across the whole repo and the entire git history (`git log -S "isNewEntry = true"`) confirms the state is never set to `true` anywhere.

So this PR does **not** fix a user-reproducible bug. It closes a silent type hole that `svelte-check` did not flag, and keeps the contract intact for whenever the auto-rename-on-create flow is wired up (likely a separate, feature-scoped ticket).

## Why no E2E test

The cleanup path is unreachable through the UI. Added **unit tests** instead (`InlineRename.test.ts`, 4 cases) that cover the component in isolation:

- Escape with `isNewFile=true` → `deleteFile(oldPath)` is called
- Escape with `isNewFile=false` → `deleteFile` is NOT called
- `renameFile` throws with `isNewFile=true` → `deleteFile(oldPath)` is called
- `renameFile` throws with `isNewFile=false` → `deleteFile` is NOT called

## Verification

- `pnpm typecheck`: clean
- `pnpm test`: 472/473 pass (+4 new tests). The 1 failure is the pre-existing flaky jsdom perf test `largeFile.test.ts`, unrelated.

Closes #121