### PR TITLE
feat(editor): accept sidebar file drops for split view (#146)

### DIFF
--- a/e2e/specs/editor-sidebar-drop.spec.ts
+++ b/e2e/specs/editor-sidebar-drop.spec.ts
@@ -1,0 +1,122 @@
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+/**
+ * #146 — dragging a note from the sidebar into an editor pane must open it
+ * in a new split. The existing `drag-drop.spec.ts` is skipped because the
+ * tree's DnD contract round-trips `dataTransfer` through the browser-generated
+ * event (setData in `ondragstart` → getData in `ondrop`), which WebKit makes
+ * read-only for synthetic events. The editor drop handler here reads the
+ * payload from the *same* DataTransfer we build in the test, so a direct
+ * dispatch works and this spec can run.
+ */
+describe("Editor: sidebar file drop (#146)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function findTreeNode(name: string): Promise<WebdriverIO.Element> {
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) return n;
+    }
+    throw new Error(`"${name}" not in tree`);
+  }
+
+  it("ignores a folder drag (no second pane created)", async () => {
+    const welcome = await findTreeNode("Welcome.md");
+    await welcome.click();
+    await browser.pause(200);
+
+    const folderNode = await findTreeNode("subfolder");
+    const pane = await browser.$(".vc-editor-pane");
+    await pane.waitForDisplayed({ timeout: 3000 });
+
+    await browser.execute(
+      (src: HTMLElement, tgt: HTMLElement, payload: string) => {
+        const rect = tgt.getBoundingClientRect();
+        const edgeX = Math.round(rect.right - 10);
+        const midY = Math.round(rect.top + rect.height / 2);
+        const dt = new DataTransfer();
+        dt.setData("text/vaultcore-folder", payload);
+        dt.effectAllowed = "move";
+        const fire = (type: "dragover" | "drop", el: HTMLElement, x: number, y: number) => {
+          const ev = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+          Object.defineProperty(ev, "dataTransfer", { value: dt, writable: false });
+          Object.defineProperty(ev, "clientX", { value: x });
+          Object.defineProperty(ev, "clientY", { value: y });
+          el.dispatchEvent(ev);
+        };
+        fire("dragover", tgt, edgeX, midY);
+        fire("drop", tgt, edgeX, midY);
+      },
+      folderNode,
+      pane,
+      `${vault.path}/subfolder`,
+    );
+
+    await browser.pause(400);
+    const panes = await browser.$$(".vc-editor-pane");
+    expect(panes.length).toBe(1);
+  });
+
+  it("drops a .md note onto the right edge and creates a right-pane split", async () => {
+    // Leave the seed tab (Welcome.md) open from the previous test.
+    const sourceNode = await findTreeNode("Ideas.md");
+    const pane = await browser.$(".vc-editor-pane");
+    await pane.waitForDisplayed({ timeout: 3000 });
+
+    await browser.execute(
+      (src: HTMLElement, tgt: HTMLElement, payload: string) => {
+        const rect = tgt.getBoundingClientRect();
+        const edgeX = Math.round(rect.right - 10);
+        const midY = Math.round(rect.top + rect.height / 2);
+
+        const dt = new DataTransfer();
+        dt.setData("text/vaultcore-file", payload);
+        dt.effectAllowed = "move";
+
+        const fire = (type: "dragstart" | "dragover" | "drop" | "dragend", el: HTMLElement, x: number, y: number) => {
+          const ev = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+          Object.defineProperty(ev, "dataTransfer", { value: dt, writable: false });
+          Object.defineProperty(ev, "clientX", { value: x });
+          Object.defineProperty(ev, "clientY", { value: y });
+          el.dispatchEvent(ev);
+        };
+
+        fire("dragstart", src, 0, 0);
+        fire("dragover", tgt, edgeX, midY);
+        fire("drop", tgt, edgeX, midY);
+        fire("dragend", src, edgeX, midY);
+      },
+      sourceNode,
+      pane,
+      `${vault.path}/Ideas.md`,
+    );
+
+    await browser.waitUntil(
+      async () => {
+        const panes = await browser.$$(".vc-editor-pane");
+        return panes.length === 2;
+      },
+      { timeout: 3000, timeoutMsg: "Split view was not created after the drop" },
+    );
+
+    const panes = await browser.$$(".vc-editor-pane");
+    // Ideas.md should be the active tab of the right-hand pane.
+    const rightActive = await panes[1]!.$(".vc-tab--active .vc-tab-label");
+    await browser.waitUntil(
+      async () => (await rightActive.getProperty("textContent")) === "Ideas.md",
+      { timeout: 3000, timeoutMsg: "Ideas.md did not become the active tab in the right pane" },
+    );
+  });
+
+});

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -15,6 +15,7 @@
   import { editorStore } from "../../store/editorStore";
   import { activeViewStore } from "../../store/activeViewStore";
   import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
+  import { openFileAsTab } from "../../lib/openFileAsTab";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
   import { searchStore } from "../../store/searchStore";
@@ -715,10 +716,16 @@
     }
   }
 
-  // Drag-to-split detection
+  // Drag-to-split detection. #146: accept sidebar file drags in addition to
+  // the existing tab-reorder flow. Folder drags (text/vaultcore-folder) are
+  // ignored — folders stay sidebar-only.
+  function isAcceptedDrag(types: readonly string[]): boolean {
+    return types.includes("text/vaultcore-tab") || types.includes("text/vaultcore-file");
+  }
+
   function handleDragover(e: DragEvent) {
     if (!e.dataTransfer) return;
-    if (!e.dataTransfer.types.includes("text/vaultcore-tab")) return;
+    if (!isAcceptedDrag(e.dataTransfer.types)) return;
     e.preventDefault();
     if (!paneEl) return;
 
@@ -739,24 +746,43 @@
     splitIndicatorSide = null;
   }
 
-  function handleDrop(e: DragEvent) {
+  async function handleDrop(e: DragEvent) {
     if (!e.dataTransfer) return;
-    const draggedTabId = e.dataTransfer.getData("text/vaultcore-tab");
-    if (!draggedTabId || !splitIndicatorSide) {
+    if (!isAcceptedDrag(e.dataTransfer.types)) {
       splitIndicatorSide = null;
       return;
     }
+    const targetPane = splitIndicatorSide;
+    splitIndicatorSide = null;
+    if (!targetPane) return;
     e.preventDefault();
 
-    if (!e.dataTransfer.types.includes("text/vaultcore-tab")) {
-      splitIndicatorSide = null;
+    const draggedTabId = e.dataTransfer.getData("text/vaultcore-tab");
+    if (draggedTabId) {
+      tabStore.activateTab(draggedTabId);
+      tabStore.moveToPane(targetPane);
       return;
     }
 
-    const targetPane = splitIndicatorSide;
-    tabStore.activateTab(draggedTabId);
-    tabStore.moveToPane(targetPane);
-    splitIndicatorSide = null;
+    const filePath = e.dataTransfer.getData("text/vaultcore-file");
+    if (!filePath) return;
+
+    // Reuse an existing tab for this path (dedupe) — otherwise open a new one
+    // through the central viewer-routing dispatcher so canvas/image/text
+    // files pick the correct viewer, same as a sidebar click would.
+    const existing = allTabs.find((t) => t.filePath === filePath);
+    if (existing) {
+      tabStore.activateTab(existing.id);
+      tabStore.moveToPane(targetPane);
+      return;
+    }
+    try {
+      const newId = await openFileAsTab(filePath);
+      if (newId) tabStore.moveToPane(targetPane);
+    } catch {
+      // openFileAsTab already routes known errors to toasts via its callers;
+      // nothing useful to surface here.
+    }
   }
 
   onMount(async () => {

--- a/src/components/Editor/__tests__/EditorPaneSidebarDrop.test.ts
+++ b/src/components/Editor/__tests__/EditorPaneSidebarDrop.test.ts
@@ -1,0 +1,246 @@
+/**
+ * #146 — EditorPane accepts sidebar file drops for split-view.
+ *
+ * Covers the two drag branches the pane now distinguishes:
+ *  - `text/vaultcore-tab` → existing tab-reorder into another pane (unchanged).
+ *  - `text/vaultcore-file` → open the dropped file (reusing an existing tab
+ *     if one exists) and move it into the target pane.
+ * Folder drags carry `text/vaultcore-folder` and must be ignored.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const { readFile } = vi.hoisted(() => ({ readFile: vi.fn() }));
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile,
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  createFile: vi.fn().mockResolvedValue(""),
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  // @ts-ignore svelte-check can't resolve this via the shim
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+vi.mock("../../Graph/graphRender", () => ({
+  mountGraph: vi.fn(),
+  updateGraph: vi.fn(),
+  destroyGraph: vi.fn(),
+  DEFAULT_FORCE_SETTINGS: {},
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import { get } from "svelte/store";
+import EditorPane from "../EditorPane.svelte";
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+/**
+ * Build a DragEvent whose dataTransfer mirrors a sidebar drag: `types`
+ * reports the MIME keys and `getData(mime)` returns the encoded path.
+ * jsdom's DataTransfer is read-only after construction, so we fake it.
+ */
+function makeDragEvent(
+  type: "dragover" | "drop",
+  entries: Array<[string, string]>,
+  opts: { clientX: number; clientY?: number },
+): DragEvent {
+  const map = new Map(entries);
+  const dt = {
+    types: Array.from(map.keys()),
+    getData: (k: string) => map.get(k) ?? "",
+    setData: vi.fn(),
+    effectAllowed: "move",
+    dropEffect: "move",
+  } as unknown as DataTransfer;
+  const ev = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+  Object.defineProperty(ev, "dataTransfer", { value: dt, writable: false });
+  Object.defineProperty(ev, "clientX", { value: opts.clientX });
+  Object.defineProperty(ev, "clientY", { value: opts.clientY ?? 100 });
+  return ev;
+}
+
+function fakeBoundingRect(el: HTMLElement, width = 800, height = 600): void {
+  el.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    right: width,
+    bottom: height,
+    width,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+describe("EditorPane sidebar-file drop (#146)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+    readFile.mockReset().mockResolvedValue("seed contents");
+  });
+
+  it("dropping a .md path on the right edge opens the file in a right-pane split", async () => {
+    tabStore.openTab("/vault/seed.md");
+    await flushAsync();
+
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const pane = container.querySelector<HTMLDivElement>(".vc-editor-pane")!;
+    fakeBoundingRect(pane);
+
+    // Hover near the right edge so splitIndicatorSide = "right".
+    pane.dispatchEvent(
+      makeDragEvent("dragover", [["text/vaultcore-file", "/vault/note.md"]], { clientX: 790 }),
+    );
+    await tick();
+
+    pane.dispatchEvent(
+      makeDragEvent("drop", [["text/vaultcore-file", "/vault/note.md"]], { clientX: 790 }),
+    );
+    await flushAsync();
+
+    const state = get(tabStore);
+    const noteTab = state.tabs.find((t) => t.filePath === "/vault/note.md");
+    expect(noteTab).toBeTruthy();
+    expect(state.splitState.right).toContain(noteTab!.id);
+    expect(state.splitState.left).not.toContain(noteTab!.id);
+  });
+
+  it("dropping a file whose tab already exists reuses it instead of creating a duplicate", async () => {
+    const existingId = tabStore.openTab("/vault/existing.md");
+    tabStore.openTab("/vault/other.md"); // so the left pane has > 1 tab after moveToPane
+    await flushAsync();
+
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const pane = container.querySelector<HTMLDivElement>(".vc-editor-pane")!;
+    fakeBoundingRect(pane);
+
+    pane.dispatchEvent(
+      makeDragEvent("dragover", [["text/vaultcore-file", "/vault/existing.md"]], { clientX: 790 }),
+    );
+    await tick();
+    pane.dispatchEvent(
+      makeDragEvent("drop", [["text/vaultcore-file", "/vault/existing.md"]], { clientX: 790 }),
+    );
+    await flushAsync();
+
+    const state = get(tabStore);
+    const tabsForPath = state.tabs.filter((t) => t.filePath === "/vault/existing.md");
+    expect(tabsForPath).toHaveLength(1);
+    expect(tabsForPath[0]!.id).toBe(existingId);
+    expect(state.splitState.right).toContain(existingId);
+  });
+
+  it("dropping a folder drag (text/vaultcore-folder) is a no-op", async () => {
+    tabStore.openTab("/vault/seed.md");
+    await flushAsync();
+    const stateBefore = get(tabStore);
+
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const pane = container.querySelector<HTMLDivElement>(".vc-editor-pane")!;
+    fakeBoundingRect(pane);
+
+    // dragover should not set an indicator; drop should not open anything.
+    pane.dispatchEvent(
+      makeDragEvent("dragover", [["text/vaultcore-folder", "/vault/sub"]], { clientX: 790 }),
+    );
+    await tick();
+    pane.dispatchEvent(
+      makeDragEvent("drop", [["text/vaultcore-folder", "/vault/sub"]], { clientX: 790 }),
+    );
+    await flushAsync();
+
+    const stateAfter = get(tabStore);
+    expect(stateAfter.tabs).toHaveLength(stateBefore.tabs.length);
+    expect(stateAfter.splitState.right).toHaveLength(0);
+  });
+
+  it("dropping in the middle of the pane (no edge) does nothing", async () => {
+    tabStore.openTab("/vault/seed.md");
+    await flushAsync();
+
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const pane = container.querySelector<HTMLDivElement>(".vc-editor-pane")!;
+    fakeBoundingRect(pane);
+
+    pane.dispatchEvent(
+      makeDragEvent("dragover", [["text/vaultcore-file", "/vault/note.md"]], { clientX: 400 }),
+    );
+    await tick();
+    pane.dispatchEvent(
+      makeDragEvent("drop", [["text/vaultcore-file", "/vault/note.md"]], { clientX: 400 }),
+    );
+    await flushAsync();
+
+    const state = get(tabStore);
+    expect(state.tabs.find((t) => t.filePath === "/vault/note.md")).toBeUndefined();
+    expect(state.splitState.right).toHaveLength(0);
+  });
+
+  it("tab-drag payload still moves the dragged tab to the target pane (regression)", async () => {
+    const id = tabStore.openTab("/vault/a.md");
+    tabStore.openTab("/vault/b.md"); // keep left non-empty so split is created, not collapsed
+    await flushAsync();
+
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const pane = container.querySelector<HTMLDivElement>(".vc-editor-pane")!;
+    fakeBoundingRect(pane);
+
+    pane.dispatchEvent(
+      makeDragEvent("dragover", [["text/vaultcore-tab", id]], { clientX: 790 }),
+    );
+    await tick();
+    pane.dispatchEvent(
+      makeDragEvent("drop", [["text/vaultcore-tab", id]], { clientX: 790 }),
+    );
+    await flushAsync();
+
+    const state = get(tabStore);
+    expect(state.splitState.right).toContain(id);
+    expect(state.splitState.left).not.toContain(id);
+  });
+});

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -409,9 +409,12 @@
   }
 
   // Drag-and-drop (FILE-05 / D-17)
+  // #146: files use `text/vaultcore-file`, directories use `text/vaultcore-folder`
+  // so the editor pane can accept file drops for split-view while rejecting folders.
   function handleDragStart(e: DragEvent) {
     if (!e.dataTransfer) return;
-    e.dataTransfer.setData("text/vaultcore-file", entry.path);
+    const mime = entry.is_dir ? "text/vaultcore-folder" : "text/vaultcore-file";
+    e.dataTransfer.setData(mime, entry.path);
     e.dataTransfer.effectAllowed = "move";
     isDragSource = true;
   }
@@ -420,9 +423,13 @@
     isDragSource = false;
   }
 
+  function isSidebarDrag(types: readonly string[]): boolean {
+    return types.includes("text/vaultcore-file") || types.includes("text/vaultcore-folder");
+  }
+
   function handleDragOver(e: DragEvent) {
     if (!entry.is_dir) return;
-    if (!e.dataTransfer?.types.includes("text/vaultcore-file")) return;
+    if (!e.dataTransfer || !isSidebarDrag(e.dataTransfer.types)) return;
     e.preventDefault();
     isDragTarget = true;
   }
@@ -434,9 +441,11 @@
   async function handleDrop(e: DragEvent) {
     isDragTarget = false;
     if (!entry.is_dir) return;
-    if (!e.dataTransfer?.types.includes("text/vaultcore-file")) return;
+    if (!e.dataTransfer || !isSidebarDrag(e.dataTransfer.types)) return;
     e.preventDefault();
-    const sourcePath = e.dataTransfer.getData("text/vaultcore-file");
+    const sourcePath =
+      e.dataTransfer.getData("text/vaultcore-file") ||
+      e.dataTransfer.getData("text/vaultcore-folder");
     if (!sourcePath || sourcePath === entry.path) return;
 
     // D-11: check backlinks before move and prompt cascade confirmation


### PR DESCRIPTION
## Summary
- Editor pane's drag handlers now accept `text/vaultcore-file` from sidebar drags alongside the existing `text/vaultcore-tab` tab-reorder flow. Drops near the left/right edge open (or reuse) a tab for the dropped file and route it through `openFileAsTab` so `.canvas`, images, and text files pick the correct viewer — same as a sidebar click.
- `TreeNode` now tags directory drags with a separate `text/vaultcore-folder` MIME; folder drops into the editor are ignored, and the tree's own folder-to-folder move still works because `handleDragOver` / `handleDrop` accept both file and folder MIMEs.
- Mid-pane drops (no edge indicator) remain a no-op to stay consistent with the existing tab-drag behavior.

Closes #146.

## Test plan
- [x] `vitest` — 588 tests passing incl. 5 new cases in `EditorPaneSidebarDrop.test.ts` covering right-edge file drop, dedupe of existing paths, folder-MIME rejection, mid-pane no-op, and tab-drag regression.
- [x] `wdio` — 49 specs passing incl. new `editor-sidebar-drop.spec.ts` asserting that a folder drag leaves the pane count at 1 and that dragging a `.md` note to the right edge creates a right-pane split with the dropped file active.