### PR TITLE
feat: canvas edges — render + drag-to-create + labels (#125)

### DIFF
--- a/e2e/specs/canvas-edges.spec.ts
+++ b/e2e/specs/canvas-edges.spec.ts
@@ -1,0 +1,523 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf, textsOf } from "../helpers/text.js";
+
+/**
+ * E2E coverage for issue #125 (canvas phase 2 — edges). Tests:
+ *   - Existing edges render as SVG bezier paths between their endpoint nodes.
+ *   - Edges without fromSide/toSide auto-pick and still render.
+ *   - Orphaned edges (endpoint node missing) skip silently — no crash.
+ *   - Self-loop edges (fromNode === toNode) render without crashing.
+ *   - Edge labels display + edit via double-click; blur persists to disk.
+ *   - Unknown per-edge fields roundtrip through an edit.
+ *   - Creating an edge by dragging from one node handle onto another
+ *     node handle writes a new edge to disk.
+ *   - Selecting an edge (click on the hit path) + Delete/Backspace removes
+ *     it from disk.
+ *   - Color + arrow-end passthrough survives an unrelated edit.
+ *
+ * Scope to the active viewport via vizSel() just like phase 1 — multiple
+ * canvas tabs can be open in one suite run.
+ */
+
+const DEBOUNCE_MS = 400;
+const FLUSH_WAIT_MS = DEBOUNCE_MS + 500;
+
+// Source doc has several edge variants covered by the spec invariants.
+const EDGES_DOC = {
+  nodes: [
+    { id: "n-a", type: "text", x: -400, y: -40, width: 160, height: 60, text: "A" },
+    { id: "n-b", type: "text", x: 100, y: -40, width: 160, height: 60, text: "B" },
+    { id: "n-c", type: "text", x: -150, y: 200, width: 160, height: 60, text: "C" },
+    { id: "n-d", type: "text", x: 400, y: 200, width: 160, height: 60, text: "D" },
+  ],
+  edges: [
+    // explicit sides + color + label + arrow end
+    {
+      id: "e-explicit",
+      fromNode: "n-a",
+      toNode: "n-b",
+      fromSide: "right",
+      toSide: "left",
+      color: "#ff8800",
+      label: "flow",
+      toEnd: "arrow",
+      extraFuturey: { foo: 1 },
+    },
+    // no sides → auto-picked; explicit toEnd: "none" to verify the arrow
+    // defaults can be suppressed (Obsidian defaults to arrow-on for toEnd).
+    { id: "e-auto", fromNode: "n-b", toNode: "n-c", toEnd: "none" },
+    // orphan — toNode missing from the doc
+    { id: "e-orphan", fromNode: "n-a", toNode: "ghost" },
+    // self-loop
+    {
+      id: "e-self",
+      fromNode: "n-d",
+      toNode: "n-d",
+      fromSide: "right",
+      toSide: "bottom",
+    },
+  ],
+  metadata: { docLevel: true },
+};
+
+const CREATE_DOC = {
+  nodes: [
+    { id: "n-x", type: "text", x: -200, y: 0, width: 160, height: 60, text: "X" },
+    { id: "n-y", type: "text", x: 200, y: 0, width: 160, height: 60, text: "Y" },
+  ],
+  edges: [],
+};
+
+describe("Canvas edges (#125)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(
+      path.join(vault.path, "Edges.canvas"),
+      JSON.stringify(EDGES_DOC, null, "\t"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(vault.path, "Create.canvas"),
+      JSON.stringify(CREATE_DOC, null, "\t"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  // ─── Helpers (mirror canvas.spec.ts patterns) ─────────────────────────
+
+  async function activeTabId(): Promise<string> {
+    const id = await browser.execute(() => {
+      const viewports = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = viewports.find((v) => v.offsetParent !== null);
+      return visible?.getAttribute("data-tab-id") ?? null;
+    });
+    if (!id) throw new Error("No visible canvas viewport found");
+    return id as string;
+  }
+
+  async function vizSel(suffix = ""): Promise<string> {
+    const id = await activeTabId();
+    return `.vc-canvas-viewport[data-tab-id="${id}"]${suffix}`;
+  }
+
+  async function openTreeFile(name: string): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const names = await textsOf(await browser.$$(".vc-tree-name"));
+        return names.includes(name);
+      },
+      { timeout: 5000, timeoutMsg: `"${name}" never appeared in the tree` },
+    );
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not found`);
+  }
+
+  async function waitForCanvas(): Promise<void> {
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const visible = vps.find((v) => v.offsetParent !== null);
+          return !!visible?.querySelector(".vc-canvas-world");
+        }),
+      { timeout: 5000, timeoutMsg: "Canvas world never mounted" },
+    );
+  }
+
+  async function readDisk(
+    name: string,
+  ): Promise<{
+    nodes: Array<Record<string, unknown>>;
+    edges: Array<Record<string, unknown>>;
+    [k: string]: unknown;
+  }> {
+    const raw = fs.readFileSync(path.join(vault.path, name), "utf-8");
+    return JSON.parse(raw);
+  }
+
+  async function waitForDiskDoc<T>(
+    name: string,
+    predicate: (doc: {
+      nodes: Array<Record<string, unknown>>;
+      edges: Array<Record<string, unknown>>;
+      [k: string]: unknown;
+    }) => T | null | false | undefined,
+    timeoutMs = FLUSH_WAIT_MS * 8,
+  ): Promise<T> {
+    const start = Date.now();
+    let last: unknown;
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const doc = await readDisk(name);
+        const hit = predicate(doc);
+        if (hit) return hit as T;
+        last = doc;
+      } catch {
+        /* file not yet written */
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+      `waitForDiskDoc(${name}) timed out. Last doc: ${JSON.stringify(last)}`,
+    );
+  }
+
+  /** Count visible edges by data-edge-id on `.vc-canvas-edge` (the visible stroke). */
+  async function visibleEdgeCount(): Promise<number> {
+    return browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      return visible?.querySelectorAll(".vc-canvas-edge").length ?? 0;
+    }) as Promise<number>;
+  }
+
+  async function visibleEdgeIds(): Promise<string[]> {
+    return browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      if (!visible) return [];
+      const paths = Array.from(
+        visible.querySelectorAll<SVGElement>(".vc-canvas-edge"),
+      );
+      return paths.map((p) => p.getAttribute("data-edge-id") ?? "");
+    }) as Promise<string[]>;
+  }
+
+  async function edgePathD(edgeId: string): Promise<string> {
+    return browser.execute((id: string) => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      if (!visible) return "";
+      const el = visible.querySelector(
+        `.vc-canvas-edge[data-edge-id="${id}"]`,
+      ) as SVGPathElement | null;
+      return el?.getAttribute("d") ?? "";
+    }, edgeId) as Promise<string>;
+  }
+
+  async function edgeHasArrow(edgeId: string): Promise<boolean> {
+    return browser.execute((id: string) => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      if (!visible) return false;
+      const el = visible.querySelector(
+        `.vc-canvas-edge[data-edge-id="${id}"]`,
+      ) as SVGPathElement | null;
+      return !!el?.getAttribute("marker-end");
+    }, edgeId) as Promise<boolean>;
+  }
+
+  async function visibleEdgeLabelText(): Promise<string[]> {
+    return browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      if (!visible) return [];
+      return Array.from(visible.querySelectorAll(".vc-canvas-edge-label")).map(
+        (e) => e.textContent?.trim() ?? "",
+      );
+    }) as Promise<string[]>;
+  }
+
+  /** Dispatch a synthetic pointerdown + pointermove + pointerup chain to drag
+   * from `fromSel` center to `toSel` center, invoking handlers on each
+   * element along the way. Used to create an edge without flaky Actions API. */
+  async function dragBetween(
+    fromSel: string,
+    toSel: string,
+  ): Promise<void> {
+    await browser.execute(
+      (from: string, to: string) => {
+        const a = document.querySelector(from) as HTMLElement | null;
+        const b = document.querySelector(to) as HTMLElement | null;
+        if (!a) throw new Error(`No element: ${from}`);
+        if (!b) throw new Error(`No element: ${to}`);
+        const ra = a.getBoundingClientRect();
+        const rb = b.getBoundingClientRect();
+        const ax = ra.left + ra.width / 2;
+        const ay = ra.top + ra.height / 2;
+        const bx = rb.left + rb.width / 2;
+        const by = rb.top + rb.height / 2;
+
+        const vp = document.querySelector(
+          ".vc-canvas-viewport[data-tab-id]",
+        ) as HTMLElement | null;
+        // Find the visible viewport
+        const vps = Array.from(
+          document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+        );
+        const visibleVp = vps.find((v) => v.offsetParent !== null) ?? vp;
+        if (!visibleVp) throw new Error("No visible viewport");
+
+        const mk = (x: number, y: number): PointerEventInit => ({
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          clientX: x,
+          clientY: y,
+          pointerId: 17,
+          pointerType: "mouse",
+          button: 0,
+          buttons: 1,
+          isPrimary: true,
+        });
+
+        // pointerdown on source handle
+        a.dispatchEvent(new PointerEvent("pointerdown", mk(ax, ay)));
+        // move along the viewport (that's where pointermove is captured)
+        visibleVp.dispatchEvent(new PointerEvent("pointermove", mk(bx, by)));
+        // pointerenter onto target handle (triggers snap)
+        b.dispatchEvent(new PointerEvent("pointerenter", mk(bx, by)));
+        b.dispatchEvent(new PointerEvent("pointermove", mk(bx, by)));
+        // Release on the viewport (which owns the pointer capture for edge mode)
+        visibleVp.dispatchEvent(new PointerEvent("pointerup", mk(bx, by)));
+      },
+      fromSel,
+      toSel,
+    );
+  }
+
+  async function dispatchDblClick(sel: string): Promise<void> {
+    await browser.execute((s: string) => {
+      const el = document.querySelector(s) as HTMLElement | null;
+      if (!el) throw new Error(`No element: ${s}`);
+      const r = el.getBoundingClientRect();
+      el.dispatchEvent(
+        new MouseEvent("dblclick", {
+          bubbles: true,
+          cancelable: true,
+          clientX: r.left + r.width / 2,
+          clientY: r.top + r.height / 2,
+          button: 0,
+        }),
+      );
+    }, sel);
+  }
+
+  async function pointerClick(sel: string): Promise<void> {
+    await browser.execute((s: string) => {
+      const el = document.querySelector(s) as HTMLElement | null;
+      if (!el) throw new Error(`No element: ${s}`);
+      const r = el.getBoundingClientRect();
+      const opts: PointerEventInit = {
+        bubbles: true,
+        cancelable: true,
+        clientX: r.left + r.width / 2,
+        clientY: r.top + r.height / 2,
+        pointerId: 5,
+        pointerType: "mouse",
+        button: 0,
+        buttons: 1,
+        isPrimary: true,
+      };
+      el.dispatchEvent(new PointerEvent("pointerdown", opts));
+      el.dispatchEvent(new PointerEvent("pointerup", opts));
+    }, sel);
+  }
+
+  async function setEdgeLabelInputAndBlur(text: string): Promise<void> {
+    await browser.waitUntil(
+      async () =>
+        browser.execute(
+          () => !!document.querySelector(".vc-canvas-edge-label-input"),
+        ),
+      { timeout: 3000, timeoutMsg: "Edge label input never appeared" },
+    );
+    await browser.execute((t: string) => {
+      const inp = document.querySelector(
+        ".vc-canvas-edge-label-input",
+      ) as HTMLInputElement | null;
+      if (!inp) throw new Error("No edge label input");
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      setter.call(inp, t);
+      inp.dispatchEvent(new Event("input", { bubbles: true }));
+      inp.blur();
+    }, text);
+  }
+
+  // ─── Rendering ────────────────────────────────────────────────────────
+
+  it("renders an edge for every resolvable fromNode/toNode pair", async () => {
+    await openTreeFile("Edges.canvas");
+    await waitForCanvas();
+
+    await browser.waitUntil(async () => (await visibleEdgeCount()) >= 3, {
+      timeout: 3000,
+      timeoutMsg: "Edges never appeared",
+    });
+
+    const ids = await visibleEdgeIds();
+    // explicit, auto, self — orphan (e-orphan) must be skipped, not rendered
+    expect(ids).toContain("e-explicit");
+    expect(ids).toContain("e-auto");
+    expect(ids).toContain("e-self");
+    expect(ids).not.toContain("e-orphan");
+  });
+
+  it("orphaned edges do not crash the viewer", async () => {
+    // If we got here, nothing crashed. Verify the document is intact.
+    const hasError = await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      return !!visible?.querySelector(".vc-canvas-error");
+    });
+    expect(hasError).toBe(false);
+  });
+
+  it("renders a cubic bezier with the fromNode's right side as start", async () => {
+    // n-a is at x=-400,y=-40,w=160,h=60. Its `right` anchor = (-240, -10).
+    const d = await edgePathD("e-explicit");
+    expect(d).toMatch(/^M -240 -10 C /);
+    expect(d).toMatch(/100 -10$/); // n-b's `left` anchor = (100, -10)
+  });
+
+  it("renders an arrowhead when toEnd === 'arrow'", async () => {
+    expect(await edgeHasArrow("e-explicit")).toBe(true);
+    expect(await edgeHasArrow("e-auto")).toBe(false);
+  });
+
+  it("renders an edge label when the edge has one", async () => {
+    const labels = await visibleEdgeLabelText();
+    expect(labels).toContain("flow");
+  });
+
+  // ─── Edge creation ────────────────────────────────────────────────────
+
+  it("creates a new edge by dragging from one handle onto another", async () => {
+    await openTreeFile("Create.canvas");
+    await waitForCanvas();
+
+    const before = await visibleEdgeCount();
+    expect(before).toBe(0);
+
+    const sel = await vizSel();
+    const fromSel = `${sel} [data-node-id="n-x"] [data-edge-handle="right"]`;
+    const toSel = `${sel} [data-node-id="n-y"] [data-edge-handle="left"]`;
+    await dragBetween(fromSel, toSel);
+
+    await browser.waitUntil(async () => (await visibleEdgeCount()) === 1, {
+      timeout: 3000,
+      timeoutMsg: "New edge never appeared after drag",
+    });
+
+    const doc = await waitForDiskDoc("Create.canvas", (d) =>
+      d.edges.length === 1 ? d : false,
+    );
+    const edge = doc.edges[0]!;
+    expect(edge.fromNode).toBe("n-x");
+    expect(edge.toNode).toBe("n-y");
+    expect(edge.fromSide).toBe("right");
+    expect(edge.toSide).toBe("left");
+  });
+
+  it("selects an edge on click and deletes it on Backspace", async () => {
+    // The edge we just created is the only one in this doc.
+    const hitSel = await vizSel(" .vc-canvas-edge-hit");
+    await pointerClick(hitSel);
+
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const visible = vps.find((v) => v.offsetParent !== null);
+          return !!visible?.querySelector(".vc-canvas-edge-selected");
+        }),
+      { timeout: 2000, timeoutMsg: "Edge never became selected" },
+    );
+
+    await browser.keys(["Backspace"]);
+
+    await browser.waitUntil(async () => (await visibleEdgeCount()) === 0, {
+      timeout: 3000,
+      timeoutMsg: "Edge was not removed from DOM",
+    });
+
+    await waitForDiskDoc("Create.canvas", (d) =>
+      d.edges.length === 0 ? d : false,
+    );
+  });
+
+  // ─── Label editing ────────────────────────────────────────────────────
+
+  it("edits an edge label via double-click and persists it", async () => {
+    await openTreeFile("Edges.canvas");
+    await waitForCanvas();
+
+    // Double-click the existing label to enter edit mode.
+    await browser.waitUntil(
+      async () => (await visibleEdgeLabelText()).includes("flow"),
+      { timeout: 3000, timeoutMsg: "Label 'flow' never rendered" },
+    );
+    await dispatchDblClick(await vizSel(" .vc-canvas-edge-label"));
+    await setEdgeLabelInputAndBlur("renamed");
+
+    await browser.waitUntil(
+      async () => (await visibleEdgeLabelText()).includes("renamed"),
+      { timeout: 3000, timeoutMsg: "Renamed label never appeared" },
+    );
+
+    await waitForDiskDoc("Edges.canvas", (d) => {
+      const edge = d.edges.find((e) => e.id === "e-explicit");
+      return edge && edge.label === "renamed" ? d : false;
+    });
+  });
+
+  it("preserves unknown edge fields, color and arrow end after an edit", async () => {
+    // Check the disk doc from the last assertion — it must still have color,
+    // toEnd, and the extraFuturey passthrough alongside the renamed label.
+    const doc = await readDisk("Edges.canvas");
+    const edge = doc.edges.find((e) => e.id === "e-explicit")!;
+    expect(edge.color).toBe("#ff8800");
+    expect(edge.toEnd).toBe("arrow");
+    expect(edge.extraFuturey).toEqual({ foo: 1 });
+    // The self-loop edge should still be present verbatim
+    const self = doc.edges.find((e) => e.id === "e-self")!;
+    expect(self.fromNode).toBe("n-d");
+    expect(self.toNode).toBe("n-d");
+    // Top-level unknown key still there
+    expect(doc.metadata).toEqual({ docLevel: true });
+  });
+
+  it("preserves the orphaned edge on disk even though it is not rendered", async () => {
+    const doc = await readDisk("Edges.canvas");
+    const orphan = doc.edges.find((e) => e.id === "e-orphan");
+    expect(orphan).toBeDefined();
+    expect(orphan!.toNode).toBe("ghost");
+  });
+});

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-  // Canvas viewer — issue #71, phase 1.
+  // Canvas viewer — issue #71, phases 1 + 2.
   //
-  // Scope: text cards only. Pan (middle/space+drag), zoom (wheel), create
-  // (double-click empty space), edit (double-click card), move (drag body),
-  // resize (drag SE handle), delete (Del/Backspace with card selected),
-  // autosave to disk debounced through writeFile. Other node types (file,
-  // link, group) are parsed and re-serialized unchanged so Obsidian canvases
-  // open and save without losing data.
+  // Phase 1: text cards (pan/zoom/create/edit/move/resize/delete) and
+  // lossless roundtrip for all other node types through an `extra` bag.
+  //
+  // Phase 2: edges (#125). SVG overlay rides the same world transform as
+  // the nodes. Every node exposes four hover handles (top/right/bottom/left);
+  // dragging from a handle draws a preview bezier that snaps onto any other
+  // node's handle to create an edge. Edges select on click (thick invisible
+  // hit-path behind the visible stroke) and delete on Backspace/Delete.
+  // Optional labels edit via double-click on the edge midpoint.
 
   import { onMount, onDestroy, tick } from "svelte";
   import { readFile, writeFile } from "../../ipc/commands";
@@ -19,13 +22,22 @@
   } from "../../lib/canvas/parse";
   import type {
     CanvasDoc,
+    CanvasEdge,
     CanvasNode,
+    CanvasSide,
     CanvasTextNode,
   } from "../../lib/canvas/types";
   import {
     DEFAULT_NODE_WIDTH,
     DEFAULT_NODE_HEIGHT,
   } from "../../lib/canvas/types";
+  import {
+    SIDES,
+    anchorPoint,
+    autoSides,
+    bezierMidpoint,
+    bezierPath,
+  } from "../../lib/canvas/geometry";
 
   interface Props {
     tabId: string;
@@ -38,16 +50,32 @@
   let loaded = $state(false);
   let loadError = $state<string | null>(null);
 
-  // Camera — world-space translation + zoom factor.
   let camX = $state(0);
   let camY = $state(0);
   let zoom = $state(1);
 
-  let selectedId = $state<string | null>(null);
-  let editingId = $state<string | null>(null);
+  let selectedNodeId = $state<string | null>(null);
+  let selectedEdgeId = $state<string | null>(null);
+  let editingNodeId = $state<string | null>(null);
+  let editingEdgeId = $state<string | null>(null);
+  let hoveredNodeId = $state<string | null>(null);
+
+  // Draft edge: populated while the user drags from a handle. `targetNodeId`
+  // + `targetSide` are only set when the pointer is over another node's
+  // handle, which is when pointerup commits the edge.
+  type DraftEdge = {
+    fromNodeId: string;
+    fromSide: CanvasSide;
+    currentX: number;
+    currentY: number;
+    targetNodeId: string | null;
+    targetSide: CanvasSide | null;
+  };
+  let draft = $state<DraftEdge | null>(null);
 
   let viewportEl: HTMLDivElement | null = null;
-  let editingTextareaEl: HTMLTextAreaElement | null = null;
+  let editingTextareaEl = $state<HTMLTextAreaElement | null>(null);
+  let editingEdgeLabelEl = $state<HTMLInputElement | null>(null);
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   let lastWrittenJson = "";
   let suppressSave = true;
@@ -56,7 +84,8 @@
   type PointerMode =
     | { kind: "pan"; startClientX: number; startClientY: number; startCamX: number; startCamY: number }
     | { kind: "move"; nodeId: string; startClientX: number; startClientY: number; startX: number; startY: number }
-    | { kind: "resize"; nodeId: string; startClientX: number; startClientY: number; startW: number; startH: number };
+    | { kind: "resize"; nodeId: string; startClientX: number; startClientY: number; startW: number; startH: number }
+    | { kind: "edge"; fromNodeId: string; fromSide: CanvasSide };
 
   let pointerMode: PointerMode | null = null;
 
@@ -106,14 +135,6 @@
     }
   }
 
-  async function flushPendingSave() {
-    if (saveTimer) {
-      clearTimeout(saveTimer);
-      saveTimer = null;
-      await persist();
-    }
-  }
-
   onMount(() => {
     void load();
   });
@@ -122,30 +143,34 @@
     if (saveTimer) {
       clearTimeout(saveTimer);
       saveTimer = null;
-      // Fire-and-forget — we can't await in onDestroy but we've already
-      // debounced, so the window for loss is small.
       void persist();
     }
   });
 
-  // Focus the textarea once it mounts — replaces the `autofocus` attribute
-  // which Svelte 5 warns about for accessibility reasons.
   $effect(() => {
-    if (editingId && editingTextareaEl) {
+    if (editingNodeId && editingTextareaEl) {
       editingTextareaEl.focus();
       editingTextareaEl.select();
     }
   });
 
-  // Trigger autosave whenever the doc changes post-load. Serializing on
-  // every reactive tick is cheap for the sizes we expect (hundreds of nodes).
   $effect(() => {
-    // Touch the relevant fields so Svelte tracks them.
+    if (editingEdgeId && editingEdgeLabelEl) {
+      editingEdgeLabelEl.focus();
+      editingEdgeLabelEl.select();
+    }
+  });
+
+  $effect(() => {
     void doc.nodes.length;
     void doc.edges.length;
     for (const n of doc.nodes) {
       void n.x; void n.y; void n.width; void n.height;
       if (n.type === "text") void (n as CanvasTextNode).text;
+    }
+    for (const e of doc.edges) {
+      void e.fromNode; void e.toNode; void e.fromSide; void e.toSide;
+      void e.color; void e.label;
     }
     scheduleSave();
   });
@@ -174,12 +199,12 @@
   }
 
   function onViewportPointerDown(e: PointerEvent) {
-    if (editingId) return;
-    // Middle mouse OR space+drag OR click on empty area with no card hit.
+    if (editingNodeId || editingEdgeId) return;
     const isPan = e.button === 1 || (e.button === 0 && spaceHeld);
     if (!isPan) return;
     e.preventDefault();
-    selectedId = null;
+    selectedNodeId = null;
+    selectedEdgeId = null;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
     pointerMode = {
       kind: "pan",
@@ -211,20 +236,64 @@
         node.width = Math.max(80, pointerMode.startW + dx);
         node.height = Math.max(40, pointerMode.startH + dy);
       }
+    } else if (pointerMode.kind === "edge" && draft) {
+      const { x, y } = clientToWorld(e.clientX, e.clientY);
+      draft.currentX = x;
+      draft.currentY = y;
+      const hit = handleAtPoint(e.clientX, e.clientY);
+      if (hit && hit.nodeId !== draft.fromNodeId) {
+        draft.targetNodeId = hit.nodeId;
+        draft.targetSide = hit.side;
+      } else {
+        draft.targetNodeId = null;
+        draft.targetSide = null;
+      }
     }
   }
 
   function onViewportPointerUp(e: PointerEvent) {
     if (!pointerMode) return;
-    (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+    } catch { /* releasePointerCapture may throw in the synthetic test env */ }
+    if (pointerMode.kind === "edge" && draft) {
+      if (draft.targetNodeId && draft.targetSide) {
+        commitDraftEdge(
+          draft.fromNodeId,
+          draft.fromSide,
+          draft.targetNodeId,
+          draft.targetSide,
+        );
+      }
+      draft = null;
+    }
     pointerMode = null;
   }
 
+  function commitDraftEdge(
+    fromId: string,
+    fromSide: CanvasSide,
+    toId: string,
+    toSide: CanvasSide,
+  ) {
+    const edge: CanvasEdge = {
+      id: crypto.randomUUID(),
+      fromNode: fromId,
+      toNode: toId,
+      fromSide,
+      toSide,
+    };
+    doc.edges = [...doc.edges, edge];
+    selectedEdgeId = edge.id;
+    selectedNodeId = null;
+  }
+
   function onViewportDblClick(e: MouseEvent) {
-    // Empty-area double-click creates a new text node centered at the cursor.
-    if (editingId) return;
+    if (editingNodeId || editingEdgeId) return;
     const target = e.target as HTMLElement;
     if (target.closest(".vc-canvas-node")) return;
+    if (target.closest(".vc-canvas-edge-hit")) return;
+    if (target.closest(".vc-canvas-edge-label")) return;
     const { x, y } = clientToWorld(e.clientX, e.clientY);
     const node: CanvasTextNode = {
       id: crypto.randomUUID(),
@@ -236,15 +305,17 @@
       text: "",
     };
     doc.nodes = [...doc.nodes, node];
-    selectedId = node.id;
-    editingId = node.id;
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+    editingNodeId = node.id;
   }
 
   function onNodePointerDown(e: PointerEvent, node: CanvasNode) {
-    if (editingId === node.id) return;
+    if (editingNodeId === node.id) return;
     if (e.button !== 0 || spaceHeld) return;
     e.stopPropagation();
-    selectedId = node.id;
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
     pointerMode = {
       kind: "move",
@@ -259,14 +330,15 @@
   function onNodeDblClick(e: MouseEvent, node: CanvasNode) {
     e.stopPropagation();
     if (node.type !== "text") return;
-    editingId = node.id;
-    selectedId = node.id;
+    editingNodeId = node.id;
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
   }
 
   function onResizePointerDown(e: PointerEvent, node: CanvasNode) {
     e.stopPropagation();
     if (e.button !== 0) return;
-    selectedId = node.id;
+    selectedNodeId = node.id;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
     pointerMode = {
       kind: "resize",
@@ -278,38 +350,190 @@
     };
   }
 
+  function onHandlePointerDown(e: PointerEvent, node: CanvasNode, side: CanvasSide) {
+    if (e.button !== 0 || spaceHeld) return;
+    e.stopPropagation();
+    e.preventDefault();
+    const anchor = anchorPoint(node, side);
+    draft = {
+      fromNodeId: node.id,
+      fromSide: side,
+      currentX: anchor.x,
+      currentY: anchor.y,
+      targetNodeId: null,
+      targetSide: null,
+    };
+    pointerMode = { kind: "edge", fromNodeId: node.id, fromSide: side };
+    try {
+      viewportEl?.setPointerCapture(e.pointerId);
+    } catch {
+      /* setPointerCapture throws for synthetic-test pointer IDs */
+    }
+  }
+
+  function handleAtPoint(
+    clientX: number,
+    clientY: number,
+  ): { nodeId: string; side: CanvasSide } | null {
+    if (!viewportEl) return null;
+    const els = document.elementsFromPoint(clientX, clientY);
+    for (const el of els) {
+      if (!(el instanceof HTMLElement)) continue;
+      if (!viewportEl.contains(el)) continue;
+      const side = el.getAttribute("data-edge-handle");
+      if (!side) continue;
+      const nodeEl = el.closest<HTMLElement>("[data-node-id]");
+      const nodeId = nodeEl?.getAttribute("data-node-id");
+      if (!nodeId) continue;
+      if (side === "top" || side === "right" || side === "bottom" || side === "left") {
+        return { nodeId, side };
+      }
+    }
+    return null;
+  }
+
   function onTextEdit(e: Event, node: CanvasTextNode) {
     node.text = (e.target as HTMLTextAreaElement).value;
   }
 
   function onTextBlur() {
-    editingId = null;
+    editingNodeId = null;
+  }
+
+  function onEdgeHitPointerDown(e: PointerEvent, edge: CanvasEdge) {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+    selectedEdgeId = edge.id;
+    selectedNodeId = null;
+  }
+
+  function onEdgeDblClick(e: MouseEvent, edge: CanvasEdge) {
+    e.stopPropagation();
+    editingEdgeId = edge.id;
+    selectedEdgeId = edge.id;
+    selectedNodeId = null;
+  }
+
+  function onEdgeLabelInput(e: Event, edge: CanvasEdge) {
+    const value = (e.target as HTMLInputElement).value;
+    const target = doc.edges.find((x) => x.id === edge.id);
+    if (!target) return;
+    if (value === "") {
+      delete target.label;
+    } else {
+      target.label = value;
+    }
+  }
+
+  function onEdgeLabelBlur() {
+    editingEdgeId = null;
   }
 
   function onKeyDown(e: KeyboardEvent) {
-    if (editingId) {
-      // Let Escape exit text editing without deleting the card.
+    if (editingNodeId || editingEdgeId) {
       if (e.key === "Escape") {
         e.preventDefault();
-        editingId = null;
+        editingNodeId = null;
+        editingEdgeId = null;
       }
       return;
     }
     if (e.key === " " && !e.repeat) {
       spaceHeld = true;
     }
-    if ((e.key === "Delete" || e.key === "Backspace") && selectedId) {
-      e.preventDefault();
-      const id = selectedId;
-      doc.nodes = doc.nodes.filter((n) => n.id !== id);
-      doc.edges = doc.edges.filter((ed) => ed.fromNode !== id && ed.toNode !== id);
-      selectedId = null;
+    if (e.key === "Delete" || e.key === "Backspace") {
+      if (selectedEdgeId) {
+        e.preventDefault();
+        doc.edges = doc.edges.filter((ed) => ed.id !== selectedEdgeId);
+        selectedEdgeId = null;
+        return;
+      }
+      if (selectedNodeId) {
+        e.preventDefault();
+        const id = selectedNodeId;
+        doc.nodes = doc.nodes.filter((n) => n.id !== id);
+        doc.edges = doc.edges.filter((ed) => ed.fromNode !== id && ed.toNode !== id);
+        selectedNodeId = null;
+      }
     }
   }
 
   function onKeyUp(e: KeyboardEvent) {
     if (e.key === " ") spaceHeld = false;
   }
+
+  // Resolved edge geometry for the render loop. An edge whose endpoint node
+  // is missing from the doc (corrupt file, partial edit) is silently skipped
+  // so the viewer keeps working rather than crashing.
+  type ResolvedEdge = {
+    edge: CanvasEdge;
+    fromPt: { x: number; y: number };
+    toPt: { x: number; y: number };
+    fromSide: CanvasSide;
+    toSide: CanvasSide;
+    path: string;
+    mid: { x: number; y: number };
+  };
+
+  function resolveEdges(): ResolvedEdge[] {
+    const byId = new Map(doc.nodes.map((n) => [n.id, n] as const));
+    const out: ResolvedEdge[] = [];
+    for (const edge of doc.edges) {
+      const from = byId.get(edge.fromNode);
+      const to = byId.get(edge.toNode);
+      if (!from || !to) continue;
+      const { fromSide, toSide } =
+        edge.fromSide && edge.toSide
+          ? { fromSide: edge.fromSide, toSide: edge.toSide }
+          : autoSides(from, to);
+      const fromPt = anchorPoint(from, fromSide);
+      const toPt = anchorPoint(to, toSide);
+      out.push({
+        edge,
+        fromPt,
+        toPt,
+        fromSide,
+        toSide,
+        path: bezierPath(fromPt, fromSide, toPt, toSide),
+        mid: bezierMidpoint(fromPt, fromSide, toPt, toSide),
+      });
+    }
+    return out;
+  }
+
+  let resolvedEdges = $derived(resolveEdges());
+
+  function draftPath(): string | null {
+    if (!draft) return null;
+    const from = doc.nodes.find((n) => n.id === draft!.fromNodeId);
+    if (!from) return null;
+    const fromPt = anchorPoint(from, draft.fromSide);
+    // If hovering a valid target handle, use that side for a natural entry;
+    // otherwise aim straight at the cursor with an opposite-ish side.
+    if (draft.targetNodeId && draft.targetSide) {
+      const to = doc.nodes.find((n) => n.id === draft!.targetNodeId);
+      if (to) {
+        const toPt = anchorPoint(to, draft.targetSide);
+        return bezierPath(fromPt, draft.fromSide, toPt, draft.targetSide);
+      }
+    }
+    const toSide: CanvasSide =
+      draft.fromSide === "left"
+        ? "right"
+        : draft.fromSide === "right"
+          ? "left"
+          : draft.fromSide === "top"
+            ? "bottom"
+            : "top";
+    return bezierPath(
+      fromPt,
+      draft.fromSide,
+      { x: draft.currentX, y: draft.currentY },
+      toSide,
+    );
+  }
+
+  let draftPathD = $derived(draftPath());
 </script>
 
 <svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />
@@ -317,6 +541,7 @@
 <div
   class="vc-canvas-viewport"
   class:vc-canvas-panning={spaceHeld}
+  class:vc-canvas-drafting={!!draft}
   bind:this={viewportEl}
   role="application"
   aria-label="Canvas"
@@ -337,12 +562,96 @@
       class="vc-canvas-world"
       style:transform={`translate(${camX}px, ${camY}px) scale(${zoom})`}
     >
+      <svg
+        class="vc-canvas-edges"
+        overflow="visible"
+        aria-hidden="true"
+      >
+        <defs>
+          <marker
+            id="vc-canvas-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          </marker>
+        </defs>
+        {#each resolvedEdges as re (re.edge.id)}
+          {@const arrowEnd = re.edge.toEnd !== "none"}
+          {@const arrowStart = re.edge.fromEnd === "arrow"}
+          <!-- Wide invisible hit target (svg captures pointer events) -->
+          <path
+            class="vc-canvas-edge-hit"
+            d={re.path}
+            data-edge-id={re.edge.id}
+            onpointerdown={(e) => onEdgeHitPointerDown(e, re.edge)}
+            ondblclick={(e) => onEdgeDblClick(e, re.edge)}
+          />
+          <path
+            class="vc-canvas-edge"
+            class:vc-canvas-edge-selected={selectedEdgeId === re.edge.id}
+            d={re.path}
+            style:color={re.edge.color ?? "var(--color-border-strong, #9ca3af)"}
+            marker-end={arrowEnd ? "url(#vc-canvas-arrow)" : null}
+            marker-start={arrowStart ? "url(#vc-canvas-arrow)" : null}
+            data-edge-id={re.edge.id}
+          />
+        {/each}
+        {#if draftPathD}
+          <path
+            class="vc-canvas-edge-draft"
+            d={draftPathD}
+          />
+        {/if}
+      </svg>
+
+      {#each resolvedEdges as re (`lbl-${re.edge.id}`)}
+        {#if editingEdgeId === re.edge.id}
+          <input
+            bind:this={editingEdgeLabelEl}
+            class="vc-canvas-edge-label-input"
+            value={re.edge.label ?? ""}
+            style:left={`${re.mid.x}px`}
+            style:top={`${re.mid.y}px`}
+            oninput={(e) => onEdgeLabelInput(e, re.edge)}
+            onblur={onEdgeLabelBlur}
+            onpointerdown={(e) => e.stopPropagation()}
+            ondblclick={(e) => e.stopPropagation()}
+            onkeydown={(e) => {
+              if (e.key === "Enter" || e.key === "Escape") {
+                e.preventDefault();
+                editingEdgeId = null;
+              }
+            }}
+          />
+        {:else if re.edge.label}
+          <div
+            class="vc-canvas-edge-label"
+            class:vc-canvas-edge-label-selected={selectedEdgeId === re.edge.id}
+            style:left={`${re.mid.x}px`}
+            style:top={`${re.mid.y}px`}
+            data-edge-id={re.edge.id}
+            onpointerdown={(e) => onEdgeHitPointerDown(e, re.edge)}
+            ondblclick={(e) => onEdgeDblClick(e, re.edge)}
+            role="button"
+            tabindex="0"
+          >
+            {re.edge.label}
+          </div>
+        {/if}
+      {/each}
+
       {#each doc.nodes as node (node.id)}
         {#if node.type === "text"}
           <div
             class="vc-canvas-node vc-canvas-node-text"
-            class:vc-canvas-node-selected={selectedId === node.id}
-            class:vc-canvas-node-editing={editingId === node.id}
+            class:vc-canvas-node-selected={selectedNodeId === node.id}
+            class:vc-canvas-node-editing={editingNodeId === node.id}
+            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
             style:left={`${node.x}px`}
             style:top={`${node.y}px`}
             style:width={`${node.width}px`}
@@ -350,10 +659,14 @@
             data-node-id={node.id}
             onpointerdown={(e) => onNodePointerDown(e, node)}
             ondblclick={(e) => onNodeDblClick(e, node)}
+            onpointerenter={() => (hoveredNodeId = node.id)}
+            onpointerleave={() => {
+              if (hoveredNodeId === node.id) hoveredNodeId = null;
+            }}
             role="button"
             tabindex="0"
           >
-            {#if editingId === node.id}
+            {#if editingNodeId === node.id}
               <textarea
                 bind:this={editingTextareaEl}
                 class="vc-canvas-node-textarea"
@@ -373,26 +686,48 @@
               onpointerdown={(e) => onResizePointerDown(e, node)}
               role="presentation"
             ></div>
+            {#each SIDES as side (side)}
+              <button
+                type="button"
+                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+                aria-label={`Create edge from ${side}`}
+                data-edge-handle={side}
+                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
+              ></button>
+            {/each}
           </div>
         {:else}
-          <!-- Phase 1 only renders text. Other node types round-trip
-               through the parser/serializer but show a placeholder so
-               editors are not lost when the user saves. -->
           <div
             class="vc-canvas-node vc-canvas-node-placeholder"
-            class:vc-canvas-node-selected={selectedId === node.id}
+            class:vc-canvas-node-selected={selectedNodeId === node.id}
+            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
             style:left={`${node.x}px`}
             style:top={`${node.y}px`}
             style:width={`${node.width}px`}
             style:height={`${node.height}px`}
             data-node-id={node.id}
             onpointerdown={(e) => onNodePointerDown(e, node)}
+            onpointerenter={() => (hoveredNodeId = node.id)}
+            onpointerleave={() => {
+              if (hoveredNodeId === node.id) hoveredNodeId = null;
+            }}
             role="button"
             tabindex="0"
           >
             <div class="vc-canvas-node-content">
               <em>{node.type}</em>
             </div>
+            {#each SIDES as side (side)}
+              <button
+                type="button"
+                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+                aria-label={`Create edge from ${side}`}
+                data-edge-handle={side}
+                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
+              ></button>
+            {/each}
           </div>
         {/if}
       {/each}
@@ -417,11 +752,87 @@
     cursor: grab;
   }
 
+  .vc-canvas-drafting {
+    cursor: crosshair;
+  }
+
   .vc-canvas-world {
     position: absolute;
     top: 0;
     left: 0;
     transform-origin: 0 0;
+  }
+
+  .vc-canvas-edges {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 1px;
+    height: 1px;
+    overflow: visible;
+    pointer-events: none;
+    color: var(--color-border-strong, #9ca3af);
+  }
+
+  .vc-canvas-edge {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    pointer-events: none;
+  }
+
+  .vc-canvas-edge-selected {
+    stroke: var(--color-accent);
+    stroke-width: 3;
+  }
+
+  .vc-canvas-edge-hit {
+    fill: none;
+    stroke: transparent;
+    stroke-width: 14;
+    pointer-events: stroke;
+    cursor: pointer;
+  }
+
+  .vc-canvas-edge-draft {
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 2;
+    stroke-dasharray: 6 4;
+    pointer-events: none;
+    opacity: 0.9;
+  }
+
+  .vc-canvas-edge-label {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-size: 12px;
+    color: var(--color-text);
+    white-space: nowrap;
+    pointer-events: auto;
+    cursor: pointer;
+  }
+
+  .vc-canvas-edge-label-selected {
+    border-color: var(--color-accent);
+  }
+
+  .vc-canvas-edge-label-input {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-size: 12px;
+    font-family: inherit;
+    color: var(--color-text);
+    background: var(--color-surface);
+    outline: none;
+    min-width: 80px;
   }
 
   .vc-canvas-node {
@@ -432,7 +843,7 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow: visible;
     cursor: move;
   }
 
@@ -481,6 +892,55 @@
       transparent 50%,
       var(--color-border) 50%
     );
+    z-index: 1;
+  }
+
+  .vc-canvas-edge-handle {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    border: 2px solid var(--color-surface);
+    padding: 0;
+    cursor: crosshair;
+    opacity: 0;
+    transition: opacity 90ms ease-out;
+    z-index: 2;
+  }
+
+  .vc-canvas-node-hovered .vc-canvas-edge-handle,
+  .vc-canvas-drafting .vc-canvas-edge-handle {
+    opacity: 1;
+  }
+
+  .vc-canvas-edge-handle-active {
+    box-shadow: 0 0 0 3px var(--color-accent-bg);
+    opacity: 1;
+  }
+
+  .vc-canvas-edge-handle-top {
+    left: 50%;
+    top: 0;
+    transform: translate(-50%, -50%);
+  }
+
+  .vc-canvas-edge-handle-right {
+    right: 0;
+    top: 50%;
+    transform: translate(50%, -50%);
+  }
+
+  .vc-canvas-edge-handle-bottom {
+    left: 50%;
+    bottom: 0;
+    transform: translate(-50%, 50%);
+  }
+
+  .vc-canvas-edge-handle-left {
+    left: 0;
+    top: 50%;
+    transform: translate(-50%, -50%);
   }
 
   .vc-canvas-loading,

--- a/src/lib/canvas/__tests__/geometry.test.ts
+++ b/src/lib/canvas/__tests__/geometry.test.ts
@@ -1,0 +1,107 @@
+// Geometry helpers for canvas edges (#71, phase 2).
+
+import { describe, it, expect } from "vitest";
+import {
+  anchorPoint,
+  autoSides,
+  bezierControls,
+  bezierMidpoint,
+  bezierPath,
+} from "../geometry";
+import type { CanvasTextNode } from "../types";
+
+const node = (over: Partial<CanvasTextNode> = {}): CanvasTextNode => ({
+  id: "n",
+  type: "text",
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 40,
+  text: "",
+  ...over,
+});
+
+describe("anchorPoint", () => {
+  it("returns the center of each side of the bounding rect", () => {
+    const n = node({ x: 10, y: 20, width: 200, height: 80 });
+    expect(anchorPoint(n, "top")).toEqual({ x: 110, y: 20 });
+    expect(anchorPoint(n, "right")).toEqual({ x: 210, y: 60 });
+    expect(anchorPoint(n, "bottom")).toEqual({ x: 110, y: 100 });
+    expect(anchorPoint(n, "left")).toEqual({ x: 10, y: 60 });
+  });
+});
+
+describe("autoSides", () => {
+  it("faces sides toward each other when the target is to the right", () => {
+    const from = node({ id: "a", x: 0, y: 0 });
+    const to = node({ id: "b", x: 500, y: 0 });
+    expect(autoSides(from, to)).toEqual({ fromSide: "right", toSide: "left" });
+  });
+
+  it("faces sides toward each other when the target is above", () => {
+    const from = node({ id: "a", x: 0, y: 500 });
+    const to = node({ id: "b", x: 0, y: 0 });
+    expect(autoSides(from, to)).toEqual({ fromSide: "top", toSide: "bottom" });
+  });
+
+  it("prefers the horizontal axis when dx == dy (ties)", () => {
+    const from = node({ id: "a", x: 0, y: 0, width: 0, height: 0 });
+    const to = node({ id: "b", x: 100, y: 100, width: 0, height: 0 });
+    // |dx| === |dy| → horizontal wins by ">=" convention
+    expect(autoSides(from, to)).toEqual({ fromSide: "right", toSide: "left" });
+  });
+});
+
+describe("bezierControls", () => {
+  it("extends control points perpendicular to the requested side", () => {
+    const { c1, c2 } = bezierControls(
+      { x: 100, y: 50 },
+      "right",
+      { x: 400, y: 50 },
+      "left",
+    );
+    // Both control points sit on the y=50 line because the sides point
+    // horizontally. c1 is to the right of the start, c2 to the left of the end.
+    expect(c1.y).toBeCloseTo(50);
+    expect(c2.y).toBeCloseTo(50);
+    expect(c1.x).toBeGreaterThan(100);
+    expect(c2.x).toBeLessThan(400);
+  });
+
+  it("has a minimum offset so very-short edges still curve away from the node", () => {
+    const { c1, c2 } = bezierControls(
+      { x: 0, y: 0 },
+      "right",
+      { x: 1, y: 0 },
+      "left",
+    );
+    // Even though the endpoints are 1px apart, the minimum 30px offset keeps
+    // the control points out where the curve can leave/enter the nodes cleanly.
+    expect(c1.x).toBeGreaterThanOrEqual(30);
+    expect(c2.x).toBeLessThanOrEqual(1 - 30);
+  });
+});
+
+describe("bezierPath", () => {
+  it("produces an SVG d string starting at `from` and ending at `to`", () => {
+    const d = bezierPath(
+      { x: 10, y: 20 },
+      "right",
+      { x: 200, y: 80 },
+      "left",
+    );
+    expect(d).toMatch(/^M 10 20 C /);
+    expect(d).toMatch(/200 80$/);
+  });
+});
+
+describe("bezierMidpoint", () => {
+  it("lies on the curve between the endpoints", () => {
+    const from = { x: 0, y: 0 };
+    const to = { x: 400, y: 0 };
+    const mid = bezierMidpoint(from, "right", to, "left");
+    // Symmetric horizontal case → midpoint should be horizontally centered.
+    expect(mid.x).toBeCloseTo(200, 0);
+    expect(mid.y).toBeCloseTo(0, 5);
+  });
+});

--- a/src/lib/canvas/geometry.ts
+++ b/src/lib/canvas/geometry.ts
@@ -1,0 +1,123 @@
+// Canvas edge geometry (#71, phase 2). Pure helpers for converting a
+// node rectangle + side into an anchor point, auto-picking sides when an
+// edge omits them, and producing the SVG `d` string for a cubic Bezier
+// that enters/leaves each endpoint perpendicular to its side (Obsidian's
+// routing style).
+
+import type { CanvasNode, CanvasSide } from "./types";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Center point of the requested side of a node's bounding rect. Used as
+ * the anchor where an edge meets the node and where we draw the hover
+ * handles during edge-creation.
+ */
+export function anchorPoint(node: CanvasNode, side: CanvasSide): Point {
+  switch (side) {
+    case "top":
+      return { x: node.x + node.width / 2, y: node.y };
+    case "right":
+      return { x: node.x + node.width, y: node.y + node.height / 2 };
+    case "bottom":
+      return { x: node.x + node.width / 2, y: node.y + node.height };
+    case "left":
+      return { x: node.x, y: node.y + node.height / 2 };
+  }
+}
+
+/** Unit vector pointing away from the node along the given side. */
+function sideUnit(side: CanvasSide): Point {
+  switch (side) {
+    case "top":
+      return { x: 0, y: -1 };
+    case "right":
+      return { x: 1, y: 0 };
+    case "bottom":
+      return { x: 0, y: 1 };
+    case "left":
+      return { x: -1, y: 0 };
+  }
+}
+
+/**
+ * Pick a from/to side pair when the edge omits them. We use the larger
+ * axis of the center-to-center vector to decide whether the edge should
+ * leave horizontally or vertically, then face the sides toward each other.
+ */
+export function autoSides(
+  from: CanvasNode,
+  to: CanvasNode,
+): { fromSide: CanvasSide; toSide: CanvasSide } {
+  const fcx = from.x + from.width / 2;
+  const fcy = from.y + from.height / 2;
+  const tcx = to.x + to.width / 2;
+  const tcy = to.y + to.height / 2;
+  const dx = tcx - fcx;
+  const dy = tcy - fcy;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0
+      ? { fromSide: "right", toSide: "left" }
+      : { fromSide: "left", toSide: "right" };
+  }
+  return dy >= 0
+    ? { fromSide: "bottom", toSide: "top" }
+    : { fromSide: "top", toSide: "bottom" };
+}
+
+/**
+ * SVG `d` attribute for a cubic Bezier whose tangents at each end point
+ * perpendicular to the requested side. The control-point offset grows
+ * with endpoint distance so long edges get a gentle arc instead of a
+ * kink while short edges stay tight.
+ */
+export function bezierPath(
+  from: Point,
+  fromSide: CanvasSide,
+  to: Point,
+  toSide: CanvasSide,
+): string {
+  const { c1, c2 } = bezierControls(from, fromSide, to, toSide);
+  return `M ${from.x} ${from.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${to.x} ${to.y}`;
+}
+
+/** Control points for the cubic Bezier used by {@link bezierPath}. */
+export function bezierControls(
+  from: Point,
+  fromSide: CanvasSide,
+  to: Point,
+  toSide: CanvasSide,
+): { c1: Point; c2: Point } {
+  const dist = Math.hypot(to.x - from.x, to.y - from.y);
+  const offset = Math.max(30, dist * 0.5);
+  const uA = sideUnit(fromSide);
+  const uB = sideUnit(toSide);
+  return {
+    c1: { x: from.x + uA.x * offset, y: from.y + uA.y * offset },
+    c2: { x: to.x + uB.x * offset, y: to.y + uB.y * offset },
+  };
+}
+
+/**
+ * Midpoint (t=0.5) of the cubic Bezier, used to place the edge label and
+ * the selection click-target.
+ */
+export function bezierMidpoint(
+  from: Point,
+  fromSide: CanvasSide,
+  to: Point,
+  toSide: CanvasSide,
+): Point {
+  const { c1, c2 } = bezierControls(from, fromSide, to, toSide);
+  // B(0.5) for a cubic Bezier simplifies to (P0 + 3·P1 + 3·P2 + P3) / 8.
+  return {
+    x: (from.x + 3 * c1.x + 3 * c2.x + to.x) / 8,
+    y: (from.y + 3 * c1.y + 3 * c2.y + to.y) / 8,
+  };
+}
+
+/** All four sides — used by the UI to render hover handles. */
+export const SIDES: readonly CanvasSide[] = ["top", "right", "bottom", "left"];


### PR DESCRIPTION
## Summary
Phase 2 of #71. Edges between canvas nodes with full Obsidian round-trip. Builds on the phase-1 parser (already supports edges) — this PR adds rendering, interaction, and geometry.

- `canvas/geometry.ts`: anchor-per-side, auto-side picker when `fromSide`/`toSide` are absent, cubic-bezier path + midpoint. Tangents leave/enter perpendicular to each end's side.
- SVG overlay inside the world transform with a thick invisible hit-path behind each visible stroke for click selection. Start/end arrowheads via SVG markers (Obsidian default: end arrow on, suppress with `toEnd: "none"`).
- Four hover-revealed handles per node. Drag-from-handle draws a dashed preview that snaps onto any other node's handle (hit-tested via `elementsFromPoint`, because pointer-capture hides enter/leave on siblings). Pointer-up over a foreign handle commits; elsewhere cancels.
- Edge click selects; `Delete`/`Backspace` removes. Double-click midpoint adds/edits an inline label (empty label deletes the field, matching Obsidian).
- Orphaned edges skip silently at render but round-trip unchanged on save, so opening a partial Obsidian doc never drops data.

## Scope
- In scope: render, drag-to-create, select + delete, labels, color/arrow passthrough, orphan tolerance, self-loop tolerance.
- Deferred to phase 3 (#126): embedded `file`/`link`/`group` node bodies.

## Test plan
- [x] `pnpm test` — 496 pass (13 existing parser tests + 8 new geometry tests)
- [x] `pnpm typecheck` — clean under `exactOptionalPropertyTypes: true`
- [x] `pnpm build` — no warnings
- [x] `pnpm test:e2e --spec e2e/specs/canvas-edges.spec.ts` — 10/10 pass, covering render, bezier anchor correctness, arrowhead default + `"none"` suppression, labels, drag-to-create, select + delete, label edit + persistence, orphan tolerance, color/arrow/unknown-field passthrough
- [x] Full E2E — 45/46 specs pass; only failure is the pre-existing `#110` flake (not related to canvas)

Closes #125