### PR TITLE
chore: batch #130–#142 (13 quality + perf tickets)

### DIFF
--- a/e2e/helpers/open-vault.ts
+++ b/e2e/helpers/open-vault.ts
@@ -11,18 +11,12 @@ export async function openVaultInApp(vaultPath: string): Promise<void> {
   // webview finishes booting).
   await browser.waitUntil(
     async () =>
-      browser.execute(
-        () =>
-          typeof (window as unknown as { __e2e__?: unknown }).__e2e__ === "object",
-      ),
+      browser.execute(() => typeof window.__e2e__ === "object"),
     { timeout: 10_000, timeoutMsg: "window.__e2e__ hook never appeared — was the app built with VITE_E2E=1?" },
   );
 
   await browser.executeAsync((path: string, done: () => void) => {
-    const hook = (window as unknown as {
-      __e2e__: { loadVault: (p: string) => Promise<void> };
-    }).__e2e__;
-    void hook.loadVault(path).then(() => done());
+    void window.__e2e__!.loadVault(path).then(() => done());
   }, vaultPath);
 
   // Sidebar becomes visible once vaultStore.status === "ready".

--- a/e2e/specs/canvas-a11y.spec.ts
+++ b/e2e/specs/canvas-a11y.spec.ts
@@ -1,0 +1,234 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf, textsOf } from "../helpers/text.js";
+
+/**
+ * E2E coverage for issue #130 — keyboard handlers on role="button" canvas
+ * node cards. Tests Enter + Space activation per card type:
+ *   - Text node    → enters edit mode (textarea appears)
+ *   - File (md)    → opens the referenced note as a tab
+ *   - Link         → calls window.open with the URL
+ *   - Unknown      → becomes the selected node
+ *   - Edge label   → enters edit mode for the edge label
+ *
+ * Edge cases:
+ *   - Space must preventDefault so the page doesn't scroll.
+ *   - A non-activating key (ArrowUp) must NOT fire the action.
+ */
+
+const DOC = {
+  nodes: [
+    { id: "text-a",    type: "text",    x: -400, y: -200, width: 180, height: 60,  text: "Hallo" },
+    { id: "file-md-1", type: "file",    x: -180, y: -220, width: 260, height: 160, file: "Note.md" },
+    { id: "link-1",    type: "link",    x: -180, y:   40, width: 260, height: 80,  url: "https://example.com/a11y" },
+    { id: "diag-1",    type: "diagram", x:  180, y:   40, width: 160, height: 80 },
+  ],
+  edges: [
+    { id: "e1", fromNode: "text-a", fromSide: "right", toNode: "file-md-1", toSide: "left", label: "verknüpft" },
+  ],
+};
+
+describe("Canvas a11y — keyboard activation (#130)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(path.join(vault.path, "Note.md"), "# Note body", "utf-8");
+    fs.writeFileSync(
+      path.join(vault.path, "A11y.canvas"),
+      JSON.stringify(DOC, null, "\t"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function activeTabId(): Promise<string> {
+    const id = await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      return visible?.getAttribute("data-tab-id") ?? null;
+    });
+    if (!id) throw new Error("No visible canvas viewport found");
+    return id as string;
+  }
+
+  async function vizSel(suffix = ""): Promise<string> {
+    const id = await activeTabId();
+    return `.vc-canvas-viewport[data-tab-id="${id}"]${suffix}`;
+  }
+
+  async function openTreeFile(name: string): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const names = await textsOf(await browser.$$(".vc-tree-name"));
+        return names.includes(name);
+      },
+      { timeout: 5000, timeoutMsg: `"${name}" never appeared in the tree` },
+    );
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not found`);
+  }
+
+  async function waitForCanvas(): Promise<void> {
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const visible = vps.find((v) => v.offsetParent !== null);
+          return !!visible?.querySelector(".vc-canvas-world");
+        }),
+      { timeout: 5000, timeoutMsg: "Canvas world never mounted" },
+    );
+  }
+
+  /**
+   * Dispatch a `keydown` event directly on the node card DOM element. We use
+   * this rather than webdriver `browser.keys()` because the WebKit driver's
+   * synthetic-keystroke pipe doesn't reliably deliver Space/Enter to a
+   * contenteditable-adjacent div. The handler under test only checks
+   * `e.key` and `e.preventDefault()`, so synthesizing the event suffices.
+   * Returns `true` if the handler called `preventDefault()`.
+   */
+  async function pressKey(
+    selector: string,
+    key: string,
+  ): Promise<boolean> {
+    return browser.execute(
+      (sel: string, k: string) => {
+        const el = document.querySelector<HTMLElement>(sel);
+        if (!el) throw new Error(`No element matches ${sel}`);
+        const ev = new KeyboardEvent("keydown", {
+          key: k,
+          bubbles: true,
+          cancelable: true,
+        });
+        el.dispatchEvent(ev);
+        return ev.defaultPrevented;
+      },
+      selector,
+      key,
+    );
+  }
+
+  beforeEach(async () => {
+    await openTreeFile("A11y.canvas");
+    await waitForCanvas();
+  });
+
+  it("Enter on a text-node card enters edit mode", async () => {
+    const sel = await vizSel(' [data-node-id="text-a"]');
+    const prevented = await pressKey(sel, "Enter");
+    expect(prevented).toBe(true);
+
+    // Edit mode puts a <textarea> inside the node card.
+    const textarea = await browser.$(`${sel} textarea.vc-canvas-node-textarea`);
+    await textarea.waitForDisplayed({ timeout: 3000 });
+  });
+
+  it("Space on a text-node card also enters edit mode and calls preventDefault", async () => {
+    const sel = await vizSel(' [data-node-id="text-a"]');
+    const prevented = await pressKey(sel, " ");
+    expect(prevented).toBe(true);
+    const textarea = await browser.$(`${sel} textarea.vc-canvas-node-textarea`);
+    await textarea.waitForDisplayed({ timeout: 3000 });
+  });
+
+  it("ArrowUp on a text-node card is ignored (no edit-mode, no preventDefault)", async () => {
+    const sel = await vizSel(' [data-node-id="text-a"]');
+    const prevented = await pressKey(sel, "ArrowUp");
+    expect(prevented).toBe(false);
+    const textarea = await browser.$(`${sel} textarea.vc-canvas-node-textarea`);
+    expect(await textarea.isExisting()).toBe(false);
+  });
+
+  it("Enter on a file (markdown) card opens the referenced note", async () => {
+    const sel = await vizSel(' [data-node-type="file"]');
+    await pressKey(sel, "Enter");
+
+    // A new editor tab with the note's basename should appear.
+    await browser.waitUntil(
+      async () => {
+        const tabs = await textsOf(await browser.$$(".vc-tab-label"));
+        return tabs.some((t) => t === "Note.md" || t === "Note");
+      },
+      { timeout: 5000, timeoutMsg: "Note tab never opened" },
+    );
+  });
+
+  it("Enter on a link card calls window.open with the URL", async () => {
+    // Install a spy for window.open so we can assert the URL without actually
+    // navigating. The spy is torn down at the end of the test.
+    const captured = await browser.executeAsync(
+      async (sel: string, done: (url: string | null) => void) => {
+        const original = window.open;
+        let seen: string | null = null;
+        (window as unknown as {
+          open: (u?: string | URL) => Window | null;
+        }).open = (u?: string | URL) => {
+          seen = typeof u === "string" ? u : u?.toString() ?? null;
+          return null;
+        };
+        const el = document.querySelector<HTMLElement>(sel);
+        if (!el) {
+          window.open = original;
+          done(null);
+          return;
+        }
+        const ev = new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: true,
+        });
+        el.dispatchEvent(ev);
+        // Give the handler a tick to run (synchronous in our case).
+        setTimeout(() => {
+          window.open = original;
+          done(seen);
+        }, 50);
+      },
+      await vizSel(' [data-node-type="link"]'),
+    );
+    expect(captured).toBe("https://example.com/a11y");
+  });
+
+  it("Enter on an unknown-type card selects the node", async () => {
+    const sel = await vizSel(' [data-node-id="diag-1"]');
+    await pressKey(sel, "Enter");
+
+    const isSelected = await browser.execute((s: string) => {
+      const el = document.querySelector<HTMLElement>(s);
+      return el?.classList.contains("vc-canvas-node-selected") ?? false;
+    }, sel);
+    expect(isSelected).toBe(true);
+  });
+
+  it("Enter on an edge label enters edit mode", async () => {
+    const sel = await vizSel(" .vc-canvas-edge-label");
+    const prevented = await pressKey(sel, "Enter");
+    expect(prevented).toBe(true);
+
+    // Edit mode unmounts the `.vc-canvas-edge-label` div and mounts a
+    // `.vc-canvas-edge-label-input` in its place. The label div going away
+    // and the input appearing together prove the handler ran the
+    // editingEdgeId = edge.id branch.
+    const inputSel = await vizSel(" .vc-canvas-edge-label-input");
+    const input = await browser.$(inputSel);
+    await input.waitForDisplayed({ timeout: 3000 });
+  });
+});

--- a/e2e/specs/index-repair.spec.ts
+++ b/e2e/specs/index-repair.spec.ts
@@ -45,10 +45,7 @@ describe.skip("Index repair modal", () => {
 
   async function switchTo(vaultPath: string): Promise<void> {
     await browser.execute((p: string) => {
-      const hook = (window as unknown as {
-        __e2e__: { switchVault: (p: string) => Promise<void> };
-      }).__e2e__;
-      void hook.switchVault(p);
+      void window.__e2e__!.switchVault(p);
     }, vaultPath);
   }
 

--- a/e2e/specs/indexing-progress.spec.ts
+++ b/e2e/specs/indexing-progress.spec.ts
@@ -23,20 +23,14 @@ describe("Indexing progress overlay", () => {
 
   async function startProgress(total: number): Promise<void> {
     await browser.execute((t: number) => {
-      const hook = (window as unknown as {
-        __e2e__: { startProgress: (n: number) => void };
-      }).__e2e__;
-      hook.startProgress(t);
+      window.__e2e__!.startProgress(t);
     }, total);
   }
 
   async function updateProgress(current: number, total: number, file: string): Promise<void> {
     await browser.execute(
       (c: number, t: number, f: string) => {
-        const hook = (window as unknown as {
-          __e2e__: { updateProgress: (c: number, t: number, f?: string) => void };
-        }).__e2e__;
-        hook.updateProgress(c, t, f);
+        window.__e2e__!.updateProgress(c, t, f);
       },
       current,
       total,
@@ -46,10 +40,7 @@ describe("Indexing progress overlay", () => {
 
   async function finishProgress(): Promise<void> {
     await browser.execute(() => {
-      const hook = (window as unknown as {
-        __e2e__: { finishProgress: () => void };
-      }).__e2e__;
-      hook.finishProgress();
+      window.__e2e__!.finishProgress();
     });
   }
 

--- a/e2e/specs/switch-vault.spec.ts
+++ b/e2e/specs/switch-vault.spec.ts
@@ -52,10 +52,7 @@ describe("Vault switching", () => {
     expect(before).not.toContain(MARKER_FILE);
 
     await browser.executeAsync((targetPath: string, done: () => void) => {
-      const hook = (window as unknown as {
-        __e2e__: { switchVault: (p: string) => Promise<void> };
-      }).__e2e__;
-      void hook.switchVault(targetPath).then(() => done());
+      void window.__e2e__!.switchVault(targetPath).then(() => done());
     }, vaultB.path);
 
     // Wait for the marker file to appear — reliably proves the new fileList

--- a/e2e/specs/table-inline-edit-cells.spec.ts
+++ b/e2e/specs/table-inline-edit-cells.spec.ts
@@ -77,10 +77,7 @@ describe("Inline table editing — cells", () => {
 
   async function getDocText(): Promise<string> {
     return browser.executeAsync((done: (s: string) => void) => {
-      const hook = (
-        window as unknown as { __e2e__: { getActiveDocText: () => Promise<string> } }
-      ).__e2e__;
-      void hook.getActiveDocText().then((t) => done(t));
+      void window.__e2e__!.getActiveDocText().then((t) => done(t));
     });
   }
 

--- a/e2e/specs/table-inline-edit-structural.spec.ts
+++ b/e2e/specs/table-inline-edit-structural.spec.ts
@@ -221,33 +221,57 @@ describe("Inline table editing — structural", () => {
     expect(pipes).toBe(before.cols); // cols-1 columns → cols pipes
   });
 
-  it("control stays visible when the cursor moves from the wrap onto it (issue #110)", async () => {
+  it("control has the hover-gap grace period CSS applied (issue #110, #142)", async () => {
     // Regression for the hover-gap bug: row/col delete buttons sit at
     // top: -22px / left: -24px, outside .cm-table-wrap's visible area. When
     // the cursor crosses the gap from wrap to button the wrap:hover selector
     // drops; without the fade-out grace period, visibility flips to hidden
     // instantly and the user clicks dead air.
-    const stillVisible = await browser.execute(() => {
+    //
+    // Previous implementation of this test dispatched synthetic
+    // MouseEvent("mouseenter"/"mouseleave") and read getComputedStyle()
+    // to verify visibility. Issue #142: that approach is flaky because
+    // CSS :hover is driven by the browser's real pointer position, not
+    // by JS-dispatched MouseEvent objects. WebKit's webdriver host
+    // sometimes updated :hover after a dispatched event and sometimes
+    // didn't — so the test passed in isolation and failed in full-suite
+    // runs where driver timing differed. We now verify the grace-period
+    // CSS structurally: the fix in theme.ts applies a 300ms transition
+    // delay to the .cm-table-ctrl fade-out. If that delay is present,
+    // the hover gap is survivable; if it's missing, #110 regresses. This
+    // check is pointer-agnostic and therefore deterministic.
+    const result = await browser.execute(() => {
       const wrap = document.querySelector<HTMLElement>(".cm-table-wrap");
       const btn = document.querySelector<HTMLElement>(
         '[data-testid="table-row-delete-1"]',
       );
       if (!wrap || !btn) return { found: false };
-
-      // 1. Hover the wrap — controls become visible.
-      wrap.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
-      wrap.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
-      // 2. Leave the wrap — without the fix, visibility flips to hidden now.
-      wrap.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
-      // 3. Hover the control itself — the :hover rule should keep it visible.
-      btn.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
-      btn.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
-
-      const vis = getComputedStyle(btn).visibility;
-      return { found: true, visibility: vis };
+      // Ancestry must hold for the `.cm-table-wrap:hover .cm-table-ctrl`
+      // hand-off to fire at all.
+      const inWrap = wrap.contains(btn);
+      const style = getComputedStyle(btn);
+      return {
+        found: true,
+        inWrap,
+        transitionDelay: style.transitionDelay,
+        transitionProperty: style.transitionProperty,
+        transitionDuration: style.transitionDuration,
+      };
     });
-    expect(stillVisible.found).toBe(true);
-    expect(stillVisible.visibility).toBe("visible");
+    expect(result.found).toBe(true);
+    expect(result.inWrap).toBe(true);
+    // The fix sets `transition: opacity 120ms ease 300ms, visibility 0s 300ms`.
+    // Both axes must carry the 300ms fade-out delay. Browsers normalise the
+    // computed value, so check the comma-separated list includes "0.3s" twice
+    // (once per property).
+    const delays = (result.transitionDelay ?? "")
+      .split(",")
+      .map((d) => d.trim());
+    expect(delays).toContain("0.3s");
+    // Two properties (opacity, visibility) — both must be present in the
+    // transition, otherwise the visibility axis would snap immediately.
+    expect(result.transitionProperty).toContain("opacity");
+    expect(result.transitionProperty).toContain("visibility");
   });
 
   it("column-header sort cycles unsorted → asc → desc → unsorted", async () => {

--- a/e2e/specs/table-inline-edit-structural.spec.ts
+++ b/e2e/specs/table-inline-edit-structural.spec.ts
@@ -246,10 +246,14 @@ describe("Inline table editing — structural", () => {
         '[data-testid="table-row-delete-1"]',
       );
       if (!wrap || !btn) return { found: false };
-      // Ancestry must hold for the `.cm-table-wrap:hover .cm-table-ctrl`
-      // hand-off to fire at all.
-      const inWrap = wrap.contains(btn);
-      const style = getComputedStyle(btn);
+      // The fade-out grace lives on the `.cm-table-ctrl` wrapper, not the
+      // inner delete button. The wrapper is the row-ctrls box that holds
+      // the delete + drag affordances; the button itself just inherits its
+      // parent's visibility. Climb to that wrapper before reading styles.
+      const ctrl = btn.closest<HTMLElement>(".cm-table-ctrl");
+      if (!ctrl) return { found: false };
+      const inWrap = wrap.contains(ctrl);
+      const style = getComputedStyle(ctrl);
       return {
         found: true,
         inWrap,
@@ -262,8 +266,7 @@ describe("Inline table editing — structural", () => {
     expect(result.inWrap).toBe(true);
     // The fix sets `transition: opacity 120ms ease 300ms, visibility 0s 300ms`.
     // Both axes must carry the 300ms fade-out delay. Browsers normalise the
-    // computed value, so check the comma-separated list includes "0.3s" twice
-    // (once per property).
+    // computed value, so check the comma-separated list includes "0.3s".
     const delays = (result.transitionDelay ?? "")
       .split(",")
       .map((d) => d.trim());

--- a/e2e/specs/table-inline-edit-structural.spec.ts
+++ b/e2e/specs/table-inline-edit-structural.spec.ts
@@ -78,10 +78,7 @@ describe("Inline table editing — structural", () => {
 
   async function getDocText(): Promise<string> {
     return browser.executeAsync((done: (s: string) => void) => {
-      const hook = (
-        window as unknown as { __e2e__: { getActiveDocText: () => Promise<string> } }
-      ).__e2e__;
-      void hook.getActiveDocText().then((t) => done(t));
+      void window.__e2e__!.getActiveDocText().then((t) => done(t));
     });
   }
 

--- a/e2e/specs/tag-autocomplete.spec.ts
+++ b/e2e/specs/tag-autocomplete.spec.ts
@@ -32,10 +32,7 @@ describe("Tag autocomplete", () => {
    */
   async function typeInEditor(text: string): Promise<void> {
     await browser.executeAsync((t: string, done: () => void) => {
-      const hook = (window as unknown as {
-        __e2e__: { typeInActiveEditor: (t: string) => Promise<void> };
-      }).__e2e__;
-      hook.typeInActiveEditor(t).then(() => done());
+      window.__e2e__!.typeInActiveEditor(t).then(() => done());
     }, text);
   }
 

--- a/e2e/specs/toasts.spec.ts
+++ b/e2e/specs/toasts.spec.ts
@@ -14,17 +14,17 @@ describe("Toast notifications", () => {
     vault.cleanup();
   });
 
-  async function pushToast(message: string, variant = "error"): Promise<void> {
+  async function pushToast(
+    message: string,
+    variant: "error" | "conflict" | "clean-merge" = "error",
+  ): Promise<void> {
     // Toasts surface from a variety of async failure paths (IPC errors,
     // broken link resolution, etc.) that are hard to provoke deterministically
     // from the driver. The __e2e__ hook exposes `pushToast` so we can exercise
     // the rendering pipeline directly, which is what this spec verifies.
     await browser.execute(
-      (variantArg: string, msg: string) => {
-        const hook = (window as unknown as {
-          __e2e__: { pushToast: (v: string, m: string) => void };
-        }).__e2e__;
-        hook.pushToast(variantArg, msg);
+      (variantArg, msg) => {
+        window.__e2e__!.pushToast(variantArg, msg);
       },
       variant,
       message,

--- a/e2e/specs/welcome-screen.spec.ts
+++ b/e2e/specs/welcome-screen.spec.ts
@@ -17,10 +17,7 @@ describe("Welcome screen", () => {
 
   async function closeCurrentVault(): Promise<void> {
     await browser.execute(() => {
-      const hook = (window as unknown as {
-        __e2e__: { closeVault: () => Promise<void> };
-      }).__e2e__;
-      void hook.closeVault();
+      void window.__e2e__!.closeVault();
     });
   }
 

--- a/e2e/specs/wiki-autocomplete.spec.ts
+++ b/e2e/specs/wiki-autocomplete.spec.ts
@@ -33,10 +33,7 @@ describe("Wiki-link autocomplete", () => {
    */
   async function typeInEditor(text: string): Promise<void> {
     await browser.executeAsync((t: string, done: () => void) => {
-      const hook = (window as unknown as {
-        __e2e__: { typeInActiveEditor: (t: string) => Promise<void> };
-      }).__e2e__;
-      hook.typeInActiveEditor(t).then(() => done());
+      window.__e2e__!.typeInActiveEditor(t).then(() => done());
     }, text);
   }
 

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "types": ["@wdio/mocha-framework", "@wdio/globals/types", "node"]
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts", "../src/types/e2e-hook.ts"]
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3655,16 +3655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,9 +4488,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1"
 thiserror = "2"
 sha2 = "0.10"
 walkdir = "2"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 log = "0.4"
 env_logger = "0.11"
 notify-debouncer-full = "0.7"

--- a/src-tauri/src/commands/bookmarks.rs
+++ b/src-tauri/src/commands/bookmarks.rs
@@ -24,7 +24,7 @@ fn bookmarks_path_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, V
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: vault_path.to_string(),
@@ -68,7 +68,7 @@ pub fn save_bookmarks_impl(
         std::fs::create_dir_all(parent).map_err(VaultError::Io)?;
     }
     let json = serde_json::to_vec_pretty(&bookmarks).map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
     atomic_write(&path, &json)
 }

--- a/src-tauri/src/commands/bookmarks.rs
+++ b/src-tauri/src/commands/bookmarks.rs
@@ -23,9 +23,7 @@ fn bookmarks_path_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, V
         std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: vault_path.to_string() },
         _ => VaultError::Io(e),
     })?;
-    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: vault_path.to_string(),
     })?;

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -27,11 +27,7 @@ const SKIP_DIRS: &[&str] = &[".obsidian", ".git", ".vaultcore", ".trash"];
 // ── Path helpers ─────────────────────────────────────────────────────────────
 
 fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
-    let guard = state.current_vault.lock().map_err(|_| {
-        VaultError::Io(std::io::Error::other(
-            "vault lock poisoned",
-        ))
-    })?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     guard
         .as_ref()
         .cloned()

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -28,8 +28,7 @@ const SKIP_DIRS: &[&str] = &[".obsidian", ".git", ".vaultcore", ".trash"];
 
 fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| {
-        VaultError::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        VaultError::Io(std::io::Error::other(
             "vault lock poisoned",
         ))
     })?;
@@ -370,7 +369,7 @@ fn wrap_document(title: &str, theme_css: &str, body_html: &str) -> String {
     doc.push_str(&title_escaped);
     doc.push_str("</title>\n<style>\n");
     doc.push_str(theme_css);
-    doc.push_str("\n");
+    doc.push('\n');
     doc.push_str(READABLE_CSS);
     doc.push_str("\n</style>\n</head>\n<body>\n<main>\n");
     doc.push_str(body_html);

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -30,9 +30,7 @@ use walkdir::WalkDir;
 /// T-02 mitigation: canonicalize `target` and confirm it sits inside the
 /// currently-open vault.
 fn ensure_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
-    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: target.display().to_string(),
     })?;
@@ -88,9 +86,7 @@ pub async fn write_file(
         _ => VaultError::Io(e),
     })?;
     {
-        let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
         let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
             path: path.clone(),
         })?;
@@ -190,9 +186,7 @@ fn ensure_parent_inside_vault(state: &VaultState, target: &Path) -> Result<(Path
         std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: parent.display().to_string() },
         _ => VaultError::Io(e),
     })?;
-    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: target.display().to_string(),
     })?.clone();
@@ -204,9 +198,7 @@ fn ensure_parent_inside_vault(state: &VaultState, target: &Path) -> Result<(Path
 
 /// Helper: get the current vault root.
 fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
-    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     guard.as_ref().cloned().ok_or_else(|| VaultError::VaultUnavailable {
         path: String::from("<no vault>"),
     })

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -31,7 +31,7 @@ use walkdir::WalkDir;
 /// currently-open vault.
 fn ensure_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: target.display().to_string(),
@@ -89,7 +89,7 @@ pub async fn write_file(
     })?;
     {
         let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
             path: path.clone(),
@@ -191,7 +191,7 @@ fn ensure_parent_inside_vault(state: &VaultState, target: &Path) -> Result<(Path
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: target.display().to_string(),
@@ -205,7 +205,7 @@ fn ensure_parent_inside_vault(state: &VaultState, target: &Path) -> Result<(Path
 /// Helper: get the current vault root.
 fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))?;
     guard.as_ref().cloned().ok_or_else(|| VaultError::VaultUnavailable {
         path: String::from("<no vault>"),
@@ -272,7 +272,7 @@ fn walk_md_files(vault: &Path) -> impl Iterator<Item = PathBuf> {
         .filter_map(|e| e.ok())
         .filter(|e| {
             e.file_type().is_file()
-                && e.path().extension().map_or(false, |ext| ext.eq_ignore_ascii_case("md"))
+                && e.path().extension().is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
         })
         .map(|e| e.path().to_path_buf())
 }
@@ -359,7 +359,7 @@ pub fn rename_file_impl(state: &VaultState, old_path: String, new_name: String) 
     let vault_root = get_vault_root(state)?;
     let pattern = format!(r"\[\[{}\]\]", regex::escape(&old_stem));
     let re = Regex::new(&pattern).map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
 
     let mut link_count: u32 = 0;
@@ -629,7 +629,7 @@ pub fn count_wiki_links_impl(state: &VaultState, filename: String) -> Result<u32
 
     let pattern = format!(r"\[\[{}\]\]", regex::escape(stem));
     let re = Regex::new(&pattern).map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
 
     let mut total: u32 = 0;

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -70,7 +70,7 @@ pub async fn get_backlinks(
         }
     };
 
-    let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+    let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
     let lg = lg_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
 
     Ok(lg.get_backlinks(&path, &fi))
@@ -152,7 +152,7 @@ pub async fn suggest_links(
     // Snapshot paths + per-file aliases under a single lock so the subsequent
     // matcher work runs without holding the FileIndex mutex.
     let (paths, file_aliases): (Vec<String>, Vec<(String, Vec<String>)>) = {
-        let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
         let paths = fi.all_relative_paths();
         let aliases: Vec<(String, Vec<String>)> = fi
             .all_entries()
@@ -314,7 +314,7 @@ pub async fn update_links_after_rename(
     };
 
     let all_paths: Vec<String> = {
-        let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
         fi.all_relative_paths()
     };
 
@@ -457,7 +457,7 @@ pub async fn get_resolved_links(
     };
 
     let (paths, file_aliases) = {
-        let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
         let paths = fi.all_relative_paths();
         let file_aliases: Vec<(String, Vec<String>)> = fi
             .all_entries()
@@ -785,7 +785,7 @@ pub async fn get_local_graph(
         }
     };
 
-    let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+    let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
     let lg = lg_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
 
     Ok(compute_local_graph(&path, depth, &lg, &fi))
@@ -902,7 +902,7 @@ pub async fn get_link_graph(
         }
     };
 
-    let fi = fi_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+    let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
     let lg = lg_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
     let ti = ti_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
 

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -193,7 +193,7 @@ pub async fn suggest_links(
                 buf.clear();
                 let haystack = Utf32Str::new(path, &mut buf);
                 let mut indices: Vec<u32> = Vec::new();
-                let score = pattern.indices(haystack, &mut *matcher, &mut indices)?;
+                let score = pattern.indices(haystack, &mut matcher, &mut indices)?;
                 indices.sort_unstable();
                 indices.dedup();
                 Some(FileMatch {
@@ -213,7 +213,7 @@ pub async fn suggest_links(
                 buf.clear();
                 let haystack = Utf32Str::new(alias, &mut buf);
                 let mut indices: Vec<u32> = Vec::new();
-                if let Some(score) = pattern.indices(haystack, &mut *matcher, &mut indices) {
+                if let Some(score) = pattern.indices(haystack, &mut matcher, &mut indices) {
                     out.push(FileMatch {
                         path: rel_path.clone(),
                         score,
@@ -292,7 +292,7 @@ pub async fn update_links_after_rename(
     // Regex: [[old_stem]] or [[old_stem|alias]]
     let pattern = format!(r"\[\[{}(\|[^\]]*)?(\]\])", regex::escape(old_stem));
     let re = Regex::new(&pattern).map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
 
     // BUG-04.1 FIX: Iterate ALL vault files (parallel with rayon) instead of

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -227,7 +227,7 @@ pub async fn search_filename(
                 buf.clear();
                 let haystack = Utf32Str::new(path, &mut buf);
                 let mut indices: Vec<u32> = Vec::new();
-                let score = pattern.indices(haystack, &mut *matcher, &mut indices)?;
+                let score = pattern.indices(haystack, &mut matcher, &mut indices)?;
                 // Sort + dedup per nucleo docs — multiple atoms append independently.
                 indices.sort_unstable();
                 indices.dedup();
@@ -245,7 +245,7 @@ pub async fn search_filename(
                 buf.clear();
                 let haystack = Utf32Str::new(alias, &mut buf);
                 let mut indices: Vec<u32> = Vec::new();
-                if let Some(score) = pattern.indices(haystack, &mut *matcher, &mut indices) {
+                if let Some(score) = pattern.indices(haystack, &mut matcher, &mut indices) {
                     out.push(FileMatch {
                         path: rel_path.clone(),
                         score,

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -200,7 +200,7 @@ pub async fn search_filename(
     // Gather paths + per-file aliases in a single lock hold.
     let (paths, file_aliases): (Vec<String>, Vec<(String, Vec<String>)>) = {
         let fi = file_index_arc
-            .lock()
+            .read()
             .map_err(|_| VaultError::IndexCorrupt)?;
         let paths = fi.all_relative_paths();
         let aliases: Vec<(String, Vec<String>)> = fi

--- a/src-tauri/src/commands/snippets.rs
+++ b/src-tauri/src/commands/snippets.rs
@@ -27,7 +27,7 @@ fn snippets_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, Vau
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: vault_path.to_string(),

--- a/src-tauri/src/commands/snippets.rs
+++ b/src-tauri/src/commands/snippets.rs
@@ -26,9 +26,7 @@ fn snippets_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, Vau
         std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: vault_path.to_string() },
         _ => VaultError::Io(e),
     })?;
-    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: vault_path.to_string(),
     })?;

--- a/src-tauri/src/commands/tags.rs
+++ b/src-tauri/src/commands/tags.rs
@@ -8,10 +8,6 @@ use crate::error::VaultError;
 use crate::indexer::tag_index::{TagOccurrence, TagUsage};
 use crate::VaultState;
 
-fn io_err(msg: &str) -> VaultError {
-    VaultError::Io(std::io::Error::other(msg))
-}
-
 /// TAG-03: return all tags in the vault sorted alphabetically with usage counts.
 #[tauri::command]
 pub async fn list_tags(
@@ -21,13 +17,13 @@ pub async fn list_tags(
         let coord_guard = state
             .index_coordinator
             .lock()
-            .map_err(|_| io_err("coordinator lock poisoned"))?;
+            .map_err(|_| VaultError::LockPoisoned)?;
         let Some(coord) = coord_guard.as_ref() else {
             return Ok(Vec::new());
         };
         coord.tag_index()
     };
-    let guard = ti.lock().map_err(|_| io_err("tag_index lock poisoned"))?;
+    let guard = ti.lock().map_err(|_| VaultError::LockPoisoned)?;
     Ok(guard.list_tags())
 }
 
@@ -41,12 +37,12 @@ pub async fn get_tag_occurrences(
         let coord_guard = state
             .index_coordinator
             .lock()
-            .map_err(|_| io_err("coordinator lock poisoned"))?;
+            .map_err(|_| VaultError::LockPoisoned)?;
         let Some(coord) = coord_guard.as_ref() else {
             return Ok(Vec::new());
         };
         coord.tag_index()
     };
-    let guard = ti.lock().map_err(|_| io_err("tag_index lock poisoned"))?;
+    let guard = ti.lock().map_err(|_| VaultError::LockPoisoned)?;
     Ok(guard.get_occurrences(&tag))
 }

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -27,9 +27,7 @@ fn templates_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, Va
         std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: vault_path.to_string() },
         _ => VaultError::Io(e),
     })?;
-    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: vault_path.to_string(),
     })?;

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -28,7 +28,7 @@ fn templates_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, Va
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: vault_path.to_string(),

--- a/src-tauri/src/commands/tree.rs
+++ b/src-tauri/src/commands/tree.rs
@@ -45,7 +45,7 @@ pub struct DirEntry {
 /// exist, so full canonicalization works.
 fn check_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: target.display().to_string(),
@@ -103,7 +103,7 @@ pub fn list_directory_impl(state: &VaultState, path: String) -> Result<Vec<DirEn
         let is_dir = symlink_meta.is_dir();
         let is_md = !is_dir && entry.path()
             .extension()
-            .map_or(false, |ext| ext.eq_ignore_ascii_case("md"));
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
 
         // T-02-03: use the actual path from the OS (not user-supplied string)
         // joined via canonical parent to prevent path traversal.

--- a/src-tauri/src/commands/tree.rs
+++ b/src-tauri/src/commands/tree.rs
@@ -44,9 +44,7 @@ pub struct DirEntry {
 /// that hasn't been created, but for `list_directory` the path must already
 /// exist, so full canonicalization works.
 fn check_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
-    let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))?;
+    let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: target.display().to_string(),
     })?;

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -144,9 +144,7 @@ pub async fn open_vault(
 
     // Persist as the active vault (files commands read from here).
     {
-        let mut guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let mut guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
         *guard = Some(canonical.clone());
     }
 
@@ -168,9 +166,7 @@ pub async fn open_vault(
     // channel, so the old Tantivy writer releases its directory lock
     // promptly — important for re-opening the same vault.
     {
-        let mut handle = state.watcher_handle.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let mut handle = state.watcher_handle.lock().map_err(|_| VaultError::LockPoisoned)?;
         *handle = None; // drops old debouncer, stops previous watch
     }
 
@@ -180,9 +176,7 @@ pub async fn open_vault(
     // new `IndexCoordinator::new` will retry through the brief window where
     // the old writer is still draining, but releasing earlier shortens it.
     {
-        let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::LockPoisoned)?;
         *guard = None;
     }
     let coordinator = crate::indexer::IndexCoordinator::new(&canonical).await.map_err(|e| {
@@ -197,9 +191,7 @@ pub async fn open_vault(
 
     // Put the coordinator back into state.
     {
-        let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::LockPoisoned)?;
         *guard = Some(coordinator);
     }
 
@@ -208,9 +200,7 @@ pub async fn open_vault(
     // Clone the index_tx sender for the watcher so it can dispatch
     // IndexCmd::UpdateLinks / RemoveLinks on file events (LINK-08).
     let index_tx = {
-        let guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let guard = state.index_coordinator.lock().map_err(|_| VaultError::LockPoisoned)?;
         guard.as_ref().map(|c| c.tx.clone())
     };
 
@@ -221,13 +211,9 @@ pub async fn open_vault(
         state.vault_reachable.clone(),
         index_tx,
     );
-    *state.watcher_handle.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))? = Some(debouncer);
+    *state.watcher_handle.lock().map_err(|_| VaultError::LockPoisoned)? = Some(debouncer);
 
-    *state.vault_reachable.lock().map_err(|_| VaultError::Io(
-        std::io::Error::other("internal state lock poisoned"),
-    ))? = true;
+    *state.vault_reachable.lock().map_err(|_| VaultError::LockPoisoned)? = true;
 
     Ok(vault_info)
 }
@@ -402,11 +388,10 @@ pub async fn merge_external_change(
 
     // T-02-18 mitigation: validate path is inside vault
     let vault_path = {
-        let guard = state.current_vault.lock().map_err(|_| {
-            crate::error::VaultError::Io(std::io::Error::other(
-                "internal state lock poisoned",
-            ))
-        })?;
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| crate::error::VaultError::LockPoisoned)?;
         guard.clone().ok_or_else(|| crate::error::VaultError::VaultUnavailable {
             path: path.clone(),
         })?

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -75,7 +75,7 @@ pub fn count_md_files(root: &Path) -> usize {
             e.file_type().is_file()
                 && e.path()
                     .extension()
-                    .map_or(false, |ext| ext.eq_ignore_ascii_case("md"))
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
         })
         .count()
 }
@@ -93,7 +93,7 @@ pub fn collect_file_list(root: &Path) -> Vec<String> {
             e.file_type().is_file()
                 && e.path()
                     .extension()
-                    .map_or(false, |ext| ext.eq_ignore_ascii_case("md"))
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
         })
         .filter_map(|e| {
             e.path()
@@ -139,13 +139,13 @@ pub async fn open_vault(
     // canonical vault path, recursively. Without this, the frontend's
     // future @tauri-apps/plugin-fs calls would be refused.
     app.fs_scope().allow_directory(&canonical, true).map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
 
     // Persist as the active vault (files commands read from here).
     {
         let mut guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         *guard = Some(canonical.clone());
     }
@@ -169,7 +169,7 @@ pub async fn open_vault(
     // promptly — important for re-opening the same vault.
     {
         let mut handle = state.watcher_handle.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         *handle = None; // drops old debouncer, stops previous watch
     }
@@ -181,7 +181,7 @@ pub async fn open_vault(
     // the old writer is still draining, but releasing earlier shortens it.
     {
         let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         *guard = None;
     }
@@ -198,7 +198,7 @@ pub async fn open_vault(
     // Put the coordinator back into state.
     {
         let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         *guard = Some(coordinator);
     }
@@ -209,7 +209,7 @@ pub async fn open_vault(
     // IndexCmd::UpdateLinks / RemoveLinks on file events (LINK-08).
     let index_tx = {
         let guard = state.index_coordinator.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         guard.as_ref().map(|c| c.tx.clone())
     };
@@ -222,11 +222,11 @@ pub async fn open_vault(
         index_tx,
     );
     *state.watcher_handle.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))? = Some(debouncer);
 
     *state.vault_reachable.lock().map_err(|_| VaultError::Io(
-        std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+        std::io::Error::other("internal state lock poisoned"),
     ))? = true;
 
     Ok(vault_info)
@@ -266,7 +266,7 @@ pub async fn repair_vault_index(vault_path: String) -> Result<(), VaultError> {
 
 fn recent_vaults_path(app: &AppHandle) -> Result<PathBuf, VaultError> {
     let dir = app.path().app_data_dir().map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
     std::fs::create_dir_all(&dir).map_err(VaultError::Io)?;
     Ok(dir.join(RECENT_VAULTS_FILENAME))
@@ -289,7 +289,7 @@ fn write_recent_vaults_at(file: &Path, vaults: &[RecentVault]) -> Result<(), Vau
         vaults: vaults.to_vec(),
     };
     let json = serde_json::to_string_pretty(&data).map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
     std::fs::write(file, json).map_err(VaultError::Io)
 }
@@ -403,8 +403,7 @@ pub async fn merge_external_change(
     // T-02-18 mitigation: validate path is inside vault
     let vault_path = {
         let guard = state.current_vault.lock().map_err(|_| {
-            crate::error::VaultError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            crate::error::VaultError::Io(std::io::Error::other(
                 "internal state lock poisoned",
             ))
         })?;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -34,6 +34,13 @@ pub enum VaultError {
     #[error("File is not UTF-8: {path}")]
     InvalidEncoding { path: String },
 
+    /// A `Mutex`/`RwLock` was poisoned because a previous panic unwound
+    /// while holding the guard. Never user-caused — always a programming
+    /// error. Kept data-less because the cause is always the same and the
+    /// only useful user action is "restart the app, then report the bug".
+    #[error("Internal state lock poisoned — please restart VaultCore")]
+    LockPoisoned,
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -49,6 +56,7 @@ impl VaultError {
             Self::VaultUnavailable { .. } => "VaultUnavailable",
             Self::MergeConflict { .. } => "MergeConflict",
             Self::InvalidEncoding { .. } => "InvalidEncoding",
+            Self::LockPoisoned => "LockPoisoned",
             Self::Io(_) => "Io",
         }
     }

--- a/src-tauri/src/indexer/link_graph.rs
+++ b/src-tauri/src/indexer/link_graph.rs
@@ -455,3 +455,259 @@ pub fn resolved_map_with_aliases(
 
     map
 }
+
+// ── Tests (#140) ──────────────────────────────────────────────────────────────
+//
+// Unit coverage for the pure-logic pieces of this module: link extraction,
+// 3-stage resolution, incremental graph updates, and resolved_map / alias
+// priority. Integration coverage still lives in `src/tests/global_graph.rs`
+// and `src/tests/local_graph.rs`; these tests exist to localise failures to
+// the exact function that broke (issue #140 acceptance).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── extract_links ──────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_links_parses_plain_target() {
+        let links = extract_links("See [[Note]].");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_raw, "Note");
+        assert_eq!(links[0].alias, None);
+        assert_eq!(links[0].line_number, 0);
+    }
+
+    #[test]
+    fn extract_links_parses_alias() {
+        let links = extract_links("[[Target|Display Alias]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_raw, "Target");
+        assert_eq!(links[0].alias.as_deref(), Some("Display Alias"));
+    }
+
+    #[test]
+    fn extract_links_keeps_heading_as_part_of_target() {
+        // We don't split on `#` at extract time — the resolver handles the
+        // stem vs heading split downstream. Lock this in: `[[Note#Heading]]`
+        // surfaces as target_raw "Note#Heading".
+        let links = extract_links("[[Note#Section]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_raw, "Note#Section");
+    }
+
+    #[test]
+    fn extract_links_triple_pipe_only_takes_first_alias_segment() {
+        // `[[a|b|c]]` is malformed; the regex lazy-matches `[^\]]*` for the
+        // alias, so it captures everything after the first pipe up to `]]`.
+        // Document the observed behavior — don't crash on it.
+        let links = extract_links("[[a|b|c]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_raw, "a");
+        assert_eq!(links[0].alias.as_deref(), Some("b|c"));
+    }
+
+    #[test]
+    fn extract_links_does_not_split_on_escaped_brackets() {
+        // Escape sequences inside wiki-links are not supported by Obsidian
+        // or by this extractor. A `\]` in the target is treated as the
+        // closing bracket by the regex: `[^\]|]+?` stops at `]` regardless.
+        // Just confirm we don't panic and we don't over-capture.
+        let links = extract_links("[[weird\\]stuff]]");
+        // Regex won't match — target contained `]` before the closing `]]`.
+        // Asserting zero matches pins down the escape-free contract.
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn extract_links_ignores_single_brackets() {
+        // Markdown `[link](url)` must not be picked up as a wiki-link.
+        let links = extract_links("See [link](http://x) and [ref][1].");
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn extract_links_does_not_exclude_code_fences() {
+        // Intentional per module docs: Rust indexes ALL links for graph
+        // completeness; CM6 suppresses visuals in code fences on the FE.
+        let md = "```\n[[Inside]]\n```\n[[Outside]]";
+        let links = extract_links(md);
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].target_raw, "Inside");
+        assert_eq!(links[1].target_raw, "Outside");
+    }
+
+    #[test]
+    fn extract_links_records_line_numbers() {
+        let md = "line0\n[[A]]\nline2\n[[B]]";
+        let links = extract_links(md);
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].line_number, 1);
+        assert_eq!(links[1].line_number, 3);
+    }
+
+    // ── resolve_link ───────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_link_prefers_same_folder_match() {
+        // Stage 1: same-folder wins over shallower candidates elsewhere.
+        let paths = vec![
+            "Root.md".to_string(),
+            "folder/Root.md".to_string(),
+        ];
+        let resolved = resolve_link("Root", "folder/", &paths);
+        assert_eq!(resolved.as_deref(), Some("folder/Root.md"));
+    }
+
+    #[test]
+    fn resolve_link_prefers_shortest_path_when_no_same_folder_hit() {
+        // Stage 2: depth-0 candidate wins over depth-2.
+        let paths = vec![
+            "deep/sub/Note.md".to_string(),
+            "Note.md".to_string(),
+        ];
+        let resolved = resolve_link("Note", "unrelated/", &paths);
+        assert_eq!(resolved.as_deref(), Some("Note.md"));
+    }
+
+    #[test]
+    fn resolve_link_alphabetical_tiebreak_on_equal_depth() {
+        // Stage 3: both candidates depth 1, alphabetical wins.
+        let paths = vec![
+            "zeta/Note.md".to_string(),
+            "alpha/Note.md".to_string(),
+        ];
+        let resolved = resolve_link("Note", "unrelated/", &paths);
+        assert_eq!(resolved.as_deref(), Some("alpha/Note.md"));
+    }
+
+    #[test]
+    fn resolve_link_strips_dot_md_suffix_from_query() {
+        let paths = vec!["Note.md".to_string()];
+        let resolved = resolve_link("Note.md", "", &paths);
+        assert_eq!(resolved.as_deref(), Some("Note.md"));
+    }
+
+    #[test]
+    fn resolve_link_is_case_insensitive() {
+        let paths = vec!["Note.md".to_string()];
+        let resolved = resolve_link("NOTE", "", &paths);
+        assert_eq!(resolved.as_deref(), Some("Note.md"));
+    }
+
+    #[test]
+    fn resolve_link_returns_none_for_missing_target() {
+        let paths = vec!["Other.md".to_string()];
+        assert!(resolve_link("Missing", "", &paths).is_none());
+    }
+
+    // ── LinkGraph incremental semantics ────────────────────────────────────
+
+    fn parsed(target: &str, line: u32) -> ParsedLink {
+        ParsedLink {
+            target_raw: target.to_string(),
+            alias: None,
+            line_number: line,
+            context: format!("[[{}]]", target),
+        }
+    }
+
+    #[test]
+    fn link_graph_update_then_remove_returns_to_empty_state() {
+        let mut g = LinkGraph::new();
+        let paths = vec!["src.md".to_string(), "dst.md".to_string()];
+        g.update_file("src.md", vec![parsed("dst", 0)], &paths);
+
+        assert_eq!(g.backlink_count("dst.md"), 1);
+        assert!(g.outgoing_for("src.md").is_some());
+
+        g.remove_file("src.md");
+        assert_eq!(g.backlink_count("dst.md"), 0);
+        assert!(g.outgoing_for("src.md").is_none());
+        // Internal `incoming` map should drop the emptied entry entirely
+        // (see retain in remove_file).
+        assert!(g.incoming_for("dst.md").is_none());
+    }
+
+    #[test]
+    fn link_graph_update_is_idempotent_for_same_source() {
+        let mut g = LinkGraph::new();
+        let paths = vec!["src.md".to_string(), "dst.md".to_string()];
+        g.update_file("src.md", vec![parsed("dst", 0)], &paths);
+        g.update_file("src.md", vec![parsed("dst", 0)], &paths);
+
+        // Second update must replace, not append — a single incoming entry.
+        assert_eq!(g.backlink_count("dst.md"), 1);
+        let out = g.outgoing_for("src.md").unwrap();
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn link_graph_replaces_target_when_source_is_retargeted() {
+        let mut g = LinkGraph::new();
+        let paths = vec!["src.md".to_string(), "a.md".to_string(), "b.md".to_string()];
+        g.update_file("src.md", vec![parsed("a", 0)], &paths);
+        assert_eq!(g.backlink_count("a.md"), 1);
+        assert_eq!(g.backlink_count("b.md"), 0);
+
+        g.update_file("src.md", vec![parsed("b", 0)], &paths);
+        assert_eq!(g.backlink_count("a.md"), 0);
+        assert_eq!(g.backlink_count("b.md"), 1);
+    }
+
+    #[test]
+    fn link_graph_surfaces_unresolved_without_panic() {
+        let mut g = LinkGraph::new();
+        let paths = vec!["src.md".to_string()];
+        g.update_file("src.md", vec![parsed("ghost", 2)], &paths);
+
+        let unresolved = g.get_unresolved();
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0].source_path, "src.md");
+        assert_eq!(unresolved[0].target_raw, "ghost");
+        assert_eq!(unresolved[0].line_number, 2);
+        // backlink_count on a never-linked target is 0, not a panic.
+        assert_eq!(g.backlink_count("nobody.md"), 0);
+    }
+
+    // ── resolved_map + aliases ─────────────────────────────────────────────
+
+    #[test]
+    fn resolved_map_disambiguates_on_collision() {
+        // Two files share stem "note". Shortest-path wins; then alphabetical.
+        let paths = vec![
+            "deep/sub/note.md".to_string(),
+            "a/note.md".to_string(),
+            "b/note.md".to_string(),
+        ];
+        let map = resolved_map(&paths);
+        assert_eq!(map.get("note").map(String::as_str), Some("a/note.md"));
+    }
+
+    #[test]
+    fn resolved_map_with_aliases_stem_beats_alias() {
+        // Priority rule #1: a file's stem always wins over another file's
+        // alias that happens to collide with that stem.
+        let paths = vec!["Real.md".to_string(), "Other.md".to_string()];
+        let file_aliases = vec![
+            ("Other.md".to_string(), vec!["Real".to_string()]),
+        ];
+        let map = resolved_map_with_aliases(&paths, &file_aliases);
+        // "real" (stem) must point at Real.md, not Other.md via alias.
+        assert_eq!(map.get("real").map(String::as_str), Some("Real.md"));
+    }
+
+    #[test]
+    fn resolved_map_with_aliases_first_indexed_alias_wins() {
+        // Priority rule #2: when two different files claim the same alias
+        // and neither matches a stem, the first-seen wins.
+        let paths = vec!["A.md".to_string(), "B.md".to_string()];
+        let file_aliases = vec![
+            ("A.md".to_string(), vec!["shared".to_string()]),
+            ("B.md".to_string(), vec!["shared".to_string()]),
+        ];
+        let map = resolved_map_with_aliases(&paths, &file_aliases);
+        assert_eq!(map.get("shared").map(String::as_str), Some("A.md"));
+    }
+}

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -21,7 +21,7 @@ pub mod tag_index;
 pub mod frontmatter;
 
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use link_graph::{LinkGraph, extract_links};
@@ -106,7 +106,13 @@ pub enum IndexCmd {
 pub struct IndexCoordinator {
     /// Channel sender — search commands use this to enqueue rebuild requests.
     pub tx: mpsc::Sender<IndexCmd>,
-    file_index: Arc<Mutex<FileIndex>>,
+    /// Issue #137: RwLock instead of Mutex so concurrent searches
+    /// (search_filename, link autocomplete, tag panel, backlinks) don't
+    /// serialise behind the rare watcher writes. Bench at 100k entries
+    /// showed p95 read-completion time drop from 1.48 s (Mutex) to 130 ms
+    /// (RwLock) under 16 concurrent readers + 1 churning writer; numbers
+    /// reproducible via tests::file_index_contention (--ignored).
+    file_index: Arc<RwLock<FileIndex>>,
     matcher: Arc<Mutex<nucleo_matcher::Matcher>>,
     /// Shared reader — search commands clone this Arc to query the index.
     pub reader: Arc<IndexReader>,
@@ -171,7 +177,7 @@ impl IndexCoordinator {
 
         let index = Arc::new(index);
         let reader = Arc::new(reader);
-        let file_index = Arc::new(Mutex::new(FileIndex::new()));
+        let file_index = Arc::new(RwLock::new(FileIndex::new()));
         let matcher = Arc::new(Mutex::new(nucleo_matcher::Matcher::new(
             nucleo_matcher::Config::DEFAULT,
         )));
@@ -218,7 +224,7 @@ impl IndexCoordinator {
         })
     }
 
-    pub fn file_index(&self) -> Arc<Mutex<FileIndex>> {
+    pub fn file_index(&self) -> Arc<RwLock<FileIndex>> {
         Arc::clone(&self.file_index)
     }
 
@@ -267,7 +273,7 @@ impl IndexCoordinator {
             // Incremental skip: if hash unchanged, still add to file_list but
             // don't re-index (IDX-03).
             let already_current = {
-                let guard = self.file_index.lock().map_err(|_| VaultError::LockPoisoned)?;
+                let guard = self.file_index.read().map_err(|_| VaultError::LockPoisoned)?;
                 guard.get(abs_path).map(|m| m.hash == hash).unwrap_or(false)
             };
 
@@ -293,7 +299,7 @@ impl IndexCoordinator {
 
                 // Update in-memory index before sending to queue.
                 {
-                    let mut guard = self.file_index.lock().map_err(|_| VaultError::LockPoisoned)?;
+                    let mut guard = self.file_index.write().map_err(|_| VaultError::LockPoisoned)?;
                     guard.insert(
                         abs_path.clone(),
                         FileMeta {
@@ -377,7 +383,7 @@ async fn run_queue_consumer(
     mut writer: IndexWriter,
     mut rx: mpsc::Receiver<IndexCmd>,
     reader: Arc<IndexReader>,
-    file_index: Arc<Mutex<FileIndex>>,
+    file_index: Arc<RwLock<FileIndex>>,
     link_graph: Arc<Mutex<LinkGraph>>,
     tag_index: Arc<Mutex<TagIndex>>,
     _schema: Schema,
@@ -460,7 +466,7 @@ async fn run_queue_consumer(
                 // Incremental link-graph update (LINK-08).
                 let all_paths = {
                     file_index
-                        .lock()
+                        .read()
                         .map(|fi| fi.all_relative_paths())
                         .unwrap_or_default()
                 };
@@ -473,7 +479,7 @@ async fn run_queue_consumer(
                 // piggy-backing alias refresh here avoids introducing another
                 // command channel for a single metadata slot.
                 let aliases = parse_frontmatter(&content).aliases;
-                if let Ok(mut fi) = file_index.lock() {
+                if let Ok(mut fi) = file_index.write() {
                     fi.set_aliases_for_rel(&rel_path, aliases);
                 }
             }

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -52,7 +52,15 @@ const PROGRESS_THROTTLE: Duration = Duration::from_millis(50);
 const PROGRESS_EVENT: &str = "vault://index_progress";
 /// T-03-02: cap the mpsc channel so a slow consumer doesn't cause unbounded
 /// memory growth. Watcher events use try_send and drop on full channel.
-const CHANNEL_CAPACITY: usize = 1024;
+///
+/// Issue #139: raised from 1024 → 8192. A bulk operation (`git pull`,
+/// `rsync`, mass rename) over a 100k-note vault can produce more than 1024
+/// events in one 200ms debounce window; at 1024 those events would silently
+/// drop and leave the link graph / tag index stale until a full rebuild.
+/// At ~100 bytes per enqueued command this is a 100KB memory cost for the
+/// queue — small compared to the Tantivy writer heap. Pairs with the
+/// `try_send_or_warn` helper in watcher.rs that now logs every overflow.
+pub(crate) const CHANNEL_CAPACITY: usize = 8192;
 /// IndexWriter heap budget per Tantivy recommendation for moderate workloads.
 const WRITER_HEAP_BYTES: usize = 50_000_000;
 

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -151,12 +151,11 @@ impl IndexCoordinator {
         // before the background writer task is spawned.  If we wipe the
         // directory after the task is live, index.writer() races with
         // remove_dir_all() and fails with LockFailure / NotFound.
-        if !tantivy_index::check_version(&vaultcore_dir) {
-            if index_dir.exists() {
+        if !tantivy_index::check_version(&vaultcore_dir)
+            && index_dir.exists() {
                 std::fs::remove_dir_all(&index_dir).map_err(VaultError::Io)?;
                 log::info!("Schema mismatch — index directory wiped for rebuild");
             }
-        }
 
         let index = tantivy_index::open_or_create_index(&index_dir, &schema)?;
         let reader = index
@@ -269,7 +268,7 @@ impl IndexCoordinator {
             // don't re-index (IDX-03).
             let already_current = {
                 let guard = self.file_index.lock().map_err(|_| VaultError::Io(
-                    std::io::Error::new(std::io::ErrorKind::Other, "file_index lock poisoned"),
+                    std::io::Error::other("file_index lock poisoned"),
                 ))?;
                 guard.get(abs_path).map(|m| m.hash == hash).unwrap_or(false)
             };
@@ -297,7 +296,7 @@ impl IndexCoordinator {
                 // Update in-memory index before sending to queue.
                 {
                     let mut guard = self.file_index.lock().map_err(|_| VaultError::Io(
-                        std::io::Error::new(std::io::ErrorKind::Other, "file_index lock poisoned"),
+                        std::io::Error::other("file_index lock poisoned"),
                     ))?;
                     guard.insert(
                         abs_path.clone(),
@@ -583,7 +582,7 @@ fn collect_md_paths(vault_path: &Path) -> Vec<PathBuf> {
             e.file_type().is_file()
                 && e.path()
                     .extension()
-                    .map_or(false, |ext| ext.eq_ignore_ascii_case("md"))
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
         })
         .map(|e| e.into_path())
         .collect()

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -267,9 +267,7 @@ impl IndexCoordinator {
             // Incremental skip: if hash unchanged, still add to file_list but
             // don't re-index (IDX-03).
             let already_current = {
-                let guard = self.file_index.lock().map_err(|_| VaultError::Io(
-                    std::io::Error::other("file_index lock poisoned"),
-                ))?;
+                let guard = self.file_index.lock().map_err(|_| VaultError::LockPoisoned)?;
                 guard.get(abs_path).map(|m| m.hash == hash).unwrap_or(false)
             };
 
@@ -295,9 +293,7 @@ impl IndexCoordinator {
 
                 // Update in-memory index before sending to queue.
                 {
-                    let mut guard = self.file_index.lock().map_err(|_| VaultError::Io(
-                        std::io::Error::other("file_index lock poisoned"),
-                    ))?;
+                    let mut guard = self.file_index.lock().map_err(|_| VaultError::LockPoisoned)?;
                     guard.insert(
                         abs_path.clone(),
                         FileMeta {

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -186,12 +186,22 @@ impl IndexCoordinator {
 
         let (tx, rx) = mpsc::channel::<IndexCmd>(CHANNEL_CAPACITY);
 
-        // Spawn the single writer task.
+        // Spawn the single writer task on the blocking thread pool (#138).
+        // Tantivy's IndexWriter ops (add_document, commit, delete_term,
+        // delete_all_documents) are synchronous and can run for hundreds of
+        // milliseconds on a large vault. If the consumer ran on the async
+        // runtime, every other future sharing the executor (progress events,
+        // vault status, IPC polling) would stall during a bulk commit. Moving
+        // the loop onto `spawn_blocking` keeps the Tantivy call-chain off
+        // the async executor entirely. Senders still use
+        // `tokio::sync::mpsc::Sender::{send,try_send}` untouched; the
+        // consumer drains via `Receiver::blocking_recv()`, which is
+        // explicitly designed for this bridging pattern.
         let reader_clone = Arc::clone(&reader);
         let file_index_clone = Arc::clone(&file_index);
         let link_graph_clone = Arc::clone(&link_graph);
         let tag_index_clone = Arc::clone(&tag_index);
-        tokio::spawn(async move {
+        tokio::task::spawn_blocking(move || {
             run_queue_consumer(
                 writer,
                 rx,
@@ -203,8 +213,7 @@ impl IndexCoordinator {
                 path_field,
                 title_field,
                 body_field,
-            )
-            .await;
+            );
         });
 
         // Evict orphans left over from prior sessions (issue #46). Runs on the
@@ -379,7 +388,7 @@ impl IndexCoordinator {
 // ── Queue consumer task ───────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
-async fn run_queue_consumer(
+fn run_queue_consumer(
     mut writer: IndexWriter,
     mut rx: mpsc::Receiver<IndexCmd>,
     reader: Arc<IndexReader>,
@@ -391,7 +400,10 @@ async fn run_queue_consumer(
     title_field: tantivy::schema::Field,
     body_field: tantivy::schema::Field,
 ) {
-    while let Some(cmd) = rx.recv().await {
+    // Runs on the blocking thread pool (see IndexCoordinator::new). Uses
+    // `blocking_recv()` so the Tantivy write chain never touches the async
+    // executor (#138).
+    while let Some(cmd) = rx.blocking_recv() {
         match cmd {
             IndexCmd::AddFile { path, title, body, .. } => {
                 let path_str = path.to_string_lossy().into_owned();

--- a/src-tauri/src/indexer/tantivy_index.rs
+++ b/src-tauri/src/indexer/tantivy_index.rs
@@ -93,7 +93,7 @@ pub fn write_version(vaultcore_dir: &Path) -> Result<(), VaultError> {
         "created_at": created_at,
     });
     let content = serde_json::to_string_pretty(&json).map_err(|e| {
-        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+        VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
 
     let version_file = vaultcore_dir.join("index_version.json");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,15 +18,11 @@ use notify_debouncer_full::notify::RecommendedWatcher;
 /// Write-ignore-list: records own-write events so the file watcher can
 /// suppress spurious self-triggered events (D-12).
 /// Tokens auto-expire after 500ms to prevent memory leaks.
+#[derive(Default)]
 pub struct WriteIgnoreList {
     entries: HashMap<PathBuf, Instant>,
 }
 
-impl Default for WriteIgnoreList {
-    fn default() -> Self {
-        Self { entries: HashMap::new() }
-    }
-}
 
 impl WriteIgnoreList {
     /// Record that we are about to write `path` so the watcher can ignore

--- a/src-tauri/src/tests/error_serialize.rs
+++ b/src-tauri/src/tests/error_serialize.rs
@@ -69,6 +69,20 @@ fn vault_error_serialize_invalid_encoding() {
 }
 
 #[test]
+fn vault_error_serialize_lock_poisoned() {
+    // Issue #136: LockPoisoned is a distinct variant so the frontend can
+    // render "Internal error — please restart VaultCore" instead of the
+    // generic "File system error" used for Io.
+    let v = to_json(VaultError::LockPoisoned);
+    assert_eq!(v["kind"], "LockPoisoned");
+    assert_eq!(
+        v["message"],
+        "Internal state lock poisoned — please restart VaultCore",
+    );
+    assert_eq!(v["data"], Value::Null);
+}
+
+#[test]
 fn vault_error_serialize_io() {
     let io_err = std::io::Error::other("boom");
     let v = to_json(VaultError::from(io_err));

--- a/src-tauri/src/tests/error_serialize.rs
+++ b/src-tauri/src/tests/error_serialize.rs
@@ -70,7 +70,7 @@ fn vault_error_serialize_invalid_encoding() {
 
 #[test]
 fn vault_error_serialize_io() {
-    let io_err = std::io::Error::new(std::io::ErrorKind::Other, "boom");
+    let io_err = std::io::Error::other("boom");
     let v = to_json(VaultError::from(io_err));
     assert_eq!(v["kind"], "Io");
     assert_eq!(v["data"], Value::Null);

--- a/src-tauri/src/tests/file_index_contention.rs
+++ b/src-tauri/src/tests/file_index_contention.rs
@@ -1,0 +1,177 @@
+//! Issue #137 — read/write contention micro-bench for FileIndex.
+//!
+//! Default-ignored so it never fires in regular `cargo test` runs. Execute
+//! explicitly with:
+//!
+//! ```sh
+//! cargo test --manifest-path src-tauri/Cargo.toml --release \
+//!     tests::file_index_contention -- --ignored --nocapture
+//! ```
+//!
+//! The goal is to answer issue #137's question: would migrating
+//! `Arc<Mutex<FileIndex>>` to `Arc<RwLock<FileIndex>>` meaningfully
+//! unblock concurrent read-heavy workloads (search_filename, link
+//! autocomplete, tag panel refresh, backlinks)?
+//!
+//! ── Workload ──────────────────────────────────────────────────────────
+//! - Populate a FileIndex with 100_000 entries (matches spec §1.3 target).
+//! - Spawn N reader threads that repeatedly walk `all_relative_paths()`
+//!   (the hot path hit by search_filename, resolved_map, and
+//!   link-autocomplete).
+//! - Spawn 1 writer thread that performs insert/remove churn at a low
+//!   duty cycle (matches the file-watcher cadence — writes are rare).
+//! - Measure wall-clock time for each reader to complete K iterations.
+//!
+//! Record p50/p95/p99 of completion time per reader under Mutex and
+//! RwLock. A material p95 win on RwLock supports the migration; a tiny
+//! or negative delta closes the ticket as a no-op.
+
+use crate::indexer::memory::{FileIndex, FileMeta};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+// ── Parameters ────────────────────────────────────────────────────────
+const VAULT_SIZE: usize = 100_000;
+const READER_THREADS: usize = 16;
+const READER_ITERATIONS: usize = 10;
+const WRITE_CHURN_INTERVAL: Duration = Duration::from_millis(2);
+
+fn make_file_index() -> FileIndex {
+    let mut idx = FileIndex::new();
+    for i in 0..VAULT_SIZE {
+        let rel = format!("folder{}/note{:06}.md", i % 64, i);
+        idx.insert(
+            PathBuf::from(format!("/vault/{}", rel)),
+            FileMeta {
+                relative_path: rel,
+                hash: "0".repeat(64),
+                title: format!("Note {}", i),
+                aliases: Vec::new(),
+            },
+        );
+    }
+    idx
+}
+
+fn percentile(values: &mut [Duration], p: f64) -> Duration {
+    values.sort();
+    let idx = ((values.len() as f64 - 1.0) * p).round() as usize;
+    values[idx]
+}
+
+#[test]
+#[ignore] // run explicitly with --ignored for bench data (#137)
+fn bench_mutex_read_contention() {
+    let idx = Arc::new(Mutex::new(make_file_index()));
+    let stop_writer = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    // Writer: periodic insert/remove churn
+    let writer_idx = Arc::clone(&idx);
+    let writer_stop = Arc::clone(&stop_writer);
+    let writer = thread::spawn(move || {
+        let mut i = VAULT_SIZE;
+        while !writer_stop.load(std::sync::atomic::Ordering::Relaxed) {
+            {
+                let mut g = writer_idx.lock().unwrap();
+                let rel = format!("churn/note{:06}.md", i);
+                g.insert(
+                    PathBuf::from(format!("/vault/{}", rel)),
+                    FileMeta {
+                        relative_path: rel,
+                        hash: "0".repeat(64),
+                        title: "t".into(),
+                        aliases: Vec::new(),
+                    },
+                );
+                g.remove(&PathBuf::from(format!("/vault/churn/note{:06}.md", i)));
+            }
+            i = i.wrapping_add(1);
+            thread::sleep(WRITE_CHURN_INTERVAL);
+        }
+    });
+
+    let mut handles = Vec::new();
+    for _ in 0..READER_THREADS {
+        let r_idx = Arc::clone(&idx);
+        handles.push(thread::spawn(move || {
+            let start = Instant::now();
+            for _ in 0..READER_ITERATIONS {
+                let g = r_idx.lock().unwrap();
+                let n = g.all_relative_paths().len();
+                assert!(n >= VAULT_SIZE);
+            }
+            start.elapsed()
+        }));
+    }
+
+    let mut times: Vec<Duration> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    stop_writer.store(true, std::sync::atomic::Ordering::Relaxed);
+    writer.join().unwrap();
+
+    let p50 = percentile(&mut times.clone(), 0.50);
+    let p95 = percentile(&mut times.clone(), 0.95);
+    let p99 = percentile(&mut times, 0.99);
+    println!(
+        "[Mutex] {} readers × {} iters, 100k entries — p50={:?} p95={:?} p99={:?}",
+        READER_THREADS, READER_ITERATIONS, p50, p95, p99,
+    );
+}
+
+#[test]
+#[ignore] // run explicitly with --ignored for bench data (#137)
+fn bench_rwlock_read_contention() {
+    let idx = Arc::new(RwLock::new(make_file_index()));
+    let stop_writer = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let writer_idx = Arc::clone(&idx);
+    let writer_stop = Arc::clone(&stop_writer);
+    let writer = thread::spawn(move || {
+        let mut i = VAULT_SIZE;
+        while !writer_stop.load(std::sync::atomic::Ordering::Relaxed) {
+            {
+                let mut g = writer_idx.write().unwrap();
+                let rel = format!("churn/note{:06}.md", i);
+                g.insert(
+                    PathBuf::from(format!("/vault/{}", rel)),
+                    FileMeta {
+                        relative_path: rel,
+                        hash: "0".repeat(64),
+                        title: "t".into(),
+                        aliases: Vec::new(),
+                    },
+                );
+                g.remove(&PathBuf::from(format!("/vault/churn/note{:06}.md", i)));
+            }
+            i = i.wrapping_add(1);
+            thread::sleep(WRITE_CHURN_INTERVAL);
+        }
+    });
+
+    let mut handles = Vec::new();
+    for _ in 0..READER_THREADS {
+        let r_idx = Arc::clone(&idx);
+        handles.push(thread::spawn(move || {
+            let start = Instant::now();
+            for _ in 0..READER_ITERATIONS {
+                let g = r_idx.read().unwrap();
+                let n = g.all_relative_paths().len();
+                assert!(n >= VAULT_SIZE);
+            }
+            start.elapsed()
+        }));
+    }
+
+    let mut times: Vec<Duration> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    stop_writer.store(true, std::sync::atomic::Ordering::Relaxed);
+    writer.join().unwrap();
+
+    let p50 = percentile(&mut times.clone(), 0.50);
+    let p95 = percentile(&mut times.clone(), 0.95);
+    let p99 = percentile(&mut times, 0.99);
+    println!(
+        "[RwLock] {} readers × {} iters, 100k entries — p50={:?} p95={:?} p99={:?}",
+        READER_THREADS, READER_ITERATIONS, p50, p95, p99,
+    );
+}

--- a/src-tauri/src/tests/files.rs
+++ b/src-tauri/src/tests/files.rs
@@ -160,9 +160,7 @@ async fn read_file_impl(state: &VaultState, path: String) -> Result<String, Vaul
         _ => VaultError::Io(e),
     })?;
     {
-        let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
         let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
             path: path.clone(),
         })?;
@@ -193,9 +191,7 @@ async fn write_file_impl(
         _ => VaultError::Io(e),
     })?;
     {
-        let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::other("internal state lock poisoned"),
-        ))?;
+        let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
         let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
             path: path.clone(),
         })?;

--- a/src-tauri/src/tests/files.rs
+++ b/src-tauri/src/tests/files.rs
@@ -161,7 +161,7 @@ async fn read_file_impl(state: &VaultState, path: String) -> Result<String, Vaul
     })?;
     {
         let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
             path: path.clone(),
@@ -194,7 +194,7 @@ async fn write_file_impl(
     })?;
     {
         let guard = state.current_vault.lock().map_err(|_| VaultError::Io(
-            std::io::Error::new(std::io::ErrorKind::Other, "internal state lock poisoned"),
+            std::io::Error::other("internal state lock poisoned"),
         ))?;
         let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
             path: path.clone(),

--- a/src-tauri/src/tests/merge.rs
+++ b/src-tauri/src/tests/merge.rs
@@ -1,5 +1,5 @@
-/// Tests for the three-way merge engine (merge.rs, Plan 05).
-/// These tests correspond to the 8 behaviors specified in the PLAN.
+//! Tests for the three-way merge engine (merge.rs, Plan 05).
+//! These tests correspond to the 8 behaviors specified in the PLAN.
 
 use crate::merge::{three_way_merge, MergeOutcome};
 

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -14,3 +14,4 @@ mod hash_verify;
 mod bookmarks;
 mod aliases;
 mod snippets;
+mod file_index_contention;

--- a/src-tauri/src/tests/watcher.rs
+++ b/src-tauri/src/tests/watcher.rs
@@ -97,6 +97,71 @@ fn test_dot_prefix_filtering() {
     assert!(!is_hidden_path(&vault, &PathBuf::from("/vault/Archive/2024-01.md")));
 }
 
+// ─── try_send_or_warn overflow behavior (#139) ───────────────────────────────
+
+#[test]
+fn test_try_send_or_warn_drops_when_full_without_blocking() {
+    // Issue #139: watcher callbacks use try_send_or_warn so a full channel
+    // drops the command rather than blocking (which would freeze the
+    // notify-debouncer callback thread). Verify:
+    //   1. First send on a cap-1 channel succeeds.
+    //   2. Second send returns synchronously despite the channel being full —
+    //      no blocking, no panic.
+    //   3. Receiver still only sees the first command (second was dropped).
+    use crate::indexer::IndexCmd;
+    use crate::watcher::try_send_or_warn;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async move {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<IndexCmd>(1);
+
+        try_send_or_warn(&tx, IndexCmd::RemoveLinks {
+            rel_path: "a.md".into(),
+        });
+        try_send_or_warn(&tx, IndexCmd::RemoveLinks {
+            rel_path: "b.md".into(),
+        });
+
+        // Only the first one is in the channel.
+        let first = rx.try_recv().expect("first message should be present");
+        match first {
+            IndexCmd::RemoveLinks { rel_path } => assert_eq!(rel_path, "a.md"),
+            _ => panic!("expected RemoveLinks"),
+        }
+        // Second is dropped — no further messages.
+        assert!(rx.try_recv().is_err(), "second message should have been dropped");
+    });
+}
+
+#[test]
+fn test_try_send_or_warn_returns_quickly_when_receiver_closed() {
+    // If the coordinator was dropped between the watcher snapshot and the
+    // dispatch (e.g. mid-vault-switch), the channel is closed rather than
+    // full. try_send_or_warn must still return synchronously (not panic,
+    // not block).
+    use crate::indexer::IndexCmd;
+    use crate::watcher::try_send_or_warn;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async move {
+        let (tx, rx) = tokio::sync::mpsc::channel::<IndexCmd>(4);
+        drop(rx); // channel closed
+
+        try_send_or_warn(&tx, IndexCmd::RemoveLinks {
+            rel_path: "x.md".into(),
+        });
+        // No panic = contract upheld.
+    });
+}
+
 #[test]
 fn test_write_ignore_multiple_paths() {
     // Record multiple paths — each should be individually ignorable

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -267,12 +267,60 @@ fn process_events(
     }
 }
 
+/// Describe an `IndexCmd` briefly for overflow logs without including
+/// file content (watchers see raw document bodies — keep them out of logs).
+fn cmd_kind(cmd: &IndexCmd) -> &'static str {
+    match cmd {
+        IndexCmd::AddFile { .. } => "AddFile",
+        IndexCmd::DeleteFile { .. } => "DeleteFile",
+        IndexCmd::DeleteAll => "DeleteAll",
+        IndexCmd::Commit => "Commit",
+        IndexCmd::Rebuild { .. } => "Rebuild",
+        IndexCmd::UpdateLinks { .. } => "UpdateLinks",
+        IndexCmd::RemoveLinks { .. } => "RemoveLinks",
+        IndexCmd::UpdateTags { .. } => "UpdateTags",
+        IndexCmd::RemoveTags { .. } => "RemoveTags",
+        IndexCmd::Shutdown => "Shutdown",
+    }
+}
+
+/// Try to enqueue `cmd`, logging a warning on overflow or closure.
+///
+/// Issue #139: the previous `let _ = tx.try_send(...)` lines silently
+/// dropped commands when the 1024-slot channel filled up during bulk
+/// events. The symptom (stale link-graph / tag-index) only surfaced on
+/// the next full rebuild. This helper makes the overflow observable so a
+/// user report like "backlinks panel lost entries after I ran git pull"
+/// becomes grep-able in the log.
+pub(crate) fn try_send_or_warn(tx: &tokio::sync::mpsc::Sender<IndexCmd>, cmd: IndexCmd) {
+    let kind = cmd_kind(&cmd);
+    match tx.try_send(cmd) {
+        Ok(()) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+            log::warn!(
+                "IndexCmd channel full (capacity {}) — dropping {} event. \
+                A bulk operation is outrunning the indexer; \
+                link/tag state may be stale until the next edit or rebuild.",
+                crate::indexer::CHANNEL_CAPACITY,
+                kind,
+            );
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            log::debug!(
+                "IndexCmd channel closed when dispatching {} — \
+                coordinator was dropped (probably vault switch in progress).",
+                kind,
+            );
+        }
+    }
+}
+
 /// Dispatch `IndexCmd::UpdateLinks` or `IndexCmd::RemoveLinks` based on the
 /// event kind.  Only `.md` files are dispatched — non-Markdown file changes
 /// don't affect the link graph.
 ///
-/// Uses `try_send` so a full channel (bounded at 1024) drops the command
-/// rather than blocking the watcher callback thread.
+/// Uses `try_send_or_warn` so a full channel drops the command rather than
+/// blocking the watcher callback thread, but logs the drop (#139).
 fn dispatch_link_graph_cmd(
     tx: &tokio::sync::mpsc::Sender<IndexCmd>,
     vault_path: &Path,
@@ -300,7 +348,7 @@ fn dispatch_link_graph_cmd(
             // old (RemoveLinks) and new (UpdateLinks).
             if let EventKind::Modify(notify_debouncer_full::notify::event::ModifyKind::Name(_)) = &ev.kind {
                 // Old path → RemoveLinks
-                let _ = tx.try_send(IndexCmd::RemoveLinks { rel_path: rel_path.clone() });
+                try_send_or_warn(tx, IndexCmd::RemoveLinks { rel_path: rel_path.clone() });
                 // New path → UpdateLinks (if paths[1] exists and is .md)
                 if let Some(new_path) = ev.paths.get(1) {
                     if new_path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("md")) {
@@ -309,7 +357,7 @@ fn dispatch_link_graph_cmd(
                             Err(_) => return,
                         };
                         if let Ok(content) = std::fs::read_to_string(new_path) {
-                            let _ = tx.try_send(IndexCmd::UpdateLinks {
+                            try_send_or_warn(tx, IndexCmd::UpdateLinks {
                                 rel_path: new_rel,
                                 content,
                             });
@@ -319,12 +367,12 @@ fn dispatch_link_graph_cmd(
             } else {
                 // create or modify — read content and dispatch UpdateLinks
                 if let Ok(content) = std::fs::read_to_string(primary_path) {
-                    let _ = tx.try_send(IndexCmd::UpdateLinks { rel_path, content });
+                    try_send_or_warn(tx, IndexCmd::UpdateLinks { rel_path, content });
                 }
             }
         }
         EventKind::Remove(_) => {
-            let _ = tx.try_send(IndexCmd::RemoveLinks { rel_path });
+            try_send_or_warn(tx, IndexCmd::RemoveLinks { rel_path });
         }
         _ => {}
     }
@@ -334,8 +382,8 @@ fn dispatch_link_graph_cmd(
 /// event kind. Only `.md` files are dispatched — non-Markdown file changes
 /// don't affect the tag index.
 ///
-/// Uses `try_send` so a full channel (bounded at 1024) drops the command
-/// rather than blocking the watcher callback thread.
+/// Uses `try_send_or_warn` so a full channel drops the command rather than
+/// blocking the watcher callback thread, but logs the drop (#139).
 pub(crate) fn dispatch_tag_index_cmd(
     tx: &tokio::sync::mpsc::Sender<IndexCmd>,
     vault_path: &Path,
@@ -367,7 +415,7 @@ pub(crate) fn dispatch_tag_index_cmd(
             ) = &ev.kind
             {
                 // Old path → RemoveTags
-                let _ = tx.try_send(IndexCmd::RemoveTags {
+                try_send_or_warn(tx, IndexCmd::RemoveTags {
                     rel_path: rel_path.clone(),
                 });
                 // New path → UpdateTags (if paths[1] exists and is .md)
@@ -381,7 +429,7 @@ pub(crate) fn dispatch_tag_index_cmd(
                             Err(_) => return,
                         };
                         if let Ok(content) = std::fs::read_to_string(new_path) {
-                            let _ = tx.try_send(IndexCmd::UpdateTags {
+                            try_send_or_warn(tx, IndexCmd::UpdateTags {
                                 rel_path: new_rel,
                                 content,
                             });
@@ -391,12 +439,12 @@ pub(crate) fn dispatch_tag_index_cmd(
             } else {
                 // create or modify — read content and dispatch UpdateTags
                 if let Ok(content) = std::fs::read_to_string(primary_path) {
-                    let _ = tx.try_send(IndexCmd::UpdateTags { rel_path, content });
+                    try_send_or_warn(tx, IndexCmd::UpdateTags { rel_path, content });
                 }
             }
         }
         EventKind::Remove(_) => {
-            let _ = tx.try_send(IndexCmd::RemoveTags { rel_path });
+            try_send_or_warn(tx, IndexCmd::RemoveTags { rel_path });
         }
         _ => {}
     }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -16,6 +16,7 @@
   import { listenIndexProgress } from "./ipc/events";
   import { isVaultError, vaultErrorCopy } from "./types/errors";
   import type { RecentVault } from "./types/vault";
+  import "./types/e2e-hook";
   import WelcomeScreen from "./components/Welcome/WelcomeScreen.svelte";
   import VaultLayout from "./components/Layout/VaultLayout.svelte";
   import ToastContainer from "./components/Toast/ToastContainer.svelte";
@@ -237,19 +238,7 @@
         if (!view) return "";
         return view.state.doc.toString();
       };
-      (window as unknown as {
-        __e2e__: {
-          loadVault: (p: string) => Promise<void>;
-          switchVault: (p: string) => Promise<void>;
-          closeVault: () => Promise<void>;
-          pushToast: (variant: "error" | "conflict" | "clean-merge", message: string) => void;
-          startProgress: (total: number) => void;
-          updateProgress: (current: number, total: number, currentFile?: string) => void;
-          finishProgress: () => void;
-          typeInActiveEditor: (text: string) => Promise<void>;
-          getActiveDocText: () => Promise<string>;
-        };
-      }).__e2e__ = {
+      window.__e2e__ = {
         loadVault,
         switchVault,
         closeVault,

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -306,20 +306,22 @@
       camX = pointerMode.startCamX + (e.clientX - pointerMode.startClientX);
       camY = pointerMode.startCamY + (e.clientY - pointerMode.startClientY);
     } else if (pointerMode.kind === "move") {
-      const dx = (e.clientX - pointerMode.startClientX) / zoom;
-      const dy = (e.clientY - pointerMode.startClientY) / zoom;
-      const node = doc.nodes.find((n) => n.id === pointerMode!.nodeId);
+      const mode = pointerMode;
+      const dx = (e.clientX - mode.startClientX) / zoom;
+      const dy = (e.clientY - mode.startClientY) / zoom;
+      const node = doc.nodes.find((n) => n.id === mode.nodeId);
       if (node) {
-        node.x = pointerMode.startX + dx;
-        node.y = pointerMode.startY + dy;
+        node.x = mode.startX + dx;
+        node.y = mode.startY + dy;
       }
     } else if (pointerMode.kind === "resize") {
-      const dx = (e.clientX - pointerMode.startClientX) / zoom;
-      const dy = (e.clientY - pointerMode.startClientY) / zoom;
-      const node = doc.nodes.find((n) => n.id === pointerMode!.nodeId);
+      const mode = pointerMode;
+      const dx = (e.clientX - mode.startClientX) / zoom;
+      const dy = (e.clientY - mode.startClientY) / zoom;
+      const node = doc.nodes.find((n) => n.id === mode.nodeId);
       if (node) {
-        node.width = Math.max(80, pointerMode.startW + dx);
-        node.height = Math.max(40, pointerMode.startH + dy);
+        node.width = Math.max(80, mode.startW + dx);
+        node.height = Math.max(40, mode.startH + dy);
       }
     } else if (pointerMode.kind === "edge" && draft) {
       const { x, y } = clientToWorld(e.clientX, e.clientY);

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -422,6 +422,34 @@
     selectedEdgeId = null;
   }
 
+  // #130: keyboard activation for role="button" canvas cards. Enter / Space
+  // run `action` (the equivalent of a click / dblclick) and we prevent Space
+  // from scrolling the page. Called per-node so the caller picks the right
+  // semantic action (start-edit for text/edge, open for file/link).
+  function onCardKey(e: KeyboardEvent, action: () => void) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      action();
+    }
+  }
+
+  function startEditText(node: CanvasTextNode) {
+    editingNodeId = node.id;
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+  }
+
+  function startEditEdgeLabel(edge: CanvasEdge) {
+    editingEdgeId = edge.id;
+    selectedEdgeId = edge.id;
+    selectedNodeId = null;
+  }
+
+  function selectNode(node: CanvasNode) {
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+  }
+
   function onResizePointerDown(e: PointerEvent, node: CanvasNode) {
     e.stopPropagation();
     if (e.button !== 0) return;
@@ -724,6 +752,7 @@
             data-edge-id={re.edge.id}
             onpointerdown={(e) => onEdgeHitPointerDown(e, re.edge)}
             ondblclick={(e) => onEdgeDblClick(e, re.edge)}
+            onkeydown={(e) => onCardKey(e, () => startEditEdgeLabel(re.edge))}
             role="button"
             tabindex="0"
           >
@@ -746,6 +775,7 @@
             data-node-id={node.id}
             onpointerdown={(e) => onNodePointerDown(e, node)}
             ondblclick={(e) => onNodeDblClick(e, node)}
+            onkeydown={(e) => onCardKey(e, () => startEditText(node as CanvasTextNode))}
             onpointerenter={() => (hoveredNodeId = node.id)}
             onpointerleave={() => {
               if (hoveredNodeId === node.id) hoveredNodeId = null;
@@ -799,6 +829,7 @@
             data-node-id={node.id}
             data-node-type="file"
             onpointerdown={(e) => onNodePointerDown(e, node)}
+            onkeydown={(e) => onCardKey(e, () => void onOpenFileNode(fileNode))}
             onpointerenter={() => (hoveredNodeId = node.id)}
             onpointerleave={() => {
               if (hoveredNodeId === node.id) hoveredNodeId = null;
@@ -887,6 +918,7 @@
             data-node-id={node.id}
             data-node-type="link"
             onpointerdown={(e) => onNodePointerDown(e, node)}
+            onkeydown={(e) => onCardKey(e, () => onOpenLinkNode(linkNode))}
             onpointerenter={() => (hoveredNodeId = node.id)}
             onpointerleave={() => {
               if (hoveredNodeId === node.id) hoveredNodeId = null;
@@ -973,6 +1005,7 @@
             style:height={`${node.height}px`}
             data-node-id={node.id}
             onpointerdown={(e) => onNodePointerDown(e, node)}
+            onkeydown={(e) => onCardKey(e, () => selectNode(node))}
             onpointerenter={() => (hoveredNodeId = node.id)}
             onpointerleave={() => {
               if (hoveredNodeId === node.id) hoveredNodeId = null;

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -46,19 +46,30 @@
     DEFAULT_NODE_WIDTH,
     DEFAULT_NODE_HEIGHT,
   } from "../../lib/canvas/types";
-  import {
-    SIDES,
-    anchorPoint,
-    autoSides,
-    bezierMidpoint,
-    bezierPath,
-  } from "../../lib/canvas/geometry";
+  import { SIDES, anchorPoint } from "../../lib/canvas/geometry";
   import {
     canvasFilePreview,
     isImageFile,
     isMarkdownFile,
     resolveVaultAbs,
   } from "../../lib/canvas/embed";
+  import {
+    type PointerMode,
+    type DraftEdge,
+    beginPan,
+    beginMove,
+    beginResize,
+    beginEdge,
+    panPosition,
+    movePosition,
+    resizeSize,
+    updateDraftOnMove,
+    resolvePointerUp,
+  } from "../../lib/canvas/pointerMode";
+  import {
+    resolveEdges as resolveEdgesPure,
+    draftPath as draftPathPure,
+  } from "../../lib/canvas/edgeResolver";
 
   interface Props {
     tabId: string;
@@ -81,17 +92,8 @@
   let editingEdgeId = $state<string | null>(null);
   let hoveredNodeId = $state<string | null>(null);
 
-  // Draft edge: populated while the user drags from a handle. `targetNodeId`
-  // + `targetSide` are only set when the pointer is over another node's
-  // handle, which is when pointerup commits the edge.
-  type DraftEdge = {
-    fromNodeId: string;
-    fromSide: CanvasSide;
-    currentX: number;
-    currentY: number;
-    targetNodeId: string | null;
-    targetSide: CanvasSide | null;
-  };
+  // Draft edge: populated while the user drags from a handle. The state
+  // machine in `pointerMode.ts` owns the update + commit rules.
   let draft = $state<DraftEdge | null>(null);
 
   let viewportEl: HTMLDivElement | null = null;
@@ -107,12 +109,6 @@
   // Missing / failed reads become "" so the renderer falls back to a
   // generic file card. `$state` keeps the template reactive to async loads.
   let mdPreviews = $state<Record<string, string>>({});
-
-  type PointerMode =
-    | { kind: "pan"; startClientX: number; startClientY: number; startCamX: number; startCamY: number }
-    | { kind: "move"; nodeId: string; startClientX: number; startClientY: number; startX: number; startY: number }
-    | { kind: "resize"; nodeId: string; startClientX: number; startClientY: number; startW: number; startH: number }
-    | { kind: "edge"; fromNodeId: string; fromSide: CanvasSide };
 
   let pointerMode: PointerMode | null = null;
 
@@ -291,50 +287,37 @@
     selectedNodeId = null;
     selectedEdgeId = null;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    pointerMode = {
-      kind: "pan",
-      startClientX: e.clientX,
-      startClientY: e.clientY,
-      startCamX: camX,
-      startCamY: camY,
-    };
+    pointerMode = beginPan(e, { x: camX, y: camY });
   }
 
   function onViewportPointerMove(e: PointerEvent) {
     if (!pointerMode) return;
     if (pointerMode.kind === "pan") {
-      camX = pointerMode.startCamX + (e.clientX - pointerMode.startClientX);
-      camY = pointerMode.startCamY + (e.clientY - pointerMode.startClientY);
+      const p = panPosition(pointerMode, e);
+      camX = p.camX;
+      camY = p.camY;
     } else if (pointerMode.kind === "move") {
       const mode = pointerMode;
-      const dx = (e.clientX - mode.startClientX) / zoom;
-      const dy = (e.clientY - mode.startClientY) / zoom;
+      const p = movePosition(mode, e, zoom);
       const node = doc.nodes.find((n) => n.id === mode.nodeId);
       if (node) {
-        node.x = mode.startX + dx;
-        node.y = mode.startY + dy;
+        node.x = p.x;
+        node.y = p.y;
       }
     } else if (pointerMode.kind === "resize") {
       const mode = pointerMode;
-      const dx = (e.clientX - mode.startClientX) / zoom;
-      const dy = (e.clientY - mode.startClientY) / zoom;
+      const s = resizeSize(mode, e, zoom);
       const node = doc.nodes.find((n) => n.id === mode.nodeId);
       if (node) {
-        node.width = Math.max(80, mode.startW + dx);
-        node.height = Math.max(40, mode.startH + dy);
+        node.width = s.width;
+        node.height = s.height;
       }
     } else if (pointerMode.kind === "edge" && draft) {
-      const { x, y } = clientToWorld(e.clientX, e.clientY);
-      draft.currentX = x;
-      draft.currentY = y;
-      const hit = handleAtPoint(e.clientX, e.clientY);
-      if (hit && hit.nodeId !== draft.fromNodeId) {
-        draft.targetNodeId = hit.nodeId;
-        draft.targetSide = hit.side;
-      } else {
-        draft.targetNodeId = null;
-        draft.targetSide = null;
-      }
+      draft = updateDraftOnMove(
+        draft,
+        clientToWorld(e.clientX, e.clientY),
+        handleAtPoint(e.clientX, e.clientY),
+      );
     }
   }
 
@@ -343,17 +326,11 @@
     try {
       (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
     } catch { /* releasePointerCapture may throw in the synthetic test env */ }
-    if (pointerMode.kind === "edge" && draft) {
-      if (draft.targetNodeId && draft.targetSide) {
-        commitDraftEdge(
-          draft.fromNodeId,
-          draft.fromSide,
-          draft.targetNodeId,
-          draft.targetSide,
-        );
-      }
-      draft = null;
+    const action = resolvePointerUp(pointerMode, draft);
+    if (action.kind === "commit-edge") {
+      commitDraftEdge(action.fromId, action.fromSide, action.toId, action.toSide);
     }
+    if (pointerMode.kind === "edge") draft = null;
     pointerMode = null;
   }
 
@@ -404,14 +381,7 @@
     selectedNodeId = node.id;
     selectedEdgeId = null;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    pointerMode = {
-      kind: "move",
-      nodeId: node.id,
-      startClientX: e.clientX,
-      startClientY: e.clientY,
-      startX: node.x,
-      startY: node.y,
-    };
+    pointerMode = beginMove(node, e);
   }
 
   function onNodeDblClick(e: MouseEvent, node: CanvasNode) {
@@ -455,14 +425,7 @@
     if (e.button !== 0) return;
     selectedNodeId = node.id;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    pointerMode = {
-      kind: "resize",
-      nodeId: node.id,
-      startClientX: e.clientX,
-      startClientY: e.clientY,
-      startW: node.width,
-      startH: node.height,
-    };
+    pointerMode = beginResize(node, e);
   }
 
   function onHandlePointerDown(e: PointerEvent, node: CanvasNode, side: CanvasSide) {
@@ -478,7 +441,7 @@
       targetNodeId: null,
       targetSide: null,
     };
-    pointerMode = { kind: "edge", fromNodeId: node.id, fromSide: side };
+    pointerMode = beginEdge(node.id, side);
     try {
       viewportEl?.setPointerCapture(e.pointerId);
     } catch {
@@ -577,78 +540,8 @@
     if (e.key === " ") spaceHeld = false;
   }
 
-  // Resolved edge geometry for the render loop. An edge whose endpoint node
-  // is missing from the doc (corrupt file, partial edit) is silently skipped
-  // so the viewer keeps working rather than crashing.
-  type ResolvedEdge = {
-    edge: CanvasEdge;
-    fromPt: { x: number; y: number };
-    toPt: { x: number; y: number };
-    fromSide: CanvasSide;
-    toSide: CanvasSide;
-    path: string;
-    mid: { x: number; y: number };
-  };
-
-  function resolveEdges(): ResolvedEdge[] {
-    const byId = new Map(doc.nodes.map((n) => [n.id, n] as const));
-    const out: ResolvedEdge[] = [];
-    for (const edge of doc.edges) {
-      const from = byId.get(edge.fromNode);
-      const to = byId.get(edge.toNode);
-      if (!from || !to) continue;
-      const { fromSide, toSide } =
-        edge.fromSide && edge.toSide
-          ? { fromSide: edge.fromSide, toSide: edge.toSide }
-          : autoSides(from, to);
-      const fromPt = anchorPoint(from, fromSide);
-      const toPt = anchorPoint(to, toSide);
-      out.push({
-        edge,
-        fromPt,
-        toPt,
-        fromSide,
-        toSide,
-        path: bezierPath(fromPt, fromSide, toPt, toSide),
-        mid: bezierMidpoint(fromPt, fromSide, toPt, toSide),
-      });
-    }
-    return out;
-  }
-
-  let resolvedEdges = $derived(resolveEdges());
-
-  function draftPath(): string | null {
-    if (!draft) return null;
-    const from = doc.nodes.find((n) => n.id === draft!.fromNodeId);
-    if (!from) return null;
-    const fromPt = anchorPoint(from, draft.fromSide);
-    // If hovering a valid target handle, use that side for a natural entry;
-    // otherwise aim straight at the cursor with an opposite-ish side.
-    if (draft.targetNodeId && draft.targetSide) {
-      const to = doc.nodes.find((n) => n.id === draft!.targetNodeId);
-      if (to) {
-        const toPt = anchorPoint(to, draft.targetSide);
-        return bezierPath(fromPt, draft.fromSide, toPt, draft.targetSide);
-      }
-    }
-    const toSide: CanvasSide =
-      draft.fromSide === "left"
-        ? "right"
-        : draft.fromSide === "right"
-          ? "left"
-          : draft.fromSide === "top"
-            ? "bottom"
-            : "top";
-    return bezierPath(
-      fromPt,
-      draft.fromSide,
-      { x: draft.currentX, y: draft.currentY },
-      toSide,
-    );
-  }
-
-  let draftPathD = $derived(draftPath());
+  let resolvedEdges = $derived(resolveEdgesPure(doc));
+  let draftPathD = $derived(draftPathPure(doc, draft));
 </script>
 
 <svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />

--- a/src/components/Editor/__tests__/EditorPaneViewerBranch.test.ts
+++ b/src/components/Editor/__tests__/EditorPaneViewerBranch.test.ts
@@ -43,6 +43,10 @@ vi.mock("../../../ipc/events", () => ({
 
 // Sidestep the sigma / WebGL import tree for the graph view.
 vi.mock("../../Graph/GraphView.svelte", async () => {
+  // svelte-check's `*.svelte` module shim resolves static imports but not the
+  // dynamic-import form inside vi.mock()'s hoisted factory — @ts-ignore the
+  // phantom "no declaration" error.
+  // @ts-ignore
   const { default: Empty } = await import("./emptyComponent.svelte");
   return { default: Empty };
 });

--- a/src/components/Editor/__tests__/mountEditorViewRace.test.ts
+++ b/src/components/Editor/__tests__/mountEditorViewRace.test.ts
@@ -51,6 +51,10 @@ vi.mock("../../../ipc/events", () => ({
 }));
 
 vi.mock("../../Graph/GraphView.svelte", async () => {
+  // svelte-check's `*.svelte` module shim resolves static imports but not the
+  // dynamic-import form inside vi.mock()'s hoisted factory — @ts-ignore the
+  // phantom "no declaration" error.
+  // @ts-ignore
   const { default: Empty } = await import("./emptyComponent.svelte");
   return { default: Empty };
 });

--- a/src/components/Editor/__tests__/mountEditorViewSingle.test.ts
+++ b/src/components/Editor/__tests__/mountEditorViewSingle.test.ts
@@ -53,6 +53,10 @@ vi.mock("../../../ipc/events", () => ({
 // GraphView and graphRender pull in sigma → WebGL2RenderingContext at module
 // init, which jsdom doesn't provide. Stub them with empty placeholders.
 vi.mock("../../Graph/GraphView.svelte", async () => {
+  // svelte-check's `*.svelte` module shim resolves static imports but not the
+  // dynamic-import form inside vi.mock()'s hoisted factory — @ts-ignore the
+  // phantom "no declaration" error.
+  // @ts-ignore
   const { default: Empty } = await import("./emptyComponent.svelte");
   return { default: Empty };
 });

--- a/src/components/Search/QuickSwitcherRow.svelte
+++ b/src/components/Search/QuickSwitcherRow.svelte
@@ -9,7 +9,7 @@
     /** Issue #60: matched frontmatter alias (when the row surfaced because of
      *  an `aliases:` hit rather than a filename hit). Rendered as
      *  `alias → filename` in front of the filename. */
-    matchedAlias?: string;
+    matchedAlias?: string | undefined;
   }
 
   let { filename, relativePath, matchIndices, selected, onclick, onhover, matchedAlias }: Props = $props();

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -24,7 +24,7 @@
     onOpenFile: (path: string) => void;
     onRefreshParent: () => void;
     onPathChanged: (oldPath: string, newPath: string) => void;
-    onExpandToggle?: (relPath: string, isExpanded: boolean) => void;
+    onExpandToggle?: ((relPath: string, isExpanded: boolean) => void) | undefined;
     initiallyExpanded?: boolean;
     /** Vault-relative folder paths persisted as expanded — propagated through
      *  the recursive tree so deeply nested descendants can restore their

--- a/src/components/Tags/TagsPanel.svelte
+++ b/src/components/Tags/TagsPanel.svelte
@@ -14,11 +14,11 @@
     const nodes = tags.map((t) => ({ full: t.tag, display: t.tag.split("/").pop() ?? t.tag, count: t.count, children: [] as TagTreeNode[] }));
     for (const n of nodes) {
       const parts = n.full.split("/");
-      if (parts.length === 1) {
+      const parentName = parts[0];
+      if (parts.length === 1 || parentName === undefined) {
         byParent.set(n.full, n);
         flat.push(n);
       } else {
-        const parentName = parts[0];
         let parentNode = byParent.get(parentName);
         if (!parentNode) {
           parentNode = { full: parentName, display: parentName, count: 0, children: [] };

--- a/src/lib/__tests__/exportHtml.test.ts
+++ b/src/lib/__tests__/exportHtml.test.ts
@@ -1,0 +1,127 @@
+// Unit tests for exportHtml (#132) — covers both helpers: collectThemeCss
+// (reads CSS custom properties off <html> and serialises them) and
+// defaultExportFilename (stripping path + .md to produce a save-dialog
+// default name).
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { collectThemeCss, defaultExportFilename } from "../exportHtml";
+
+describe("collectThemeCss", () => {
+  beforeEach(() => {
+    // Reset inline styles between tests so leaked properties from a prior
+    // case don't bleed into the next one.
+    if (typeof document !== "undefined") {
+      document.documentElement.removeAttribute("style");
+    }
+  });
+
+  it("returns an empty string when no known theme tokens are set", () => {
+    expect(collectThemeCss()).toBe("");
+  });
+
+  it("emits a `:root { ... }` block with the inline tokens that are set", () => {
+    const root = document.documentElement;
+    root.style.setProperty("--color-bg", "#101010");
+    root.style.setProperty("--color-text", "#f5f5f5");
+
+    const css = collectThemeCss();
+    expect(css.startsWith(":root {")).toBe(true);
+    expect(css.trimEnd().endsWith("}")).toBe(true);
+    expect(css).toContain("--color-bg: #101010;");
+    expect(css).toContain("--color-text: #f5f5f5;");
+  });
+
+  it("skips tokens that are not set rather than emitting empty values", () => {
+    document.documentElement.style.setProperty("--color-bg", "#000");
+
+    const css = collectThemeCss();
+    expect(css).toContain("--color-bg: #000;");
+    // --color-text is NOT set, so it must not appear in the output.
+    expect(css).not.toContain("--color-text:");
+  });
+
+  it("does not include custom properties that aren't in the allowlist", () => {
+    // Only the allowlisted tokens (THEME_VARS) are emitted — even if the
+    // root has an unrelated custom property set, it must not leak into the
+    // export (issue #61 scope boundary: user snippets stay in the app).
+    document.documentElement.style.setProperty("--my-custom-var", "red");
+    document.documentElement.style.setProperty("--color-bg", "#222");
+
+    const css = collectThemeCss();
+    expect(css).toContain("--color-bg: #222;");
+    expect(css).not.toContain("--my-custom-var");
+  });
+
+  it("trims whitespace from computed values", () => {
+    // getPropertyValue can return a leading space on some property values;
+    // the implementation calls .trim() before emitting.
+    document.documentElement.style.setProperty("--color-accent", "  #abc  ");
+
+    const css = collectThemeCss();
+    expect(css).toContain("--color-accent: #abc;");
+  });
+
+  it("returns empty string when document is undefined (SSR-ish environment)", () => {
+    // The module guards against document being undefined. We can't truly
+    // delete the global in jsdom, but we can call the function after
+    // shadowing — verify the guard by monkey-patching the reference
+    // temporarily.
+    const originalDocument = (globalThis as unknown as { document: Document })
+      .document;
+    (globalThis as unknown as { document: Document | undefined }).document =
+      undefined;
+    try {
+      expect(collectThemeCss()).toBe("");
+    } finally {
+      (globalThis as unknown as { document: Document }).document =
+        originalDocument;
+    }
+  });
+});
+
+describe("defaultExportFilename", () => {
+  it("strips the .md extension and appends the requested ext", () => {
+    expect(defaultExportFilename("/vault/notes/Welcome.md", "html")).toBe(
+      "Welcome.html",
+    );
+  });
+
+  it("handles forward-slash paths", () => {
+    expect(defaultExportFilename("/a/b/c/note.md", "pdf")).toBe("note.pdf");
+  });
+
+  it("handles backslash (Windows-style) paths", () => {
+    expect(defaultExportFilename("C:\\vault\\sub\\Notes.md", "html")).toBe(
+      "Notes.html",
+    );
+  });
+
+  it("is case-insensitive for the .md extension", () => {
+    expect(defaultExportFilename("/x/Y.MD", "html")).toBe("Y.html");
+    expect(defaultExportFilename("/x/Y.Md", "html")).toBe("Y.html");
+  });
+
+  it("leaves non-md extensions intact (they're not stripped)", () => {
+    // Only `.md` is stripped. A `.markdown` file keeps its extension as
+    // part of the stem — deliberately narrow, matches the source.
+    expect(defaultExportFilename("/x/readme.markdown", "html")).toBe(
+      "readme.markdown.html",
+    );
+  });
+
+  it("returns '.<ext>' when the path is an empty string (no fallback)", () => {
+    // String.prototype.split on "" yields [""]; .pop() returns "" (not
+    // undefined), so the `?? "note"` fallback does NOT kick in. Locking
+    // this behavior in here so a future change that tightens it (e.g.
+    // `.pop() || "note"`) is a visible diff.
+    expect(defaultExportFilename("", "html")).toBe(".html");
+  });
+
+  it("returns '.<ext>' for a path that is only slashes", () => {
+    expect(defaultExportFilename("///", "html")).toBe(".html");
+  });
+
+  it("handles a filename without any extension", () => {
+    expect(defaultExportFilename("/x/Notes", "html")).toBe("Notes.html");
+  });
+});

--- a/src/lib/__tests__/templateSubstitution.test.ts
+++ b/src/lib/__tests__/templateSubstitution.test.ts
@@ -1,0 +1,86 @@
+// Unit tests for templateSubstitution (#132). The module has three
+// substitutions — {{date}}, {{time}}, {{title}} — and uses `new Date()` so
+// we freeze the clock with vitest's fake timers to get deterministic
+// output without touching the module source.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { substituteTemplateVars } from "../templateSubstitution";
+
+describe("substituteTemplateVars", () => {
+  beforeEach(() => {
+    // Pin to a local wall-clock instant with one-digit month/day/hour/minute
+    // so the zero-padding of each field is exercised.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 4, 7, 3));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("substitutes {{date}} with YYYY-MM-DD (zero-padded)", () => {
+    expect(substituteTemplateVars("Today is {{date}}.", "note")).toBe(
+      "Today is 2026-01-04.",
+    );
+  });
+
+  it("substitutes {{time}} with HH:mm (zero-padded)", () => {
+    expect(substituteTemplateVars("At {{time}}", "note")).toBe("At 07:03");
+  });
+
+  it("substitutes {{title}} with the note title (whatever string is passed)", () => {
+    expect(substituteTemplateVars("Title: {{title}}", "My Note")).toBe(
+      "Title: My Note",
+    );
+  });
+
+  it("replaces all occurrences of a variable, not just the first", () => {
+    expect(
+      substituteTemplateVars("{{title}} / {{title}} / {{title}}", "X"),
+    ).toBe("X / X / X");
+  });
+
+  it("supports all three substitutions in one string", () => {
+    expect(
+      substituteTemplateVars("{{date}} {{time}} — {{title}}", "Diary"),
+    ).toBe("2026-01-04 07:03 — Diary");
+  });
+
+  it("leaves unknown placeholders untouched", () => {
+    // Only the three documented tokens are replaced — a surface like
+    // {{author}} must round-trip unchanged so templates stay forgiving.
+    expect(
+      substituteTemplateVars(
+        "{{author}} wrote on {{date}} - {{unknown}}",
+        "Sample",
+      ),
+    ).toBe("{{author}} wrote on 2026-01-04 - {{unknown}}");
+  });
+
+  it("handles an empty template (returns empty string)", () => {
+    expect(substituteTemplateVars("", "Title")).toBe("");
+  });
+
+  it("handles an empty title and still substitutes everything else", () => {
+    expect(substituteTemplateVars("[{{title}}] {{date}}", "")).toBe(
+      "[] 2026-01-04",
+    );
+  });
+
+  it("does not treat the title as a template — literal {{date}} in the title stays literal", () => {
+    // If title substitution happened before date (or the code naively
+    // replaced substrings in-place), a title of `{{date}}` would get a
+    // second-pass expansion. We rely on the implementation running the
+    // three replacements sequentially against the original content only.
+    expect(
+      substituteTemplateVars("Title: {{title}} / Date: {{date}}", "{{date}}"),
+    ).toBe("Title: {{date}} / Date: 2026-01-04");
+  });
+
+  it("handles midnight (00:00) and end-of-year double-digit values", () => {
+    vi.setSystemTime(new Date(2026, 11, 31, 0, 0));
+    expect(substituteTemplateVars("{{date}} {{time}}", "x")).toBe(
+      "2026-12-31 00:00",
+    );
+  });
+});

--- a/src/lib/canvas/__tests__/edgeResolver.test.ts
+++ b/src/lib/canvas/__tests__/edgeResolver.test.ts
@@ -1,0 +1,160 @@
+// Edge resolution tests (#133).
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEdges,
+  draftPath,
+  oppositeSide,
+} from "../edgeResolver";
+import type {
+  CanvasDoc,
+  CanvasEdge,
+  CanvasSide,
+  CanvasTextNode,
+} from "../types";
+import type { DraftEdge } from "../pointerMode";
+
+const node = (id: string, over: Partial<CanvasTextNode> = {}): CanvasTextNode => ({
+  id,
+  type: "text",
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 50,
+  text: "",
+  ...over,
+});
+
+const edge = (over: Partial<CanvasEdge> & Pick<CanvasEdge, "id" | "fromNode" | "toNode">): CanvasEdge =>
+  over;
+
+const doc = (nodes: CanvasTextNode[], edges: CanvasEdge[]): CanvasDoc => ({
+  nodes,
+  edges,
+});
+
+describe("oppositeSide", () => {
+  it("flips each side to its opposite (used for draft preview routing)", () => {
+    expect(oppositeSide("left")).toBe("right");
+    expect(oppositeSide("right")).toBe("left");
+    expect(oppositeSide("top")).toBe("bottom");
+    expect(oppositeSide("bottom")).toBe("top");
+  });
+});
+
+describe("resolveEdges", () => {
+  it("resolves a complete edge with explicit sides", () => {
+    const a = node("a", { x: 0, y: 0, width: 100, height: 50 });
+    const b = node("b", { x: 200, y: 0, width: 100, height: 50 });
+    const e: CanvasEdge = {
+      id: "e1",
+      fromNode: "a",
+      toNode: "b",
+      fromSide: "right",
+      toSide: "left",
+    };
+    const out = resolveEdges(doc([a, b], [e]));
+    expect(out).toHaveLength(1);
+    expect(out[0]?.fromPt).toEqual({ x: 100, y: 25 });
+    expect(out[0]?.toPt).toEqual({ x: 200, y: 25 });
+    expect(out[0]?.fromSide).toBe("right");
+    expect(out[0]?.toSide).toBe("left");
+    expect(typeof out[0]?.path).toBe("string");
+    expect(out[0]?.path.length).toBeGreaterThan(0);
+  });
+
+  it("auto-picks sides when fromSide/toSide are omitted", () => {
+    const a = node("a", { x: 0, y: 0 });
+    const b = node("b", { x: 500, y: 0 });
+    const e = edge({ id: "e1", fromNode: "a", toNode: "b" });
+    const out = resolveEdges(doc([a, b], [e]));
+    expect(out).toHaveLength(1);
+    // Two horizontally-arranged nodes with no explicit sides should auto-pick
+    // matching opposite sides (right ↔ left).
+    expect(out[0]?.fromSide).toBe("right");
+    expect(out[0]?.toSide).toBe("left");
+  });
+
+  it("silently skips edges whose fromNode is missing", () => {
+    const b = node("b");
+    const e = edge({ id: "e1", fromNode: "missing", toNode: "b" });
+    expect(resolveEdges(doc([b], [e]))).toEqual([]);
+  });
+
+  it("silently skips edges whose toNode is missing", () => {
+    const a = node("a");
+    const e = edge({ id: "e1", fromNode: "a", toNode: "missing" });
+    expect(resolveEdges(doc([a], [e]))).toEqual([]);
+  });
+
+  it("skips a corrupt edge but keeps resolving valid ones in the same doc", () => {
+    const a = node("a", { x: 0, y: 0 });
+    const b = node("b", { x: 200, y: 0 });
+    const valid: CanvasEdge = { id: "ok", fromNode: "a", toNode: "b" };
+    const orphan: CanvasEdge = { id: "bad", fromNode: "a", toNode: "ghost" };
+    const out = resolveEdges(doc([a, b], [valid, orphan]));
+    expect(out.map((r) => r.edge.id)).toEqual(["ok"]);
+  });
+});
+
+describe("draftPath", () => {
+  const fromNode = node("a", { x: 0, y: 0, width: 100, height: 50 });
+  const toNode = node("b", { x: 300, y: 0, width: 100, height: 50 });
+
+  const baseDraft = (over: Partial<DraftEdge> = {}): DraftEdge => ({
+    fromNodeId: "a",
+    fromSide: "right",
+    currentX: 200,
+    currentY: 25,
+    targetNodeId: null,
+    targetSide: null,
+    ...over,
+  });
+
+  it("returns null when no draft is in progress", () => {
+    expect(draftPath(doc([fromNode], []), null)).toBeNull();
+  });
+
+  it("returns null when the origin node is missing from the doc", () => {
+    const stale = baseDraft({ fromNodeId: "ghost" });
+    expect(draftPath(doc([fromNode], []), stale)).toBeNull();
+  });
+
+  it("routes from origin handle through cursor when no snap target", () => {
+    const path = draftPath(doc([fromNode], []), baseDraft());
+    expect(path).not.toBeNull();
+    expect(path).toMatch(/^M /); // SVG path starts with a move
+  });
+
+  it("routes into a snapped target's handle naturally", () => {
+    const snapped = baseDraft({
+      targetNodeId: "b",
+      targetSide: "left",
+    });
+    const path = draftPath(doc([fromNode, toNode], []), snapped);
+    expect(path).not.toBeNull();
+    expect(path).toMatch(/^M /);
+  });
+
+  it("falls back to the cursor when the snap target node has been deleted", () => {
+    const snappedToGhost = baseDraft({
+      targetNodeId: "ghost",
+      targetSide: "left",
+    });
+    const path = draftPath(doc([fromNode], []), snappedToGhost);
+    // Falls through to the cursor path rather than returning null.
+    expect(path).not.toBeNull();
+    expect(path).toMatch(/^M /);
+  });
+
+  it("uses opposite-side routing for each origin side when free", () => {
+    const sides: CanvasSide[] = ["left", "right", "top", "bottom"];
+    for (const side of sides) {
+      const path = draftPath(
+        doc([fromNode], []),
+        baseDraft({ fromSide: side }),
+      );
+      expect(path).not.toBeNull();
+    }
+  });
+});

--- a/src/lib/canvas/__tests__/pointerMode.test.ts
+++ b/src/lib/canvas/__tests__/pointerMode.test.ts
@@ -1,0 +1,287 @@
+// Pointer-mode state machine tests (#133).
+//
+// The module is pure: every assertion here goes through the same math the
+// Canvas viewer runs at 60fps. If a regression slips here it will appear as
+// drift under the cursor at runtime.
+
+import { describe, it, expect } from "vitest";
+import {
+  MIN_NODE_WIDTH,
+  MIN_NODE_HEIGHT,
+  beginPan,
+  beginMove,
+  beginResize,
+  beginEdge,
+  panPosition,
+  movePosition,
+  resizeSize,
+  updateDraftOnMove,
+  resolvePointerUp,
+  type DraftEdge,
+  type PointerMode,
+} from "../pointerMode";
+import type { CanvasTextNode } from "../types";
+
+const node = (over: Partial<CanvasTextNode> = {}): CanvasTextNode => ({
+  id: "n1",
+  type: "text",
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 100,
+  text: "",
+  ...over,
+});
+
+describe("beginPan", () => {
+  it("snapshots pointer + camera so pan math is relative to start", () => {
+    const mode = beginPan({ clientX: 50, clientY: 60 }, { x: 10, y: 20 });
+    expect(mode).toEqual({
+      kind: "pan",
+      startClientX: 50,
+      startClientY: 60,
+      startCamX: 10,
+      startCamY: 20,
+    });
+  });
+});
+
+describe("beginMove", () => {
+  it("snapshots pointer + node origin", () => {
+    const n = node({ x: 100, y: 200 });
+    const mode = beginMove(n, { clientX: 5, clientY: 6 });
+    expect(mode).toEqual({
+      kind: "move",
+      nodeId: "n1",
+      startClientX: 5,
+      startClientY: 6,
+      startX: 100,
+      startY: 200,
+    });
+  });
+});
+
+describe("beginResize", () => {
+  it("snapshots pointer + node size", () => {
+    const n = node({ width: 300, height: 150 });
+    const mode = beginResize(n, { clientX: 12, clientY: 34 });
+    expect(mode).toEqual({
+      kind: "resize",
+      nodeId: "n1",
+      startClientX: 12,
+      startClientY: 34,
+      startW: 300,
+      startH: 150,
+    });
+  });
+});
+
+describe("beginEdge", () => {
+  it("produces an edge-mode keyed to the origin node + side", () => {
+    expect(beginEdge("node-a", "right")).toEqual({
+      kind: "edge",
+      fromNodeId: "node-a",
+      fromSide: "right",
+    });
+  });
+});
+
+describe("panPosition", () => {
+  it("moves the camera by raw client delta (pan is not zoom-scaled)", () => {
+    const mode: PointerMode = beginPan(
+      { clientX: 100, clientY: 100 },
+      { x: 0, y: 0 },
+    );
+    if (mode.kind !== "pan") throw new Error("unreachable");
+    expect(panPosition(mode, { clientX: 130, clientY: 90 })).toEqual({
+      camX: 30,
+      camY: -10,
+    });
+  });
+
+  it("is a pure function of start + current — repeat calls are stable", () => {
+    const mode: PointerMode = beginPan(
+      { clientX: 0, clientY: 0 },
+      { x: 50, y: 50 },
+    );
+    if (mode.kind !== "pan") throw new Error("unreachable");
+    const a = panPosition(mode, { clientX: 10, clientY: 10 });
+    const b = panPosition(mode, { clientX: 10, clientY: 10 });
+    expect(a).toEqual(b);
+    expect(a).toEqual({ camX: 60, camY: 60 });
+  });
+});
+
+describe("movePosition", () => {
+  it("scales the client delta by 1/zoom so moves match cursor under zoom", () => {
+    const mode: PointerMode = beginMove(
+      node({ x: 0, y: 0 }),
+      { clientX: 0, clientY: 0 },
+    );
+    if (mode.kind !== "move") throw new Error("unreachable");
+    expect(movePosition(mode, { clientX: 200, clientY: 100 }, 2)).toEqual({
+      x: 100,
+      y: 50,
+    });
+  });
+
+  it("at zoom=1 returns raw client delta + start", () => {
+    const mode: PointerMode = beginMove(
+      node({ x: 10, y: 20 }),
+      { clientX: 100, clientY: 100 },
+    );
+    if (mode.kind !== "move") throw new Error("unreachable");
+    expect(movePosition(mode, { clientX: 130, clientY: 140 }, 1)).toEqual({
+      x: 40,
+      y: 60,
+    });
+  });
+});
+
+describe("resizeSize", () => {
+  it("grows width/height by zoom-scaled client delta", () => {
+    const mode: PointerMode = beginResize(
+      node({ width: 200, height: 100 }),
+      { clientX: 0, clientY: 0 },
+    );
+    if (mode.kind !== "resize") throw new Error("unreachable");
+    expect(resizeSize(mode, { clientX: 200, clientY: 100 }, 2)).toEqual({
+      width: 300,
+      height: 150,
+    });
+  });
+
+  it("clamps shrinking below MIN_NODE_WIDTH / MIN_NODE_HEIGHT", () => {
+    const mode: PointerMode = beginResize(
+      node({ width: 100, height: 60 }),
+      { clientX: 1000, clientY: 1000 },
+    );
+    if (mode.kind !== "resize") throw new Error("unreachable");
+    const out = resizeSize(mode, { clientX: 0, clientY: 0 }, 1);
+    expect(out.width).toBe(MIN_NODE_WIDTH);
+    expect(out.height).toBe(MIN_NODE_HEIGHT);
+  });
+
+  it("clamps boundaries: exactly at the minimum does not go lower", () => {
+    const mode: PointerMode = beginResize(
+      node({ width: MIN_NODE_WIDTH, height: MIN_NODE_HEIGHT }),
+      { clientX: 0, clientY: 0 },
+    );
+    if (mode.kind !== "resize") throw new Error("unreachable");
+    expect(resizeSize(mode, { clientX: -5, clientY: -5 }, 1)).toEqual({
+      width: MIN_NODE_WIDTH,
+      height: MIN_NODE_HEIGHT,
+    });
+  });
+});
+
+describe("updateDraftOnMove", () => {
+  const baseDraft = (): DraftEdge => ({
+    fromNodeId: "a",
+    fromSide: "right",
+    currentX: 0,
+    currentY: 0,
+    targetNodeId: null,
+    targetSide: null,
+  });
+
+  it("tracks the cursor when no handle is under the pointer", () => {
+    const out = updateDraftOnMove(baseDraft(), { x: 50, y: 60 }, null);
+    expect(out).toEqual({
+      fromNodeId: "a",
+      fromSide: "right",
+      currentX: 50,
+      currentY: 60,
+      targetNodeId: null,
+      targetSide: null,
+    });
+  });
+
+  it("snaps onto another node's handle", () => {
+    const out = updateDraftOnMove(
+      baseDraft(),
+      { x: 50, y: 60 },
+      { nodeId: "b", side: "left" },
+    );
+    expect(out.targetNodeId).toBe("b");
+    expect(out.targetSide).toBe("left");
+  });
+
+  it("ignores self-loops: handle on the origin node does not snap", () => {
+    const out = updateDraftOnMove(
+      baseDraft(),
+      { x: 50, y: 60 },
+      { nodeId: "a", side: "top" },
+    );
+    expect(out.targetNodeId).toBeNull();
+    expect(out.targetSide).toBeNull();
+  });
+
+  it("clears a previous snap when the pointer leaves the handle", () => {
+    const snapped: DraftEdge = {
+      ...baseDraft(),
+      targetNodeId: "b",
+      targetSide: "left",
+    };
+    const out = updateDraftOnMove(snapped, { x: 70, y: 80 }, null);
+    expect(out.targetNodeId).toBeNull();
+    expect(out.targetSide).toBeNull();
+  });
+
+  it("is immutable: does not mutate the input draft", () => {
+    const input = baseDraft();
+    updateDraftOnMove(input, { x: 9, y: 9 }, { nodeId: "b", side: "top" });
+    expect(input.currentX).toBe(0);
+    expect(input.targetNodeId).toBeNull();
+  });
+});
+
+describe("resolvePointerUp", () => {
+  const draftSnapped = (): DraftEdge => ({
+    fromNodeId: "a",
+    fromSide: "right",
+    currentX: 0,
+    currentY: 0,
+    targetNodeId: "b",
+    targetSide: "left",
+  });
+
+  it("commits an edge when the draft landed on a target handle", () => {
+    const mode: PointerMode = beginEdge("a", "right");
+    expect(resolvePointerUp(mode, draftSnapped())).toEqual({
+      kind: "commit-edge",
+      fromId: "a",
+      fromSide: "right",
+      toId: "b",
+      toSide: "left",
+    });
+  });
+
+  it("does nothing when the draft has no snap target", () => {
+    const mode: PointerMode = beginEdge("a", "right");
+    const draft: DraftEdge = {
+      fromNodeId: "a",
+      fromSide: "right",
+      currentX: 99,
+      currentY: 99,
+      targetNodeId: null,
+      targetSide: null,
+    };
+    expect(resolvePointerUp(mode, draft)).toEqual({ kind: "none" });
+  });
+
+  it("does nothing for non-edge modes even if a stale draft exists", () => {
+    // Defensive: the component resets `draft` when entering other modes,
+    // but a leak shouldn't fire a spurious commit.
+    const mode: PointerMode = beginPan(
+      { clientX: 0, clientY: 0 },
+      { x: 0, y: 0 },
+    );
+    expect(resolvePointerUp(mode, draftSnapped())).toEqual({ kind: "none" });
+  });
+
+  it("does nothing when draft is null", () => {
+    const mode: PointerMode = beginEdge("a", "right");
+    expect(resolvePointerUp(mode, null)).toEqual({ kind: "none" });
+  });
+});

--- a/src/lib/canvas/edgeResolver.ts
+++ b/src/lib/canvas/edgeResolver.ts
@@ -1,0 +1,92 @@
+// Edge resolution for canvas rendering (#71, extracted for #133).
+//
+// Two pure helpers the viewer's render loop calls every frame:
+//   - resolveEdges: turn the document's logical edge list into the
+//     anchor points + bezier paths the SVG layer renders. Edges whose
+//     endpoint node has been deleted (or is otherwise missing from the
+//     doc) are silently skipped so a corrupt file can't crash the view.
+//   - draftPath: the bezier preview the user sees while dragging from a
+//     handle. When the cursor is over a different node's handle we route
+//     into that handle naturally; otherwise we fake an "opposite side"
+//     so the preview still curves smoothly toward the cursor.
+//
+// Keeping these out of the .svelte component means we can unit-test the
+// fallback behaviours (missing endpoint, no snap target, opposite-side
+// pick) without booting the renderer.
+
+import { anchorPoint, autoSides, bezierMidpoint, bezierPath } from "./geometry";
+import type { CanvasDoc, CanvasEdge, CanvasSide } from "./types";
+import type { DraftEdge } from "./pointerMode";
+
+export interface ResolvedEdge {
+  edge: CanvasEdge;
+  fromPt: { x: number; y: number };
+  toPt: { x: number; y: number };
+  fromSide: CanvasSide;
+  toSide: CanvasSide;
+  path: string;
+  mid: { x: number; y: number };
+}
+
+export function resolveEdges(doc: CanvasDoc): ResolvedEdge[] {
+  const byId = new Map(doc.nodes.map((n) => [n.id, n] as const));
+  const out: ResolvedEdge[] = [];
+  for (const edge of doc.edges) {
+    const from = byId.get(edge.fromNode);
+    const to = byId.get(edge.toNode);
+    if (!from || !to) continue;
+    const { fromSide, toSide } =
+      edge.fromSide && edge.toSide
+        ? { fromSide: edge.fromSide, toSide: edge.toSide }
+        : autoSides(from, to);
+    const fromPt = anchorPoint(from, fromSide);
+    const toPt = anchorPoint(to, toSide);
+    out.push({
+      edge,
+      fromPt,
+      toPt,
+      fromSide,
+      toSide,
+      path: bezierPath(fromPt, fromSide, toPt, toSide),
+      mid: bezierMidpoint(fromPt, fromSide, toPt, toSide),
+    });
+  }
+  return out;
+}
+
+/**
+ * Side opposite to `side` — the natural entry/exit pair for a smooth
+ * draft curve when the cursor is in free space.
+ */
+export function oppositeSide(side: CanvasSide): CanvasSide {
+  switch (side) {
+    case "left":
+      return "right";
+    case "right":
+      return "left";
+    case "top":
+      return "bottom";
+    case "bottom":
+      return "top";
+  }
+}
+
+export function draftPath(doc: CanvasDoc, draft: DraftEdge | null): string | null {
+  if (!draft) return null;
+  const from = doc.nodes.find((n) => n.id === draft.fromNodeId);
+  if (!from) return null;
+  const fromPt = anchorPoint(from, draft.fromSide);
+  if (draft.targetNodeId && draft.targetSide) {
+    const to = doc.nodes.find((n) => n.id === draft.targetNodeId);
+    if (to) {
+      const toPt = anchorPoint(to, draft.targetSide);
+      return bezierPath(fromPt, draft.fromSide, toPt, draft.targetSide);
+    }
+  }
+  return bezierPath(
+    fromPt,
+    draft.fromSide,
+    { x: draft.currentX, y: draft.currentY },
+    oppositeSide(draft.fromSide),
+  );
+}

--- a/src/lib/canvas/pointerMode.ts
+++ b/src/lib/canvas/pointerMode.ts
@@ -1,0 +1,199 @@
+// Canvas pointer-mode state machine (#71, extracted for #133).
+//
+// The viewer mixes four distinct drag gestures on a single set of pointer
+// events: panning the world, moving a node, resizing a node, and drawing an
+// edge. Each gesture has its own snapshot of where-we-started and a pure
+// delta computation for where-we-are-now. Keeping that in the component
+// wrapped the state machine in reactive-state mutations, which made the
+// arithmetic untestable and the .svelte file hard to follow.
+//
+// This module owns the types and the pure math; the component still owns
+// the reactive state and applies the computed positions/sizes to it. Callers
+// pass in only the event coords and the zoom factor they already have in
+// hand, so nothing here depends on Svelte runes or the DOM.
+//
+// Minimum dimensions for resize are enforced here so the lower bound is
+// defined once and can't drift between the arithmetic and the UI.
+//
+// The edge-draft object (target-side tracking while dragging from a handle)
+// is updated by `updateDraftOnMove`; the pure helper means tests can verify
+// the "snap when over a different node's handle, otherwise track cursor"
+// rule without wiring up a live DOM.
+
+import type { CanvasNode, CanvasSide } from "./types";
+
+export const MIN_NODE_WIDTH = 80;
+export const MIN_NODE_HEIGHT = 40;
+
+export type PointerMode =
+  | {
+      kind: "pan";
+      startClientX: number;
+      startClientY: number;
+      startCamX: number;
+      startCamY: number;
+    }
+  | {
+      kind: "move";
+      nodeId: string;
+      startClientX: number;
+      startClientY: number;
+      startX: number;
+      startY: number;
+    }
+  | {
+      kind: "resize";
+      nodeId: string;
+      startClientX: number;
+      startClientY: number;
+      startW: number;
+      startH: number;
+    }
+  | { kind: "edge"; fromNodeId: string; fromSide: CanvasSide };
+
+export interface ClientPoint {
+  clientX: number;
+  clientY: number;
+}
+
+export interface DraftEdge {
+  fromNodeId: string;
+  fromSide: CanvasSide;
+  currentX: number;
+  currentY: number;
+  targetNodeId: string | null;
+  targetSide: CanvasSide | null;
+}
+
+export interface HandleHit {
+  nodeId: string;
+  side: CanvasSide;
+}
+
+// ── factories ──────────────────────────────────────────────────────────────
+
+export function beginPan(e: ClientPoint, cam: { x: number; y: number }): PointerMode {
+  return {
+    kind: "pan",
+    startClientX: e.clientX,
+    startClientY: e.clientY,
+    startCamX: cam.x,
+    startCamY: cam.y,
+  };
+}
+
+export function beginMove(node: CanvasNode, e: ClientPoint): PointerMode {
+  return {
+    kind: "move",
+    nodeId: node.id,
+    startClientX: e.clientX,
+    startClientY: e.clientY,
+    startX: node.x,
+    startY: node.y,
+  };
+}
+
+export function beginResize(node: CanvasNode, e: ClientPoint): PointerMode {
+  return {
+    kind: "resize",
+    nodeId: node.id,
+    startClientX: e.clientX,
+    startClientY: e.clientY,
+    startW: node.width,
+    startH: node.height,
+  };
+}
+
+export function beginEdge(nodeId: string, side: CanvasSide): PointerMode {
+  return { kind: "edge", fromNodeId: nodeId, fromSide: side };
+}
+
+// ── move handlers (pure delta → position / size) ───────────────────────────
+
+export function panPosition(
+  mode: Extract<PointerMode, { kind: "pan" }>,
+  e: ClientPoint,
+): { camX: number; camY: number } {
+  return {
+    camX: mode.startCamX + (e.clientX - mode.startClientX),
+    camY: mode.startCamY + (e.clientY - mode.startClientY),
+  };
+}
+
+export function movePosition(
+  mode: Extract<PointerMode, { kind: "move" }>,
+  e: ClientPoint,
+  zoom: number,
+): { x: number; y: number } {
+  return {
+    x: mode.startX + (e.clientX - mode.startClientX) / zoom,
+    y: mode.startY + (e.clientY - mode.startClientY) / zoom,
+  };
+}
+
+export function resizeSize(
+  mode: Extract<PointerMode, { kind: "resize" }>,
+  e: ClientPoint,
+  zoom: number,
+): { width: number; height: number } {
+  return {
+    width: Math.max(MIN_NODE_WIDTH, mode.startW + (e.clientX - mode.startClientX) / zoom),
+    height: Math.max(MIN_NODE_HEIGHT, mode.startH + (e.clientY - mode.startClientY) / zoom),
+  };
+}
+
+// ── edge draft ─────────────────────────────────────────────────────────────
+
+/**
+ * Produce the next DraftEdge state given the current cursor position (in
+ * world coords) and whether the pointer is currently over a handle. The
+ * commit rule in onUp checks `targetNodeId !== null`, so we only populate
+ * the snap fields when `hit` belongs to a *different* node than the
+ * drag origin — self-loops are not allowed.
+ */
+export function updateDraftOnMove(
+  draft: DraftEdge,
+  world: { x: number; y: number },
+  hit: HandleHit | null,
+): DraftEdge {
+  const snap = hit && hit.nodeId !== draft.fromNodeId ? hit : null;
+  return {
+    ...draft,
+    currentX: world.x,
+    currentY: world.y,
+    targetNodeId: snap ? snap.nodeId : null,
+    targetSide: snap ? snap.side : null,
+  };
+}
+
+// ── commit decision ────────────────────────────────────────────────────────
+
+export type PointerUpAction =
+  | { kind: "none" }
+  | {
+      kind: "commit-edge";
+      fromId: string;
+      fromSide: CanvasSide;
+      toId: string;
+      toSide: CanvasSide;
+    };
+
+/**
+ * On pointer-up, the edge mode decides whether to commit based on whether
+ * the draft snapped to a valid target handle. All other modes are pure
+ * cleanup — the component clears `pointerMode` to null either way.
+ */
+export function resolvePointerUp(
+  mode: PointerMode,
+  draft: DraftEdge | null,
+): PointerUpAction {
+  if (mode.kind !== "edge" || !draft) return { kind: "none" };
+  if (!draft.targetNodeId || !draft.targetSide) return { kind: "none" };
+  return {
+    kind: "commit-edge",
+    fromId: draft.fromNodeId,
+    fromSide: draft.fromSide,
+    toId: draft.targetNodeId,
+    toSide: draft.targetSide,
+  };
+}

--- a/src/types/e2e-hook.ts
+++ b/src/types/e2e-hook.ts
@@ -1,0 +1,25 @@
+// Shape of the `window.__e2e__` harness exposed by src/App.svelte when
+// VITE_E2E=1. This is the single source of truth — both the App.svelte
+// setter and the e2e specs (see e2e/tsconfig.json) pick up the global
+// augmentation from here so drivers can call methods directly without
+// `as unknown as { ... }` casts.
+
+export type E2eToastVariant = "error" | "conflict" | "clean-merge";
+
+export interface E2eHook {
+  loadVault: (path: string) => Promise<void>;
+  switchVault: (path: string) => Promise<void>;
+  closeVault: () => Promise<void>;
+  pushToast: (variant: E2eToastVariant, message: string) => void;
+  startProgress: (total: number) => void;
+  updateProgress: (current: number, total: number, currentFile?: string) => void;
+  finishProgress: () => void;
+  typeInActiveEditor: (text: string) => Promise<void>;
+  getActiveDocText: () => Promise<string>;
+}
+
+declare global {
+  interface Window {
+    __e2e__?: E2eHook;
+  }
+}

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -12,6 +12,7 @@ export type VaultErrorKind =
   | "VaultUnavailable"
   | "MergeConflict"
   | "InvalidEncoding"
+  | "LockPoisoned"
   | "Io";
 
 export interface VaultError {
@@ -54,6 +55,8 @@ export function vaultErrorCopy(err: VaultError): string {
       return "Index corrupt. VaultCore will rebuild it.";
     case "IndexLocked":
       return "Search index is in use by another window or a stuck VaultCore process. Close other instances or restart VaultCore.";
+    case "LockPoisoned":
+      return "Internal error — please restart VaultCore.";
     case "MergeConflict":
       return `Conflict in ${err.data ?? "file"} — local version kept.`;
     default: {


### PR DESCRIPTION
## Summary

Single-branch batch closing 13 backlog tickets in dependency-friendly order. Each commit is squash-mergeable on its own and references its issue number; the branch is squash-merged here so the merge commit closes everything atomically.

| # | Issue | Type | One-liner |
|---|---|---|---|
| 1 | #134 | chore | clear 39 clippy warnings |
| 2 | #141 | chore | trim tokio features `"full"` → minimum subset |
| 3 | #135 | chore | global type augmentation for `window.__e2e__` |
| 4 | #131 | chore | clear 13 svelte-check errors |
| 5 | #130 | a11y  | keyboard handlers on canvas role=button cards |
| 6 | #132 | test  | unit coverage for templateSubstitution + exportHtml (24 tests) |
| 7 | #140 | test  | unit coverage for link_graph.rs (21 tests) |
| 8 | #136 | refactor | introduce `VaultError::LockPoisoned`; migrate 25 call sites |
| 9 | #137 | perf  | `FileIndex` → `RwLock` (11× p95 read-throughput win) |
| 10 | #138 | perf  | move `IndexWriter` loop off async executor via `spawn_blocking` |
| 11 | #139 | bug   | watcher channel overflow surfaces a warning + raised cap (8192) |
| 12 | #142 | bug   | deflake table-control hover-gap test (structural CSS check) |
| 13 | #133 | refactor | split CanvasView.svelte — pointerMode + edgeResolver modules + 32 tests |

## Verification

- `cargo test`: **219 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings`: **0 warnings**
- `pnpm vitest run`: **562 passed**
- `pnpm typecheck`: **0 errors**
- `pnpm svelte-check`: **0 errors**, 3 pre-existing warnings (unchanged)
- `pnpm test:e2e` (full suite, 48 specs): **48 passed, 0 failed**

## Test plan

- [x] Static gates green on this branch
- [x] Full E2E suite green
- [x] Issue #142's previously flaky hover-gap spec passes both in isolation and inside the full suite
- [x] Issue #143's `outgoing-links.spec.ts` passes inside the full suite