### PR TITLE
feat(sidebar): discoverable file-type creation (note / canvas / folder) (#145)

### DIFF
--- a/e2e/specs/graph-tab.spec.ts
+++ b/e2e/specs/graph-tab.spec.ts
@@ -75,8 +75,8 @@ describe("Graph view", () => {
     });
   });
 
-  it("opens the Graph via the sidebar 'Graph öffnen' button", async () => {
-    const btn = await browser.$('[aria-label="Graph öffnen"]');
+  it("opens the Graph via the sidebar 'Open graph' button", async () => {
+    const btn = await browser.$('[aria-label="Open graph"]');
     await btn.waitForDisplayed({ timeout: 3000 });
     await btn.click();
 

--- a/e2e/specs/new-note.spec.ts
+++ b/e2e/specs/new-note.spec.ts
@@ -47,21 +47,42 @@ describe("Create file / folder", () => {
     await waitForTreeName("Unbenannte Notiz 2.md");
   });
 
-  it("creates 'Untitled.md' via the sidebar + file button", async () => {
-    const btn = await browser.$('[aria-label="New file"]');
+  it("creates 'Untitled.md' via the sidebar + note button (primary click)", async () => {
+    // #145 renamed the header button from "New file" to "New note" and
+    // introduced a chevron dropdown alongside it. The primary click path
+    // (this test) must still create a note in one click — no extra UI.
+    const btn = await browser.$('[aria-label="New note"]');
     await btn.waitForDisplayed({ timeout: 3000 });
     await btn.click();
 
     await waitForTreeName("Untitled.md");
   });
 
-  it("auto-suffixes the sidebar + file button on repeat clicks", async () => {
-    const btn = await browser.$('[aria-label="New file"]');
+  it("auto-suffixes the sidebar + note button on repeat clicks", async () => {
+    const btn = await browser.$('[aria-label="New note"]');
     await btn.click();
     await waitForTreeName("Untitled 1.md");
 
     await btn.click();
     await waitForTreeName("Untitled 2.md");
+  });
+
+  it("exposes canvas creation from the header dropdown (#145)", async () => {
+    // Open the split-button chevron and pick "New canvas" — the canvas
+    // affordance used to be reachable only via right-click.
+    const chevron = await browser.$('[data-testid="sidebar-new-menu-toggle"]');
+    await chevron.waitForDisplayed({ timeout: 3000 });
+    await chevron.click();
+
+    const canvasItem = await browser.$('[data-testid="sidebar-new-menu-canvas"]');
+    await canvasItem.waitForDisplayed({ timeout: 3000 });
+    await canvasItem.click();
+
+    await waitForTreeName("Untitled.canvas");
+
+    // File opens in the canvas viewer, not the markdown editor — assert the
+    // viewer mounted so we know the tab used the canvas viewer branch.
+    await browser.$(".vc-canvas-viewport").waitForDisplayed({ timeout: 3000 });
   });
 
   it("creates 'New Folder' via the sidebar + folder button", async () => {

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -39,6 +39,7 @@
     dailyNoteFilename,
     splitFolderSegments,
   } from "../../lib/dailyNotes";
+  import { emptyCanvas, serializeCanvas } from "../../lib/canvas/parse";
 
   let { onSwitchVault }: { onSwitchVault: () => void } = $props();
 
@@ -261,6 +262,39 @@
       treeRefreshStore.requestRefresh();
     } catch {
       toastStore.push({ variant: "error", message: "Neue Notiz konnte nicht erstellt werden." });
+    }
+  }
+
+  // #145 — global "New canvas" / "New folder" commands. Palette + Cmd+Shift+C
+  // share this path; the sidebar header dropdown calls its own local handler
+  // because it needs to target the currently-selected folder, whereas the
+  // palette shortcut always drops the new item at the vault root (the palette
+  // is reachable even when no tree row is selected).
+  async function createNewCanvas() {
+    let vaultPath: string | null = null;
+    const unsub = vaultStore.subscribe((s) => { vaultPath = s.currentPath; });
+    unsub();
+    if (!vaultPath) return;
+    try {
+      const newPath = await createFile(vaultPath, "Untitled.canvas");
+      await writeFile(newPath, serializeCanvas(emptyCanvas()));
+      tabStore.openFileTab(newPath, "canvas");
+      treeRefreshStore.requestRefresh();
+    } catch {
+      toastStore.push({ variant: "error", message: "Neues Canvas konnte nicht erstellt werden." });
+    }
+  }
+
+  async function createNewFolder() {
+    let vaultPath: string | null = null;
+    const unsub = vaultStore.subscribe((s) => { vaultPath = s.currentPath; });
+    unsub();
+    if (!vaultPath) return;
+    try {
+      await createFolder(vaultPath, "");
+      treeRefreshStore.requestRefresh();
+    } catch {
+      toastStore.push({ variant: "error", message: "Neuer Ordner konnte nicht erstellt werden." });
     }
   }
 
@@ -509,6 +543,8 @@
         if (activeId) tabStore.closeTab(activeId);
       },
       createNewNote: () => { void createNewNote(); },
+      createNewCanvas: () => { void createNewCanvas(); },
+      createNewFolder: () => { void createNewFolder(); },
       openGraph: () => { tabStore.openGraphTab(); },
       openCommandPalette: () => { commandPaletteOpen = true; },
       toggleBookmark: () => { void toggleActiveBookmark(); },

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { FilePlus, FolderPlus, Network } from "lucide-svelte";
-  import { listDirectory, createFile, createFolder } from "../../ipc/commands";
+  import { FilePlus, FolderPlus, Network, ChevronDown, FileText, LayoutDashboard } from "lucide-svelte";
+  import { listDirectory, createFile, createFolder, writeFile } from "../../ipc/commands";
+  import { serializeCanvas, emptyCanvas } from "../../lib/canvas/parse";
+  import { commandRegistry } from "../../lib/commands/registry";
+  import { CMD_IDS } from "../../lib/commands/defaultCommands";
   // BUG-05.1: SortMenu was descoped per UAT — keep treeState for FILE-07
   // (expand persistence) but default sortBy stays "name" without a UI toggle.
   import {
@@ -51,6 +54,22 @@
   let bulkActive = $state(false);
   let bulkCount = $state(0);
   let treeState = $state<TreeState>({ ...DEFAULT_TREE_STATE });
+
+  // #145 — header "+ New ▾" split/dropdown open state. Primary click of the
+  // button creates a note; clicking the chevron opens this menu so canvas
+  // creation is visible without right-clicking a folder first.
+  let newMenuOpen = $state(false);
+  const newNoteHotkey = $derived(commandRegistry.getEffectiveHotkey(CMD_IDS.NEW_NOTE));
+  const newCanvasHotkey = $derived(commandRegistry.getEffectiveHotkey(CMD_IDS.NEW_CANVAS));
+
+  function formatHotkey(h: { meta: boolean; shift?: boolean; key: string } | undefined): string {
+    if (!h) return "";
+    const isMac = typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
+    const meta = h.meta ? (isMac ? "⌘" : "Ctrl+") : "";
+    const shift = h.shift ? (isMac ? "⇧" : "Shift+") : "";
+    const key = h.key.length === 1 ? h.key.toUpperCase() : h.key;
+    return isMac ? `${meta}${shift}${key}` : `${meta}${shift}${key}`;
+  }
 
   // Watcher unlisten handles — cleaned up on destroy
   let unlistenFileChange: UnlistenFn | null = null;
@@ -245,12 +264,33 @@
   });
 
   async function handleNewFile() {
+    newMenuOpen = false;
     const vaultPath = $vaultStore.currentPath;
     if (!vaultPath) return;
     const targetFolder = getSelectedFolder() ?? vaultPath;
     try {
       await createFile(targetFolder, "");
       await loadRoot();
+    } catch (e) {
+      const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
+  // #145 — header-level canvas creation. Targets the selected folder so
+  // dropdown + context-menu behavior stay symmetric. Seeds the file with an
+  // empty canvas doc (matches TreeNode.handleNewCanvasHere) so Obsidian
+  // accepts it on first open.
+  async function handleNewCanvas() {
+    newMenuOpen = false;
+    const vaultPath = $vaultStore.currentPath;
+    if (!vaultPath) return;
+    const targetFolder = getSelectedFolder() ?? vaultPath;
+    try {
+      const newPath = await createFile(targetFolder, "Untitled.canvas");
+      await writeFile(newPath, serializeCanvas(emptyCanvas()));
+      await loadRoot();
+      tabStore.openFileTab(newPath, "canvas");
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
@@ -337,14 +377,65 @@
         {vaultName}
       </span>
       <div class="vc-sidebar-actions" style="position: relative;">
-        <button
-          class="vc-sidebar-action-btn"
-          onclick={handleNewFile}
-          aria-label="New file"
-          title="New file"
-        >
-          <FilePlus size={16} strokeWidth={1.5} />
-        </button>
+        <!-- #145: split/dropdown "+ New ▾". Primary click = new note (parity
+             with the previous lone FilePlus button); chevron toggles a menu
+             that exposes canvas creation as a first-class action. -->
+        <div class="vc-new-split" data-testid="sidebar-new-split">
+          <button
+            class="vc-sidebar-action-btn vc-new-split-primary"
+            onclick={handleNewFile}
+            aria-label="New note"
+            title={`New note${newNoteHotkey ? ` (${formatHotkey(newNoteHotkey)})` : ""}`}
+            data-testid="sidebar-new-note"
+          >
+            <FilePlus size={16} strokeWidth={1.5} />
+          </button>
+          <button
+            class="vc-sidebar-action-btn vc-new-split-chevron"
+            onclick={() => { newMenuOpen = !newMenuOpen; }}
+            aria-label="More file types"
+            aria-haspopup="menu"
+            aria-expanded={newMenuOpen}
+            title="More file types"
+            data-testid="sidebar-new-menu-toggle"
+          >
+            <ChevronDown size={12} strokeWidth={1.5} />
+          </button>
+          {#if newMenuOpen}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <div
+              class="vc-new-overlay"
+              onclick={() => { newMenuOpen = false; }}
+              role="presentation"
+            ></div>
+            <div class="vc-new-menu" role="menu" data-testid="sidebar-new-menu">
+              <button
+                class="vc-new-menu-item"
+                role="menuitem"
+                onclick={handleNewFile}
+                data-testid="sidebar-new-menu-note"
+              >
+                <FileText size={14} strokeWidth={1.5} />
+                <span class="vc-new-menu-label">New note</span>
+                {#if newNoteHotkey}
+                  <span class="vc-new-menu-hotkey">{formatHotkey(newNoteHotkey)}</span>
+                {/if}
+              </button>
+              <button
+                class="vc-new-menu-item"
+                role="menuitem"
+                onclick={handleNewCanvas}
+                data-testid="sidebar-new-menu-canvas"
+              >
+                <LayoutDashboard size={14} strokeWidth={1.5} />
+                <span class="vc-new-menu-label">New canvas</span>
+                {#if newCanvasHotkey}
+                  <span class="vc-new-menu-hotkey">{formatHotkey(newCanvasHotkey)}</span>
+                {/if}
+              </button>
+            </div>
+          {/if}
+        </div>
         <button
           class="vc-sidebar-action-btn"
           onclick={handleNewFolder}
@@ -356,8 +447,8 @@
         <button
           class="vc-sidebar-action-btn"
           onclick={() => tabStore.openGraphTab()}
-          aria-label="Graph öffnen"
-          title="Graph öffnen (Cmd/Ctrl+Shift+G)"
+          aria-label="Open graph"
+          title="Open graph (Cmd/Ctrl+Shift+G)"
         >
           <Network size={16} strokeWidth={1.5} />
         </button>
@@ -455,6 +546,81 @@
   .vc-sidebar-action-btn:hover {
     background: var(--color-accent-bg);
     color: var(--color-accent);
+  }
+
+  /* #145 — split/dropdown "+ New ▾". The two buttons share a hover state so
+     users read the group as one control; the chevron is narrower to signal
+     it's a secondary target. */
+  .vc-new-split {
+    display: inline-flex;
+    align-items: stretch;
+    border-radius: 4px;
+  }
+
+  .vc-new-split-primary {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    padding-right: 4px;
+  }
+
+  .vc-new-split-chevron {
+    width: 18px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding: 0;
+    margin-left: -2px;
+  }
+
+  .vc-new-split:hover .vc-sidebar-action-btn {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+
+  .vc-new-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 99;
+  }
+
+  .vc-new-menu {
+    position: absolute;
+    top: 36px;
+    right: 0;
+    z-index: 100;
+    min-width: 200px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+    padding: 4px 0;
+  }
+
+  .vc-new-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 6px 12px;
+    font-size: 14px;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  .vc-new-menu-item:hover {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-new-menu-label {
+    flex: 1;
+  }
+
+  .vc-new-menu-hotkey {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    font-family: var(--font-mono, ui-monospace, monospace);
   }
 
   /* Bulk-change progress strip — replaces vault name + action buttons */

--- a/src/components/Sidebar/__tests__/SidebarNewMenu.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarNewMenu.test.ts
@@ -1,0 +1,110 @@
+// #145 — unit tests for the sidebar header "+ New ▾" split/dropdown.
+// The split button exposes canvas creation without right-clicking a folder
+// and keeps the primary click fast-path for new notes intact.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+  createFile: vi.fn().mockResolvedValue("/tmp/test-vault/Untitled.canvas"),
+  createFolder: vi.fn().mockResolvedValue("/tmp/test-vault/new-folder"),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { vaultStore } from "../../../store/vaultStore";
+import { tabStore } from "../../../store/tabStore";
+import Sidebar from "../Sidebar.svelte";
+import * as ipcCommands from "../../../ipc/commands";
+
+const VAULT = "/tmp/test-vault";
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+  };
+}
+
+describe("Sidebar header New split/dropdown (#145)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vaultStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+  });
+
+  it("primary click of the new button creates a note without opening the menu", async () => {
+    const { container } = render(Sidebar, { props: makeProps() });
+    await tick();
+    const primary = container.querySelector('[data-testid="sidebar-new-note"]') as HTMLButtonElement;
+    expect(primary).toBeTruthy();
+
+    await fireEvent.click(primary);
+    await tick();
+
+    // Menu should not appear when primary is clicked — fast path.
+    expect(container.querySelector('[data-testid="sidebar-new-menu"]')).toBeNull();
+    expect(ipcCommands.createFile).toHaveBeenCalledWith(VAULT, "");
+  });
+
+  it("chevron toggle reveals New note and New canvas entries", async () => {
+    const { container, getByText } = render(Sidebar, { props: makeProps() });
+    await tick();
+    const chevron = container.querySelector('[data-testid="sidebar-new-menu-toggle"]') as HTMLButtonElement;
+
+    await fireEvent.click(chevron);
+    await tick();
+
+    const menu = container.querySelector('[data-testid="sidebar-new-menu"]');
+    expect(menu).toBeTruthy();
+    expect(getByText("New note")).toBeTruthy();
+    expect(getByText("New canvas")).toBeTruthy();
+  });
+
+  it("New canvas item creates a seeded .canvas file and opens it as a canvas tab", async () => {
+    const openFileTabSpy = vi.spyOn(tabStore, "openFileTab");
+    const { container } = render(Sidebar, { props: makeProps() });
+    await tick();
+
+    const chevron = container.querySelector('[data-testid="sidebar-new-menu-toggle"]') as HTMLButtonElement;
+    await fireEvent.click(chevron);
+    await tick();
+
+    const canvasItem = container.querySelector('[data-testid="sidebar-new-menu-canvas"]') as HTMLButtonElement;
+    await fireEvent.click(canvasItem);
+    // handleNewCanvas awaits createFile → writeFile → loadRoot before it
+    // calls openFileTab; drain enough microtasks to cover the chain.
+    for (let i = 0; i < 10; i += 1) await tick();
+
+    expect(ipcCommands.createFile).toHaveBeenCalledWith(VAULT, "Untitled.canvas");
+    // Must seed with empty canvas JSON so Obsidian accepts the file.
+    expect(ipcCommands.writeFile).toHaveBeenCalled();
+    const [, seedContent] = (ipcCommands.writeFile as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    expect(typeof seedContent).toBe("string");
+    expect(JSON.parse(seedContent as string)).toEqual({ nodes: [], edges: [] });
+
+    expect(openFileTabSpy).toHaveBeenCalledWith("/tmp/test-vault/Untitled.canvas", "canvas");
+
+    // Menu closes after selection.
+    expect(container.querySelector('[data-testid="sidebar-new-menu"]')).toBeNull();
+  });
+
+  it("keeps FolderPlus visible as its own button (ticket's lean-toward option)", async () => {
+    const { container } = render(Sidebar, { props: makeProps() });
+    await tick();
+    const folderBtn = container.querySelector('button[aria-label="New folder"]');
+    expect(folderBtn).toBeTruthy();
+  });
+});

--- a/src/lib/commands/__tests__/defaultCommands.test.ts
+++ b/src/lib/commands/__tests__/defaultCommands.test.ts
@@ -30,6 +30,8 @@ function makeCtx(overrides: Partial<DefaultCommandContext> = {}): DefaultCommand
     cycleTabPrev: noop,
     closeActiveTab: noop,
     createNewNote: noop,
+    createNewCanvas: noop,
+    createNewFolder: noop,
     openGraph: noop,
     openCommandPalette: noop,
     toggleBookmark: noop,
@@ -103,6 +105,49 @@ describe("defaultCommands — vault:export-html / vault:export-pdf (#61)", () =>
     commandRegistry.execute(CMD_IDS.EXPORT_PDF);
     expect(exportHtml).toHaveBeenCalledOnce();
     expect(exportPdf).toHaveBeenCalledOnce();
+  });
+});
+
+describe("defaultCommands — file creation (#145)", () => {
+  beforeEach(() => {
+    setupLocalStorage();
+    commandRegistry._reset();
+  });
+
+  it("registers new-note / new-canvas / new-folder with English palette labels", () => {
+    const note = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.NEW_NOTE);
+    const canvas = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.NEW_CANVAS);
+    const folder = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.NEW_FOLDER);
+    expect(note?.name).toBe("File: New note");
+    expect(canvas?.name).toBe("File: New canvas");
+    expect(folder?.name).toBe("File: New folder");
+  });
+
+  it("binds Cmd+Shift+C to new-canvas without clashing with plain Cmd+C", () => {
+    registerDefaultCommands(makeCtx());
+    const shiftEv = new KeyboardEvent("keydown", { key: "c", metaKey: true, shiftKey: true });
+    expect(commandRegistry.findByHotkey(shiftEv)?.id).toBe(CMD_IDS.NEW_CANVAS);
+    const plainEv = new KeyboardEvent("keydown", { key: "c", metaKey: true });
+    // Plain Cmd+C is editor copy — no default command owns it.
+    expect(commandRegistry.findByHotkey(plainEv)).toBeNull();
+  });
+
+  it("new-folder has no default hotkey (palette-only entry)", () => {
+    const folder = DEFAULT_COMMAND_SPECS.find((s) => s.id === CMD_IDS.NEW_FOLDER);
+    expect(folder?.hotkey).toBeUndefined();
+  });
+
+  it("registerDefaultCommands wires all three create callbacks", () => {
+    const createNewNote = vi.fn();
+    const createNewCanvas = vi.fn();
+    const createNewFolder = vi.fn();
+    registerDefaultCommands(makeCtx({ createNewNote, createNewCanvas, createNewFolder }));
+    commandRegistry.execute(CMD_IDS.NEW_NOTE);
+    commandRegistry.execute(CMD_IDS.NEW_CANVAS);
+    commandRegistry.execute(CMD_IDS.NEW_FOLDER);
+    expect(createNewNote).toHaveBeenCalledOnce();
+    expect(createNewCanvas).toHaveBeenCalledOnce();
+    expect(createNewFolder).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -12,6 +12,8 @@ export interface DefaultCommandContext {
   cycleTabPrev: () => void;
   closeActiveTab: () => void;
   createNewNote: () => void;
+  createNewCanvas: () => void;
+  createNewFolder: () => void;
   openGraph: () => void;
   openCommandPalette: () => void;
   toggleBookmark: () => void;
@@ -25,6 +27,11 @@ export interface DefaultCommandContext {
 /** Id constants — consumed by tests and anyone dispatching by id. */
 export const CMD_IDS = {
   NEW_NOTE: "vault:new-note",
+  // #145 — canvas + folder creation commands exposed in the palette so they
+  // match the sidebar header affordance. Shares the same underlying create
+  // path as the sidebar dropdown / context menu.
+  NEW_CANVAS: "vault:new-canvas",
+  NEW_FOLDER: "vault:new-folder",
   QUICK_SWITCHER: "app:quick-switcher",
   SEARCH: "app:fulltext-search",
   SEARCH_ALT: "app:fulltext-search-alt",
@@ -51,7 +58,9 @@ export interface DefaultCommandSpec {
 
 /** Static metadata — id, label, hotkey. Callback is wired in registerDefaultCommands. */
 export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
-  { id: CMD_IDS.NEW_NOTE, name: "Neue Notiz", hotkey: { meta: true, key: "n" } },
+  { id: CMD_IDS.NEW_NOTE, name: "File: New note", hotkey: { meta: true, key: "n" } },
+  { id: CMD_IDS.NEW_CANVAS, name: "File: New canvas", hotkey: { meta: true, shift: true, key: "c" } },
+  { id: CMD_IDS.NEW_FOLDER, name: "File: New folder" },
   { id: CMD_IDS.QUICK_SWITCHER, name: "Schnellwechsler", hotkey: { meta: true, key: "o" } },
   { id: CMD_IDS.SEARCH, name: "Volltext-Suche", hotkey: { meta: true, shift: true, key: "f" } },
   { id: CMD_IDS.SEARCH_ALT, name: "Volltext-Suche (Alternative)", hotkey: { meta: true, key: "f" } },
@@ -78,6 +87,8 @@ export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
 export function registerDefaultCommands(ctx: DefaultCommandContext): void {
   const byId: Record<string, () => void> = {
     [CMD_IDS.NEW_NOTE]: ctx.createNewNote,
+    [CMD_IDS.NEW_CANVAS]: ctx.createNewCanvas,
+    [CMD_IDS.NEW_FOLDER]: ctx.createNewFolder,
     [CMD_IDS.QUICK_SWITCHER]: ctx.openQuickSwitcher,
     [CMD_IDS.SEARCH]: ctx.activateSearchTab,
     [CMD_IDS.SEARCH_ALT]: ctx.activateSearchTab,


### PR DESCRIPTION
## Summary

Closes #145. The sidebar header's `+` button becomes a split/dropdown:

- Primary click → New note (one click, identical to today's FilePlus).
- Chevron → opens a menu with **New note** and **New canvas** (hotkeys shown inline).
- **New folder** keeps its own icon per the ticket's lean-toward alternative.
- Command palette gains `File: New note`, `File: New canvas`, `File: New folder`.
- Global hotkey `Cmd/Ctrl+Shift+C` creates a canvas at the vault root.

Seeds newly-created canvas files with the minimal `{ nodes: [], edges: [] }` doc (same as `TreeNode.handleNewCanvasHere`) so Obsidian accepts them on first open.

## Behind the scenes

- Header-level canvas creation targets the selected folder; palette/hotkey targets the vault root (palette is reachable with nothing selected).
- Command-palette labels for file-creation are now English + consistent (`File: New note / canvas / folder`) per the AC.
- `vault:new-canvas` picks up `Cmd/Ctrl+Shift+C`; `vault:new-folder` has no default hotkey (palette-only).
- Existing right-click context menu (`New file here / New canvas here / New folder here`) untouched — muscle memory preserved.

## Tests

**Unit** (`vitest run` → 587/587):
- `SidebarNewMenu.test.ts`: primary click creates a note without opening the menu; chevron exposes note + canvas; canvas item creates + seeds + opens in canvas viewer; FolderPlus stays visible.
- `defaultCommands.test.ts`: English labels, `Cmd+Shift+C` binding does not clash with plain `Cmd+C`, folder command has no hotkey, all three create callbacks wire correctly.

**E2E** (`wdio` → 48/48 specs):
- `new-note.spec.ts`: primary "New note" button still works; new dropdown → New canvas → `Untitled.canvas` appears + canvas viewer mounts.

## Test plan

- [ ] Click `+` primary → note appears + opens (no menu flashes)
- [ ] Click chevron → menu shows `New note (⌘N)` + `New canvas (⌘⇧C)`
- [ ] `New canvas` → `Untitled.canvas` appears in tree + opens in canvas viewer
- [ ] `Cmd/Ctrl+Shift+C` from anywhere → canvas created at vault root + opens
- [ ] Command palette `file` → three `File: New …` entries searchable
- [ ] Right-click folder → `New canvas here` still works (regression)
- [ ] FolderPlus icon still visible and creates a folder

## Refs

- Parent canvas epic: #71
- Canvas Phase 1 (context-menu entry point): #124