### PR TITLE
feat: canvas viewer with text cards + Obsidian roundtrip (#124)

### DIFF
--- a/e2e/specs/canvas.spec.ts
+++ b/e2e/specs/canvas.spec.ts
@@ -1,0 +1,549 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf, textsOf } from "../helpers/text.js";
+
+/**
+ * E2E coverage for issue #124 (canvas phase 1). Tests:
+ *   - Opening an Obsidian `.canvas` file renders CanvasView instead of CM6.
+ *   - Existing text nodes render with their content and position.
+ *   - Roundtrip: saving preserves unknown node / edge / top-level fields.
+ *   - Create a text card via double-click on empty space.
+ *   - Edit a text card via double-click, blur autosaves to disk.
+ *   - Delete the selected card via Backspace.
+ *   - Empty / non-text-node inputs do not crash the viewer.
+ *   - "New canvas here" in the sidebar context menu creates + opens the file.
+ *   - Dragging a card persists the new coordinates on disk.
+ *
+ * Multiple canvas tabs can be open at the same time — most DOM queries
+ * therefore scope to the visible (active) viewport via `vizSel(...)` which
+ * reads the data-tab-id off the only `.vc-canvas-viewport` whose
+ * `offsetParent !== null`. That avoids grabbing a hidden sibling tab.
+ */
+
+const DEBOUNCE_MS = 400;
+const FLUSH_WAIT_MS = DEBOUNCE_MS + 500; // buffer for the write round-trip
+
+const ROUNDTRIP_DOC = {
+  nodes: [
+    {
+      id: "text-1",
+      type: "text",
+      x: -120,
+      y: -40,
+      width: 240,
+      height: 80,
+      text: "Hallo Canvas",
+      styleAttributes: { theme: "dark" },
+    },
+    {
+      id: "group-1",
+      type: "group",
+      x: 200,
+      y: 100,
+      width: 300,
+      height: 200,
+      label: "Gruppe A",
+      background: "#112233",
+      futureProp: 42,
+    },
+  ],
+  edges: [
+    {
+      id: "edge-1",
+      fromNode: "text-1",
+      toNode: "group-1",
+      fromSide: "right",
+      toSide: "left",
+      unknownEdgeField: ["stays"],
+    },
+  ],
+  metadata: { schemaVersion: 2 },
+};
+
+describe("Canvas viewer (#124)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(
+      path.join(vault.path, "Roundtrip.canvas"),
+      JSON.stringify(ROUNDTRIP_DOC, null, "\t"),
+      "utf-8",
+    );
+    fs.writeFileSync(path.join(vault.path, "Empty.canvas"), "", "utf-8");
+    fs.writeFileSync(
+      path.join(vault.path, "Edit.canvas"),
+      JSON.stringify({ nodes: [], edges: [] }, null, "\t"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  // ─── Helpers ──────────────────────────────────────────────────────────
+
+  async function activeTabId(): Promise<string> {
+    const id = await browser.execute(() => {
+      // The viewport has data-tab-id; find the one that is currently visible.
+      const viewports = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = viewports.find((v) => v.offsetParent !== null);
+      return visible?.getAttribute("data-tab-id") ?? null;
+    });
+    if (!id) throw new Error("No visible canvas viewport found");
+    return id as string;
+  }
+
+  /** Builds a selector scoped to the active canvas's viewport. */
+  async function vizSel(suffix = ""): Promise<string> {
+    const id = await activeTabId();
+    return `.vc-canvas-viewport[data-tab-id="${id}"]${suffix}`;
+  }
+
+  async function openTreeFile(name: string): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const names = await textsOf(await browser.$$(".vc-tree-name"));
+        return names.includes(name);
+      },
+      { timeout: 5000, timeoutMsg: `"${name}" never appeared in the tree` },
+    );
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not found`);
+  }
+
+  async function waitForCanvas(): Promise<void> {
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const visible = vps.find((v) => v.offsetParent !== null);
+          return !!visible?.querySelector(".vc-canvas-world");
+        }),
+      { timeout: 5000, timeoutMsg: "Canvas world never mounted" },
+    );
+  }
+
+  async function readCanvasFromDisk(
+    name: string,
+  ): Promise<{
+    nodes: unknown[];
+    edges: unknown[];
+    [k: string]: unknown;
+  }> {
+    const raw = fs.readFileSync(path.join(vault.path, name), "utf-8");
+    return JSON.parse(raw);
+  }
+
+  async function waitForDiskDoc<T>(
+    name: string,
+    predicate: (doc: {
+      nodes: unknown[];
+      edges: unknown[];
+      [k: string]: unknown;
+    }) => T | null | false | undefined,
+    timeoutMs = FLUSH_WAIT_MS * 6,
+  ): Promise<T> {
+    const start = Date.now();
+    let last: unknown;
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const doc = await readCanvasFromDisk(name);
+        const hit = predicate(doc);
+        if (hit) return hit as T;
+        last = doc;
+      } catch {
+        /* file not yet written */
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+      `waitForDiskDoc(${name}) timed out. Last doc: ${JSON.stringify(last)}`,
+    );
+  }
+
+  async function dispatchDblClick(
+    selector: string,
+    offsetX?: number,
+    offsetY?: number,
+  ): Promise<void> {
+    await browser.execute(
+      (sel: string, ox: number | null, oy: number | null) => {
+        const el = document.querySelector(sel) as HTMLElement | null;
+        if (!el) throw new Error(`No element: ${sel}`);
+        const rect = el.getBoundingClientRect();
+        const clientX = ox === null ? rect.left + rect.width / 2 : rect.left + ox;
+        const clientY = oy === null ? rect.top + rect.height / 2 : rect.top + oy;
+        const ev = new MouseEvent("dblclick", {
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+          button: 0,
+        });
+        el.dispatchEvent(ev);
+      },
+      selector,
+      offsetX ?? null,
+      offsetY ?? null,
+    );
+  }
+
+  /** Set the active editing textarea's value + fire input + blur. */
+  async function typeInActiveTextareaAndBlur(text: string): Promise<void> {
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const ta = document.querySelector(".vc-canvas-node-textarea");
+          return !!ta;
+        }),
+      { timeout: 3000, timeoutMsg: "No editing textarea appeared" },
+    );
+    await browser.execute((t: string) => {
+      const ta = document.querySelector(
+        ".vc-canvas-node-textarea",
+      ) as HTMLTextAreaElement | null;
+      if (!ta) throw new Error("No textarea");
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )!.set!;
+      setter.call(ta, t);
+      ta.dispatchEvent(new Event("input", { bubbles: true }));
+      ta.blur();
+    }, text);
+  }
+
+  async function pointerClick(selector: string): Promise<void> {
+    await browser.execute((sel: string) => {
+      const el = document.querySelector(sel) as HTMLElement | null;
+      if (!el) throw new Error(`No element: ${sel}`);
+      const rect = el.getBoundingClientRect();
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      const opts: PointerEventInit = {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        pointerId: 2,
+        pointerType: "mouse",
+        button: 0,
+        buttons: 1,
+        isPrimary: true,
+      };
+      el.dispatchEvent(new PointerEvent("pointerdown", opts));
+      el.dispatchEvent(new PointerEvent("pointerup", opts));
+    }, selector);
+  }
+
+  async function pointerDrag(
+    selector: string,
+    dx: number,
+    dy: number,
+  ): Promise<void> {
+    await browser.execute(
+      (sel: string, mx: number, my: number) => {
+        const el = document.querySelector(sel) as HTMLElement | null;
+        if (!el) throw new Error(`No element: ${sel}`);
+        const rect = el.getBoundingClientRect();
+        const startX = rect.left + rect.width / 2;
+        const startY = rect.top + rect.height / 2;
+        const opts = (x: number, y: number): PointerEventInit => ({
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          pointerId: 1,
+          pointerType: "mouse",
+          button: 0,
+          buttons: 1,
+          isPrimary: true,
+        });
+        el.dispatchEvent(new PointerEvent("pointerdown", opts(startX, startY)));
+        el.dispatchEvent(
+          new PointerEvent("pointermove", opts(startX + mx, startY + my)),
+        );
+        el.dispatchEvent(
+          new PointerEvent("pointerup", opts(startX + mx, startY + my)),
+        );
+      },
+      selector,
+      dx,
+      dy,
+    );
+  }
+
+  async function visibleTextNodes(): Promise<number> {
+    return browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      if (!visible) return 0;
+      return visible.querySelectorAll(".vc-canvas-node-text").length;
+    }) as Promise<number>;
+  }
+
+  async function visiblePlaceholders(): Promise<number> {
+    return browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      if (!visible) return 0;
+      return visible.querySelectorAll(".vc-canvas-node-placeholder").length;
+    }) as Promise<number>;
+  }
+
+  async function visibleTextNodeContent(): Promise<string> {
+    return browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      const content = visible?.querySelector(
+        ".vc-canvas-node-text .vc-canvas-node-content",
+      );
+      return content?.textContent?.trim() ?? "";
+    }) as Promise<string>;
+  }
+
+  // ─── Open + render ────────────────────────────────────────────────────
+
+  it("opens a .canvas file in the canvas viewer (not CM6)", async () => {
+    await openTreeFile("Roundtrip.canvas");
+    await waitForCanvas();
+
+    const hasCm = await browser.execute(() => {
+      const containers = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-editor-container"),
+      );
+      const active = containers.find((el) => el.offsetParent !== null);
+      return !!active?.querySelector(".cm-editor");
+    });
+    expect(hasCm).toBe(false);
+  });
+
+  it("labels the tab with the .canvas filename", async () => {
+    const activeLabel = await browser.$(".vc-tab--active .vc-tab-label");
+    await activeLabel.waitForDisplayed({ timeout: 3000 });
+    expect(await textOf(activeLabel)).toBe("Roundtrip.canvas");
+  });
+
+  it("renders existing text nodes with their content", async () => {
+    expect(await visibleTextNodes()).toBe(1);
+    expect(await visibleTextNodeContent()).toBe("Hallo Canvas");
+  });
+
+  it("renders non-text node types as placeholders (round-trip only)", async () => {
+    expect(await visiblePlaceholders()).toBe(1);
+  });
+
+  // ─── Roundtrip ────────────────────────────────────────────────────────
+
+  it("preserves unknown node, edge, and top-level fields after an edit", async () => {
+    // Dbl-click the text card to enter edit mode.
+    await dispatchDblClick(await vizSel(" .vc-canvas-node-text"));
+    await typeInActiveTextareaAndBlur("Hallo Canvas Bearbeitet");
+
+    const doc = await waitForDiskDoc("Roundtrip.canvas", (d) => {
+      const nodes = d.nodes as Array<Record<string, unknown>>;
+      const text = nodes.find((n) => n.id === "text-1") as
+        | { text?: string }
+        | undefined;
+      return text?.text?.includes("Bearbeitet") ? d : false;
+    });
+
+    const textNode = (doc.nodes as Array<Record<string, unknown>>).find(
+      (n) => n.id === "text-1",
+    )!;
+    const groupNode = (doc.nodes as Array<Record<string, unknown>>).find(
+      (n) => n.id === "group-1",
+    )!;
+    const edge = (doc.edges as Array<Record<string, unknown>>)[0]!;
+
+    expect(textNode.styleAttributes).toEqual({ theme: "dark" });
+    expect(groupNode.futureProp).toBe(42);
+    expect(groupNode.label).toBe("Gruppe A");
+    expect(groupNode.background).toBe("#112233");
+    expect(edge.unknownEdgeField).toEqual(["stays"]);
+    expect(edge.fromSide).toBe("right");
+    expect(edge.toSide).toBe("left");
+    expect(doc.metadata).toEqual({ schemaVersion: 2 });
+  });
+
+  // ─── Create + edit + delete ───────────────────────────────────────────
+
+  it("creates a new text card on double-click in empty space", async () => {
+    await openTreeFile("Edit.canvas");
+    await waitForCanvas();
+
+    const before = await visibleTextNodes();
+
+    await dispatchDblClick(await vizSel(), 80, 120);
+    await typeInActiveTextareaAndBlur("Erstes Kärtchen");
+
+    await browser.waitUntil(
+      async () => (await visibleTextNodes()) === before + 1,
+      {
+        timeout: 3000,
+        timeoutMsg: "Card never appeared after double-click",
+      },
+    );
+
+    await waitForDiskDoc("Edit.canvas", (d) => {
+      const nodes = d.nodes as Array<Record<string, unknown>>;
+      return nodes.length === 1 && nodes[0]!.text === "Erstes Kärtchen"
+        ? d
+        : false;
+    });
+  });
+
+  it("deletes the selected text card on Backspace", async () => {
+    await pointerClick(await vizSel(" .vc-canvas-node-text"));
+    await browser.keys(["Backspace"]);
+
+    await browser.waitUntil(
+      async () => (await visibleTextNodes()) === 0,
+      { timeout: 3000, timeoutMsg: "Card was never removed from DOM" },
+    );
+
+    await waitForDiskDoc("Edit.canvas", (d) =>
+      (d.nodes as unknown[]).length === 0 ? d : false,
+    );
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────
+
+  it("opens an empty .canvas file without crashing", async () => {
+    await openTreeFile("Empty.canvas");
+    await waitForCanvas();
+
+    expect(await visibleTextNodes()).toBe(0);
+    expect(await visiblePlaceholders()).toBe(0);
+
+    const hasError = await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      return !!visible?.querySelector(".vc-canvas-error");
+    });
+    expect(hasError).toBe(false);
+  });
+
+  it("creates a new card in the previously-empty canvas and persists it", async () => {
+    await dispatchDblClick(await vizSel(), 200, 200);
+    await typeInActiveTextareaAndBlur("seed");
+
+    await browser.waitUntil(
+      async () => (await visibleTextNodes()) === 1,
+      { timeout: 3000, timeoutMsg: "Seeded card never appeared" },
+    );
+    await waitForDiskDoc("Empty.canvas", (d) => {
+      const nodes = d.nodes as Array<Record<string, unknown>>;
+      return nodes.length === 1 && nodes[0]!.text === "seed" ? d : false;
+    });
+  });
+
+  // ─── Sidebar integration ──────────────────────────────────────────────
+
+  it("creates a blank canvas via the 'New canvas here' sidebar menu", async () => {
+    const folder = await (async () => {
+      const nodes = await browser.$$(".vc-tree-name");
+      for (const n of nodes) {
+        if ((await textOf(n)) === "subfolder") return n;
+      }
+      throw new Error("subfolder not in tree");
+    })();
+
+    await browser.execute((el: HTMLElement) => {
+      const rect = el.getBoundingClientRect();
+      const ev = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+        button: 2,
+      });
+      el.dispatchEvent(ev);
+    }, folder);
+
+    await browser.$(".vc-context-menu").waitForDisplayed({ timeout: 3000 });
+    const items = await browser.$$(".vc-context-item");
+    let clicked = false;
+    for (const item of items) {
+      if ((await textOf(item)).toLowerCase().includes("canvas")) {
+        await item.click();
+        clicked = true;
+        break;
+      }
+    }
+    expect(clicked).toBe(true);
+
+    await browser.waitUntil(
+      async () => {
+        const names = await textsOf(await browser.$$(".vc-tree-name"));
+        return names.includes("Untitled.canvas");
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "'Untitled.canvas' never appeared in tree",
+      },
+    );
+
+    const activeLabel = await browser.$(".vc-tab--active .vc-tab-label");
+    await activeLabel.waitForDisplayed({ timeout: 3000 });
+    expect(await textOf(activeLabel)).toBe("Untitled.canvas");
+
+    const disk = JSON.parse(
+      fs.readFileSync(
+        path.join(vault.path, "subfolder", "Untitled.canvas"),
+        "utf-8",
+      ),
+    );
+    expect(disk).toEqual({ nodes: [], edges: [] });
+
+    await waitForCanvas();
+  });
+
+  // ─── Move ─────────────────────────────────────────────────────────────
+
+  it("drags a text card and persists the new coordinates", async () => {
+    await dispatchDblClick(await vizSel(), 100, 100);
+    await typeInActiveTextareaAndBlur("draggable");
+
+    const seeded = await waitForDiskDoc("subfolder/Untitled.canvas", (d) => {
+      const nodes = d.nodes as Array<Record<string, unknown>>;
+      return nodes.length === 1 && nodes[0]!.text === "draggable" ? d : false;
+    });
+    const startX = (seeded.nodes as Array<Record<string, unknown>>)[0]!
+      .x as number;
+    const startY = (seeded.nodes as Array<Record<string, unknown>>)[0]!
+      .y as number;
+
+    await pointerDrag(await vizSel(" .vc-canvas-node-text"), 60, 30);
+
+    await waitForDiskDoc("subfolder/Untitled.canvas", (d) => {
+      const node = (d.nodes as Array<Record<string, unknown>>)[0]!;
+      return (node.x as number) !== startX || (node.y as number) !== startY
+        ? d
+        : false;
+    });
+  });
+});

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -1,0 +1,500 @@
+<script lang="ts">
+  // Canvas viewer — issue #71, phase 1.
+  //
+  // Scope: text cards only. Pan (middle/space+drag), zoom (wheel), create
+  // (double-click empty space), edit (double-click card), move (drag body),
+  // resize (drag SE handle), delete (Del/Backspace with card selected),
+  // autosave to disk debounced through writeFile. Other node types (file,
+  // link, group) are parsed and re-serialized unchanged so Obsidian canvases
+  // open and save without losing data.
+
+  import { onMount, onDestroy, tick } from "svelte";
+  import { readFile, writeFile } from "../../ipc/commands";
+  import { toastStore } from "../../store/toastStore";
+  import { isVaultError, vaultErrorCopy } from "../../types/errors";
+  import {
+    parseCanvas,
+    serializeCanvas,
+    emptyCanvas,
+  } from "../../lib/canvas/parse";
+  import type {
+    CanvasDoc,
+    CanvasNode,
+    CanvasTextNode,
+  } from "../../lib/canvas/types";
+  import {
+    DEFAULT_NODE_WIDTH,
+    DEFAULT_NODE_HEIGHT,
+  } from "../../lib/canvas/types";
+
+  interface Props {
+    tabId: string;
+    abs: string;
+  }
+
+  let { tabId, abs }: Props = $props();
+
+  let doc = $state<CanvasDoc>(emptyCanvas());
+  let loaded = $state(false);
+  let loadError = $state<string | null>(null);
+
+  // Camera — world-space translation + zoom factor.
+  let camX = $state(0);
+  let camY = $state(0);
+  let zoom = $state(1);
+
+  let selectedId = $state<string | null>(null);
+  let editingId = $state<string | null>(null);
+
+  let viewportEl: HTMLDivElement | null = null;
+  let editingTextareaEl: HTMLTextAreaElement | null = null;
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastWrittenJson = "";
+  let suppressSave = true;
+  let spaceHeld = $state(false);
+
+  type PointerMode =
+    | { kind: "pan"; startClientX: number; startClientY: number; startCamX: number; startCamY: number }
+    | { kind: "move"; nodeId: string; startClientX: number; startClientY: number; startX: number; startY: number }
+    | { kind: "resize"; nodeId: string; startClientX: number; startClientY: number; startW: number; startH: number };
+
+  let pointerMode: PointerMode | null = null;
+
+  const MIN_ZOOM = 0.15;
+  const MAX_ZOOM = 4;
+
+  async function load() {
+    try {
+      const text = await readFile(abs);
+      doc = parseCanvas(text);
+      lastWrittenJson = serializeCanvas(doc);
+    } catch (e) {
+      const ve = isVaultError(e)
+        ? e
+        : { kind: "Io" as const, message: String(e), data: null };
+      loadError = vaultErrorCopy(ve);
+      toastStore.push({ variant: "error", message: loadError });
+      doc = emptyCanvas();
+      lastWrittenJson = serializeCanvas(doc);
+    } finally {
+      loaded = true;
+      await tick();
+      suppressSave = false;
+    }
+  }
+
+  function scheduleSave() {
+    if (suppressSave || !loaded) return;
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      void persist();
+    }, 400);
+  }
+
+  async function persist() {
+    const serialized = serializeCanvas(doc);
+    if (serialized === lastWrittenJson) return;
+    try {
+      await writeFile(abs, serialized);
+      lastWrittenJson = serialized;
+    } catch (e) {
+      const ve = isVaultError(e)
+        ? e
+        : { kind: "Io" as const, message: String(e), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
+  async function flushPendingSave() {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+      await persist();
+    }
+  }
+
+  onMount(() => {
+    void load();
+  });
+
+  onDestroy(() => {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+      // Fire-and-forget — we can't await in onDestroy but we've already
+      // debounced, so the window for loss is small.
+      void persist();
+    }
+  });
+
+  // Focus the textarea once it mounts — replaces the `autofocus` attribute
+  // which Svelte 5 warns about for accessibility reasons.
+  $effect(() => {
+    if (editingId && editingTextareaEl) {
+      editingTextareaEl.focus();
+      editingTextareaEl.select();
+    }
+  });
+
+  // Trigger autosave whenever the doc changes post-load. Serializing on
+  // every reactive tick is cheap for the sizes we expect (hundreds of nodes).
+  $effect(() => {
+    // Touch the relevant fields so Svelte tracks them.
+    void doc.nodes.length;
+    void doc.edges.length;
+    for (const n of doc.nodes) {
+      void n.x; void n.y; void n.width; void n.height;
+      if (n.type === "text") void (n as CanvasTextNode).text;
+    }
+    scheduleSave();
+  });
+
+  function clientToWorld(clientX: number, clientY: number): { x: number; y: number } {
+    if (!viewportEl) return { x: 0, y: 0 };
+    const rect = viewportEl.getBoundingClientRect();
+    const vx = clientX - rect.left;
+    const vy = clientY - rect.top;
+    return { x: (vx - camX) / zoom, y: (vy - camY) / zoom };
+  }
+
+  function onWheel(e: WheelEvent) {
+    e.preventDefault();
+    if (!viewportEl) return;
+    const rect = viewportEl.getBoundingClientRect();
+    const vx = e.clientX - rect.left;
+    const vy = e.clientY - rect.top;
+    const worldX = (vx - camX) / zoom;
+    const worldY = (vy - camY) / zoom;
+    const factor = Math.exp(-e.deltaY * 0.0015);
+    const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom * factor));
+    camX = vx - worldX * next;
+    camY = vy - worldY * next;
+    zoom = next;
+  }
+
+  function onViewportPointerDown(e: PointerEvent) {
+    if (editingId) return;
+    // Middle mouse OR space+drag OR click on empty area with no card hit.
+    const isPan = e.button === 1 || (e.button === 0 && spaceHeld);
+    if (!isPan) return;
+    e.preventDefault();
+    selectedId = null;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    pointerMode = {
+      kind: "pan",
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      startCamX: camX,
+      startCamY: camY,
+    };
+  }
+
+  function onViewportPointerMove(e: PointerEvent) {
+    if (!pointerMode) return;
+    if (pointerMode.kind === "pan") {
+      camX = pointerMode.startCamX + (e.clientX - pointerMode.startClientX);
+      camY = pointerMode.startCamY + (e.clientY - pointerMode.startClientY);
+    } else if (pointerMode.kind === "move") {
+      const dx = (e.clientX - pointerMode.startClientX) / zoom;
+      const dy = (e.clientY - pointerMode.startClientY) / zoom;
+      const node = doc.nodes.find((n) => n.id === pointerMode!.nodeId);
+      if (node) {
+        node.x = pointerMode.startX + dx;
+        node.y = pointerMode.startY + dy;
+      }
+    } else if (pointerMode.kind === "resize") {
+      const dx = (e.clientX - pointerMode.startClientX) / zoom;
+      const dy = (e.clientY - pointerMode.startClientY) / zoom;
+      const node = doc.nodes.find((n) => n.id === pointerMode!.nodeId);
+      if (node) {
+        node.width = Math.max(80, pointerMode.startW + dx);
+        node.height = Math.max(40, pointerMode.startH + dy);
+      }
+    }
+  }
+
+  function onViewportPointerUp(e: PointerEvent) {
+    if (!pointerMode) return;
+    (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+    pointerMode = null;
+  }
+
+  function onViewportDblClick(e: MouseEvent) {
+    // Empty-area double-click creates a new text node centered at the cursor.
+    if (editingId) return;
+    const target = e.target as HTMLElement;
+    if (target.closest(".vc-canvas-node")) return;
+    const { x, y } = clientToWorld(e.clientX, e.clientY);
+    const node: CanvasTextNode = {
+      id: crypto.randomUUID(),
+      type: "text",
+      x: x - DEFAULT_NODE_WIDTH / 2,
+      y: y - DEFAULT_NODE_HEIGHT / 2,
+      width: DEFAULT_NODE_WIDTH,
+      height: DEFAULT_NODE_HEIGHT,
+      text: "",
+    };
+    doc.nodes = [...doc.nodes, node];
+    selectedId = node.id;
+    editingId = node.id;
+  }
+
+  function onNodePointerDown(e: PointerEvent, node: CanvasNode) {
+    if (editingId === node.id) return;
+    if (e.button !== 0 || spaceHeld) return;
+    e.stopPropagation();
+    selectedId = node.id;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    pointerMode = {
+      kind: "move",
+      nodeId: node.id,
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      startX: node.x,
+      startY: node.y,
+    };
+  }
+
+  function onNodeDblClick(e: MouseEvent, node: CanvasNode) {
+    e.stopPropagation();
+    if (node.type !== "text") return;
+    editingId = node.id;
+    selectedId = node.id;
+  }
+
+  function onResizePointerDown(e: PointerEvent, node: CanvasNode) {
+    e.stopPropagation();
+    if (e.button !== 0) return;
+    selectedId = node.id;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    pointerMode = {
+      kind: "resize",
+      nodeId: node.id,
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      startW: node.width,
+      startH: node.height,
+    };
+  }
+
+  function onTextEdit(e: Event, node: CanvasTextNode) {
+    node.text = (e.target as HTMLTextAreaElement).value;
+  }
+
+  function onTextBlur() {
+    editingId = null;
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (editingId) {
+      // Let Escape exit text editing without deleting the card.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        editingId = null;
+      }
+      return;
+    }
+    if (e.key === " " && !e.repeat) {
+      spaceHeld = true;
+    }
+    if ((e.key === "Delete" || e.key === "Backspace") && selectedId) {
+      e.preventDefault();
+      const id = selectedId;
+      doc.nodes = doc.nodes.filter((n) => n.id !== id);
+      doc.edges = doc.edges.filter((ed) => ed.fromNode !== id && ed.toNode !== id);
+      selectedId = null;
+    }
+  }
+
+  function onKeyUp(e: KeyboardEvent) {
+    if (e.key === " ") spaceHeld = false;
+  }
+</script>
+
+<svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />
+
+<div
+  class="vc-canvas-viewport"
+  class:vc-canvas-panning={spaceHeld}
+  bind:this={viewportEl}
+  role="application"
+  aria-label="Canvas"
+  data-tab-id={tabId}
+  onpointerdown={onViewportPointerDown}
+  onpointermove={onViewportPointerMove}
+  onpointerup={onViewportPointerUp}
+  onpointercancel={onViewportPointerUp}
+  ondblclick={onViewportDblClick}
+  onwheel={onWheel}
+>
+  {#if !loaded}
+    <div class="vc-canvas-loading">Loading canvas…</div>
+  {:else if loadError}
+    <div class="vc-canvas-error">{loadError}</div>
+  {:else}
+    <div
+      class="vc-canvas-world"
+      style:transform={`translate(${camX}px, ${camY}px) scale(${zoom})`}
+    >
+      {#each doc.nodes as node (node.id)}
+        {#if node.type === "text"}
+          <div
+            class="vc-canvas-node vc-canvas-node-text"
+            class:vc-canvas-node-selected={selectedId === node.id}
+            class:vc-canvas-node-editing={editingId === node.id}
+            style:left={`${node.x}px`}
+            style:top={`${node.y}px`}
+            style:width={`${node.width}px`}
+            style:height={`${node.height}px`}
+            data-node-id={node.id}
+            onpointerdown={(e) => onNodePointerDown(e, node)}
+            ondblclick={(e) => onNodeDblClick(e, node)}
+            role="button"
+            tabindex="0"
+          >
+            {#if editingId === node.id}
+              <textarea
+                bind:this={editingTextareaEl}
+                class="vc-canvas-node-textarea"
+                value={(node as CanvasTextNode).text}
+                oninput={(e) => onTextEdit(e, node as CanvasTextNode)}
+                onblur={onTextBlur}
+                onpointerdown={(e) => e.stopPropagation()}
+                ondblclick={(e) => e.stopPropagation()}
+              ></textarea>
+            {:else}
+              <div class="vc-canvas-node-content">
+                {(node as CanvasTextNode).text || "Empty card"}
+              </div>
+            {/if}
+            <div
+              class="vc-canvas-resize-handle"
+              onpointerdown={(e) => onResizePointerDown(e, node)}
+              role="presentation"
+            ></div>
+          </div>
+        {:else}
+          <!-- Phase 1 only renders text. Other node types round-trip
+               through the parser/serializer but show a placeholder so
+               editors are not lost when the user saves. -->
+          <div
+            class="vc-canvas-node vc-canvas-node-placeholder"
+            class:vc-canvas-node-selected={selectedId === node.id}
+            style:left={`${node.x}px`}
+            style:top={`${node.y}px`}
+            style:width={`${node.width}px`}
+            style:height={`${node.height}px`}
+            data-node-id={node.id}
+            onpointerdown={(e) => onNodePointerDown(e, node)}
+            role="button"
+            tabindex="0"
+          >
+            <div class="vc-canvas-node-content">
+              <em>{node.type}</em>
+            </div>
+          </div>
+        {/if}
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .vc-canvas-viewport {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: var(--color-bg);
+    background-image: radial-gradient(var(--color-border) 1px, transparent 1px);
+    background-size: 24px 24px;
+    touch-action: none;
+    user-select: none;
+  }
+
+  .vc-canvas-panning {
+    cursor: grab;
+  }
+
+  .vc-canvas-world {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: 0 0;
+  }
+
+  .vc-canvas-node {
+    position: absolute;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    cursor: move;
+  }
+
+  .vc-canvas-node-selected {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 2px var(--color-accent-bg);
+  }
+
+  .vc-canvas-node-content {
+    padding: 8px;
+    font-size: 14px;
+    color: var(--color-text);
+    white-space: pre-wrap;
+    word-break: break-word;
+    flex: 1;
+    overflow: auto;
+  }
+
+  .vc-canvas-node-placeholder .vc-canvas-node-content {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .vc-canvas-node-textarea {
+    flex: 1;
+    resize: none;
+    border: none;
+    outline: none;
+    padding: 8px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--color-text);
+    background: var(--color-surface);
+    box-sizing: border-box;
+  }
+
+  .vc-canvas-resize-handle {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 12px;
+    height: 12px;
+    cursor: nwse-resize;
+    background: linear-gradient(
+      135deg,
+      transparent 50%,
+      var(--color-border) 50%
+    );
+  }
+
+  .vc-canvas-loading,
+  .vc-canvas-error {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+    font-size: 14px;
+  }
+
+  .vc-canvas-error {
+    color: var(--color-error);
+  }
+</style>

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -7,6 +7,7 @@
   import GraphView from "../Graph/GraphView.svelte";
   import ImagePreview from "./ImagePreview.svelte";
   import UnsupportedPreview from "./UnsupportedPreview.svelte";
+  import CanvasView from "../Canvas/CanvasView.svelte";
   import ReadingView from "./ReadingView.svelte";
   import { tabStore } from "../../store/tabStore";
   import type { Tab } from "../../store/tabStore";
@@ -141,6 +142,7 @@
     if (!t) return false;
     if (t.type === "graph") return false;
     if (t.viewer === "image" || t.viewer === "unsupported") return false;
+    if (t.viewer === "canvas") return false;
     return true;
   }
 
@@ -840,6 +842,14 @@
           style:display={tab.id === paneActiveTabId ? "block" : "none"}
         >
           <UnsupportedPreview abs={tab.filePath} />
+        </div>
+      {:else if tab.viewer === "canvas"}
+        <div
+          class="vc-editor-container"
+          data-tab-id={tab.id}
+          style:display={tab.id === paneActiveTabId ? "block" : "none"}
+        >
+          <CanvasView tabId={tab.id} abs={tab.filePath} />
         </div>
       {:else}
         <!-- #63: both containers are rendered; visibility is toggled by

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ChevronRight, Folder, FolderOpen, FileText, File, MoreHorizontal, Star } from "lucide-svelte";
-  import { listDirectory, createFile, createFolder, deleteFile, moveFile, updateLinksAfterRename, getBacklinks } from "../../ipc/commands";
+  import { listDirectory, createFile, createFolder, deleteFile, moveFile, updateLinksAfterRename, getBacklinks, writeFile } from "../../ipc/commands";
+  import { serializeCanvas, emptyCanvas } from "../../lib/canvas/parse";
   import { toastStore } from "../../store/toastStore";
   import type { RenameResult } from "../../types/links";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
@@ -373,6 +374,25 @@
     }
   }
 
+  async function handleNewCanvasHere() {
+    closeContextMenu();
+    try {
+      const newPath = await createFile(entry.path, "Untitled.canvas");
+      // Seed the file with an empty canvas doc so Obsidian recognizes the
+      // format immediately — an empty string would otherwise parse to a
+      // blank doc but fail Obsidian's schema validation on first open.
+      await writeFile(newPath, serializeCanvas(emptyCanvas()));
+      expanded = true;
+      persistExpanded();
+      await loadChildren();
+      expanded = true;
+      tabStore.openFileTab(newPath, "canvas");
+    } catch (e) {
+      const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
   async function handleNewFolderHere() {
     closeContextMenu();
     try {
@@ -618,6 +638,7 @@
       <button class="vc-context-item vc-context-item--danger" onclick={openDeleteConfirm}>Move to Trash</button>
       {#if entry.is_dir}
         <button class="vc-context-item" onclick={handleNewFileHere}>New file here</button>
+        <button class="vc-context-item" onclick={handleNewCanvasHere}>New canvas here</button>
         <button class="vc-context-item" onclick={handleNewFolderHere}>New folder here</button>
       {/if}
     </div>

--- a/src/lib/__tests__/openFileAsTab.test.ts
+++ b/src/lib/__tests__/openFileAsTab.test.ts
@@ -46,6 +46,13 @@ describe("openFileAsTab", () => {
     expect(readFile).not.toHaveBeenCalled();
   });
 
+  it("opens a `.canvas` file with the canvas viewer without probing (#71)", async () => {
+    await openFileAsTab("/vault/board.canvas");
+    const state = get(tabStore);
+    expect(state.tabs[0]!.viewer).toBe("canvas");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
   it("opens an unknown UTF-8 file as text after probing", async () => {
     readFile.mockResolvedValueOnce("plain text content");
     await openFileAsTab("/vault/script.unknownext");

--- a/src/lib/__tests__/tabKind.test.ts
+++ b/src/lib/__tests__/tabKind.test.ts
@@ -40,6 +40,11 @@ describe("getTabKind", () => {
     expect(getTabKind("doc.markdown")).toBe("markdown");
   });
 
+  it("classifies `.canvas` files as canvas (#71)", () => {
+    expect(getTabKind("board.canvas")).toBe("canvas");
+    expect(getTabKind("/abs/Notes/board.CANVAS")).toBe("canvas");
+  });
+
   it("classifies all known image extensions as image", () => {
     for (const ext of IMAGE_EXTS) {
       expect(getTabKind(`asset.${ext}`)).toBe("image");

--- a/src/lib/canvas/__tests__/parse.test.ts
+++ b/src/lib/canvas/__tests__/parse.test.ts
@@ -1,0 +1,240 @@
+// Parser / serializer tests for the Obsidian `.canvas` format (#71, phase 1).
+// The critical invariant is roundtrip preservation — opening, mutating one
+// node, and saving must not drop unknown fields a producer wrote.
+
+import { describe, it, expect } from "vitest";
+import { parseCanvas, serializeCanvas, emptyCanvas } from "../parse";
+
+describe("parseCanvas", () => {
+  it("returns an empty doc for empty / whitespace input", () => {
+    expect(parseCanvas("")).toEqual({ nodes: [], edges: [] });
+    expect(parseCanvas("   \n  ")).toEqual({ nodes: [], edges: [] });
+  });
+
+  it("parses text nodes with coordinates and text", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [
+          {
+            id: "a",
+            type: "text",
+            x: 10,
+            y: 20,
+            width: 200,
+            height: 80,
+            text: "hello",
+          },
+        ],
+        edges: [],
+      }),
+    );
+    expect(doc.nodes).toHaveLength(1);
+    expect(doc.nodes[0]).toMatchObject({
+      id: "a",
+      type: "text",
+      x: 10,
+      y: 20,
+      width: 200,
+      height: 80,
+      text: "hello",
+    });
+  });
+
+  it("parses file / link / group node variants", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [
+          { id: "f", type: "file", x: 0, y: 0, width: 1, height: 1, file: "note.md" },
+          { id: "l", type: "link", x: 0, y: 0, width: 1, height: 1, url: "https://example.com" },
+          { id: "g", type: "group", x: 0, y: 0, width: 10, height: 10, label: "Group A" },
+        ],
+        edges: [],
+      }),
+    );
+    expect(doc.nodes[0]).toMatchObject({ type: "file", file: "note.md" });
+    expect(doc.nodes[1]).toMatchObject({ type: "link", url: "https://example.com" });
+    expect(doc.nodes[2]).toMatchObject({ type: "group", label: "Group A" });
+  });
+
+  it("parses edges with optional sides and colors", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [],
+        edges: [
+          {
+            id: "e1",
+            fromNode: "a",
+            toNode: "b",
+            fromSide: "right",
+            toSide: "left",
+            color: "#ff0000",
+            label: "flow",
+          },
+        ],
+      }),
+    );
+    expect(doc.edges[0]).toMatchObject({
+      id: "e1",
+      fromNode: "a",
+      toNode: "b",
+      fromSide: "right",
+      toSide: "left",
+      color: "#ff0000",
+      label: "flow",
+    });
+  });
+
+  it("drops nodes missing id or type", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [
+          { type: "text", x: 0, y: 0, width: 1, height: 1, text: "no id" },
+          { id: "x", x: 0, y: 0, width: 1, height: 1, text: "no type" },
+          { id: "ok", type: "text", x: 0, y: 0, width: 1, height: 1, text: "keep" },
+        ],
+        edges: [],
+      }),
+    );
+    expect(doc.nodes).toHaveLength(1);
+    expect(doc.nodes[0]).toMatchObject({ id: "ok" });
+  });
+
+  it("fills missing coordinate / size fields with defaults", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [{ id: "a", type: "text", text: "x" }],
+        edges: [],
+      }),
+    );
+    expect(doc.nodes[0]).toMatchObject({ x: 0, y: 0, width: 250, height: 60 });
+  });
+
+  it("captures unknown node fields in `extra`", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [
+          {
+            id: "a",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 1,
+            height: 1,
+            text: "x",
+            styleAttributes: { theme: "dark" },
+            futureField: 42,
+          },
+        ],
+        edges: [],
+      }),
+    );
+    expect(doc.nodes[0]!.extra).toEqual({
+      styleAttributes: { theme: "dark" },
+      futureField: 42,
+    });
+  });
+
+  it("captures unknown edge fields in `extra`", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [],
+        edges: [
+          {
+            id: "e",
+            fromNode: "a",
+            toNode: "b",
+            somethingNew: true,
+          },
+        ],
+      }),
+    );
+    expect(doc.edges[0]!.extra).toEqual({ somethingNew: true });
+  });
+
+  it("captures unknown top-level fields in `extra`", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [],
+        edges: [],
+        metadata: { v: 2 },
+      }),
+    );
+    expect(doc.extra).toEqual({ metadata: { v: 2 } });
+  });
+});
+
+describe("serializeCanvas", () => {
+  it("writes tab-indented JSON with nodes+edges", () => {
+    const out = serializeCanvas({
+      nodes: [
+        { id: "a", type: "text", x: 0, y: 0, width: 250, height: 60, text: "hi" },
+      ],
+      edges: [],
+    });
+    expect(out).toContain("\t");
+    const parsed = JSON.parse(out);
+    expect(parsed.nodes[0]).toMatchObject({ id: "a", type: "text", text: "hi" });
+    expect(parsed.edges).toEqual([]);
+  });
+
+  it("emits an empty canvas as nodes+edges arrays", () => {
+    const out = serializeCanvas(emptyCanvas());
+    expect(JSON.parse(out)).toEqual({ nodes: [], edges: [] });
+  });
+
+  it("roundtrips unknown node / edge / top-level fields", () => {
+    const input = {
+      nodes: [
+        {
+          id: "a",
+          type: "text",
+          x: 10,
+          y: 20,
+          width: 200,
+          height: 80,
+          text: "hi",
+          styleAttributes: { theme: "dark" },
+        },
+        {
+          id: "b",
+          type: "futureType",
+          x: 1,
+          y: 2,
+          width: 3,
+          height: 4,
+          customProp: "keep me",
+        },
+      ],
+      edges: [
+        {
+          id: "e",
+          fromNode: "a",
+          toNode: "b",
+          somethingNew: [1, 2, 3],
+        },
+      ],
+      metadata: { version: 2 },
+    };
+    const doc = parseCanvas(JSON.stringify(input));
+    const out = serializeCanvas(doc);
+    const parsed = JSON.parse(out);
+    expect(parsed.nodes[0].styleAttributes).toEqual({ theme: "dark" });
+    expect(parsed.nodes[1].type).toBe("futureType");
+    expect(parsed.nodes[1].customProp).toBe("keep me");
+    expect(parsed.edges[0].somethingNew).toEqual([1, 2, 3]);
+    expect(parsed.metadata).toEqual({ version: 2 });
+  });
+
+  it("does not emit undefined optional fields", () => {
+    const out = serializeCanvas({
+      nodes: [
+        { id: "a", type: "text", x: 0, y: 0, width: 1, height: 1, text: "x" },
+      ],
+      edges: [{ id: "e", fromNode: "a", toNode: "a" }],
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.nodes[0]).not.toHaveProperty("color");
+    expect(parsed.edges[0]).not.toHaveProperty("fromSide");
+    expect(parsed.edges[0]).not.toHaveProperty("toEnd");
+  });
+});

--- a/src/lib/canvas/parse.ts
+++ b/src/lib/canvas/parse.ts
@@ -1,0 +1,278 @@
+// Parse / serialize Obsidian-compatible `.canvas` files (issue #71, phase 1).
+//
+// Roundtrip rules:
+//  - Unknown node / edge / top-level fields are captured into an `extra` bag
+//    and restored verbatim on serialize.
+//  - Output is pretty-printed JSON with tab indentation — matches Obsidian's
+//    on-disk format so vaults diffed via git stay stable across editors.
+//  - An empty canvas serializes to `{ "nodes": [], "edges": [] }`.
+
+import type {
+  CanvasDoc,
+  CanvasEdge,
+  CanvasFileNode,
+  CanvasGroupNode,
+  CanvasLinkNode,
+  CanvasNode,
+  CanvasSide,
+  CanvasTextNode,
+  CanvasUnknownNode,
+} from "./types";
+
+const KNOWN_NODE_KEYS = new Set([
+  "id",
+  "type",
+  "x",
+  "y",
+  "width",
+  "height",
+  "color",
+  // text
+  "text",
+  // file
+  "file",
+  "subpath",
+  // link
+  "url",
+  // group
+  "label",
+  "background",
+  "backgroundStyle",
+]);
+
+const KNOWN_EDGE_KEYS = new Set([
+  "id",
+  "fromNode",
+  "toNode",
+  "fromSide",
+  "toSide",
+  "fromEnd",
+  "toEnd",
+  "color",
+  "label",
+]);
+
+const KNOWN_DOC_KEYS = new Set(["nodes", "edges"]);
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function pickExtra(
+  raw: Record<string, unknown>,
+  known: Set<string>,
+): Record<string, unknown> | undefined {
+  let extra: Record<string, unknown> | undefined;
+  for (const [k, v] of Object.entries(raw)) {
+    if (!known.has(k)) {
+      if (!extra) extra = {};
+      extra[k] = v;
+    }
+  }
+  return extra;
+}
+
+function asNumber(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+
+function asString(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function asSide(v: unknown): CanvasSide | undefined {
+  return v === "top" || v === "right" || v === "bottom" || v === "left"
+    ? v
+    : undefined;
+}
+
+function parseNode(raw: unknown): CanvasNode | null {
+  if (!isObject(raw)) return null;
+  const id = asString(raw.id);
+  const type = asString(raw.type);
+  if (!id || !type) return null;
+  const base = {
+    id,
+    x: asNumber(raw.x, 0),
+    y: asNumber(raw.y, 0),
+    width: asNumber(raw.width, 250),
+    height: asNumber(raw.height, 60),
+    ...(typeof raw.color === "string" ? { color: raw.color } : {}),
+  };
+  const extraMaybe = pickExtra(raw, KNOWN_NODE_KEYS);
+  const extra = extraMaybe ? { extra: extraMaybe } : {};
+  switch (type) {
+    case "text": {
+      const node: CanvasTextNode = {
+        ...base,
+        type: "text",
+        text: asString(raw.text),
+        ...extra,
+      };
+      return node;
+    }
+    case "file": {
+      const node: CanvasFileNode = {
+        ...base,
+        type: "file",
+        file: asString(raw.file),
+        ...(typeof raw.subpath === "string" ? { subpath: raw.subpath } : {}),
+        ...extra,
+      };
+      return node;
+    }
+    case "link": {
+      const node: CanvasLinkNode = {
+        ...base,
+        type: "link",
+        url: asString(raw.url),
+        ...extra,
+      };
+      return node;
+    }
+    case "group": {
+      const node: CanvasGroupNode = {
+        ...base,
+        type: "group",
+        ...(typeof raw.label === "string" ? { label: raw.label } : {}),
+        ...(typeof raw.background === "string"
+          ? { background: raw.background }
+          : {}),
+        ...(typeof raw.backgroundStyle === "string"
+          ? { backgroundStyle: raw.backgroundStyle }
+          : {}),
+        ...extra,
+      };
+      return node;
+    }
+    default: {
+      const node: CanvasUnknownNode = {
+        ...base,
+        type,
+        ...extra,
+      };
+      return node;
+    }
+  }
+}
+
+function parseEdge(raw: unknown): CanvasEdge | null {
+  if (!isObject(raw)) return null;
+  const id = asString(raw.id);
+  const fromNode = asString(raw.fromNode);
+  const toNode = asString(raw.toNode);
+  if (!id || !fromNode || !toNode) return null;
+  const extraMaybe = pickExtra(raw, KNOWN_EDGE_KEYS);
+  const asEnd = (v: unknown): "none" | "arrow" | undefined =>
+    v === "none" || v === "arrow" ? v : undefined;
+  const fromSide = asSide(raw.fromSide);
+  const toSide = asSide(raw.toSide);
+  const fromEnd = asEnd(raw.fromEnd);
+  const toEnd = asEnd(raw.toEnd);
+  return {
+    id,
+    fromNode,
+    toNode,
+    ...(fromSide !== undefined ? { fromSide } : {}),
+    ...(toSide !== undefined ? { toSide } : {}),
+    ...(fromEnd !== undefined ? { fromEnd } : {}),
+    ...(toEnd !== undefined ? { toEnd } : {}),
+    ...(typeof raw.color === "string" ? { color: raw.color } : {}),
+    ...(typeof raw.label === "string" ? { label: raw.label } : {}),
+    ...(extraMaybe ? { extra: extraMaybe } : {}),
+  };
+}
+
+/**
+ * Parse a `.canvas` file body. Empty / whitespace-only bodies become an
+ * empty doc so a freshly created file opens without an error. Malformed
+ * JSON throws — the caller should surface a toast and refuse to open.
+ */
+export function parseCanvas(text: string): CanvasDoc {
+  const trimmed = text.trim();
+  if (!trimmed) return { nodes: [], edges: [] };
+  const raw = JSON.parse(trimmed);
+  if (!isObject(raw)) return { nodes: [], edges: [] };
+  const nodes = Array.isArray(raw.nodes)
+    ? raw.nodes.map(parseNode).filter((n): n is CanvasNode => n !== null)
+    : [];
+  const edges = Array.isArray(raw.edges)
+    ? raw.edges.map(parseEdge).filter((e): e is CanvasEdge => e !== null)
+    : [];
+  const extra = pickExtra(raw, KNOWN_DOC_KEYS);
+  return { nodes, edges, ...(extra ? { extra } : {}) };
+}
+
+function serializeNode(n: CanvasNode): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    id: n.id,
+    type: n.type,
+    x: n.x,
+    y: n.y,
+    width: n.width,
+    height: n.height,
+  };
+  if (n.color !== undefined) out.color = n.color;
+  if (n.type === "text") {
+    out.text = (n as CanvasTextNode).text;
+  } else if (n.type === "file") {
+    const fn = n as CanvasFileNode;
+    out.file = fn.file;
+    if (fn.subpath !== undefined) out.subpath = fn.subpath;
+  } else if (n.type === "link") {
+    out.url = (n as CanvasLinkNode).url;
+  } else if (n.type === "group") {
+    const gn = n as CanvasGroupNode;
+    if (gn.label !== undefined) out.label = gn.label;
+    if (gn.background !== undefined) out.background = gn.background;
+    if (gn.backgroundStyle !== undefined) out.backgroundStyle = gn.backgroundStyle;
+  }
+  if (n.extra) {
+    for (const [k, v] of Object.entries(n.extra)) {
+      if (!(k in out)) out[k] = v;
+    }
+  }
+  return out;
+}
+
+function serializeEdge(e: CanvasEdge): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    id: e.id,
+    fromNode: e.fromNode,
+    toNode: e.toNode,
+  };
+  if (e.fromSide !== undefined) out.fromSide = e.fromSide;
+  if (e.toSide !== undefined) out.toSide = e.toSide;
+  if (e.fromEnd !== undefined) out.fromEnd = e.fromEnd;
+  if (e.toEnd !== undefined) out.toEnd = e.toEnd;
+  if (e.color !== undefined) out.color = e.color;
+  if (e.label !== undefined) out.label = e.label;
+  if (e.extra) {
+    for (const [k, v] of Object.entries(e.extra)) {
+      if (!(k in out)) out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Serialize to Obsidian-compatible JSON. Uses tab indentation to match the
+ * on-disk format Obsidian writes so git diffs stay stable.
+ */
+export function serializeCanvas(doc: CanvasDoc): string {
+  const out: Record<string, unknown> = {
+    nodes: doc.nodes.map(serializeNode),
+    edges: doc.edges.map(serializeEdge),
+  };
+  if (doc.extra) {
+    for (const [k, v] of Object.entries(doc.extra)) {
+      if (!(k in out)) out[k] = v;
+    }
+  }
+  return JSON.stringify(out, null, "\t");
+}
+
+/** Empty doc used when the caller needs a blank canvas. */
+export function emptyCanvas(): CanvasDoc {
+  return { nodes: [], edges: [] };
+}

--- a/src/lib/canvas/types.ts
+++ b/src/lib/canvas/types.ts
@@ -1,0 +1,84 @@
+// Obsidian-compatible Canvas document model (issue #71, phase 1).
+// Spec reference: https://jsoncanvas.org/spec/1.0/
+//
+// Each node / edge preserves unknown fields verbatim via the `extra` bag so
+// VaultCore never drops data it does not understand — opening an Obsidian
+// canvas, editing one text card, and saving must roundtrip every other
+// field the producer wrote (colors, styleAttributes, future fields, …).
+
+/** Side a connector can dock to on a node's bounding rect. */
+export type CanvasSide = "top" | "right" | "bottom" | "left";
+
+export interface CanvasNodeBase {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color?: string;
+  /** Unknown fields passed through unchanged on save. */
+  extra?: Record<string, unknown>;
+}
+
+export interface CanvasTextNode extends CanvasNodeBase {
+  type: "text";
+  text: string;
+}
+
+export interface CanvasFileNode extends CanvasNodeBase {
+  type: "file";
+  file: string;
+  subpath?: string;
+}
+
+export interface CanvasLinkNode extends CanvasNodeBase {
+  type: "link";
+  url: string;
+}
+
+export interface CanvasGroupNode extends CanvasNodeBase {
+  type: "group";
+  label?: string;
+  background?: string;
+  backgroundStyle?: string;
+}
+
+/**
+ * A node we parsed but do not render yet. Phase 1 only renders "text";
+ * other types round-trip through this variant so saves do not destroy them.
+ */
+export interface CanvasUnknownNode extends CanvasNodeBase {
+  type: string;
+}
+
+export type CanvasNode =
+  | CanvasTextNode
+  | CanvasFileNode
+  | CanvasLinkNode
+  | CanvasGroupNode
+  | CanvasUnknownNode;
+
+export interface CanvasEdge {
+  id: string;
+  fromNode: string;
+  toNode: string;
+  fromSide?: CanvasSide;
+  toSide?: CanvasSide;
+  fromEnd?: "none" | "arrow";
+  toEnd?: "none" | "arrow";
+  color?: string;
+  label?: string;
+  /** Unknown fields passed through unchanged on save. */
+  extra?: Record<string, unknown>;
+}
+
+export interface CanvasDoc {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+  /** Top-level unknown fields passed through unchanged on save. */
+  extra?: Record<string, unknown>;
+}
+
+/** Default width / height applied when a node omits the field. Matches Obsidian. */
+export const DEFAULT_NODE_WIDTH = 250;
+export const DEFAULT_NODE_HEIGHT = 60;

--- a/src/lib/openFileAsTab.ts
+++ b/src/lib/openFileAsTab.ts
@@ -25,6 +25,9 @@ export async function openFileAsTab(absPath: string): Promise<string | null> {
   if (ext === "md" || ext === "markdown") {
     return tabStore.openTab(absPath);
   }
+  if (ext === "canvas") {
+    return tabStore.openFileTab(absPath, "canvas");
+  }
   if (IMAGE_EXTS.has(ext)) {
     return tabStore.openFileTab(absPath, "image");
   }

--- a/src/lib/tabKind.ts
+++ b/src/lib/tabKind.ts
@@ -29,7 +29,7 @@ export const TEXT_EXTS = new Set([
 ]);
 
 /** Tab viewer — what UI branch EditorPane should render for a tab. */
-export type TabKind = "markdown" | "image" | "text" | "unsupported";
+export type TabKind = "markdown" | "image" | "text" | "unsupported" | "canvas";
 
 /**
  * Extract the lowercase extension from a path (without the leading dot).
@@ -50,6 +50,7 @@ export function getExtension(path: string): string {
 export function getTabKind(path: string): TabKind {
   const ext = getExtension(path);
   if (ext === "md" || ext === "markdown") return "markdown";
+  if (ext === "canvas") return "canvas";
   if (IMAGE_EXTS.has(ext)) return "image";
   if (TEXT_EXTS.has(ext)) return "text";
   // Unknown extension — caller should try UTF-8 read and fall back

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -18,7 +18,7 @@ export type TabType = "file" | "graph";
  * EditorPane renders. Omitted on markdown tabs for backwards compatibility
  * with existing callers that never set this field.
  */
-export type TabViewer = "markdown" | "image" | "text" | "unsupported";
+export type TabViewer = "markdown" | "image" | "text" | "unsupported" | "canvas";
 
 /**
  * Reading Mode vs Edit Mode (#63). Persisted per-tab; only meaningful for


### PR DESCRIPTION
## Summary
Phase 1 of #71 (infinite canvas). Ships a working canvas viewer with text cards and full Obsidian-compatible roundtrip.

- Parser + serializer for the Obsidian `.canvas` JSON format. Unknown node/edge/top-level fields are preserved verbatim via an `extra` bag so opening and saving an Obsidian canvas never drops data.
- `CanvasView.svelte` — pan (middle mouse or space+drag), zoom (wheel, 0.15x–4x), text-card create (double-click empty space), move (drag body), resize (SE handle), edit (double-click card), delete (Del/Backspace), select-to-focus. Autosave is debounced at 400ms with a flush on unmount.
- `TabViewer` gains a `"canvas"` variant, wired through `tabKind`, `openFileAsTab`, the `EditorPane` dispatch, and the `tabHasEditor` guard so canvas tabs do not mount a CM6 editor.
- "New canvas here" added to the sidebar folder context menu — seeds the file with an empty doc so Obsidian accepts it on first open.
- Non-text nodes (file/link/group/future types) render as a placeholder in phase 1 but round-trip through parse/serialize unchanged.

## Scope
- In scope: text cards, pan/zoom, roundtrip of every other node type as opaque payload.
- Deferred to phase 2 (#125): edges.
- Deferred to phase 3 (#126): embedded file/image/link nodes.

## Test plan
- [x] `pnpm test` — 486 pass (parser: 13 new tests for roundtrip, unknown field preservation, malformed input)
- [x] `pnpm typecheck` — clean under `exactOptionalPropertyTypes: true`
- [x] `pnpm build` — no a11y warnings
- [ ] Manual UAT: open an Obsidian `.canvas`, add a text card, save, reopen in Obsidian — verify no data loss
- [ ] Manual UAT: create via "New canvas here", populate, save, reload app — verify persistence

Closes #124