### PR TITLE
feat: canvas embedded nodes — files, images, links, groups (#126)

### DIFF
--- a/e2e/specs/canvas-embedded.spec.ts
+++ b/e2e/specs/canvas-embedded.spec.ts
@@ -1,0 +1,506 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf, textsOf } from "../helpers/text.js";
+
+/**
+ * E2E coverage for issue #126 (canvas phase 3 — embedded nodes). Tests:
+ *   - File (markdown) nodes show the rendered preview pulled from disk.
+ *   - File (image) nodes render as `<img>` with a working convertFileSrc URL.
+ *   - Link nodes render a URL card with an Open control.
+ *   - Group nodes render as a translucent labelled container behind other nodes.
+ *   - Clicking a markdown file node's "Open" opens it in the editor pane.
+ *   - Clicking an image file node's "Open" opens the image tab.
+ *   - Clicking a link node's "Open" invokes window.open with the URL.
+ *   - Roundtrip: editing the canvas preserves file.subpath, link unknown
+ *     fields, and group background/style passthrough.
+ *   - Corrupt / unknown node types do not crash the viewer.
+ */
+
+const DEBOUNCE_MS = 400;
+const FLUSH_WAIT_MS = DEBOUNCE_MS + 500;
+
+const PNG_1PX = Buffer.from(
+  "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c63000100000500010d0a2db40000000049454e44ae426082",
+  "hex",
+);
+
+const NOTE_MD = `---
+title: Embedded note
+tags: [canvas, embed]
+---
+# Einbettung
+
+Dieser Text ist der **Vorschau-Body** aus dem eingebetteten Note.
+
+- Punkt eins
+- Punkt zwei
+`;
+
+const EMBEDDED_DOC = {
+  nodes: [
+    {
+      id: "text-a",
+      type: "text",
+      x: -400,
+      y: -200,
+      width: 180,
+      height: 60,
+      text: "Hallo",
+    },
+    {
+      id: "file-md-1",
+      type: "file",
+      x: -180,
+      y: -220,
+      width: 320,
+      height: 200,
+      file: "Embedded Note.md",
+      subpath: "#Einbettung",
+      futureFileField: { kept: true },
+    },
+    {
+      id: "file-img-1",
+      type: "file",
+      x: 180,
+      y: -220,
+      width: 160,
+      height: 160,
+      file: "attachments/dot.png",
+    },
+    {
+      id: "link-1",
+      type: "link",
+      x: -180,
+      y: 40,
+      width: 320,
+      height: 80,
+      url: "https://example.com/vaultcore",
+      unknownLinkField: "stays",
+    },
+    {
+      id: "group-1",
+      type: "group",
+      x: -420,
+      y: -260,
+      width: 820,
+      height: 520,
+      label: "Gruppe A",
+      background: "attachments/dot.png",
+      backgroundStyle: "cover",
+      futureGroupField: 99,
+    },
+    {
+      id: "unknown-1",
+      type: "diagram",
+      x: 180,
+      y: 40,
+      width: 160,
+      height: 80,
+      weirdField: 1,
+    },
+  ],
+  edges: [],
+  metadata: { topLevel: "kept" },
+};
+
+describe("Canvas embedded nodes (#126)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    // Note body for the markdown-file node.
+    fs.writeFileSync(
+      path.join(vault.path, "Embedded Note.md"),
+      NOTE_MD,
+      "utf-8",
+    );
+    // Image for the file-image node.
+    fs.writeFileSync(path.join(vault.path, "attachments", "dot.png"), PNG_1PX);
+    fs.writeFileSync(
+      path.join(vault.path, "Embedded.canvas"),
+      JSON.stringify(EMBEDDED_DOC, null, "\t"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  // ─── Helpers ──────────────────────────────────────────────────────────
+
+  async function activeTabId(): Promise<string> {
+    const id = await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      return visible?.getAttribute("data-tab-id") ?? null;
+    });
+    if (!id) throw new Error("No visible canvas viewport found");
+    return id as string;
+  }
+
+  async function vizSel(suffix = ""): Promise<string> {
+    const id = await activeTabId();
+    return `.vc-canvas-viewport[data-tab-id="${id}"]${suffix}`;
+  }
+
+  async function openTreeFile(name: string): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const names = await textsOf(await browser.$$(".vc-tree-name"));
+        return names.includes(name);
+      },
+      { timeout: 5000, timeoutMsg: `"${name}" never appeared in the tree` },
+    );
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not found`);
+  }
+
+  async function waitForCanvas(): Promise<void> {
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const visible = vps.find((v) => v.offsetParent !== null);
+          return !!visible?.querySelector(".vc-canvas-world");
+        }),
+      { timeout: 5000, timeoutMsg: "Canvas world never mounted" },
+    );
+  }
+
+  async function readDisk(name: string): Promise<{
+    nodes: Array<Record<string, unknown>>;
+    edges: Array<Record<string, unknown>>;
+    [k: string]: unknown;
+  }> {
+    const raw = fs.readFileSync(path.join(vault.path, name), "utf-8");
+    return JSON.parse(raw);
+  }
+
+  async function waitForDiskDoc<T>(
+    name: string,
+    predicate: (doc: {
+      nodes: Array<Record<string, unknown>>;
+      edges: Array<Record<string, unknown>>;
+      [k: string]: unknown;
+    }) => T | null | false | undefined,
+    timeoutMs = FLUSH_WAIT_MS * 8,
+  ): Promise<T> {
+    const start = Date.now();
+    let last: unknown;
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const doc = await readDisk(name);
+        const hit = predicate(doc);
+        if (hit) return hit as T;
+        last = doc;
+      } catch {
+        /* file not yet written */
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+      `waitForDiskDoc(${name}) timed out. Last doc: ${JSON.stringify(last)}`,
+    );
+  }
+
+  async function pointerClick(sel: string): Promise<void> {
+    await browser.execute((s: string) => {
+      const el = document.querySelector(s) as HTMLElement | null;
+      if (!el) throw new Error(`No element: ${s}`);
+      const r = el.getBoundingClientRect();
+      const opts: PointerEventInit = {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: r.left + r.width / 2,
+        clientY: r.top + r.height / 2,
+        pointerId: 7,
+        pointerType: "mouse",
+        button: 0,
+        buttons: 1,
+        isPrimary: true,
+      };
+      el.dispatchEvent(new PointerEvent("pointerdown", opts));
+      el.dispatchEvent(new PointerEvent("pointerup", opts));
+      el.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          clientX: r.left + r.width / 2,
+          clientY: r.top + r.height / 2,
+          button: 0,
+        }),
+      );
+    }, sel);
+  }
+
+  // ─── Tests ────────────────────────────────────────────────────────────
+
+  it("renders text, file-md, file-image, link, group and unknown nodes", async () => {
+    await openTreeFile("Embedded.canvas");
+    await waitForCanvas();
+
+    const vp = await vizSel();
+    // Wait until every expected node type has mounted.
+    await browser.waitUntil(
+      async () => {
+        const counts = await browser.execute((sel: string) => {
+          const v = document.querySelector(sel);
+          if (!v) return null;
+          return {
+            text: v.querySelectorAll(".vc-canvas-node-text").length,
+            file: v.querySelectorAll(".vc-canvas-node-file").length,
+            link: v.querySelectorAll(".vc-canvas-node-link").length,
+            group: v.querySelectorAll(".vc-canvas-node-group").length,
+            placeholder: v.querySelectorAll(".vc-canvas-node-placeholder")
+              .length,
+          };
+        }, vp);
+        if (!counts) return false;
+        return (
+          counts.text === 1 &&
+          counts.file === 2 &&
+          counts.link === 1 &&
+          counts.group === 1 &&
+          counts.placeholder === 1
+        );
+      },
+      { timeout: 8000, timeoutMsg: "Not all node variants mounted" },
+    );
+  });
+
+  it("file-image node renders an <img> whose src uses the asset: protocol", async () => {
+    const vp = await vizSel();
+    await browser.waitUntil(
+      async () => {
+        const src = await browser.execute((sel: string) => {
+          const img = document.querySelector<HTMLImageElement>(
+            `${sel} [data-node-id="file-img-1"] img[data-canvas-image="true"]`,
+          );
+          return img?.src ?? null;
+        }, vp);
+        return typeof src === "string" && src.length > 0;
+      },
+      { timeout: 5000, timeoutMsg: "Image node never got a src" },
+    );
+
+    const src = (await browser.execute((sel: string) => {
+      const img = document.querySelector<HTMLImageElement>(
+        `${sel} [data-node-id="file-img-1"] img[data-canvas-image="true"]`,
+      );
+      return img?.src ?? "";
+    }, vp)) as string;
+
+    // convertFileSrc uses the asset:// (or http://asset.localhost) protocol.
+    expect(src).toMatch(/^(asset:\/\/|http:\/\/asset\.localhost)/);
+    // The image's vault-relative path is part of the URL.
+    expect(src).toContain("dot.png");
+  });
+
+  it("file-md node shows the rendered markdown preview", async () => {
+    const vp = await vizSel();
+    await browser.waitUntil(
+      async () => {
+        const html = await browser.execute((sel: string) => {
+          const el = document.querySelector(
+            `${sel} [data-node-id="file-md-1"] .vc-canvas-node-md`,
+          ) as HTMLElement | null;
+          return el?.innerHTML ?? "";
+        }, vp);
+        // Frontmatter must be stripped; headings + list items should appear.
+        return (
+          typeof html === "string" &&
+          html.includes("<h1") &&
+          html.includes("Einbettung") &&
+          !html.includes("title: Embedded note")
+        );
+      },
+      { timeout: 8000, timeoutMsg: "Markdown preview never rendered" },
+    );
+  });
+
+  it("group node renders with its label", async () => {
+    const vp = await vizSel();
+    const label = (await browser.execute((sel: string) => {
+      const el = document.querySelector(
+        `${sel} [data-node-id="group-1"] .vc-canvas-node-group-label`,
+      ) as HTMLElement | null;
+      return el?.textContent?.trim() ?? "";
+    }, vp)) as string;
+    expect(label).toBe("Gruppe A");
+  });
+
+  it("link node shows its URL and an Open control", async () => {
+    const vp = await vizSel();
+    const [urlText, btnCount] = (await browser.execute((sel: string) => {
+      const host = document.querySelector(
+        `${sel} [data-node-id="link-1"]`,
+      ) as HTMLElement | null;
+      const url = host?.querySelector<HTMLElement>(
+        ".vc-canvas-node-link-url",
+      );
+      const btn = host?.querySelectorAll<HTMLButtonElement>(
+        '[data-canvas-open="link"]',
+      );
+      return [url?.textContent?.trim() ?? "", btn?.length ?? 0];
+    }, vp)) as [string, number];
+    expect(urlText).toBe("https://example.com/vaultcore");
+    expect(btnCount).toBe(1);
+  });
+
+  it("clicking Open on the markdown file node opens it as a tab", async () => {
+    const vp = await vizSel();
+    const sel = `${vp} [data-node-id="file-md-1"] [data-canvas-open="md"]`;
+    await pointerClick(sel);
+
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const tabs = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-tab-title, .vc-tab"),
+          );
+          return tabs.some((t) =>
+            (t.textContent ?? "").includes("Embedded Note"),
+          );
+        }),
+      { timeout: 5000, timeoutMsg: "Embedded Note tab never appeared" },
+    );
+  });
+
+  it("clicking Open on the image file node opens the image tab", async () => {
+    // Re-activate the canvas tab (previous test swapped to the note tab).
+    await openTreeFile("Embedded.canvas");
+    await waitForCanvas();
+
+    const vp = await vizSel();
+    const sel = `${vp} [data-node-id="file-img-1"] [data-canvas-open="image"]`;
+    await pointerClick(sel);
+
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const tabs = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-tab-title, .vc-tab"),
+          );
+          return tabs.some((t) => (t.textContent ?? "").includes("dot.png"));
+        }),
+      { timeout: 5000, timeoutMsg: "dot.png tab never appeared" },
+    );
+  });
+
+  it("clicking Open on the link node calls window.open with the URL", async () => {
+    // Re-open canvas (prior tests may have switched tabs).
+    await openTreeFile("Embedded.canvas");
+    await waitForCanvas();
+
+    const vp = await vizSel();
+    const sel = `${vp} [data-node-id="link-1"] [data-canvas-open="link"]`;
+
+    // Install a window.open spy that records calls on a global.
+    await browser.execute(() => {
+      (window as unknown as { __openCalls: string[] }).__openCalls = [];
+      const orig = window.open.bind(window);
+      window.open = ((url?: string | URL) => {
+        (window as unknown as { __openCalls: string[] }).__openCalls.push(
+          String(url ?? ""),
+        );
+        return null;
+      }) as typeof window.open;
+      (window as unknown as { __origOpen: typeof window.open }).__origOpen =
+        orig;
+    });
+
+    await pointerClick(sel);
+
+    const calls = (await browser.execute(() => {
+      return (
+        (window as unknown as { __openCalls?: string[] }).__openCalls ?? []
+      );
+    })) as string[];
+
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(calls[0]).toBe("https://example.com/vaultcore");
+  });
+
+  it("roundtrip preserves file.subpath, link unknown fields, and group background", async () => {
+    // Re-open the canvas and trigger an autosave by nudging the text node.
+    await openTreeFile("Embedded.canvas");
+    await waitForCanvas();
+
+    const vp = await vizSel();
+
+    // Simulate a small move of the text node (top-left corner) so the doc
+    // gets rewritten through the same serialization path.
+    await browser.execute((sel: string) => {
+      const el = document.querySelector(
+        `${sel} [data-node-id="text-a"]`,
+      ) as HTMLElement | null;
+      if (!el) throw new Error("text-a node missing");
+      const r = el.getBoundingClientRect();
+      const mk = (x: number, y: number): PointerEventInit => ({
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: x,
+        clientY: y,
+        pointerId: 31,
+        pointerType: "mouse",
+        button: 0,
+        buttons: 1,
+        isPrimary: true,
+      });
+      const cx = r.left + r.width / 2;
+      const cy = r.top + r.height / 2;
+      el.dispatchEvent(new PointerEvent("pointerdown", mk(cx, cy)));
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      visible?.dispatchEvent(
+        new PointerEvent("pointermove", mk(cx + 20, cy + 10)),
+      );
+      visible?.dispatchEvent(new PointerEvent("pointerup", mk(cx + 20, cy + 10)));
+    }, vp);
+
+    await waitForDiskDoc("Embedded.canvas", (doc) => {
+      const byId = new Map(
+        (doc.nodes as Array<Record<string, unknown>>).map((n) => [
+          n.id as string,
+          n,
+        ]),
+      );
+      const file = byId.get("file-md-1");
+      const link = byId.get("link-1");
+      const group = byId.get("group-1");
+      const unknown = byId.get("unknown-1");
+      if (!file || !link || !group || !unknown) return false;
+      const topLevelOk = doc.metadata &&
+        (doc.metadata as { topLevel?: string }).topLevel === "kept";
+      return (
+        topLevelOk &&
+        file.subpath === "#Einbettung" &&
+        (file.futureFileField as { kept?: boolean } | undefined)?.kept === true &&
+        link.unknownLinkField === "stays" &&
+        group.background === "attachments/dot.png" &&
+        group.backgroundStyle === "cover" &&
+        group.futureGroupField === 99 &&
+        unknown.type === "diagram" &&
+        unknown.weirdField === 1
+      );
+    });
+  });
+});

--- a/e2e/specs/canvas.spec.ts
+++ b/e2e/specs/canvas.spec.ts
@@ -350,8 +350,19 @@ describe("Canvas viewer (#124)", () => {
     expect(await visibleTextNodeContent()).toBe("Hallo Canvas");
   });
 
-  it("renders non-text node types as placeholders (round-trip only)", async () => {
-    expect(await visiblePlaceholders()).toBe(1);
+  it("renders non-text node types with their dedicated card (round-trip safe)", async () => {
+    // ROUNDTRIP_DOC has one group node which now renders as a proper
+    // .vc-canvas-node-group card (phase 3). Unknown-type nodes still fall
+    // back to .vc-canvas-node-placeholder.
+    const groupCount = (await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      return visible?.querySelectorAll(".vc-canvas-node-group").length ?? 0;
+    })) as number;
+    expect(groupCount).toBe(1);
+    expect(await visiblePlaceholders()).toBe(0);
   });
 
   // ─── Roundtrip ────────────────────────────────────────────────────────

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -10,11 +10,23 @@
   // node's handle to create an edge. Edges select on click (thick invisible
   // hit-path behind the visible stroke) and delete on Backspace/Delete.
   // Optional labels edit via double-click on the edge midpoint.
+  //
+  // Phase 3: embedded content (#126). File nodes render as an image, a
+  // markdown-preview card, or a filename card — clicking the card's "Open"
+  // control routes the file through openFileAsTab so the user can jump
+  // into the main editor. Link nodes render a click-to-open card whose
+  // target opens in the OS browser. Group nodes render as a labelled
+  // translucent container that sits visually behind other nodes.
 
-  import { onMount, onDestroy, tick } from "svelte";
+  import { onMount, onDestroy, tick, untrack } from "svelte";
+  import { convertFileSrc } from "@tauri-apps/api/core";
+  import { get } from "svelte/store";
   import { readFile, writeFile } from "../../ipc/commands";
   import { toastStore } from "../../store/toastStore";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
+  import { vaultStore } from "../../store/vaultStore";
+  import { openFileAsTab } from "../../lib/openFileAsTab";
+  import { renderMarkdownToHtml } from "../Editor/reading/markdownRenderer";
   import {
     parseCanvas,
     serializeCanvas,
@@ -23,6 +35,9 @@
   import type {
     CanvasDoc,
     CanvasEdge,
+    CanvasFileNode,
+    CanvasGroupNode,
+    CanvasLinkNode,
     CanvasNode,
     CanvasSide,
     CanvasTextNode,
@@ -38,6 +53,12 @@
     bezierMidpoint,
     bezierPath,
   } from "../../lib/canvas/geometry";
+  import {
+    canvasFilePreview,
+    isImageFile,
+    isMarkdownFile,
+    resolveVaultAbs,
+  } from "../../lib/canvas/embed";
 
   interface Props {
     tabId: string;
@@ -80,6 +101,12 @@
   let lastWrittenJson = "";
   let suppressSave = true;
   let spaceHeld = $state(false);
+
+  // Rendered-markdown previews for file-nodes, keyed by vault-relative
+  // `file` field so multiple file-nodes at the same note share one read.
+  // Missing / failed reads become "" so the renderer falls back to a
+  // generic file card. `$state` keeps the template reactive to async loads.
+  let mdPreviews = $state<Record<string, string>>({});
 
   type PointerMode =
     | { kind: "pan"; startClientX: number; startClientY: number; startCamX: number; startCamY: number }
@@ -174,6 +201,64 @@
     }
     scheduleSave();
   });
+
+  // Lazily load markdown body for every file-node that points at an .md note.
+  // We resolve the file relative to the current vault root; when the vault
+  // path is missing (e.g., a stray canvas opened without a vault) we fall
+  // back to a generic card by leaving the preview unset.
+  $effect(() => {
+    const vaultPath = get(vaultStore).currentPath;
+    if (!vaultPath) return;
+    for (const n of doc.nodes) {
+      if (n.type !== "file") continue;
+      const file = (n as CanvasFileNode).file;
+      if (!file || !isMarkdownFile(file)) continue;
+      if (file in untrack(() => mdPreviews)) continue;
+      // Reserve the slot synchronously so we don't re-queue the same file.
+      mdPreviews = { ...mdPreviews, [file]: "" };
+      const absPath = resolveVaultAbs(vaultPath, file);
+      void readFile(absPath).then(
+        (body) => {
+          mdPreviews = {
+            ...mdPreviews,
+            [file]: renderMarkdownToHtml(canvasFilePreview(body)),
+          };
+        },
+        () => {
+          /* preview failure stays as "" — renderer shows a generic card */
+        },
+      );
+    }
+  });
+
+  async function onOpenFileNode(node: CanvasFileNode) {
+    const vaultPath = get(vaultStore).currentPath;
+    if (!vaultPath) return;
+    try {
+      await openFileAsTab(resolveVaultAbs(vaultPath, node.file));
+    } catch (e) {
+      const ve = isVaultError(e)
+        ? e
+        : { kind: "Io" as const, message: String(e), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
+  function onOpenLinkNode(node: CanvasLinkNode) {
+    try {
+      window.open(node.url, "_blank", "noopener,noreferrer");
+    } catch {
+      /* popup blocked or unsupported — silently swallow */
+    }
+  }
+
+  // Groups render first so other nodes stack visually on top of them.
+  // Two-pass sort keeps doc.nodes order stable within each band so picks
+  // based on DOM order (hit-testing) stay predictable.
+  let orderedNodes = $derived([
+    ...doc.nodes.filter((n) => n.type === "group"),
+    ...doc.nodes.filter((n) => n.type !== "group"),
+  ]);
 
   function clientToWorld(clientX: number, clientY: number): { x: number; y: number } {
     if (!viewportEl) return { x: 0, y: 0 };
@@ -645,7 +730,7 @@
         {/if}
       {/each}
 
-      {#each doc.nodes as node (node.id)}
+      {#each orderedNodes as node (node.id)}
         {#if node.type === "text"}
           <div
             class="vc-canvas-node vc-canvas-node-text"
@@ -680,6 +765,184 @@
               <div class="vc-canvas-node-content">
                 {(node as CanvasTextNode).text || "Empty card"}
               </div>
+            {/if}
+            <div
+              class="vc-canvas-resize-handle"
+              onpointerdown={(e) => onResizePointerDown(e, node)}
+              role="presentation"
+            ></div>
+            {#each SIDES as side (side)}
+              <button
+                type="button"
+                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+                aria-label={`Create edge from ${side}`}
+                data-edge-handle={side}
+                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
+              ></button>
+            {/each}
+          </div>
+        {:else if node.type === "file"}
+          {@const fileNode = node as CanvasFileNode}
+          {@const vaultPath = $vaultStore.currentPath}
+          {@const abs = vaultPath ? resolveVaultAbs(vaultPath, fileNode.file) : null}
+          <div
+            class="vc-canvas-node vc-canvas-node-file"
+            class:vc-canvas-node-selected={selectedNodeId === node.id}
+            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+            style:left={`${node.x}px`}
+            style:top={`${node.y}px`}
+            style:width={`${node.width}px`}
+            style:height={`${node.height}px`}
+            data-node-id={node.id}
+            data-node-type="file"
+            onpointerdown={(e) => onNodePointerDown(e, node)}
+            onpointerenter={() => (hoveredNodeId = node.id)}
+            onpointerleave={() => {
+              if (hoveredNodeId === node.id) hoveredNodeId = null;
+            }}
+            role="button"
+            tabindex="0"
+          >
+            {#if isImageFile(fileNode.file) && abs}
+              <img
+                class="vc-canvas-node-image"
+                src={convertFileSrc(abs)}
+                alt={fileNode.file}
+                draggable="false"
+                data-canvas-image="true"
+              />
+              <button
+                type="button"
+                class="vc-canvas-node-open vc-canvas-node-open-overlay"
+                data-canvas-open="image"
+                onpointerdown={(e) => e.stopPropagation()}
+                onclick={(e) => { e.stopPropagation(); void onOpenFileNode(fileNode); }}
+              >
+                Open
+              </button>
+            {:else if isMarkdownFile(fileNode.file)}
+              <div class="vc-canvas-node-file-header" data-canvas-file={fileNode.file}>
+                <span class="vc-canvas-node-file-name">{fileNode.file}</span>
+                <button
+                  type="button"
+                  class="vc-canvas-node-open"
+                  data-canvas-open="md"
+                  onpointerdown={(e) => e.stopPropagation()}
+                  onclick={(e) => { e.stopPropagation(); void onOpenFileNode(fileNode); }}
+                >
+                  Open
+                </button>
+              </div>
+              {#if mdPreviews[fileNode.file]}
+                <div class="vc-canvas-node-md markdown-body">{@html mdPreviews[fileNode.file]}</div>
+              {:else}
+                <div class="vc-canvas-node-md vc-canvas-node-md-loading">Loading preview…</div>
+              {/if}
+            {:else}
+              <div class="vc-canvas-node-file-header" data-canvas-file={fileNode.file}>
+                <span class="vc-canvas-node-file-name">{fileNode.file}</span>
+                <button
+                  type="button"
+                  class="vc-canvas-node-open"
+                  data-canvas-open="file"
+                  onpointerdown={(e) => e.stopPropagation()}
+                  onclick={(e) => { e.stopPropagation(); void onOpenFileNode(fileNode); }}
+                >
+                  Open
+                </button>
+              </div>
+              <div class="vc-canvas-node-file-body">
+                Attached file
+              </div>
+            {/if}
+            <div
+              class="vc-canvas-resize-handle"
+              onpointerdown={(e) => onResizePointerDown(e, node)}
+              role="presentation"
+            ></div>
+            {#each SIDES as side (side)}
+              <button
+                type="button"
+                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+                aria-label={`Create edge from ${side}`}
+                data-edge-handle={side}
+                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
+              ></button>
+            {/each}
+          </div>
+        {:else if node.type === "link"}
+          {@const linkNode = node as CanvasLinkNode}
+          <div
+            class="vc-canvas-node vc-canvas-node-link"
+            class:vc-canvas-node-selected={selectedNodeId === node.id}
+            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+            style:left={`${node.x}px`}
+            style:top={`${node.y}px`}
+            style:width={`${node.width}px`}
+            style:height={`${node.height}px`}
+            data-node-id={node.id}
+            data-node-type="link"
+            onpointerdown={(e) => onNodePointerDown(e, node)}
+            onpointerenter={() => (hoveredNodeId = node.id)}
+            onpointerleave={() => {
+              if (hoveredNodeId === node.id) hoveredNodeId = null;
+            }}
+            role="button"
+            tabindex="0"
+          >
+            <div class="vc-canvas-node-file-header">
+              <span class="vc-canvas-node-link-url" title={linkNode.url}>{linkNode.url}</span>
+              <button
+                type="button"
+                class="vc-canvas-node-open"
+                data-canvas-open="link"
+                onpointerdown={(e) => e.stopPropagation()}
+                onclick={(e) => { e.stopPropagation(); onOpenLinkNode(linkNode); }}
+              >
+                Open
+              </button>
+            </div>
+            <div class="vc-canvas-node-file-body">External link</div>
+            <div
+              class="vc-canvas-resize-handle"
+              onpointerdown={(e) => onResizePointerDown(e, node)}
+              role="presentation"
+            ></div>
+            {#each SIDES as side (side)}
+              <button
+                type="button"
+                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+                aria-label={`Create edge from ${side}`}
+                data-edge-handle={side}
+                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
+              ></button>
+            {/each}
+          </div>
+        {:else if node.type === "group"}
+          {@const groupNode = node as CanvasGroupNode}
+          <div
+            class="vc-canvas-node vc-canvas-node-group"
+            class:vc-canvas-node-selected={selectedNodeId === node.id}
+            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+            style:left={`${node.x}px`}
+            style:top={`${node.y}px`}
+            style:width={`${node.width}px`}
+            style:height={`${node.height}px`}
+            data-node-id={node.id}
+            data-node-type="group"
+            onpointerdown={(e) => onNodePointerDown(e, node)}
+            onpointerenter={() => (hoveredNodeId = node.id)}
+            onpointerleave={() => {
+              if (hoveredNodeId === node.id) hoveredNodeId = null;
+            }}
+            role="group"
+            aria-label={groupNode.label ?? "Group"}
+          >
+            {#if groupNode.label}
+              <div class="vc-canvas-node-group-label">{groupNode.label}</div>
             {/if}
             <div
               class="vc-canvas-resize-handle"
@@ -865,6 +1128,113 @@
   .vc-canvas-node-placeholder .vc-canvas-node-content {
     color: var(--color-text-muted);
     font-style: italic;
+  }
+
+  .vc-canvas-node-file,
+  .vc-canvas-node-link {
+    overflow: hidden;
+  }
+
+  .vc-canvas-node-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+    pointer-events: none;
+    background: #000;
+  }
+
+  .vc-canvas-node-file-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 12px;
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    flex: 0 0 auto;
+  }
+
+  .vc-canvas-node-file-name,
+  .vc-canvas-node-link-url {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-text);
+  }
+
+  .vc-canvas-node-open {
+    flex: 0 0 auto;
+    font-size: 11px;
+    padding: 2px 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .vc-canvas-node-open:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .vc-canvas-node-open-overlay {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 3;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.35);
+  }
+
+  .vc-canvas-node-open-overlay:hover {
+    background: rgba(0, 0, 0, 0.75);
+  }
+
+  .vc-canvas-node-file-body {
+    padding: 8px;
+    font-size: 13px;
+    color: var(--color-text-muted);
+    flex: 1;
+    overflow: auto;
+  }
+
+  .vc-canvas-node-md {
+    padding: 8px;
+    font-size: 13px;
+    color: var(--color-text);
+    flex: 1;
+    overflow: auto;
+    line-height: 1.45;
+  }
+
+  .vc-canvas-node-md-loading {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .vc-canvas-node-group {
+    background: var(--color-accent-bg, rgba(64, 120, 192, 0.08));
+    border-style: dashed;
+    cursor: move;
+  }
+
+  .vc-canvas-node-group-label {
+    position: absolute;
+    top: -24px;
+    left: 0;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 2px 8px;
+    pointer-events: none;
   }
 
   .vc-canvas-node-textarea {

--- a/src/lib/canvas/__tests__/embed.test.ts
+++ b/src/lib/canvas/__tests__/embed.test.ts
@@ -1,0 +1,73 @@
+// Unit tests for canvas embed helpers (#71, phase 3).
+
+import { describe, it, expect } from "vitest";
+import {
+  canvasFilePreview,
+  isImageFile,
+  isMarkdownFile,
+  resolveVaultAbs,
+} from "../embed";
+
+describe("isImageFile", () => {
+  it("matches common image extensions case-insensitively", () => {
+    expect(isImageFile("photo.png")).toBe(true);
+    expect(isImageFile("Photo.JPG")).toBe(true);
+    expect(isImageFile("sub/image.webp")).toBe(true);
+    expect(isImageFile("diagram.svg")).toBe(true);
+  });
+
+  it("rejects non-image extensions", () => {
+    expect(isImageFile("notes.md")).toBe(false);
+    expect(isImageFile("archive.tar.gz")).toBe(false);
+    expect(isImageFile("noext")).toBe(false);
+  });
+});
+
+describe("isMarkdownFile", () => {
+  it("matches .md and .markdown", () => {
+    expect(isMarkdownFile("readme.md")).toBe(true);
+    expect(isMarkdownFile("Notes.MARKDOWN")).toBe(true);
+    expect(isMarkdownFile("subdir/a.md")).toBe(true);
+  });
+
+  it("rejects other extensions", () => {
+    expect(isMarkdownFile("photo.png")).toBe(false);
+    expect(isMarkdownFile("readme.txt")).toBe(false);
+  });
+});
+
+describe("resolveVaultAbs", () => {
+  it("joins the vault root and a vault-relative file path", () => {
+    expect(resolveVaultAbs("/vault", "notes/a.md")).toBe("/vault/notes/a.md");
+  });
+
+  it("normalises trailing slashes and leading slashes", () => {
+    expect(resolveVaultAbs("/vault/", "/a.md")).toBe("/vault/a.md");
+    expect(resolveVaultAbs("/vault///", "//a.md")).toBe("/vault/a.md");
+  });
+
+  it("converts backslashes to forward slashes so the result is portable", () => {
+    expect(resolveVaultAbs("C:\\vault", "sub\\file.md")).toBe(
+      "C:/vault/sub/file.md",
+    );
+  });
+});
+
+describe("canvasFilePreview", () => {
+  it("strips YAML frontmatter", () => {
+    const body =
+      "---\ntitle: test\ntags: [a,b]\n---\nFirst paragraph body.";
+    expect(canvasFilePreview(body)).toBe("First paragraph body.");
+  });
+
+  it("truncates at the char limit with an ellipsis", () => {
+    const body = "x".repeat(1000);
+    const out = canvasFilePreview(body, 100);
+    expect(out.length).toBeLessThanOrEqual(101);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("leaves short bodies untouched", () => {
+    expect(canvasFilePreview("short")).toBe("short");
+  });
+});

--- a/src/lib/canvas/embed.ts
+++ b/src/lib/canvas/embed.ts
@@ -1,0 +1,50 @@
+// Helpers for rendering embedded canvas nodes (#71, phase 3).
+// All functions here are pure (no IPC) so the view layer can unit-test
+// classification and path resolution without spinning up the app.
+
+import { IMAGE_EXTS, getExtension } from "../tabKind";
+
+/** True if `fileRel` names an image the canvas viewer should show inline. */
+export function isImageFile(fileRel: string): boolean {
+  return IMAGE_EXTS.has(getExtension(fileRel));
+}
+
+/** True if `fileRel` is a markdown note whose body we render as preview. */
+export function isMarkdownFile(fileRel: string): boolean {
+  const ext = getExtension(fileRel);
+  return ext === "md" || ext === "markdown";
+}
+
+/**
+ * Join a canvas-file-node's vault-relative `file` field onto an absolute
+ * vault path. Both `/` and `\` separators are normalised so the result
+ * is safe to pass to `convertFileSrc` / `readFile`.
+ */
+export function resolveVaultAbs(
+  vaultPath: string,
+  fileRel: string,
+): string {
+  const root = vaultPath.replace(/\\/g, "/").replace(/\/+$/, "");
+  const rel = fileRel.replace(/\\/g, "/").replace(/^\/+/, "");
+  return `${root}/${rel}`;
+}
+
+/**
+ * Extract a short "preview" slice from a markdown body so a file-node card
+ * can show something the reader recognizes at-a-glance. Strips YAML
+ * frontmatter and collapses whitespace — we hand the remainder to the
+ * full markdown renderer so wiki-links and embeds still render.
+ */
+export function canvasFilePreview(body: string, maxChars = 800): string {
+  let text = body;
+  if (text.startsWith("---")) {
+    const closeIdx = text.indexOf("\n---", 3);
+    if (closeIdx !== -1) {
+      text = text.slice(closeIdx + 4).replace(/^\s+/, "");
+    }
+  }
+  if (text.length > maxChars) {
+    text = text.slice(0, maxChars).trimEnd() + "…";
+  }
+  return text;
+}


### PR DESCRIPTION
## Summary

Phase 3 of the canvas viewer (part of #71, closes #126).

- File nodes render as an image (via `convertFileSrc`), a markdown-preview card (YAML frontmatter stripped + truncated body via `renderMarkdownToHtml`), or a generic filename card with an Open button.
- Link nodes render a URL card with an Open button that calls `window.open`.
- Group nodes render as translucent labelled containers behind other nodes.
- Unknown / future node types still fall back to the round-trip-safe placeholder.
- All `Open` buttons route through `openFileAsTab` so the main editor handles note/image dispatch.
- Full passthrough preserved: `file.subpath`, unknown link fields, `group.background` / `backgroundStyle`, and top-level metadata all survive edits.

## Test plan

- [x] `src/lib/canvas/__tests__/embed.test.ts` — 10 unit tests (image/md classification, path normalisation incl. Windows backslashes, frontmatter stripping, truncation)
- [x] `e2e/specs/canvas-embedded.spec.ts` — 9 E2E tests:
  - Text / file-md / file-image / link / group / unknown render side-by-side
  - Image `<img>` has an `asset://` src
  - Markdown preview strips frontmatter and renders headings
  - Group label appears
  - Link Open control is present with the correct URL
  - Clicking Open on an .md file opens the note tab
  - Clicking Open on an image file opens the image tab
  - Clicking Open on a link calls `window.open(url)`
  - Roundtrip preserves `file.subpath`, unknown link fields, `group.background` / `backgroundStyle`, unknown node types and top-level metadata
- [x] `canvas.spec.ts` (phase 1) updated since group nodes now render as proper cards instead of placeholders
- [x] Phase 1 + Phase 2 canvas E2E still pass (21 tests)
- [x] `pnpm exec svelte-check --threshold error` — no new errors (13 before, 13 after, all pre-existing)