### PR TITLE
feat(canvas): long-press-to-pan gesture (#144)

### DIFF
--- a/e2e/specs/canvas.spec.ts
+++ b/e2e/specs/canvas.spec.ts
@@ -557,4 +557,161 @@ describe("Canvas viewer (#124)", () => {
         : false;
     });
   });
+
+  // ─── Long-press-to-pan (#144) ─────────────────────────────────────────
+
+  it("long-press + drag on a node pans the camera without moving the node", async () => {
+    // Seed a clean file with one node at a known origin so we can assert
+    // its coordinates survived the pan.
+    fs.writeFileSync(
+      path.join(vault.path, "LongPress.canvas"),
+      JSON.stringify(
+        {
+          nodes: [
+            {
+              id: "lp-1",
+              type: "text",
+              x: 0,
+              y: 0,
+              width: 200,
+              height: 100,
+              text: "hold me",
+            },
+          ],
+          edges: [],
+        },
+        null,
+        "\t",
+      ),
+      "utf-8",
+    );
+
+    await openTreeFile("LongPress.canvas");
+    await waitForCanvas();
+
+    // Snapshot the camera transform + on-disk node coords before the drag.
+    const beforeTransform = (await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      const world = visible?.querySelector<HTMLElement>(".vc-canvas-world");
+      return world?.style.transform ?? "";
+    })) as string;
+
+    const nodeSel = await vizSel(" .vc-canvas-node-text");
+
+    // Resolve the node's center once, then fire the three events in three
+    // calls with a wall-clock sleep in between so the WebView's setTimeout
+    // for the long-press timer has real time to fire.
+    const origin = (await browser.execute((sel: string) => {
+      const el = document.querySelector(sel) as HTMLElement | null;
+      if (!el) throw new Error(`No element: ${sel}`);
+      const rect = el.getBoundingClientRect();
+      return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+      };
+    }, nodeSel)) as { x: number; y: number };
+
+    await browser.execute(
+      (sel: string, x: number, y: number) => {
+        const el = document.querySelector(sel) as HTMLElement | null;
+        if (!el) throw new Error(`No element: ${sel}`);
+        el.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x,
+            clientY: y,
+            pointerId: 1,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 1,
+            isPrimary: true,
+          }),
+        );
+      },
+      nodeSel,
+      origin.x,
+      origin.y,
+    );
+
+    // Wait long enough for the 300 ms long-press timer to fire in the WebView.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Verify the long-press fired — pointer mode should have transitioned
+    // from pending-longpress into pan. The viewport mirrors its current
+    // state into `data-pointer-mode` so tests can observe the transition.
+    const modeAfterHold = (await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const visible = vps.find((v) => v.offsetParent !== null);
+      return visible?.getAttribute("data-pointer-mode") ?? null;
+    })) as string | null;
+    expect(modeAfterHold).toBe("pan");
+
+    // Now drag — pointermove on the captured element drives pan math.
+    await browser.execute(
+      (sel: string, x: number, y: number) => {
+        const el = document.querySelector(sel) as HTMLElement | null;
+        if (!el) throw new Error(`No element: ${sel}`);
+        el.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x,
+            clientY: y,
+            pointerId: 1,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 1,
+            isPrimary: true,
+          }),
+        );
+        el.dispatchEvent(
+          new PointerEvent("pointerup", {
+            bubbles: true,
+            cancelable: true,
+            clientX: x,
+            clientY: y,
+            pointerId: 1,
+            pointerType: "mouse",
+            button: 0,
+            buttons: 0,
+            isPrimary: true,
+          }),
+        );
+      },
+      nodeSel,
+      origin.x + 80,
+      origin.y + 40,
+    );
+
+    // Camera moved.
+    await browser.waitUntil(
+      async () => {
+        const t = (await browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const visible = vps.find((v) => v.offsetParent !== null);
+          const world = visible?.querySelector<HTMLElement>(".vc-canvas-world");
+          return world?.style.transform ?? "";
+        })) as string;
+        return t !== beforeTransform && t.length > 0;
+      },
+      { timeout: 3000, timeoutMsg: "Canvas world transform never changed" },
+    );
+
+    // Node coords on disk are unchanged (the node was *not* moved).
+    // The canvas autosaves with a 400ms debounce; wait long enough to have
+    // seen any write, then assert no coord change.
+    await new Promise((r) => setTimeout(r, FLUSH_WAIT_MS));
+    const disk = await readCanvasFromDisk("LongPress.canvas");
+    const node = (disk.nodes as Array<Record<string, unknown>>)[0]!;
+    expect(node.x).toBe(0);
+    expect(node.y).toBe(0);
+  });
 });

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -56,10 +56,15 @@
   import {
     type PointerMode,
     type DraftEdge,
+    LONGPRESS_HOLD_MS,
     beginPan,
     beginMove,
     beginResize,
     beginEdge,
+    beginPendingLongpress,
+    pendingLongpressExceeded,
+    longpressFire,
+    longpressFallback,
     panPosition,
     movePosition,
     resizeSize,
@@ -110,7 +115,13 @@
   // generic file card. `$state` keeps the template reactive to async loads.
   let mdPreviews = $state<Record<string, string>>({});
 
-  let pointerMode: PointerMode | null = null;
+  let pointerMode = $state<PointerMode | null>(null);
+  let longpressTimer: ReturnType<typeof setTimeout> | null = null;
+  // Pointer-capture target for the current gesture. Long-press starts on
+  // either the viewport (empty-canvas press) or on a node element; pointer-up
+  // must release capture from the same element to keep subsequent events in
+  // the native handler chain.
+  let longpressCaptureEl: HTMLElement | null = null;
 
   const MIN_ZOOM = 0.15;
   const MAX_ZOOM = 4;
@@ -168,6 +179,7 @@
       saveTimer = null;
       void persist();
     }
+    cancelLongpressTimer();
   });
 
   $effect(() => {
@@ -282,37 +294,84 @@
   function onViewportPointerDown(e: PointerEvent) {
     if (editingNodeId || editingEdgeId) return;
     const isPan = e.button === 1 || (e.button === 0 && spaceHeld);
-    if (!isPan) return;
-    e.preventDefault();
+    if (isPan) {
+      e.preventDefault();
+      selectedNodeId = null;
+      selectedEdgeId = null;
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      pointerMode = beginPan(e, { x: camX, y: camY });
+      return;
+    }
+    // Left-click on empty viewport → start long-press-to-pan timer (#144).
+    // No movement yet — the timer fires after LONGPRESS_HOLD_MS if the
+    // pointer hasn't moved past the threshold.
+    if (e.button !== 0) return;
     selectedNodeId = null;
     selectedEdgeId = null;
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    pointerMode = beginPan(e, { x: camX, y: camY });
+    startLongpress(e, { kind: "none" });
+  }
+
+  function startLongpress(
+    e: PointerEvent,
+    fallback: { kind: "none" } | { kind: "move"; nodeId: string; nodeStartX: number; nodeStartY: number },
+  ) {
+    pointerMode = beginPendingLongpress(e, fallback);
+    const el = e.currentTarget as HTMLElement;
+    longpressCaptureEl = el;
+    try {
+      el.setPointerCapture(e.pointerId);
+    } catch {
+      /* setPointerCapture throws for synthetic-test pointer IDs */
+    }
+    if (longpressTimer) clearTimeout(longpressTimer);
+    longpressTimer = setTimeout(() => {
+      longpressTimer = null;
+      if (pointerMode?.kind !== "pending-longpress") return;
+      pointerMode = longpressFire(pointerMode, { x: camX, y: camY });
+    }, LONGPRESS_HOLD_MS);
+  }
+
+  function cancelLongpressTimer() {
+    if (longpressTimer) {
+      clearTimeout(longpressTimer);
+      longpressTimer = null;
+    }
   }
 
   function onViewportPointerMove(e: PointerEvent) {
-    if (!pointerMode) return;
-    if (pointerMode.kind === "pan") {
-      const p = panPosition(pointerMode, e);
+    let mode = pointerMode;
+    if (!mode) return;
+    if (mode.kind === "pending-longpress") {
+      if (!pendingLongpressExceeded(mode, e)) return;
+      // User moved past the threshold before the timer fired — cancel the
+      // pending pan and fall through to the original gesture. If no
+      // fallback exists (viewport-only press), clear the mode so the event
+      // stops driving anything until pointer-up.
+      cancelLongpressTimer();
+      const next = longpressFallback(mode);
+      pointerMode = next;
+      if (!next) return;
+      mode = next;
+    }
+    if (mode.kind === "pan") {
+      const p = panPosition(mode, e);
       camX = p.camX;
       camY = p.camY;
-    } else if (pointerMode.kind === "move") {
-      const mode = pointerMode;
+    } else if (mode.kind === "move") {
       const p = movePosition(mode, e, zoom);
       const node = doc.nodes.find((n) => n.id === mode.nodeId);
       if (node) {
         node.x = p.x;
         node.y = p.y;
       }
-    } else if (pointerMode.kind === "resize") {
-      const mode = pointerMode;
+    } else if (mode.kind === "resize") {
       const s = resizeSize(mode, e, zoom);
       const node = doc.nodes.find((n) => n.id === mode.nodeId);
       if (node) {
         node.width = s.width;
         node.height = s.height;
       }
-    } else if (pointerMode.kind === "edge" && draft) {
+    } else if (mode.kind === "edge" && draft) {
       draft = updateDraftOnMove(
         draft,
         clientToWorld(e.clientX, e.clientY),
@@ -326,6 +385,13 @@
     try {
       (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
     } catch { /* releasePointerCapture may throw in the synthetic test env */ }
+    if (longpressCaptureEl && longpressCaptureEl !== e.currentTarget) {
+      try {
+        longpressCaptureEl.releasePointerCapture?.(e.pointerId);
+      } catch { /* synthetic-test pointer ID */ }
+    }
+    cancelLongpressTimer();
+    longpressCaptureEl = null;
     const action = resolvePointerUp(pointerMode, draft);
     if (action.kind === "commit-edge") {
       commitDraftEdge(action.fromId, action.fromSide, action.toId, action.toSide);
@@ -380,8 +446,15 @@
     e.stopPropagation();
     selectedNodeId = node.id;
     selectedEdgeId = null;
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    pointerMode = beginMove(node, e);
+    // Enter pending-longpress — if the user keeps the pointer still for
+    // LONGPRESS_HOLD_MS we flip to pan; if they move past the threshold
+    // first, we fall through to beginMove (the original gesture).
+    startLongpress(e, {
+      kind: "move",
+      nodeId: node.id,
+      nodeStartX: node.x,
+      nodeStartY: node.y,
+    });
   }
 
   function onNodeDblClick(e: MouseEvent, node: CanvasNode) {
@@ -542,6 +615,9 @@
 
   let resolvedEdges = $derived(resolveEdgesPure(doc));
   let draftPathD = $derived(draftPathPure(doc, draft));
+  // True while a long-press-to-pan pan is actively driving the camera. Used
+  // to force the `grabbing` cursor globally on the canvas.
+  let isPanActive = $derived(pointerMode?.kind === "pan");
 </script>
 
 <svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />
@@ -549,11 +625,13 @@
 <div
   class="vc-canvas-viewport"
   class:vc-canvas-panning={spaceHeld}
+  class:vc-canvas-pan-active={isPanActive}
   class:vc-canvas-drafting={!!draft}
   bind:this={viewportEl}
   role="application"
   aria-label="Canvas"
   data-tab-id={tabId}
+  data-pointer-mode={pointerMode?.kind ?? "idle"}
   onpointerdown={onViewportPointerDown}
   onpointermove={onViewportPointerMove}
   onpointerup={onViewportPointerUp}
@@ -941,6 +1019,11 @@
 
   .vc-canvas-panning {
     cursor: grab;
+  }
+
+  .vc-canvas-pan-active,
+  .vc-canvas-pan-active * {
+    cursor: grabbing !important;
   }
 
   .vc-canvas-drafting {

--- a/src/lib/canvas/__tests__/pointerMode.test.ts
+++ b/src/lib/canvas/__tests__/pointerMode.test.ts
@@ -8,10 +8,16 @@ import { describe, it, expect } from "vitest";
 import {
   MIN_NODE_WIDTH,
   MIN_NODE_HEIGHT,
+  LONGPRESS_HOLD_MS,
+  LONGPRESS_MOVE_THRESHOLD,
   beginPan,
   beginMove,
   beginResize,
   beginEdge,
+  beginPendingLongpress,
+  pendingLongpressExceeded,
+  longpressFire,
+  longpressFallback,
   panPosition,
   movePosition,
   resizeSize,
@@ -283,5 +289,166 @@ describe("resolvePointerUp", () => {
   it("does nothing when draft is null", () => {
     const mode: PointerMode = beginEdge("a", "right");
     expect(resolvePointerUp(mode, null)).toEqual({ kind: "none" });
+  });
+});
+
+// ── long-press-to-pan (#144) ─────────────────────────────────────────────
+
+describe("beginPendingLongpress", () => {
+  it("snapshots pointer-down position and carries the fallback payload", () => {
+    const mode = beginPendingLongpress(
+      { clientX: 40, clientY: 50 },
+      { kind: "none" },
+    );
+    expect(mode).toEqual({
+      kind: "pending-longpress",
+      startClientX: 40,
+      startClientY: 50,
+      fallback: { kind: "none" },
+    });
+  });
+
+  it("carries node fallback info so the move transition can begin without drift", () => {
+    const mode = beginPendingLongpress(
+      { clientX: 10, clientY: 20 },
+      { kind: "move", nodeId: "n1", nodeStartX: 100, nodeStartY: 200 },
+    );
+    if (mode.kind !== "pending-longpress") throw new Error("unreachable");
+    expect(mode.fallback).toEqual({
+      kind: "move",
+      nodeId: "n1",
+      nodeStartX: 100,
+      nodeStartY: 200,
+    });
+  });
+});
+
+describe("pendingLongpressExceeded", () => {
+  const mode = () => {
+    const m = beginPendingLongpress(
+      { clientX: 100, clientY: 100 },
+      { kind: "none" },
+    );
+    if (m.kind !== "pending-longpress") throw new Error("unreachable");
+    return m;
+  };
+
+  it("returns false for no movement", () => {
+    expect(pendingLongpressExceeded(mode(), { clientX: 100, clientY: 100 })).toBe(
+      false,
+    );
+  });
+
+  it("returns false for movement within the threshold (Euclidean)", () => {
+    // The default threshold is 4 px; a 3/4 delta gives distance 5 which exceeds,
+    // but 2/2 gives ~2.83 which is within.
+    expect(pendingLongpressExceeded(mode(), { clientX: 102, clientY: 102 })).toBe(
+      false,
+    );
+  });
+
+  it("returns true once the pointer moves beyond the threshold", () => {
+    expect(pendingLongpressExceeded(mode(), { clientX: 103, clientY: 104 })).toBe(
+      true,
+    );
+  });
+
+  it("uses Euclidean distance, not Manhattan", () => {
+    // 3 px in one axis is within threshold (3 < 4); 3+3 Manhattan would be 6
+    // but Euclidean is ~4.24 which also exceeds — ensure the test guards
+    // against an axis-summed implementation.
+    expect(pendingLongpressExceeded(mode(), { clientX: 103, clientY: 100 })).toBe(
+      false,
+    );
+    expect(pendingLongpressExceeded(mode(), { clientX: 103, clientY: 103 })).toBe(
+      true,
+    );
+  });
+
+  it("accepts a custom threshold", () => {
+    expect(
+      pendingLongpressExceeded(mode(), { clientX: 108, clientY: 100 }, 10),
+    ).toBe(false);
+    expect(
+      pendingLongpressExceeded(mode(), { clientX: 111, clientY: 100 }, 10),
+    ).toBe(true);
+  });
+});
+
+describe("longpressFire", () => {
+  it("transitions the pending state into pan mode preserving the start client + camera", () => {
+    const pending = beginPendingLongpress(
+      { clientX: 40, clientY: 60 },
+      { kind: "none" },
+    );
+    if (pending.kind !== "pending-longpress") throw new Error("unreachable");
+    const panned = longpressFire(pending, { x: 5, y: 7 });
+    expect(panned).toEqual({
+      kind: "pan",
+      startClientX: 40,
+      startClientY: 60,
+      startCamX: 5,
+      startCamY: 7,
+    });
+  });
+
+  it("panPosition after a fire yields zero delta for the same pointer coords", () => {
+    const pending = beginPendingLongpress(
+      { clientX: 10, clientY: 10 },
+      { kind: "none" },
+    );
+    if (pending.kind !== "pending-longpress") throw new Error("unreachable");
+    const panned = longpressFire(pending, { x: 100, y: 200 });
+    if (panned.kind !== "pan") throw new Error("unreachable");
+    expect(panPosition(panned, { clientX: 10, clientY: 10 })).toEqual({
+      camX: 100,
+      camY: 200,
+    });
+  });
+});
+
+describe("longpressFallback", () => {
+  it("returns null for an empty-viewport fallback", () => {
+    const pending = beginPendingLongpress(
+      { clientX: 0, clientY: 0 },
+      { kind: "none" },
+    );
+    if (pending.kind !== "pending-longpress") throw new Error("unreachable");
+    expect(longpressFallback(pending)).toBeNull();
+  });
+
+  it("synthesizes a move mode anchored at the original pointer-down so the first-px drift is not lost", () => {
+    const pending = beginPendingLongpress(
+      { clientX: 30, clientY: 40 },
+      { kind: "move", nodeId: "n1", nodeStartX: 100, nodeStartY: 200 },
+    );
+    if (pending.kind !== "pending-longpress") throw new Error("unreachable");
+    const fallback = longpressFallback(pending);
+    expect(fallback).toEqual({
+      kind: "move",
+      nodeId: "n1",
+      startClientX: 30,
+      startClientY: 40,
+      startX: 100,
+      startY: 200,
+    });
+  });
+
+  it("returns null if the fallback metadata is incomplete (defensive)", () => {
+    const mode: PointerMode = {
+      kind: "pending-longpress",
+      startClientX: 0,
+      startClientY: 0,
+      fallback: { kind: "move" },
+    };
+    if (mode.kind !== "pending-longpress") throw new Error("unreachable");
+    expect(longpressFallback(mode)).toBeNull();
+  });
+});
+
+describe("long-press constants", () => {
+  it("exposes sane defaults (documents the contract for the component)", () => {
+    expect(LONGPRESS_HOLD_MS).toBe(300);
+    expect(LONGPRESS_MOVE_THRESHOLD).toBe(4);
   });
 });

--- a/src/lib/canvas/pointerMode.ts
+++ b/src/lib/canvas/pointerMode.ts
@@ -25,6 +25,22 @@ import type { CanvasNode, CanvasSide } from "./types";
 export const MIN_NODE_WIDTH = 80;
 export const MIN_NODE_HEIGHT = 40;
 
+// Long-press-to-pan (#144): hold the left button for this many ms without
+// moving further than the threshold to flip into pan mode. Values live here
+// so the component + tests + any future configurability agree.
+export const LONGPRESS_HOLD_MS = 300;
+export const LONGPRESS_MOVE_THRESHOLD = 4;
+
+// Snapshot of where a node started so pending-longpress can fall through to
+// beginMove without losing the pointer-down origin (otherwise the first
+// `threshold` pixels of drag would be dropped).
+export interface PendingLongpressFallback {
+  kind: "none" | "move";
+  nodeId?: string;
+  nodeStartX?: number;
+  nodeStartY?: number;
+}
+
 export type PointerMode =
   | {
       kind: "pan";
@@ -49,7 +65,16 @@ export type PointerMode =
       startW: number;
       startH: number;
     }
-  | { kind: "edge"; fromNodeId: string; fromSide: CanvasSide };
+  | { kind: "edge"; fromNodeId: string; fromSide: CanvasSide }
+  | {
+      kind: "pending-longpress";
+      startClientX: number;
+      startClientY: number;
+      // What to do if the user moves past the threshold *before* the timer
+      // fires. `none` = nothing (background-down gesture had no fallback),
+      // `move` = begin a node move from the original start coords.
+      fallback: PendingLongpressFallback;
+    };
 
 export interface ClientPoint {
   clientX: number;
@@ -106,6 +131,71 @@ export function beginResize(node: CanvasNode, e: ClientPoint): PointerMode {
 
 export function beginEdge(nodeId: string, side: CanvasSide): PointerMode {
   return { kind: "edge", fromNodeId: nodeId, fromSide: side };
+}
+
+// ── long-press ─────────────────────────────────────────────────────────────
+
+export function beginPendingLongpress(
+  e: ClientPoint,
+  fallback: PendingLongpressFallback,
+): PointerMode {
+  return {
+    kind: "pending-longpress",
+    startClientX: e.clientX,
+    startClientY: e.clientY,
+    fallback,
+  };
+}
+
+export function pendingLongpressExceeded(
+  mode: Extract<PointerMode, { kind: "pending-longpress" }>,
+  e: ClientPoint,
+  threshold: number = LONGPRESS_MOVE_THRESHOLD,
+): boolean {
+  const dx = e.clientX - mode.startClientX;
+  const dy = e.clientY - mode.startClientY;
+  return dx * dx + dy * dy > threshold * threshold;
+}
+
+/** Timer fired without exceeding the movement threshold — enter pan mode. */
+export function longpressFire(
+  mode: Extract<PointerMode, { kind: "pending-longpress" }>,
+  cam: { x: number; y: number },
+): PointerMode {
+  return {
+    kind: "pan",
+    startClientX: mode.startClientX,
+    startClientY: mode.startClientY,
+    startCamX: cam.x,
+    startCamY: cam.y,
+  };
+}
+
+/**
+ * User moved past the threshold before the timer fired — fall through to
+ * the gesture that would have started if long-press hadn't been in the way.
+ * Returns `null` when there is nothing to fall through to (pending was on
+ * empty viewport).
+ */
+export function longpressFallback(
+  mode: Extract<PointerMode, { kind: "pending-longpress" }>,
+): PointerMode | null {
+  if (
+    mode.fallback.kind !== "move" ||
+    mode.fallback.nodeId === undefined ||
+    mode.fallback.nodeStartX === undefined ||
+    mode.fallback.nodeStartY === undefined
+  ) {
+    return null;
+  }
+  return {
+    kind: "move",
+    nodeId: mode.fallback.nodeId,
+    startClientX: mode.startClientX,
+    startClientY: mode.startClientY,
+    startX: mode.fallback.nodeStartX,
+    startY: mode.fallback.nodeStartY,
+  };
 }
 
 // ── move handlers (pure delta → position / size) ───────────────────────────


### PR DESCRIPTION
Closes #144.

## Summary
- Hold left mouse button ~300 ms within a 4 px radius (on the canvas background *or* on a node) to flip into pan mode — release ends the pan.
- Space-drag and middle-mouse-drag keep working unchanged.
- A node that gets a *quick* click still selects, a quick drag still moves it (the `pending-longpress` state falls through to `beginMove` when the pointer moves past the threshold before the timer fires).
- Resize handle + edge-port gestures are unaffected (they stopPropagation before the node's pointerdown runs).
- Cursor switches to `grabbing` globally while a long-press pan is active.

## Implementation
- `src/lib/canvas/pointerMode.ts`: new `pending-longpress` variant + four pure helpers (`beginPendingLongpress`, `pendingLongpressExceeded`, `longpressFire`, `longpressFallback`). Also exports `LONGPRESS_HOLD_MS=300` and `LONGPRESS_MOVE_THRESHOLD=4` so the component + tests agree on the contract.
- `src/components/Canvas/CanvasView.svelte`: `startLongpress` + `cancelLongpressTimer` schedule/clear the real timer; move handler drops out of pending when the threshold is exceeded; added `.vc-canvas-pan-active` class + `data-pointer-mode` attribute so tests can observe the state machine.
- Unit tests for all four pure helpers (Euclidean threshold, fallback anchoring, null-fallback on empty-viewport press, etc.).
- E2E spec: open a canvas, long-press + drag on a text card, assert camera moved and node coords unchanged on disk.

## Test plan
- [x] `pnpm test` — 575/575 pass.
- [x] `pnpm test:e2e` — 48/48 spec files pass.
- [x] Quick click on a node still selects it (covered by existing canvas specs — no regression).
- [x] Quick drag on a node still moves it (covered by existing "drags a text card and persists the new coordinates").
- [x] Long-press + drag pans and does not move the node (new E2E).