### PR TITLE
feat(editor): inline [[...]] and ![[...]] for .canvas (#147)

### DIFF
--- a/e2e/specs/canvas-wiki-embed.spec.ts
+++ b/e2e/specs/canvas-wiki-embed.spec.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+/**
+ * E2E coverage for #147 — wiki-links and embeds must resolve `.canvas` the
+ * same way they resolve `.md`. We seed a small canvas and a note that both
+ * links to it (`[[Board]]`) and embeds it (`![[Board]]`), then:
+ *   - click the wiki-link → a CanvasView opens in a tab.
+ *   - assert the embed widget paints an SVG preview (rect per node) in the
+ *     active `.cm-content`.
+ */
+
+const BOARD_CANVAS = {
+  nodes: [
+    { id: "a", type: "text", text: "Alpha", x: 0, y: 0, width: 120, height: 40 },
+    { id: "b", type: "text", text: "Beta", x: 200, y: 80, width: 120, height: 40 },
+  ],
+  edges: [{ id: "e1", fromNode: "a", toNode: "b" }],
+};
+
+describe("Canvas wiki-links & embeds (#147)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(
+      path.join(vault.path, "Board.canvas"),
+      JSON.stringify(BOARD_CANVAS, null, "\t"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(vault.path, "Linker.md"),
+      [
+        "# Linker",
+        "",
+        "A link to the canvas: [[Board]]",
+        "",
+        "And an embed of it:",
+        "",
+        "![[Board]]",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not in tree`);
+  }
+
+  it("renders a canvas embed SVG preview inside the active editor", async () => {
+    await openTreeFile("Linker.md");
+
+    await browser.waitUntil(
+      async () => {
+        const els = await browser.$$(".cm-content");
+        for (const el of els) if (await el.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000, timeoutMsg: "Editor never displayed for Linker.md" },
+    );
+
+    await browser.waitUntil(
+      async () => {
+        const found = await browser.execute(() => {
+          const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+          const active = panes.find((el) => el.offsetParent !== null);
+          if (!active) return false;
+          const svg = active.querySelector(".cm-embed-canvas svg");
+          if (!svg) return false;
+          return svg.querySelectorAll("rect").length >= 2;
+        });
+        return found;
+      },
+      { timeout: 8000, timeoutMsg: "Canvas embed SVG with >=2 rects never rendered" },
+    );
+  });
+
+  it("opens a canvas tab when the [[Board]] wiki-link is clicked", async () => {
+    await browser.execute(() => {
+      const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+      const active = panes.find((el) => el.offsetParent !== null);
+      if (!active) throw new Error("no active editor");
+      const link = active.querySelector<HTMLElement>(".cm-wikilink-resolved");
+      if (!link) throw new Error("no .cm-wikilink-resolved in active editor");
+      // wikiLink.ts listens for `mousedown`, not `click`.
+      link.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+    });
+
+    await browser.waitUntil(
+      async () => {
+        const vps = await browser.$$(".vc-canvas-viewport");
+        for (const vp of vps) if (await vp.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000, timeoutMsg: "Canvas viewport never became visible after link click" },
+    );
+
+    const activeLabel = await browser.$(".vc-tab--active .vc-tab-label");
+    await browser.waitUntil(
+      async () => ((await activeLabel.getProperty("textContent")) as string).includes("Board"),
+      { timeout: 3000, timeoutMsg: "Active tab never switched to Board" },
+    );
+  });
+});

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -456,7 +456,7 @@ pub async fn get_resolved_links(
         }
     };
 
-    let (paths, file_aliases) = {
+    let (mut paths, file_aliases) = {
         let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
         let paths = fi.all_relative_paths();
         let file_aliases: Vec<(String, Vec<String>)> = fi
@@ -465,6 +465,22 @@ pub async fn get_resolved_links(
             .collect();
         (paths, file_aliases)
     };
+
+    // #147 — wiki-links like `[[mycanvas]]` should resolve to `.canvas` files
+    // the same way they resolve to notes. Canvases are not indexed by Tantivy
+    // or the FileIndex, so walk the filesystem once here and union the results
+    // into the path list fed to `resolved_map_with_aliases`. The cost is the
+    // same O(N) directory walk the attachment command already performs.
+    let vault_path = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        guard.clone()
+    };
+    if let Some(vp) = vault_path {
+        paths.extend(crate::indexer::collect_canvas_rel_paths(&vp));
+    }
 
     Ok(link_graph::resolved_map_with_aliases(&paths, &file_aliases))
 }

--- a/src-tauri/src/indexer/link_graph.rs
+++ b/src-tauri/src/indexer/link_graph.rs
@@ -101,10 +101,18 @@ pub fn extract_links(content: &str) -> Vec<ParsedLink> {
 
 // ── resolve_link ───────────────────────────────────────────────────────────────
 
-/// Extract the filename stem (basename without `.md` extension) from a path.
+/// Extract the filename stem (basename without `.md` or `.canvas` extension)
+/// from a path. `.canvas` is accepted so wiki-links like `[[mycanvas]]` can
+/// resolve to `mycanvas.canvas` the same way they resolve to `mycanvas.md`.
 fn path_stem(p: &str) -> &str {
     let base = p.rsplit('/').next().unwrap_or(p);
-    base.strip_suffix(".md").unwrap_or(base)
+    if let Some(s) = base.strip_suffix(".md") {
+        return s;
+    }
+    if let Some(s) = base.strip_suffix(".canvas") {
+        return s;
+    }
+    base
 }
 
 /// Extract the parent folder portion of a vault-relative path.
@@ -132,8 +140,11 @@ fn path_depth(p: &str) -> usize {
 ///
 /// Security (T-04-01): returns a vault-relative path, never an absolute path.
 pub fn resolve_link(target_raw: &str, source_folder: &str, all_rel_paths: &[String]) -> Option<String> {
-    // Strip .md suffix from the target if the user included it
-    let stem = target_raw.strip_suffix(".md").unwrap_or(target_raw);
+    // Strip .md or .canvas suffix from the target if the user included one.
+    let stem = target_raw
+        .strip_suffix(".md")
+        .or_else(|| target_raw.strip_suffix(".canvas"))
+        .unwrap_or(target_raw);
     let stem_lower = stem.to_lowercase();
 
     // Stage 1: exact stem match in the same folder as the source

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -609,3 +609,35 @@ fn collect_md_paths(vault_path: &Path) -> Vec<PathBuf> {
         .map(|e| e.into_path())
         .collect()
 }
+
+/// Collect all `.canvas` relative paths (forward-slash, vault-relative) under
+/// `vault_path`. Used by `get_resolved_links` so wiki-links like
+/// `[[mycanvas]]` resolve to `.canvas` files the same way they resolve to
+/// `.md` files (#147). Canvas files are not indexed by Tantivy or the
+/// FileIndex — link resolution is the only thing we need them for.
+pub fn collect_canvas_rel_paths(vault_path: &Path) -> Vec<String> {
+    walkdir::WalkDir::new(vault_path)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            if e.depth() == 0 {
+                return true;
+            }
+            let name = e.file_name().to_str().unwrap_or("");
+            !name.starts_with('.')
+        })
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().is_file()
+                && e.path()
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("canvas"))
+        })
+        .filter_map(|e| {
+            e.path()
+                .strip_prefix(vault_path)
+                .ok()
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+        })
+        .collect()
+}

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -209,7 +209,15 @@
         void reloadResolvedLinks();
         return;
       }
-      tabStore.openTab(`${vault}/${relPath}`);
+      const absPath = `${vault}/${relPath}`;
+      // #147 — `.canvas` targets need the canvas viewer; plain notes keep
+      // the synchronous `openTab` fast path so markdown clicks stay on the
+      // "zero IPC" path.
+      if (relPath.endsWith(".canvas")) {
+        tabStore.openFileTab(absPath, "canvas");
+      } else {
+        tabStore.openTab(absPath);
+      }
     } else {
       // LINK-04, D-08: click-to-create at vault root
       const filename = detail.target.endsWith(".md")

--- a/src/components/Editor/__tests__/canvasEmbedPreview.test.ts
+++ b/src/components/Editor/__tests__/canvasEmbedPreview.test.ts
@@ -1,0 +1,74 @@
+// #147 — inline canvas embed rendering. These tests drive the SVG preview
+// helper that the CM6 embed widget calls after it fetches the .canvas file.
+// We only need a DOM (jsdom) — no Tauri runtime — to assert that nodes and
+// edges land in the SVG with auto-fit viewBox, and that empty / invalid
+// canvases surface a friendly placeholder instead of blowing up.
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+}));
+vi.mock("../../../ipc/commands", () => ({
+  readFile: vi.fn().mockResolvedValue(""),
+}));
+
+import { __renderCanvasPreviewForTests } from "../embedPlugin";
+
+function mountPreview(json: string): HTMLElement {
+  const el = document.createElement("div");
+  __renderCanvasPreviewForTests(el, json);
+  return el;
+}
+
+describe("canvas embed preview (#147)", () => {
+  it("renders one <rect> per node and one <line> per edge inside a viewBox that contains all nodes", () => {
+    const doc = {
+      nodes: [
+        { id: "a", type: "text", text: "Hello", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "World", x: 200, y: 80, width: 120, height: 50 },
+      ],
+      edges: [{ id: "e", fromNode: "a", toNode: "b" }],
+    };
+    const el = mountPreview(JSON.stringify(doc));
+    const svg = el.querySelector("svg")!;
+    expect(svg).toBeTruthy();
+
+    const viewBox = svg.getAttribute("viewBox")!.split(/\s+/).map(Number);
+    const [vbX, vbY, vbW, vbH] = viewBox as [number, number, number, number];
+    // minX=0, minY=0, maxX=320, maxY=130 with pad=20 → viewBox -20 -20 360 170
+    expect(vbX).toBe(-20);
+    expect(vbY).toBe(-20);
+    expect(vbW).toBe(360);
+    expect(vbH).toBe(170);
+
+    expect(svg.querySelectorAll("rect")).toHaveLength(2);
+    expect(svg.querySelectorAll("line")).toHaveLength(1);
+    // Labels: first line of text for text nodes.
+    const labels = Array.from(svg.querySelectorAll("text")).map((t) => t.textContent);
+    expect(labels).toContain("Hello");
+    expect(labels).toContain("World");
+  });
+
+  it("renders an (empty canvas) placeholder when the file has no nodes", () => {
+    const el = mountPreview(JSON.stringify({ nodes: [], edges: [] }));
+    expect(el.querySelector(".cm-embed-canvas-empty")).toBeTruthy();
+    expect(el.textContent).toContain("empty canvas");
+  });
+
+  it("reports an invalid-canvas warning when the payload is not JSON", () => {
+    const el = mountPreview("not-json");
+    expect(el.textContent).toContain("invalid canvas file");
+  });
+
+  it("drops edges whose endpoints reference missing nodes without throwing", () => {
+    const doc = {
+      nodes: [{ id: "a", type: "text", text: "only", x: 0, y: 0, width: 80, height: 30 }],
+      edges: [{ id: "dangling", fromNode: "a", toNode: "ghost" }],
+    };
+    const el = mountPreview(JSON.stringify(doc));
+    const svg = el.querySelector("svg")!;
+    expect(svg.querySelectorAll("rect")).toHaveLength(1);
+    expect(svg.querySelectorAll("line")).toHaveLength(0);
+  });
+});

--- a/src/components/Editor/__tests__/canvasWikiLink.test.ts
+++ b/src/components/Editor/__tests__/canvasWikiLink.test.ts
@@ -1,0 +1,41 @@
+// #147 — wiki-links and embeds now resolve `.canvas` targets the same way
+// they resolve `.md`. These tests lock in the frontend resolution layer:
+// `resolveTarget` strips both extensions and honours the shared lowercased
+// stem map that `getResolvedLinks` populates.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { setResolvedLinks, resolveTarget } from "../wikiLink";
+
+describe("resolveTarget — .canvas support (#147)", () => {
+  beforeEach(() => {
+    setResolvedLinks(new Map());
+  });
+
+  it("resolves [[mycanvas]] to the matching .canvas path", () => {
+    setResolvedLinks(new Map([["mycanvas", "notes/mycanvas.canvas"]]));
+    expect(resolveTarget("mycanvas")).toBe("notes/mycanvas.canvas");
+  });
+
+  it("resolves [[mycanvas.canvas]] (explicit extension) to the same target", () => {
+    setResolvedLinks(new Map([["mycanvas", "notes/mycanvas.canvas"]]));
+    expect(resolveTarget("mycanvas.canvas")).toBe("notes/mycanvas.canvas");
+  });
+
+  it("still resolves [[myNote.md]] — the .md branch was not regressed", () => {
+    setResolvedLinks(new Map([["mynote", "MyNote.md"]]));
+    expect(resolveTarget("MyNote.md")).toBe("MyNote.md");
+    expect(resolveTarget("MyNote")).toBe("MyNote.md");
+  });
+
+  it("returns null for a target that is neither in the stem map nor aliased", () => {
+    setResolvedLinks(new Map());
+    expect(resolveTarget("ghost")).toBeNull();
+    expect(resolveTarget("ghost.canvas")).toBeNull();
+  });
+
+  it("is case-insensitive on the stem lookup", () => {
+    setResolvedLinks(new Map([["mycanvas", "mycanvas.canvas"]]));
+    expect(resolveTarget("MyCanvas")).toBe("mycanvas.canvas");
+    expect(resolveTarget("MYCANVAS.canvas")).toBe("mycanvas.canvas");
+  });
+});

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -31,6 +31,9 @@ import { vaultStore } from "../../store/vaultStore";
 import { tabStore } from "../../store/tabStore";
 import { readFile } from "../../ipc/commands";
 import { listenFileChange } from "../../ipc/events";
+import { parseCanvas } from "../../lib/canvas/parse";
+import type { CanvasNode } from "../../lib/canvas/types";
+import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from "../../lib/canvas/types";
 
 // ── Regex ──────────────────────────────────────────────────────────────────────
 
@@ -220,6 +223,193 @@ class NoteEmbedWidget extends WidgetType {
   }
 }
 
+/**
+ * #147 — inline read-only mini-canvas for `![[mycanvas]]`. Renders node
+ * rectangles and edges as a single SVG that auto-fits all nodes into the
+ * widget's box. Clicking anywhere opens the full canvas viewer via the
+ * standard tabStore path.
+ */
+class CanvasEmbedWidget extends WidgetType {
+  constructor(readonly relPath: string, readonly widthPx: number | null) {
+    super();
+  }
+
+  eq(other: CanvasEmbedWidget): boolean {
+    return this.relPath === other.relPath && this.widthPx === other.widthPx;
+  }
+
+  toDOM(): HTMLElement {
+    const wrap = document.createElement("div");
+    wrap.className = "cm-embed-canvas";
+    wrap.setAttribute("data-embed-path", this.relPath);
+    wrap.setAttribute("role", "button");
+    wrap.setAttribute("tabindex", "0");
+    wrap.title = `Open ${this.relPath}`;
+    if (this.widthPx !== null) {
+      wrap.style.width = `${this.widthPx}px`;
+    }
+
+    const content = document.createElement("div");
+    content.className = "cm-embed-canvas-body";
+    content.textContent = "…";
+    wrap.appendChild(content);
+
+    const abs = absFromRel(this.relPath);
+    const openCanvas = (): void => {
+      if (!abs) return;
+      tabStore.openFileTab(abs, "canvas");
+    };
+    wrap.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      openCanvas();
+    });
+    wrap.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openCanvas();
+      }
+    });
+
+    const cached = canvasContentCache.get(this.relPath);
+    if (cached !== undefined) {
+      renderCanvasPreviewInto(content, cached);
+    } else if (abs) {
+      readFile(abs)
+        .then((src) => {
+          canvasContentCache.set(this.relPath, src);
+          renderCanvasPreviewInto(content, src);
+        })
+        .catch(() => {
+          content.textContent = `\u26A0 cannot read: ${this.relPath}`;
+        });
+    }
+
+    return wrap;
+  }
+
+  ignoreEvent(event: Event): boolean {
+    // Let click + keydown through to our own listener so the embed is
+    // actionable even though CM6 otherwise swallows widget events.
+    return !(event.type === "click" || event.type === "keydown");
+  }
+}
+
+/** Cache the raw canvas JSON so re-renders don't re-hit readFile. */
+const canvasContentCache: Map<string, string> = new Map();
+
+function renderCanvasPreviewInto(el: HTMLElement, rawJson: string): void {
+  el.textContent = "";
+  let doc;
+  try {
+    doc = parseCanvas(rawJson);
+  } catch {
+    el.textContent = "\u26A0 invalid canvas file";
+    return;
+  }
+  const nodes = doc.nodes;
+  if (nodes.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "cm-embed-canvas-empty";
+    empty.textContent = "(empty canvas)";
+    el.appendChild(empty);
+    return;
+  }
+
+  // Compute bounding box including default sizes for nodes missing width/height.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const n of nodes) {
+    const w = n.width || DEFAULT_NODE_WIDTH;
+    const h = n.height || DEFAULT_NODE_HEIGHT;
+    if (n.x < minX) minX = n.x;
+    if (n.y < minY) minY = n.y;
+    if (n.x + w > maxX) maxX = n.x + w;
+    if (n.y + h > maxY) maxY = n.y + h;
+  }
+  const pad = 20;
+  const vbX = minX - pad;
+  const vbY = minY - pad;
+  const vbW = maxX - minX + pad * 2;
+  const vbH = maxY - minY + pad * 2;
+
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", `${vbX} ${vbY} ${vbW} ${vbH}`);
+  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+  svg.setAttribute("class", "cm-embed-canvas-svg");
+
+  // Edges first, so nodes paint over.
+  const nodeMap = new Map<string, CanvasNode>(nodes.map((n) => [n.id, n]));
+  for (const edge of doc.edges) {
+    const a = nodeMap.get(edge.fromNode);
+    const b = nodeMap.get(edge.toNode);
+    if (!a || !b) continue;
+    const ax = a.x + (a.width || DEFAULT_NODE_WIDTH) / 2;
+    const ay = a.y + (a.height || DEFAULT_NODE_HEIGHT) / 2;
+    const bx = b.x + (b.width || DEFAULT_NODE_WIDTH) / 2;
+    const by = b.y + (b.height || DEFAULT_NODE_HEIGHT) / 2;
+    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    line.setAttribute("x1", String(ax));
+    line.setAttribute("y1", String(ay));
+    line.setAttribute("x2", String(bx));
+    line.setAttribute("y2", String(by));
+    line.setAttribute("stroke", "currentColor");
+    line.setAttribute("stroke-width", "2");
+    line.setAttribute("opacity", "0.5");
+    svg.appendChild(line);
+  }
+
+  for (const n of nodes) {
+    const w = n.width || DEFAULT_NODE_WIDTH;
+    const h = n.height || DEFAULT_NODE_HEIGHT;
+    const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    rect.setAttribute("x", String(n.x));
+    rect.setAttribute("y", String(n.y));
+    rect.setAttribute("width", String(w));
+    rect.setAttribute("height", String(h));
+    rect.setAttribute("rx", "6");
+    rect.setAttribute("ry", "6");
+    rect.setAttribute("fill", "var(--vc-bg-secondary, #f5f5f5)");
+    rect.setAttribute("stroke", "currentColor");
+    rect.setAttribute("stroke-width", "1.5");
+    svg.appendChild(rect);
+    // Lightweight label: for text nodes we preview the first line; for other
+    // nodes we show the type so the reader sees the structure at a glance.
+    const label = nodeLabel(n);
+    if (label) {
+      const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      text.setAttribute("x", String(n.x + 8));
+      text.setAttribute("y", String(n.y + 20));
+      text.setAttribute("font-size", "14");
+      text.setAttribute("fill", "currentColor");
+      text.textContent = label;
+      svg.appendChild(text);
+    }
+  }
+
+  el.appendChild(svg);
+}
+
+function nodeLabel(n: CanvasNode): string {
+  // `CanvasUnknownNode` overlaps every other variant on the `type` discriminant,
+  // so read optional fields through a loose record to keep the union-narrowing
+  // from collapsing into the fallback branch.
+  const any = n as unknown as Record<string, unknown>;
+  if (n.type === "text") {
+    const raw = typeof any["text"] === "string" ? (any["text"] as string) : "";
+    const firstLine = raw.split("\n", 1)[0] ?? "";
+    return firstLine.length > 40 ? `${firstLine.slice(0, 37)}…` : firstLine;
+  }
+  if (n.type === "file") return typeof any["file"] === "string" ? (any["file"] as string) : "(file)";
+  if (n.type === "link") return typeof any["url"] === "string" ? (any["url"] as string) : "(link)";
+  if (n.type === "group") {
+    return typeof any["label"] === "string" ? (any["label"] as string) : "(group)";
+  }
+  return n.type;
+}
+
 class BrokenEmbedWidget extends WidgetType {
   constructor(readonly target: string) {
     super();
@@ -318,18 +508,23 @@ function buildDecorations(view: EditorView): DecorationSet {
         deco = Decoration.replace({ widget: new BrokenEmbedWidget(target) });
       }
     } else {
-      // Note embed. We intentionally ignore the #heading capture for now and
-      // render the entire target note; heading slicing is a follow-up.
+      // Note / canvas embed. We intentionally ignore the #heading capture for
+      // now and render the entire target; heading slicing is a follow-up.
       const rel = resolveTarget(target);
       if (rel !== null) {
-        const cached = noteContentCache.get(rel);
-        if (cached === undefined) {
-          scheduleNoteFetch(view, rel);
-          // Show a muted placeholder while the fetch is in flight so the UI
-          // doesn't flash with a stale version of the target note.
-          deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, "…") });
+        if (rel.endsWith(".canvas")) {
+          // #147 — route canvas targets through the SVG preview widget.
+          deco = Decoration.replace({ widget: new CanvasEmbedWidget(rel, sizePx) });
         } else {
-          deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, cached) });
+          const cached = noteContentCache.get(rel);
+          if (cached === undefined) {
+            scheduleNoteFetch(view, rel);
+            // Show a muted placeholder while the fetch is in flight so the UI
+            // doesn't flash with a stale version of the target note.
+            deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, "…") });
+          } else {
+            deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, cached) });
+          }
         }
       } else {
         deco = Decoration.replace({ widget: new BrokenEmbedWidget(target) });
@@ -422,4 +617,10 @@ export const embedPlugin = ViewPlugin.fromClass(
 export function __resetEmbedCachesForTests(): void {
   noteContentCache.clear();
   noteFetchInFlight.clear();
+  canvasContentCache.clear();
+}
+
+/** Test-only: render an SVG preview for a raw canvas JSON string into `el`. */
+export function __renderCanvasPreviewForTests(el: HTMLElement, rawJson: string): void {
+  renderCanvasPreviewInto(el, rawJson);
 }

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -247,6 +247,33 @@ export const markdownTheme = EditorView.theme({
     color: "var(--color-text-muted)",
     fontStyle: "italic",
   },
+  ".cm-embed-canvas": {
+    display: "block",
+    width: "100%",
+    aspectRatio: "16 / 9",
+    margin: "8px 0",
+    border: "1px solid var(--color-border)",
+    borderRadius: "6px",
+    backgroundColor: "var(--color-surface-2, var(--color-bg))",
+    cursor: "pointer",
+    overflow: "hidden",
+    color: "var(--color-text)",
+  },
+  ".cm-embed-canvas-body": {
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ".cm-embed-canvas-svg": {
+    width: "100%",
+    height: "100%",
+  },
+  ".cm-embed-canvas-empty": {
+    color: "var(--color-text-muted)",
+    fontStyle: "italic",
+  },
 
   // ── Inline HTML rendering (#70) ──────────────────────────────────────────
   ".cm-html-rendered": {

--- a/src/components/Editor/wikiLink.ts
+++ b/src/components/Editor/wikiLink.ts
@@ -44,13 +44,20 @@ export function setResolvedLinks(map: Map<string, string>): void {
  * Synchronous lookup used by both the ViewPlugin (decoration) and the
  * EditorPane click handler.
  *
- * @param target - Raw link target from `[[target]]` (may include `.md` suffix;
- *   alias is already stripped by the caller via the regex group 1 capture).
+ * @param target - Raw link target from `[[target]]` (may include a `.md` or
+ *   `.canvas` suffix — #147; alias is already stripped by the caller via
+ *   the regex group 1 capture).
  * @returns Vault-relative path, or `null` if the target is not resolved.
  */
 export function resolveTarget(target: string): string | null {
-  const stem = (target.endsWith(".md") ? target.slice(0, -3) : target).toLowerCase();
+  const stem = stripKnownExt(target).toLowerCase();
   return resolvedLinks.get(stem) ?? null;
+}
+
+function stripKnownExt(target: string): string {
+  if (target.endsWith(".md")) return target.slice(0, -3);
+  if (target.endsWith(".canvas")) return target.slice(0, -7);
+  return target;
 }
 
 // ── Code block detection ───────────────────────────────────────────────────────
@@ -116,7 +123,7 @@ function buildDecorations(view: EditorView): DecorationSet {
 
     if (isInsideCodeBlock(view.state, from)) continue;
 
-    const stem: string = rawTarget.endsWith(".md") ? rawTarget.slice(0, -3) : rawTarget;
+    const stem: string = stripKnownExt(rawTarget);
     const resolved = resolvedLinks.has(stem.toLowerCase());
 
     const aliasText = m[2];


### PR DESCRIPTION
## Summary
- `.canvas` is now a first-class link target — `[[Board]]` and `![[Board]]` resolve to `Board.canvas` the same way they resolve to `Board.md`, with lowercased-stem lookup in `get_resolved_links`.
- Clicking a resolved canvas wiki-link opens the file in a `CanvasView` tab (via `tabStore.openFileTab(abs, "canvas")`).
- `![[canvas]]` embeds render a lightweight SVG preview inline in the editor — one `<rect>` per node, one `<line>` per edge, auto-fit viewBox. Empty / invalid canvases fall back to friendly placeholders.

## Scope notes
Follow-up tickets cover: backlinks on canvases, link autocomplete scoping, and canvas resolution inside ReadingView.

## Test plan
- [x] 9 new unit tests (`canvasWikiLink.test.ts` + `canvasEmbedPreview.test.ts`) — green.
- [x] Full vitest suite: 597 passing.
- [x] Rust `cargo test --lib`: 219 passing.
- [x] 2 new E2E tests (`canvas-wiki-embed.spec.ts`) — green.
- [x] Full E2E suite: 50 specs passing.