### PR TITLE
fix(search): re-run current query after rebuild (#148)

### DIFF
--- a/e2e/specs/search-rebuild-refetch.spec.ts
+++ b/e2e/specs/search-rebuild-refetch.spec.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+/**
+ * E2E coverage for #148 — after "Index neu aufbauen" in the Suche panel,
+ * the results list must be recomputed against the fresh index. Without
+ * this, newly-indexed files only appear once the user edits the query.
+ *
+ * Scenario:
+ *   1. Seed a vault with Alpha.md tagged #yoda.
+ *   2. Run `#yoda` → 1 result.
+ *   3. Write Beta.md (also tagged #yoda) directly to disk.
+ *   4. Click rebuild → result list grows to 2 without query edit.
+ */
+
+describe("Search re-runs after rebuild (#148)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(path.join(vault.path, "Alpha.md"), "# Alpha\n\n#yoda\n", "utf-8");
+    await openVaultInApp(vault.path);
+    await browser.pause(1500); // initial indexing
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function ensureSearchTabActive(): Promise<WebdriverIO.Element> {
+    await browser.keys(["Control", "Shift", "f"]);
+    const panel = await browser.$(".vc-search-panel");
+    await panel.waitForDisplayed({ timeout: 3000 });
+    const input = await browser.$(".vc-search-input");
+    await input.waitForDisplayed({ timeout: 3000 });
+    return input;
+  }
+
+  async function typeQuery(input: WebdriverIO.Element, q: string): Promise<void> {
+    await input.click();
+    await input.setValue(q);
+    await browser.pause(400);
+  }
+
+  it("refreshes the results list after a rebuild without editing the query", async () => {
+    const input = await ensureSearchTabActive();
+    await typeQuery(input, "#yoda");
+
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-search-result-row")).length >= 1,
+      { timeout: 3000, timeoutMsg: "Initial #yoda search returned no hits" },
+    );
+    const initialRows = await browser.$$(".vc-search-result-row");
+    const initialNames: string[] = [];
+    for (const r of initialRows) {
+      const n = await r.$(".vc-search-result-filename");
+      initialNames.push(await textOf(n));
+    }
+    expect(initialNames.some((n) => n.includes("Alpha"))).toBe(true);
+    expect(initialNames.some((n) => n.includes("Beta"))).toBe(false);
+
+    // Add a second #yoda note on disk. The watcher flips indexStale = true
+    // but won't auto-rebuild — that's the manual rebuild this test exercises.
+    fs.writeFileSync(path.join(vault.path, "Beta.md"), "# Beta\n\n#yoda\n", "utf-8");
+    await browser.pause(500);
+
+    // Click rebuild.
+    const rebuildBtn = await browser.$('button[aria-label="Index neu aufbauen"]');
+    await rebuildBtn.click();
+
+    // Wait for rebuild to finish (button re-enables) and refetch to populate.
+    await browser.waitUntil(
+      async () => {
+        const ariaDisabled = await rebuildBtn.getAttribute("aria-disabled");
+        return ariaDisabled !== "true";
+      },
+      { timeout: 15000, timeoutMsg: "Rebuild never finished" },
+    );
+
+    await browser.waitUntil(
+      async () => {
+        const rows = await browser.$$(".vc-search-result-row");
+        const names: string[] = [];
+        for (const r of rows) {
+          const n = await r.$(".vc-search-result-filename");
+          names.push(await textOf(n));
+        }
+        return names.some((n) => n.includes("Alpha")) && names.some((n) => n.includes("Beta"));
+      },
+      {
+        timeout: 8000,
+        timeoutMsg: "Results never updated to include both Alpha.md and Beta.md after rebuild",
+      },
+    );
+  });
+});

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -337,20 +337,23 @@ pub async fn rebuild_index(
         }),
     );
 
+    // #148: block until the writer commits and the reader reloads. Without
+    // this, the frontend kicks off a refetch against the *stale* reader and
+    // newly-indexed files don't appear in the results list.
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+
     // Send rebuild command to the background write-queue consumer.
     // No Mutex guard is held at this await point.
-    tx.send(IndexCmd::Rebuild { vault_path })
-        .await
-        .map_err(|_| VaultError::IndexCorrupt)?;
+    tx.send(IndexCmd::Rebuild {
+        vault_path,
+        done_tx: Some(done_tx),
+    })
+    .await
+    .map_err(|_| VaultError::IndexCorrupt)?;
 
-    // Emit "in progress" toast (rebuild completes asynchronously in the queue).
-    let _ = app.emit(
-        "vault://index_toast",
-        serde_json::json!({
-            "message": "Index wird neu aufgebaut — läuft im Hintergrund",
-            "variant": "clean-merge"
-        }),
-    );
+    // Wait for the consumer to signal reload. A dropped sender (consumer
+    // exited) surfaces as IndexCorrupt — same treatment as a send failure.
+    done_rx.await.map_err(|_| VaultError::IndexCorrupt)?;
 
     Ok(())
 }

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -83,6 +83,10 @@ pub enum IndexCmd {
     Commit,
     Rebuild {
         vault_path: PathBuf,
+        /// Signaled after the writer commits and the reader reloads so the
+        /// IPC caller can `.await` completion (#148 — the Search panel must
+        /// re-run its query only once the fresh index is readable).
+        done_tx: Option<tokio::sync::oneshot::Sender<()>>,
     },
     Shutdown,
     /// Incrementally update link-graph entries for a file (LINK-08).
@@ -448,10 +452,11 @@ fn run_queue_consumer(
                     log::error!("Tantivy reader reload failed: {e}");
                 }
             }
-            IndexCmd::Rebuild { vault_path } => {
+            IndexCmd::Rebuild { vault_path, done_tx } => {
                 // Clear writer and re-walk — simplified rebuild within the task.
                 if let Err(e) = writer.delete_all_documents() {
                     log::error!("Tantivy delete_all failed during rebuild: {e}");
+                    if let Some(tx) = done_tx { let _ = tx.send(()); }
                     continue;
                 }
                 let paths = collect_md_paths(&vault_path);
@@ -481,6 +486,7 @@ fn run_queue_consumer(
                 } else if let Err(e) = reader.reload() {
                     log::error!("Tantivy rebuild reader reload failed: {e}");
                 }
+                if let Some(tx) = done_tx { let _ = tx.send(()); }
             }
             IndexCmd::UpdateLinks { rel_path, content } => {
                 // Incremental link-graph update (LINK-08).

--- a/src/components/Search/SearchPanel.svelte
+++ b/src/components/Search/SearchPanel.svelte
@@ -67,6 +67,7 @@
       await rebuildIndex();
       searchStore.setIndexStale(false);
       toastStore.push({ variant: "clean-merge", message: "Index aktualisiert" });
+      await searchStore.refetchIfQueryNonEmpty();
     } catch (e) {
       toastStore.push({ variant: "error", message: "Index-Neuaufbau fehlgeschlagen" });
     } finally {

--- a/src/store/__tests__/searchStore.refetchAfterRebuild.test.ts
+++ b/src/store/__tests__/searchStore.refetchAfterRebuild.test.ts
@@ -1,0 +1,77 @@
+// #148 — after rebuildIndex, the SearchPanel calls
+// `searchStore.refetchIfQueryNonEmpty()` so the freshly-built index is
+// queried again and results reflect newly-indexed content without the
+// user having to retype the query.
+//
+// We mock the IPC layer so the store exercises its control flow without
+// a Tauri runtime. Each assertion locks in one AC from the ticket.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+const searchFulltextMock = vi.fn();
+
+vi.mock("../../ipc/commands", () => ({
+  searchFulltext: (...args: unknown[]) => searchFulltextMock(...args),
+}));
+
+import { searchStore } from "../searchStore";
+
+describe("searchStore.refetchIfQueryNonEmpty (#148)", () => {
+  beforeEach(() => {
+    searchStore.reset();
+    searchFulltextMock.mockReset();
+  });
+
+  it("re-runs the current query and replaces results", async () => {
+    searchStore.setQuery("#yoda");
+    // First rebuild finds one hit; a later rebuild finds two.
+    searchFulltextMock.mockResolvedValueOnce([
+      { path: "a.md", snippet: "", score: 1 },
+      { path: "b.md", snippet: "", score: 1 },
+    ]);
+
+    await searchStore.refetchIfQueryNonEmpty();
+
+    expect(searchFulltextMock).toHaveBeenCalledTimes(1);
+    expect(searchFulltextMock).toHaveBeenCalledWith("#yoda", 100);
+    const s = get(searchStore);
+    expect(s.results).toHaveLength(2);
+    expect(s.totalFiles).toBe(2);
+    expect(s.isSearching).toBe(false);
+  });
+
+  it("is a no-op when the query is empty (no fetch issued)", async () => {
+    searchStore.setQuery("");
+    await searchStore.refetchIfQueryNonEmpty();
+    expect(searchFulltextMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the query is only whitespace", async () => {
+    searchStore.setQuery("   ");
+    await searchStore.refetchIfQueryNonEmpty();
+    expect(searchFulltextMock).not.toHaveBeenCalled();
+  });
+
+  it("marks the index stale and clears isSearching on IndexCorrupt", async () => {
+    searchStore.setQuery("#yoda");
+    searchFulltextMock.mockRejectedValueOnce({ kind: "IndexCorrupt", message: "x" });
+
+    await searchStore.refetchIfQueryNonEmpty();
+
+    const s = get(searchStore);
+    expect(s.isSearching).toBe(false);
+    expect(s.indexStale).toBe(true);
+  });
+
+  it("does not flip indexStale on unrelated errors, but clears isSearching", async () => {
+    searchStore.setQuery("#yoda");
+    searchFulltextMock.mockRejectedValueOnce(new Error("network blip"));
+
+    await searchStore.refetchIfQueryNonEmpty();
+
+    const s = get(searchStore);
+    expect(s.isSearching).toBe(false);
+    expect(s.indexStale).toBe(false);
+  });
+});

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -126,6 +126,41 @@ function createSearchStore() {
       }
     },
 
+    /**
+     * Re-execute the current query against the freshly-built index.
+     *
+     * Called after a successful rebuild (#148). If the query is empty there
+     * is nothing to fetch; otherwise we re-issue `search_fulltext` and replace
+     * the results so the panel reflects newly-indexed content without the
+     * user having to edit the query.
+     */
+    refetchIfQueryNonEmpty: async (): Promise<void> => {
+      let query = "";
+      const unsubscribe = subscribe((s) => {
+        query = s.query;
+      });
+      unsubscribe();
+      if (!query.trim()) return;
+      update((s) => ({ ...s, isSearching: true }));
+      try {
+        const results = await searchFulltext(query, 100);
+        const uniqueFileCount = new Set(results.map((r) => r.path)).size;
+        update((s) => ({
+          ...s,
+          results,
+          totalMatches: results.length,
+          totalFiles: uniqueFileCount,
+          isSearching: false,
+        }));
+      } catch (e) {
+        if (isVaultError(e) && e.kind === "IndexCorrupt") {
+          update((s) => ({ ...s, isSearching: false, indexStale: true }));
+        } else {
+          update((s) => ({ ...s, isSearching: false }));
+        }
+      }
+    },
+
     /** Full reset to initial state (vault close / new vault open). */
     reset: () => set({ ...initial }),
   };


### PR DESCRIPTION
## Summary
- Makes the \`rebuild_index\` IPC block until the writer commits and the reader reloads (oneshot handoff). The old fire-and-forget behaviour caused any immediate refetch to hit the stale reader.
- Adds \`searchStore.refetchIfQueryNonEmpty()\`; \`SearchPanel.handleRebuild\` calls it on success so newly-indexed content appears without the user editing the query.
- Empty / whitespace queries are a no-op. \`IndexCorrupt\` flips \`indexStale\` exactly like \`handleSearch\`.

## Test plan
- [x] 5 new unit tests (\`searchStore.refetchAfterRebuild.test.ts\`) — green.
- [x] Full vitest suite: 602 passing.
- [x] Rust \`cargo test --lib\`: 219 passing.
- [x] New E2E (\`search-rebuild-refetch.spec.ts\`): seeds Alpha.md #yoda, searches, adds Beta.md on disk, clicks rebuild — both hits appear without query edit.
- [x] Full E2E suite: 51 specs passing.