### PR TITLE
feat(canvas): render embeds with shared CanvasRenderer (#156)

### DIFF
--- a/e2e/specs/canvas-embed-refresh.spec.ts
+++ b/e2e/specs/canvas-embed-refresh.spec.ts
@@ -6,13 +6,15 @@ import { textOf } from "../helpers/text.js";
 
 /**
  * E2E coverage for #154 — an inline `![[board]]` embed must re-render
- * when the underlying `.canvas` file changes. Scenario:
+ * when the underlying `.canvas` file changes. After #156 the embed
+ * mounts the shared CanvasRenderer, so we count `.vc-canvas-node` DIVs
+ * instead of raw <rect> elements. Scenario:
  *   1. Seed Board.canvas with one node and Host.md that embeds it.
- *   2. Open Host.md — assert one <rect> in the embed SVG.
+ *   2. Open Host.md — assert one .vc-canvas-node in the embed.
  *   3. Overwrite Board.canvas on disk with two nodes (simulates external
  *      edit; the watcher fires listenFileChange on the frontend, the
  *      embedPlugin drops the cache and kicks a rebuild).
- *   4. Assert the embed now paints two <rect>s — no user interaction.
+ *   4. Assert the embed now paints two .vc-canvas-nodes — no user interaction.
  */
 
 const ONE_NODE = {
@@ -61,24 +63,34 @@ describe("Canvas embed live-refresh (#154)", () => {
     throw new Error(`"${name}" not in tree`);
   }
 
-  async function countRectsInActiveEmbed(): Promise<number> {
+  async function countNodesInActiveEmbed(): Promise<number> {
     return browser.execute(() => {
       const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
       const active = panes.find((el) => el.offsetParent !== null);
       if (!active) return -1;
-      const svg = active.querySelector(".cm-embed-canvas svg");
-      if (!svg) return 0;
-      return svg.querySelectorAll("rect").length;
+      const embed = active.querySelector(".cm-embed-canvas");
+      if (!embed) return 0;
+      return embed.querySelectorAll(".vc-canvas-node").length;
     });
   }
 
   it("repaints the embed when the source .canvas is rewritten on disk", async () => {
     await openTreeFile("Host.md");
 
-    // Initial paint — 1 rect.
-    await browser.waitUntil(async () => (await countRectsInActiveEmbed()) === 1, {
+    // Initial paint — 1 node.
+    await browser.waitUntil(async () => (await countNodesInActiveEmbed()) === 1, {
       timeout: 8000,
-      timeoutMsg: "Initial embed never showed exactly 1 rect",
+      timeoutMsg: "Initial embed never showed exactly 1 node",
+    }).catch(async (err) => {
+      const debug = await browser.execute(() => {
+        const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+        const active = panes.find((el) => el.offsetParent !== null);
+        return {
+          hasPane: !!active,
+          embedOuter: active?.querySelector(".cm-embed-canvas")?.outerHTML?.slice(0, 800) ?? null,
+        };
+      });
+      throw new Error(`${err}; debug: ${JSON.stringify(debug)}`);
     });
 
     // Overwrite Board.canvas with a two-node version. The fs.watcher sees
@@ -91,9 +103,9 @@ describe("Canvas embed live-refresh (#154)", () => {
       "utf-8",
     );
 
-    await browser.waitUntil(async () => (await countRectsInActiveEmbed()) === 2, {
+    await browser.waitUntil(async () => (await countNodesInActiveEmbed()) === 2, {
       timeout: 8000,
-      timeoutMsg: "Embed did not refresh to 2 rects after Board.canvas was rewritten",
+      timeoutMsg: "Embed did not refresh to 2 nodes after Board.canvas was rewritten",
     });
   });
 });

--- a/e2e/specs/canvas-wiki-embed.spec.ts
+++ b/e2e/specs/canvas-wiki-embed.spec.ts
@@ -6,11 +6,13 @@ import { textOf } from "../helpers/text.js";
 
 /**
  * E2E coverage for #147 — wiki-links and embeds must resolve `.canvas` the
- * same way they resolve `.md`. We seed a small canvas and a note that both
- * links to it (`[[Board]]`) and embeds it (`![[Board]]`), then:
+ * same way they resolve `.md`. After #156 the embed uses CanvasRenderer
+ * (HTML nodes + SVG edge overlay), so we assert `.vc-canvas-node` DIVs
+ * inside `.cm-embed-canvas`, not raw `<rect>`s. We seed a small canvas
+ * and a note that both links to it (`[[Board]]`) and embeds it
+ * (`![[Board]]`), then:
  *   - click the wiki-link → a CanvasView opens in a tab.
- *   - assert the embed widget paints an SVG preview (rect per node) in the
- *     active `.cm-content`.
+ *   - assert the embed renders at least one node DIV per canvas node.
  */
 
 const BOARD_CANVAS = {
@@ -63,7 +65,7 @@ describe("Canvas wiki-links & embeds (#147)", () => {
     throw new Error(`"${name}" not in tree`);
   }
 
-  it("renders a canvas embed SVG preview inside the active editor", async () => {
+  it("renders an HTML canvas embed preview inside the active editor", async () => {
     await openTreeFile("Linker.md");
 
     await browser.waitUntil(
@@ -81,13 +83,35 @@ describe("Canvas wiki-links & embeds (#147)", () => {
           const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
           const active = panes.find((el) => el.offsetParent !== null);
           if (!active) return false;
-          const svg = active.querySelector(".cm-embed-canvas svg");
-          if (!svg) return false;
-          return svg.querySelectorAll("rect").length >= 2;
+          const embed = active.querySelector(".cm-embed-canvas");
+          if (!embed) return false;
+          return embed.querySelectorAll(".vc-canvas-node").length >= 2;
         });
         return found;
       },
-      { timeout: 8000, timeoutMsg: "Canvas embed SVG with >=2 rects never rendered" },
+      { timeout: 8000, timeoutMsg: "Canvas embed with >=2 .vc-canvas-node divs never rendered" },
+    );
+  });
+
+  it("embed renders the node text verbatim (not an SVG-label truncation)", async () => {
+    // Wait for the embed DOM to settle. Prior test guarantees at least two
+    // nodes; we now assert the node *content* contains the full text, not
+    // the first-40-character truncation the old SVG renderer produced.
+    await browser.waitUntil(
+      async () => {
+        const texts = await browser.execute(() => {
+          const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+          const active = panes.find((el) => el.offsetParent !== null);
+          if (!active) return [];
+          const embed = active.querySelector(".cm-embed-canvas");
+          if (!embed) return [];
+          return Array.from(embed.querySelectorAll<HTMLElement>(".vc-canvas-node-content")).map(
+            (el) => (el.textContent ?? "").trim(),
+          );
+        });
+        return texts.includes("Alpha") && texts.includes("Beta");
+      },
+      { timeout: 5000, timeoutMsg: "Embed node content did not contain both 'Alpha' and 'Beta'" },
     );
   });
 

--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -1,0 +1,814 @@
+<script lang="ts">
+  // Pure-presentation canvas renderer — #156. Renders the world DOM (nodes +
+  // edge SVG overlay) from a CanvasDoc + camera transform. Used by
+  // CanvasView.svelte (interactive) and CanvasEmbedWidget (read-only embed).
+  //
+  // Design:
+  // - All state (selection, hover, edit, draft) flows in via props. The
+  //   renderer does not own any of it — CanvasView keeps the state machine.
+  // - All user interactions surface as optional callbacks. When unset (embed
+  //   use) the handlers no-op and the resize/edge handles + editing inputs
+  //   are omitted entirely via `interactive={false}`.
+  // - $derived computations (orderedNodes, resolvedEdges, draftPathD) live
+  //   here because they are pure functions of doc + draft.
+
+  import { convertFileSrc } from "@tauri-apps/api/core";
+  import type {
+    CanvasDoc,
+    CanvasEdge,
+    CanvasFileNode,
+    CanvasGroupNode,
+    CanvasLinkNode,
+    CanvasNode,
+    CanvasSide,
+    CanvasTextNode,
+  } from "../../lib/canvas/types";
+  import { SIDES } from "../../lib/canvas/geometry";
+  import {
+    isImageFile,
+    isMarkdownFile,
+    resolveVaultAbs,
+  } from "../../lib/canvas/embed";
+  import {
+    resolveEdges as resolveEdgesPure,
+    draftPath as draftPathPure,
+  } from "../../lib/canvas/edgeResolver";
+  import type { DraftEdge } from "../../lib/canvas/pointerMode";
+
+  interface Props {
+    doc: CanvasDoc;
+    camX?: number;
+    camY?: number;
+    zoom?: number;
+    vaultPath?: string | null;
+    mdPreviews?: Record<string, string>;
+
+    interactive?: boolean;
+
+    selectedNodeId?: string | null;
+    selectedEdgeId?: string | null;
+    hoveredNodeId?: string | null;
+    editingNodeId?: string | null;
+    editingEdgeId?: string | null;
+    draft?: DraftEdge | null;
+
+    editingTextareaEl?: HTMLTextAreaElement | null;
+    editingEdgeLabelEl?: HTMLInputElement | null;
+
+    onNodePointerDown?: (e: PointerEvent, node: CanvasNode) => void;
+    onNodeDblClick?: (e: MouseEvent, node: CanvasNode) => void;
+    onNodeHoverEnter?: (node: CanvasNode) => void;
+    onNodeHoverLeave?: (node: CanvasNode) => void;
+    onResizePointerDown?: (e: PointerEvent, node: CanvasNode) => void;
+    onHandlePointerDown?: (e: PointerEvent, node: CanvasNode, side: CanvasSide) => void;
+    onCardKey?: (e: KeyboardEvent, action: () => void) => void;
+    onStartEditText?: (node: CanvasTextNode) => void;
+    onTextEdit?: (e: Event, node: CanvasTextNode) => void;
+    onTextBlur?: () => void;
+    onOpenFileNode?: (node: CanvasFileNode) => void;
+    onOpenLinkNode?: (node: CanvasLinkNode) => void;
+    onSelectNode?: (node: CanvasNode) => void;
+
+    onEdgeHitPointerDown?: (e: PointerEvent, edge: CanvasEdge) => void;
+    onEdgeDblClick?: (e: MouseEvent, edge: CanvasEdge) => void;
+    onEdgeLabelInput?: (e: Event, edge: CanvasEdge) => void;
+    onEdgeLabelBlur?: () => void;
+    onStartEditEdgeLabel?: (edge: CanvasEdge) => void;
+    onStopEditingEdge?: () => void;
+  }
+
+  let {
+    doc,
+    camX = 0,
+    camY = 0,
+    zoom = 1,
+    vaultPath = null,
+    mdPreviews = {},
+    interactive = false,
+    selectedNodeId = null,
+    selectedEdgeId = null,
+    hoveredNodeId = null,
+    editingNodeId = null,
+    editingEdgeId = null,
+    draft = null,
+    editingTextareaEl = $bindable(null),
+    editingEdgeLabelEl = $bindable(null),
+    onNodePointerDown,
+    onNodeDblClick,
+    onNodeHoverEnter,
+    onNodeHoverLeave,
+    onResizePointerDown,
+    onHandlePointerDown,
+    onCardKey,
+    onStartEditText,
+    onTextEdit,
+    onTextBlur,
+    onOpenFileNode,
+    onOpenLinkNode,
+    onSelectNode,
+    onEdgeHitPointerDown,
+    onEdgeDblClick,
+    onEdgeLabelInput,
+    onEdgeLabelBlur,
+    onStartEditEdgeLabel,
+    onStopEditingEdge,
+  }: Props = $props();
+
+  // Groups render first so other nodes stack visually on top of them.
+  // Two-pass sort keeps doc.nodes order stable within each band so picks
+  // based on DOM order (hit-testing) stay predictable.
+  let orderedNodes = $derived([
+    ...doc.nodes.filter((n) => n.type === "group"),
+    ...doc.nodes.filter((n) => n.type !== "group"),
+  ]);
+  let resolvedEdges = $derived(resolveEdgesPure(doc));
+  let draftPathD = $derived(draftPathPure(doc, draft));
+</script>
+
+<div
+  class="vc-canvas-world"
+  class:vc-canvas-readonly={!interactive}
+  style:transform={`translate(${camX}px, ${camY}px) scale(${zoom})`}
+>
+  <svg
+    class="vc-canvas-edges"
+    overflow="visible"
+    aria-hidden="true"
+  >
+    <defs>
+      <marker
+        id="vc-canvas-arrow"
+        viewBox="0 0 10 10"
+        refX="9"
+        refY="5"
+        markerWidth="6"
+        markerHeight="6"
+        orient="auto-start-reverse"
+      >
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+      </marker>
+    </defs>
+    {#each resolvedEdges as re (re.edge.id)}
+      {@const arrowEnd = re.edge.toEnd !== "none"}
+      {@const arrowStart = re.edge.fromEnd === "arrow"}
+      {#if interactive}
+        <path
+          class="vc-canvas-edge-hit"
+          d={re.path}
+          data-edge-id={re.edge.id}
+          onpointerdown={(e) => onEdgeHitPointerDown?.(e, re.edge)}
+          ondblclick={(e) => onEdgeDblClick?.(e, re.edge)}
+        />
+      {/if}
+      <path
+        class="vc-canvas-edge"
+        class:vc-canvas-edge-selected={selectedEdgeId === re.edge.id}
+        d={re.path}
+        style:color={re.edge.color ?? "var(--color-border-strong, #9ca3af)"}
+        marker-end={arrowEnd ? "url(#vc-canvas-arrow)" : null}
+        marker-start={arrowStart ? "url(#vc-canvas-arrow)" : null}
+        data-edge-id={re.edge.id}
+      />
+    {/each}
+    {#if draftPathD}
+      <path
+        class="vc-canvas-edge-draft"
+        d={draftPathD}
+      />
+    {/if}
+  </svg>
+
+  {#each resolvedEdges as re (`lbl-${re.edge.id}`)}
+    {#if interactive && editingEdgeId === re.edge.id}
+      <input
+        bind:this={editingEdgeLabelEl}
+        class="vc-canvas-edge-label-input"
+        value={re.edge.label ?? ""}
+        style:left={`${re.mid.x}px`}
+        style:top={`${re.mid.y}px`}
+        oninput={(e) => onEdgeLabelInput?.(e, re.edge)}
+        onblur={() => onEdgeLabelBlur?.()}
+        onpointerdown={(e) => e.stopPropagation()}
+        ondblclick={(e) => e.stopPropagation()}
+        onkeydown={(e) => {
+          if (e.key === "Enter" || e.key === "Escape") {
+            e.preventDefault();
+            onStopEditingEdge?.();
+          }
+        }}
+      />
+    {:else if re.edge.label}
+      {#if interactive}
+        <div
+          class="vc-canvas-edge-label"
+          class:vc-canvas-edge-label-selected={selectedEdgeId === re.edge.id}
+          style:left={`${re.mid.x}px`}
+          style:top={`${re.mid.y}px`}
+          data-edge-id={re.edge.id}
+          onpointerdown={(e) => onEdgeHitPointerDown?.(e, re.edge)}
+          ondblclick={(e) => onEdgeDblClick?.(e, re.edge)}
+          onkeydown={(e) => onCardKey?.(e, () => onStartEditEdgeLabel?.(re.edge))}
+          role="button"
+          tabindex="0"
+        >
+          {re.edge.label}
+        </div>
+      {:else}
+        <div
+          class="vc-canvas-edge-label"
+          style:left={`${re.mid.x}px`}
+          style:top={`${re.mid.y}px`}
+          data-edge-id={re.edge.id}
+        >
+          {re.edge.label}
+        </div>
+      {/if}
+    {/if}
+  {/each}
+
+  {#each orderedNodes as node (node.id)}
+    {#if node.type === "text"}
+      <div
+        class="vc-canvas-node vc-canvas-node-text"
+        class:vc-canvas-node-selected={selectedNodeId === node.id}
+        class:vc-canvas-node-editing={editingNodeId === node.id}
+        class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+        style:left={`${node.x}px`}
+        style:top={`${node.y}px`}
+        style:width={`${node.width}px`}
+        style:height={`${node.height}px`}
+        data-node-id={node.id}
+        onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        ondblclick={interactive ? (e) => onNodeDblClick?.(e, node) : undefined}
+        onkeydown={interactive ? (e) => onCardKey?.(e, () => onStartEditText?.(node as CanvasTextNode)) : undefined}
+        onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
+        onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
+        role={interactive ? "button" : undefined}
+        tabindex={interactive ? 0 : undefined}
+      >
+        {#if interactive && editingNodeId === node.id}
+          <textarea
+            bind:this={editingTextareaEl}
+            class="vc-canvas-node-textarea"
+            value={(node as CanvasTextNode).text}
+            oninput={(e) => onTextEdit?.(e, node as CanvasTextNode)}
+            onblur={() => onTextBlur?.()}
+            onpointerdown={(e) => e.stopPropagation()}
+            ondblclick={(e) => e.stopPropagation()}
+          ></textarea>
+        {:else}
+          <div class="vc-canvas-node-content">
+            {(node as CanvasTextNode).text || "Empty card"}
+          </div>
+        {/if}
+        {#if interactive}
+          <div
+            class="vc-canvas-resize-handle"
+            onpointerdown={(e) => onResizePointerDown?.(e, node)}
+            role="presentation"
+          ></div>
+          {#each SIDES as side (side)}
+            <button
+              type="button"
+              class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+              class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+              aria-label={`Create edge from ${side}`}
+              data-edge-handle={side}
+              onpointerdown={(e) => onHandlePointerDown?.(e, node, side)}
+            ></button>
+          {/each}
+        {/if}
+      </div>
+    {:else if node.type === "file"}
+      {@const fileNode = node as CanvasFileNode}
+      {@const abs = vaultPath ? resolveVaultAbs(vaultPath, fileNode.file) : null}
+      <div
+        class="vc-canvas-node vc-canvas-node-file"
+        class:vc-canvas-node-selected={selectedNodeId === node.id}
+        class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+        style:left={`${node.x}px`}
+        style:top={`${node.y}px`}
+        style:width={`${node.width}px`}
+        style:height={`${node.height}px`}
+        data-node-id={node.id}
+        data-node-type="file"
+        onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        onkeydown={interactive ? (e) => onCardKey?.(e, () => onOpenFileNode?.(fileNode)) : undefined}
+        onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
+        onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
+        role={interactive ? "button" : undefined}
+        tabindex={interactive ? 0 : undefined}
+      >
+        {#if isImageFile(fileNode.file) && abs}
+          <img
+            class="vc-canvas-node-image"
+            src={convertFileSrc(abs)}
+            alt={fileNode.file}
+            draggable="false"
+            data-canvas-image="true"
+          />
+          {#if interactive}
+            <button
+              type="button"
+              class="vc-canvas-node-open vc-canvas-node-open-overlay"
+              data-canvas-open="image"
+              onpointerdown={(e) => e.stopPropagation()}
+              onclick={(e) => { e.stopPropagation(); onOpenFileNode?.(fileNode); }}
+            >
+              Open
+            </button>
+          {/if}
+        {:else if isMarkdownFile(fileNode.file)}
+          <div class="vc-canvas-node-file-header" data-canvas-file={fileNode.file}>
+            <span class="vc-canvas-node-file-name">{fileNode.file}</span>
+            {#if interactive}
+              <button
+                type="button"
+                class="vc-canvas-node-open"
+                data-canvas-open="md"
+                onpointerdown={(e) => e.stopPropagation()}
+                onclick={(e) => { e.stopPropagation(); onOpenFileNode?.(fileNode); }}
+              >
+                Open
+              </button>
+            {/if}
+          </div>
+          {#if mdPreviews[fileNode.file]}
+            <div class="vc-canvas-node-md markdown-body">{@html mdPreviews[fileNode.file]}</div>
+          {:else}
+            <div class="vc-canvas-node-md vc-canvas-node-md-loading">Loading preview…</div>
+          {/if}
+        {:else}
+          <div class="vc-canvas-node-file-header" data-canvas-file={fileNode.file}>
+            <span class="vc-canvas-node-file-name">{fileNode.file}</span>
+            {#if interactive}
+              <button
+                type="button"
+                class="vc-canvas-node-open"
+                data-canvas-open="file"
+                onpointerdown={(e) => e.stopPropagation()}
+                onclick={(e) => { e.stopPropagation(); onOpenFileNode?.(fileNode); }}
+              >
+                Open
+              </button>
+            {/if}
+          </div>
+          <div class="vc-canvas-node-file-body">
+            Attached file
+          </div>
+        {/if}
+        {#if interactive}
+          <div
+            class="vc-canvas-resize-handle"
+            onpointerdown={(e) => onResizePointerDown?.(e, node)}
+            role="presentation"
+          ></div>
+          {#each SIDES as side (side)}
+            <button
+              type="button"
+              class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+              class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+              aria-label={`Create edge from ${side}`}
+              data-edge-handle={side}
+              onpointerdown={(e) => onHandlePointerDown?.(e, node, side)}
+            ></button>
+          {/each}
+        {/if}
+      </div>
+    {:else if node.type === "link"}
+      {@const linkNode = node as CanvasLinkNode}
+      <div
+        class="vc-canvas-node vc-canvas-node-link"
+        class:vc-canvas-node-selected={selectedNodeId === node.id}
+        class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+        style:left={`${node.x}px`}
+        style:top={`${node.y}px`}
+        style:width={`${node.width}px`}
+        style:height={`${node.height}px`}
+        data-node-id={node.id}
+        data-node-type="link"
+        onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        onkeydown={interactive ? (e) => onCardKey?.(e, () => onOpenLinkNode?.(linkNode)) : undefined}
+        onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
+        onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
+        role={interactive ? "button" : undefined}
+        tabindex={interactive ? 0 : undefined}
+      >
+        <div class="vc-canvas-node-file-header">
+          <span class="vc-canvas-node-link-url" title={linkNode.url}>{linkNode.url}</span>
+          {#if interactive}
+            <button
+              type="button"
+              class="vc-canvas-node-open"
+              data-canvas-open="link"
+              onpointerdown={(e) => e.stopPropagation()}
+              onclick={(e) => { e.stopPropagation(); onOpenLinkNode?.(linkNode); }}
+            >
+              Open
+            </button>
+          {/if}
+        </div>
+        <div class="vc-canvas-node-file-body">External link</div>
+        {#if interactive}
+          <div
+            class="vc-canvas-resize-handle"
+            onpointerdown={(e) => onResizePointerDown?.(e, node)}
+            role="presentation"
+          ></div>
+          {#each SIDES as side (side)}
+            <button
+              type="button"
+              class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+              class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+              aria-label={`Create edge from ${side}`}
+              data-edge-handle={side}
+              onpointerdown={(e) => onHandlePointerDown?.(e, node, side)}
+            ></button>
+          {/each}
+        {/if}
+      </div>
+    {:else if node.type === "group"}
+      {@const groupNode = node as CanvasGroupNode}
+      <div
+        class="vc-canvas-node vc-canvas-node-group"
+        class:vc-canvas-node-selected={selectedNodeId === node.id}
+        class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+        style:left={`${node.x}px`}
+        style:top={`${node.y}px`}
+        style:width={`${node.width}px`}
+        style:height={`${node.height}px`}
+        data-node-id={node.id}
+        data-node-type="group"
+        onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
+        onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
+        role="group"
+        aria-label={groupNode.label ?? "Group"}
+      >
+        {#if groupNode.label}
+          <div class="vc-canvas-node-group-label">{groupNode.label}</div>
+        {/if}
+        {#if interactive}
+          <div
+            class="vc-canvas-resize-handle"
+            onpointerdown={(e) => onResizePointerDown?.(e, node)}
+            role="presentation"
+          ></div>
+          {#each SIDES as side (side)}
+            <button
+              type="button"
+              class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+              class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+              aria-label={`Create edge from ${side}`}
+              data-edge-handle={side}
+              onpointerdown={(e) => onHandlePointerDown?.(e, node, side)}
+            ></button>
+          {/each}
+        {/if}
+      </div>
+    {:else}
+      <div
+        class="vc-canvas-node vc-canvas-node-placeholder"
+        class:vc-canvas-node-selected={selectedNodeId === node.id}
+        class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
+        style:left={`${node.x}px`}
+        style:top={`${node.y}px`}
+        style:width={`${node.width}px`}
+        style:height={`${node.height}px`}
+        data-node-id={node.id}
+        onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        onkeydown={interactive ? (e) => onCardKey?.(e, () => onSelectNode?.(node)) : undefined}
+        onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
+        onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
+        role={interactive ? "button" : undefined}
+        tabindex={interactive ? 0 : undefined}
+      >
+        <div class="vc-canvas-node-content">
+          <em>{node.type}</em>
+        </div>
+        {#if interactive}
+          {#each SIDES as side (side)}
+            <button
+              type="button"
+              class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
+              class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
+              aria-label={`Create edge from ${side}`}
+              data-edge-handle={side}
+              onpointerdown={(e) => onHandlePointerDown?.(e, node, side)}
+            ></button>
+          {/each}
+        {/if}
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .vc-canvas-world {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: 0 0;
+  }
+
+  .vc-canvas-edges {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 1px;
+    height: 1px;
+    overflow: visible;
+    pointer-events: none;
+    color: var(--color-border-strong, #9ca3af);
+  }
+
+  .vc-canvas-edge {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    pointer-events: none;
+  }
+
+  .vc-canvas-edge-selected {
+    stroke: var(--color-accent);
+    stroke-width: 3;
+  }
+
+  .vc-canvas-edge-hit {
+    fill: none;
+    stroke: transparent;
+    stroke-width: 14;
+    pointer-events: stroke;
+    cursor: pointer;
+  }
+
+  .vc-canvas-edge-draft {
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 2;
+    stroke-dasharray: 6 4;
+    pointer-events: none;
+    opacity: 0.9;
+  }
+
+  .vc-canvas-edge-label {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-size: 12px;
+    color: var(--color-text);
+    white-space: nowrap;
+    pointer-events: auto;
+    cursor: pointer;
+  }
+
+  .vc-canvas-readonly .vc-canvas-edge-label {
+    pointer-events: none;
+    cursor: default;
+  }
+
+  .vc-canvas-edge-label-selected {
+    border-color: var(--color-accent);
+  }
+
+  .vc-canvas-edge-label-input {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-size: 12px;
+    font-family: inherit;
+    color: var(--color-text);
+    background: var(--color-surface);
+    outline: none;
+    min-width: 80px;
+  }
+
+  .vc-canvas-node {
+    position: absolute;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+    cursor: move;
+  }
+
+  .vc-canvas-readonly .vc-canvas-node {
+    cursor: default;
+    user-select: text;
+  }
+
+  .vc-canvas-node-selected {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 2px var(--color-accent-bg);
+  }
+
+  .vc-canvas-node-content {
+    padding: 8px;
+    font-size: 14px;
+    color: var(--color-text);
+    white-space: pre-wrap;
+    word-break: break-word;
+    flex: 1;
+    overflow: auto;
+  }
+
+  .vc-canvas-node-placeholder .vc-canvas-node-content {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .vc-canvas-node-file,
+  .vc-canvas-node-link {
+    overflow: hidden;
+  }
+
+  .vc-canvas-node-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+    pointer-events: none;
+    background: #000;
+  }
+
+  .vc-canvas-node-file-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 12px;
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    flex: 0 0 auto;
+  }
+
+  .vc-canvas-node-file-name,
+  .vc-canvas-node-link-url {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-text);
+  }
+
+  .vc-canvas-node-open {
+    flex: 0 0 auto;
+    font-size: 11px;
+    padding: 2px 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .vc-canvas-node-open:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .vc-canvas-node-open-overlay {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 3;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.35);
+  }
+
+  .vc-canvas-node-open-overlay:hover {
+    background: rgba(0, 0, 0, 0.75);
+  }
+
+  .vc-canvas-node-file-body {
+    padding: 8px;
+    font-size: 13px;
+    color: var(--color-text-muted);
+    flex: 1;
+    overflow: auto;
+  }
+
+  .vc-canvas-node-md {
+    padding: 8px;
+    font-size: 13px;
+    color: var(--color-text);
+    flex: 1;
+    overflow: auto;
+    line-height: 1.45;
+  }
+
+  .vc-canvas-node-md-loading {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .vc-canvas-node-group {
+    background: var(--color-accent-bg, rgba(64, 120, 192, 0.08));
+    border-style: dashed;
+    cursor: move;
+  }
+
+  .vc-canvas-readonly .vc-canvas-node-group {
+    cursor: default;
+  }
+
+  .vc-canvas-node-group-label {
+    position: absolute;
+    top: -24px;
+    left: 0;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 2px 8px;
+    pointer-events: none;
+  }
+
+  .vc-canvas-node-textarea {
+    flex: 1;
+    resize: none;
+    border: none;
+    outline: none;
+    padding: 8px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--color-text);
+    background: var(--color-surface);
+    box-sizing: border-box;
+  }
+
+  .vc-canvas-resize-handle {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 12px;
+    height: 12px;
+    cursor: nwse-resize;
+    background: linear-gradient(
+      135deg,
+      transparent 50%,
+      var(--color-border) 50%
+    );
+    z-index: 1;
+  }
+
+  .vc-canvas-edge-handle {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    border: 2px solid var(--color-surface);
+    padding: 0;
+    cursor: crosshair;
+    opacity: 0;
+    transition: opacity 90ms ease-out;
+    z-index: 2;
+  }
+
+  .vc-canvas-node-hovered .vc-canvas-edge-handle,
+  :global(.vc-canvas-drafting) .vc-canvas-edge-handle {
+    opacity: 1;
+  }
+
+  .vc-canvas-edge-handle-active {
+    box-shadow: 0 0 0 3px var(--color-accent-bg);
+    opacity: 1;
+  }
+
+  .vc-canvas-edge-handle-top {
+    left: 50%;
+    top: 0;
+    transform: translate(-50%, -50%);
+  }
+
+  .vc-canvas-edge-handle-right {
+    right: 0;
+    top: 50%;
+    transform: translate(50%, -50%);
+  }
+
+  .vc-canvas-edge-handle-bottom {
+    left: 50%;
+    bottom: 0;
+    transform: translate(-50%, 50%);
+  }
+
+  .vc-canvas-edge-handle-left {
+    left: 0;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+</style>

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -28,6 +28,7 @@
   import { tabStore } from "../../store/tabStore";
   import { openFileAsTab } from "../../lib/openFileAsTab";
   import { renderMarkdownToHtml } from "../Editor/reading/markdownRenderer";
+  import CanvasRenderer from "./CanvasRenderer.svelte";
   import {
     parseCanvas,
     serializeCanvas,
@@ -47,7 +48,7 @@
     DEFAULT_NODE_WIDTH,
     DEFAULT_NODE_HEIGHT,
   } from "../../lib/canvas/types";
-  import { SIDES, anchorPoint } from "../../lib/canvas/geometry";
+  import { anchorPoint } from "../../lib/canvas/geometry";
   import {
     canvasFilePreview,
     isImageFile,
@@ -72,10 +73,6 @@
     updateDraftOnMove,
     resolvePointerUp,
   } from "../../lib/canvas/pointerMode";
-  import {
-    resolveEdges as resolveEdgesPure,
-    draftPath as draftPathPure,
-  } from "../../lib/canvas/edgeResolver";
 
   interface Props {
     tabId: string;
@@ -265,14 +262,6 @@
       /* popup blocked or unsupported — silently swallow */
     }
   }
-
-  // Groups render first so other nodes stack visually on top of them.
-  // Two-pass sort keeps doc.nodes order stable within each band so picks
-  // based on DOM order (hit-testing) stay predictable.
-  let orderedNodes = $derived([
-    ...doc.nodes.filter((n) => n.type === "group"),
-    ...doc.nodes.filter((n) => n.type !== "group"),
-  ]);
 
   function clientToWorld(clientX: number, clientY: number): { x: number; y: number } {
     if (!viewportEl) return { x: 0, y: 0 };
@@ -619,8 +608,6 @@
     if (e.key === " ") spaceHeld = false;
   }
 
-  let resolvedEdges = $derived(resolveEdgesPure(doc));
-  let draftPathD = $derived(draftPathPure(doc, draft));
   // True while a long-press-to-pan pan is actively driving the camera. Used
   // to force the `grabbing` cursor globally on the canvas.
   let isPanActive = $derived(pointerMode?.kind === "pan");
@@ -650,365 +637,45 @@
   {:else if loadError}
     <div class="vc-canvas-error">{loadError}</div>
   {:else}
-    <div
-      class="vc-canvas-world"
-      style:transform={`translate(${camX}px, ${camY}px) scale(${zoom})`}
-    >
-      <svg
-        class="vc-canvas-edges"
-        overflow="visible"
-        aria-hidden="true"
-      >
-        <defs>
-          <marker
-            id="vc-canvas-arrow"
-            viewBox="0 0 10 10"
-            refX="9"
-            refY="5"
-            markerWidth="6"
-            markerHeight="6"
-            orient="auto-start-reverse"
-          >
-            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
-          </marker>
-        </defs>
-        {#each resolvedEdges as re (re.edge.id)}
-          {@const arrowEnd = re.edge.toEnd !== "none"}
-          {@const arrowStart = re.edge.fromEnd === "arrow"}
-          <!-- Wide invisible hit target (svg captures pointer events) -->
-          <path
-            class="vc-canvas-edge-hit"
-            d={re.path}
-            data-edge-id={re.edge.id}
-            onpointerdown={(e) => onEdgeHitPointerDown(e, re.edge)}
-            ondblclick={(e) => onEdgeDblClick(e, re.edge)}
-          />
-          <path
-            class="vc-canvas-edge"
-            class:vc-canvas-edge-selected={selectedEdgeId === re.edge.id}
-            d={re.path}
-            style:color={re.edge.color ?? "var(--color-border-strong, #9ca3af)"}
-            marker-end={arrowEnd ? "url(#vc-canvas-arrow)" : null}
-            marker-start={arrowStart ? "url(#vc-canvas-arrow)" : null}
-            data-edge-id={re.edge.id}
-          />
-        {/each}
-        {#if draftPathD}
-          <path
-            class="vc-canvas-edge-draft"
-            d={draftPathD}
-          />
-        {/if}
-      </svg>
-
-      {#each resolvedEdges as re (`lbl-${re.edge.id}`)}
-        {#if editingEdgeId === re.edge.id}
-          <input
-            bind:this={editingEdgeLabelEl}
-            class="vc-canvas-edge-label-input"
-            value={re.edge.label ?? ""}
-            style:left={`${re.mid.x}px`}
-            style:top={`${re.mid.y}px`}
-            oninput={(e) => onEdgeLabelInput(e, re.edge)}
-            onblur={onEdgeLabelBlur}
-            onpointerdown={(e) => e.stopPropagation()}
-            ondblclick={(e) => e.stopPropagation()}
-            onkeydown={(e) => {
-              if (e.key === "Enter" || e.key === "Escape") {
-                e.preventDefault();
-                editingEdgeId = null;
-              }
-            }}
-          />
-        {:else if re.edge.label}
-          <div
-            class="vc-canvas-edge-label"
-            class:vc-canvas-edge-label-selected={selectedEdgeId === re.edge.id}
-            style:left={`${re.mid.x}px`}
-            style:top={`${re.mid.y}px`}
-            data-edge-id={re.edge.id}
-            onpointerdown={(e) => onEdgeHitPointerDown(e, re.edge)}
-            ondblclick={(e) => onEdgeDblClick(e, re.edge)}
-            onkeydown={(e) => onCardKey(e, () => startEditEdgeLabel(re.edge))}
-            role="button"
-            tabindex="0"
-          >
-            {re.edge.label}
-          </div>
-        {/if}
-      {/each}
-
-      {#each orderedNodes as node (node.id)}
-        {#if node.type === "text"}
-          <div
-            class="vc-canvas-node vc-canvas-node-text"
-            class:vc-canvas-node-selected={selectedNodeId === node.id}
-            class:vc-canvas-node-editing={editingNodeId === node.id}
-            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
-            style:left={`${node.x}px`}
-            style:top={`${node.y}px`}
-            style:width={`${node.width}px`}
-            style:height={`${node.height}px`}
-            data-node-id={node.id}
-            onpointerdown={(e) => onNodePointerDown(e, node)}
-            ondblclick={(e) => onNodeDblClick(e, node)}
-            onkeydown={(e) => onCardKey(e, () => startEditText(node as CanvasTextNode))}
-            onpointerenter={() => (hoveredNodeId = node.id)}
-            onpointerleave={() => {
-              if (hoveredNodeId === node.id) hoveredNodeId = null;
-            }}
-            role="button"
-            tabindex="0"
-          >
-            {#if editingNodeId === node.id}
-              <textarea
-                bind:this={editingTextareaEl}
-                class="vc-canvas-node-textarea"
-                value={(node as CanvasTextNode).text}
-                oninput={(e) => onTextEdit(e, node as CanvasTextNode)}
-                onblur={onTextBlur}
-                onpointerdown={(e) => e.stopPropagation()}
-                ondblclick={(e) => e.stopPropagation()}
-              ></textarea>
-            {:else}
-              <div class="vc-canvas-node-content">
-                {(node as CanvasTextNode).text || "Empty card"}
-              </div>
-            {/if}
-            <div
-              class="vc-canvas-resize-handle"
-              onpointerdown={(e) => onResizePointerDown(e, node)}
-              role="presentation"
-            ></div>
-            {#each SIDES as side (side)}
-              <button
-                type="button"
-                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
-                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
-                aria-label={`Create edge from ${side}`}
-                data-edge-handle={side}
-                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
-              ></button>
-            {/each}
-          </div>
-        {:else if node.type === "file"}
-          {@const fileNode = node as CanvasFileNode}
-          {@const vaultPath = $vaultStore.currentPath}
-          {@const abs = vaultPath ? resolveVaultAbs(vaultPath, fileNode.file) : null}
-          <div
-            class="vc-canvas-node vc-canvas-node-file"
-            class:vc-canvas-node-selected={selectedNodeId === node.id}
-            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
-            style:left={`${node.x}px`}
-            style:top={`${node.y}px`}
-            style:width={`${node.width}px`}
-            style:height={`${node.height}px`}
-            data-node-id={node.id}
-            data-node-type="file"
-            onpointerdown={(e) => onNodePointerDown(e, node)}
-            onkeydown={(e) => onCardKey(e, () => void onOpenFileNode(fileNode))}
-            onpointerenter={() => (hoveredNodeId = node.id)}
-            onpointerleave={() => {
-              if (hoveredNodeId === node.id) hoveredNodeId = null;
-            }}
-            role="button"
-            tabindex="0"
-          >
-            {#if isImageFile(fileNode.file) && abs}
-              <img
-                class="vc-canvas-node-image"
-                src={convertFileSrc(abs)}
-                alt={fileNode.file}
-                draggable="false"
-                data-canvas-image="true"
-              />
-              <button
-                type="button"
-                class="vc-canvas-node-open vc-canvas-node-open-overlay"
-                data-canvas-open="image"
-                onpointerdown={(e) => e.stopPropagation()}
-                onclick={(e) => { e.stopPropagation(); void onOpenFileNode(fileNode); }}
-              >
-                Open
-              </button>
-            {:else if isMarkdownFile(fileNode.file)}
-              <div class="vc-canvas-node-file-header" data-canvas-file={fileNode.file}>
-                <span class="vc-canvas-node-file-name">{fileNode.file}</span>
-                <button
-                  type="button"
-                  class="vc-canvas-node-open"
-                  data-canvas-open="md"
-                  onpointerdown={(e) => e.stopPropagation()}
-                  onclick={(e) => { e.stopPropagation(); void onOpenFileNode(fileNode); }}
-                >
-                  Open
-                </button>
-              </div>
-              {#if mdPreviews[fileNode.file]}
-                <div class="vc-canvas-node-md markdown-body">{@html mdPreviews[fileNode.file]}</div>
-              {:else}
-                <div class="vc-canvas-node-md vc-canvas-node-md-loading">Loading preview…</div>
-              {/if}
-            {:else}
-              <div class="vc-canvas-node-file-header" data-canvas-file={fileNode.file}>
-                <span class="vc-canvas-node-file-name">{fileNode.file}</span>
-                <button
-                  type="button"
-                  class="vc-canvas-node-open"
-                  data-canvas-open="file"
-                  onpointerdown={(e) => e.stopPropagation()}
-                  onclick={(e) => { e.stopPropagation(); void onOpenFileNode(fileNode); }}
-                >
-                  Open
-                </button>
-              </div>
-              <div class="vc-canvas-node-file-body">
-                Attached file
-              </div>
-            {/if}
-            <div
-              class="vc-canvas-resize-handle"
-              onpointerdown={(e) => onResizePointerDown(e, node)}
-              role="presentation"
-            ></div>
-            {#each SIDES as side (side)}
-              <button
-                type="button"
-                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
-                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
-                aria-label={`Create edge from ${side}`}
-                data-edge-handle={side}
-                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
-              ></button>
-            {/each}
-          </div>
-        {:else if node.type === "link"}
-          {@const linkNode = node as CanvasLinkNode}
-          <div
-            class="vc-canvas-node vc-canvas-node-link"
-            class:vc-canvas-node-selected={selectedNodeId === node.id}
-            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
-            style:left={`${node.x}px`}
-            style:top={`${node.y}px`}
-            style:width={`${node.width}px`}
-            style:height={`${node.height}px`}
-            data-node-id={node.id}
-            data-node-type="link"
-            onpointerdown={(e) => onNodePointerDown(e, node)}
-            onkeydown={(e) => onCardKey(e, () => onOpenLinkNode(linkNode))}
-            onpointerenter={() => (hoveredNodeId = node.id)}
-            onpointerleave={() => {
-              if (hoveredNodeId === node.id) hoveredNodeId = null;
-            }}
-            role="button"
-            tabindex="0"
-          >
-            <div class="vc-canvas-node-file-header">
-              <span class="vc-canvas-node-link-url" title={linkNode.url}>{linkNode.url}</span>
-              <button
-                type="button"
-                class="vc-canvas-node-open"
-                data-canvas-open="link"
-                onpointerdown={(e) => e.stopPropagation()}
-                onclick={(e) => { e.stopPropagation(); onOpenLinkNode(linkNode); }}
-              >
-                Open
-              </button>
-            </div>
-            <div class="vc-canvas-node-file-body">External link</div>
-            <div
-              class="vc-canvas-resize-handle"
-              onpointerdown={(e) => onResizePointerDown(e, node)}
-              role="presentation"
-            ></div>
-            {#each SIDES as side (side)}
-              <button
-                type="button"
-                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
-                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
-                aria-label={`Create edge from ${side}`}
-                data-edge-handle={side}
-                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
-              ></button>
-            {/each}
-          </div>
-        {:else if node.type === "group"}
-          {@const groupNode = node as CanvasGroupNode}
-          <div
-            class="vc-canvas-node vc-canvas-node-group"
-            class:vc-canvas-node-selected={selectedNodeId === node.id}
-            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
-            style:left={`${node.x}px`}
-            style:top={`${node.y}px`}
-            style:width={`${node.width}px`}
-            style:height={`${node.height}px`}
-            data-node-id={node.id}
-            data-node-type="group"
-            onpointerdown={(e) => onNodePointerDown(e, node)}
-            onpointerenter={() => (hoveredNodeId = node.id)}
-            onpointerleave={() => {
-              if (hoveredNodeId === node.id) hoveredNodeId = null;
-            }}
-            role="group"
-            aria-label={groupNode.label ?? "Group"}
-          >
-            {#if groupNode.label}
-              <div class="vc-canvas-node-group-label">{groupNode.label}</div>
-            {/if}
-            <div
-              class="vc-canvas-resize-handle"
-              onpointerdown={(e) => onResizePointerDown(e, node)}
-              role="presentation"
-            ></div>
-            {#each SIDES as side (side)}
-              <button
-                type="button"
-                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
-                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
-                aria-label={`Create edge from ${side}`}
-                data-edge-handle={side}
-                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
-              ></button>
-            {/each}
-          </div>
-        {:else}
-          <div
-            class="vc-canvas-node vc-canvas-node-placeholder"
-            class:vc-canvas-node-selected={selectedNodeId === node.id}
-            class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
-            style:left={`${node.x}px`}
-            style:top={`${node.y}px`}
-            style:width={`${node.width}px`}
-            style:height={`${node.height}px`}
-            data-node-id={node.id}
-            onpointerdown={(e) => onNodePointerDown(e, node)}
-            onkeydown={(e) => onCardKey(e, () => selectNode(node))}
-            onpointerenter={() => (hoveredNodeId = node.id)}
-            onpointerleave={() => {
-              if (hoveredNodeId === node.id) hoveredNodeId = null;
-            }}
-            role="button"
-            tabindex="0"
-          >
-            <div class="vc-canvas-node-content">
-              <em>{node.type}</em>
-            </div>
-            {#each SIDES as side (side)}
-              <button
-                type="button"
-                class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
-                class:vc-canvas-edge-handle-active={draft?.targetNodeId === node.id && draft?.targetSide === side}
-                aria-label={`Create edge from ${side}`}
-                data-edge-handle={side}
-                onpointerdown={(e) => onHandlePointerDown(e, node, side)}
-              ></button>
-            {/each}
-          </div>
-        {/if}
-      {/each}
-    </div>
+    <CanvasRenderer
+      {doc}
+      {camX}
+      {camY}
+      {zoom}
+      vaultPath={$vaultStore.currentPath}
+      {mdPreviews}
+      interactive={true}
+      {selectedNodeId}
+      {selectedEdgeId}
+      {hoveredNodeId}
+      {editingNodeId}
+      {editingEdgeId}
+      {draft}
+      bind:editingTextareaEl
+      bind:editingEdgeLabelEl
+      onNodePointerDown={onNodePointerDown}
+      onNodeDblClick={onNodeDblClick}
+      onNodeHoverEnter={(n) => (hoveredNodeId = n.id)}
+      onNodeHoverLeave={(n) => { if (hoveredNodeId === n.id) hoveredNodeId = null; }}
+      onResizePointerDown={onResizePointerDown}
+      onHandlePointerDown={onHandlePointerDown}
+      onCardKey={onCardKey}
+      onStartEditText={startEditText}
+      onTextEdit={onTextEdit}
+      onTextBlur={onTextBlur}
+      onOpenFileNode={(n) => { void onOpenFileNode(n); }}
+      onOpenLinkNode={onOpenLinkNode}
+      onSelectNode={selectNode}
+      onEdgeHitPointerDown={onEdgeHitPointerDown}
+      onEdgeDblClick={onEdgeDblClick}
+      onEdgeLabelInput={onEdgeLabelInput}
+      onEdgeLabelBlur={onEdgeLabelBlur}
+      onStartEditEdgeLabel={startEditEdgeLabel}
+      onStopEditingEdge={() => (editingEdgeId = null)}
+    />
   {/if}
 </div>
+
 
 <style>
   .vc-canvas-viewport {
@@ -1036,299 +703,6 @@
     cursor: crosshair;
   }
 
-  .vc-canvas-world {
-    position: absolute;
-    top: 0;
-    left: 0;
-    transform-origin: 0 0;
-  }
-
-  .vc-canvas-edges {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 1px;
-    height: 1px;
-    overflow: visible;
-    pointer-events: none;
-    color: var(--color-border-strong, #9ca3af);
-  }
-
-  .vc-canvas-edge {
-    fill: none;
-    stroke: currentColor;
-    stroke-width: 2;
-    pointer-events: none;
-  }
-
-  .vc-canvas-edge-selected {
-    stroke: var(--color-accent);
-    stroke-width: 3;
-  }
-
-  .vc-canvas-edge-hit {
-    fill: none;
-    stroke: transparent;
-    stroke-width: 14;
-    pointer-events: stroke;
-    cursor: pointer;
-  }
-
-  .vc-canvas-edge-draft {
-    fill: none;
-    stroke: var(--color-accent);
-    stroke-width: 2;
-    stroke-dasharray: 6 4;
-    pointer-events: none;
-    opacity: 0.9;
-  }
-
-  .vc-canvas-edge-label {
-    position: absolute;
-    transform: translate(-50%, -50%);
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    padding: 1px 6px;
-    font-size: 12px;
-    color: var(--color-text);
-    white-space: nowrap;
-    pointer-events: auto;
-    cursor: pointer;
-  }
-
-  .vc-canvas-edge-label-selected {
-    border-color: var(--color-accent);
-  }
-
-  .vc-canvas-edge-label-input {
-    position: absolute;
-    transform: translate(-50%, -50%);
-    border: 1px solid var(--color-accent);
-    border-radius: 4px;
-    padding: 1px 6px;
-    font-size: 12px;
-    font-family: inherit;
-    color: var(--color-text);
-    background: var(--color-surface);
-    outline: none;
-    min-width: 80px;
-  }
-
-  .vc-canvas-node {
-    position: absolute;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
-    display: flex;
-    flex-direction: column;
-    overflow: visible;
-    cursor: move;
-  }
-
-  .vc-canvas-node-selected {
-    border-color: var(--color-accent);
-    box-shadow: 0 0 0 2px var(--color-accent-bg);
-  }
-
-  .vc-canvas-node-content {
-    padding: 8px;
-    font-size: 14px;
-    color: var(--color-text);
-    white-space: pre-wrap;
-    word-break: break-word;
-    flex: 1;
-    overflow: auto;
-  }
-
-  .vc-canvas-node-placeholder .vc-canvas-node-content {
-    color: var(--color-text-muted);
-    font-style: italic;
-  }
-
-  .vc-canvas-node-file,
-  .vc-canvas-node-link {
-    overflow: hidden;
-  }
-
-  .vc-canvas-node-image {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    display: block;
-    pointer-events: none;
-    background: #000;
-  }
-
-  .vc-canvas-node-file-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 8px;
-    border-bottom: 1px solid var(--color-border);
-    font-size: 12px;
-    color: var(--color-text-muted);
-    background: var(--color-surface);
-    flex: 0 0 auto;
-  }
-
-  .vc-canvas-node-file-name,
-  .vc-canvas-node-link-url {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--color-text);
-  }
-
-  .vc-canvas-node-open {
-    flex: 0 0 auto;
-    font-size: 11px;
-    padding: 2px 8px;
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    background: var(--color-surface);
-    color: var(--color-text);
-    cursor: pointer;
-  }
-
-  .vc-canvas-node-open:hover {
-    border-color: var(--color-accent);
-    color: var(--color-accent);
-  }
-
-  .vc-canvas-node-open-overlay {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    z-index: 3;
-    background: rgba(0, 0, 0, 0.55);
-    color: #fff;
-    border-color: rgba(255, 255, 255, 0.35);
-  }
-
-  .vc-canvas-node-open-overlay:hover {
-    background: rgba(0, 0, 0, 0.75);
-  }
-
-  .vc-canvas-node-file-body {
-    padding: 8px;
-    font-size: 13px;
-    color: var(--color-text-muted);
-    flex: 1;
-    overflow: auto;
-  }
-
-  .vc-canvas-node-md {
-    padding: 8px;
-    font-size: 13px;
-    color: var(--color-text);
-    flex: 1;
-    overflow: auto;
-    line-height: 1.45;
-  }
-
-  .vc-canvas-node-md-loading {
-    color: var(--color-text-muted);
-    font-style: italic;
-  }
-
-  .vc-canvas-node-group {
-    background: var(--color-accent-bg, rgba(64, 120, 192, 0.08));
-    border-style: dashed;
-    cursor: move;
-  }
-
-  .vc-canvas-node-group-label {
-    position: absolute;
-    top: -24px;
-    left: 0;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--color-text);
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    padding: 2px 8px;
-    pointer-events: none;
-  }
-
-  .vc-canvas-node-textarea {
-    flex: 1;
-    resize: none;
-    border: none;
-    outline: none;
-    padding: 8px;
-    font-size: 14px;
-    font-family: inherit;
-    color: var(--color-text);
-    background: var(--color-surface);
-    box-sizing: border-box;
-  }
-
-  .vc-canvas-resize-handle {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    width: 12px;
-    height: 12px;
-    cursor: nwse-resize;
-    background: linear-gradient(
-      135deg,
-      transparent 50%,
-      var(--color-border) 50%
-    );
-    z-index: 1;
-  }
-
-  .vc-canvas-edge-handle {
-    position: absolute;
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    background: var(--color-accent);
-    border: 2px solid var(--color-surface);
-    padding: 0;
-    cursor: crosshair;
-    opacity: 0;
-    transition: opacity 90ms ease-out;
-    z-index: 2;
-  }
-
-  .vc-canvas-node-hovered .vc-canvas-edge-handle,
-  .vc-canvas-drafting .vc-canvas-edge-handle {
-    opacity: 1;
-  }
-
-  .vc-canvas-edge-handle-active {
-    box-shadow: 0 0 0 3px var(--color-accent-bg);
-    opacity: 1;
-  }
-
-  .vc-canvas-edge-handle-top {
-    left: 50%;
-    top: 0;
-    transform: translate(-50%, -50%);
-  }
-
-  .vc-canvas-edge-handle-right {
-    right: 0;
-    top: 50%;
-    transform: translate(50%, -50%);
-  }
-
-  .vc-canvas-edge-handle-bottom {
-    left: 50%;
-    bottom: 0;
-    transform: translate(-50%, 50%);
-  }
-
-  .vc-canvas-edge-handle-left {
-    left: 0;
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
 
   .vc-canvas-loading,
   .vc-canvas-error {

--- a/src/components/Canvas/__tests__/CanvasRenderer.test.ts
+++ b/src/components/Canvas/__tests__/CanvasRenderer.test.ts
@@ -1,0 +1,146 @@
+// #156 — CanvasRenderer is the pure presentation layer shared between
+// CanvasView (interactive) and the CanvasEmbedWidget (read-only). These
+// tests lock in: (a) that read-only mode hides the resize/edge handles
+// and omits the pointer/keyboard handlers, and (b) that every node type
+// renders its expected class + key data attributes so the E2E specs and
+// the main view keep agreeing on the DOM contract.
+
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://localhost/${encodeURIComponent(p)}`,
+}));
+
+import CanvasRenderer from "../CanvasRenderer.svelte";
+import type { CanvasDoc } from "../../../lib/canvas/types";
+
+function docOf(nodes: CanvasDoc["nodes"], edges: CanvasDoc["edges"] = []): CanvasDoc {
+  return { nodes, edges, extra: {} };
+}
+
+describe("CanvasRenderer (#156)", () => {
+  it("renders each node type with its expected class and data-node-id", () => {
+    const doc = docOf([
+      { id: "t", type: "text", text: "Hello", x: 0, y: 0, width: 120, height: 40 },
+      { id: "f", type: "file", file: "Note.md", x: 0, y: 50, width: 160, height: 80 },
+      { id: "l", type: "link", url: "https://example.com", x: 0, y: 150, width: 160, height: 60 },
+      { id: "g", type: "group", label: "Cluster", x: 0, y: 250, width: 300, height: 200 },
+    ]);
+
+    const { container } = render(CanvasRenderer, {
+      props: { doc, interactive: true, vaultPath: "/vault" },
+    });
+
+    expect(container.querySelector('[data-node-id="t"].vc-canvas-node-text')).toBeTruthy();
+    expect(container.querySelector('[data-node-id="f"].vc-canvas-node-file')).toBeTruthy();
+    expect(container.querySelector('[data-node-id="l"].vc-canvas-node-link')).toBeTruthy();
+    expect(container.querySelector('[data-node-id="g"].vc-canvas-node-group')).toBeTruthy();
+  });
+
+  it("text node content is visible inside the DOM (no 40-char truncation any more)", () => {
+    const longText = "Line 1\nLine 2 that is long enough that the old SVG label would have cut it at forty characters.";
+    const doc = docOf([
+      { id: "t", type: "text", text: longText, x: 0, y: 0, width: 300, height: 120 },
+    ]);
+    const { container } = render(CanvasRenderer, { props: { doc, interactive: false } });
+    const content = container.querySelector(".vc-canvas-node-content")!;
+    expect(content.textContent).toBe(longText);
+  });
+
+  it("read-only mode (interactive=false) omits resize + edge handles", () => {
+    const doc = docOf([
+      { id: "t", type: "text", text: "x", x: 0, y: 0, width: 100, height: 40 },
+    ]);
+    const { container } = render(CanvasRenderer, { props: { doc, interactive: false } });
+    expect(container.querySelector(".vc-canvas-resize-handle")).toBeNull();
+    expect(container.querySelectorAll(".vc-canvas-edge-handle")).toHaveLength(0);
+    expect(container.querySelector(".vc-canvas-readonly")).toBeTruthy();
+  });
+
+  it("interactive mode renders resize + edge handles for a text node", () => {
+    const doc = docOf([
+      { id: "t", type: "text", text: "x", x: 0, y: 0, width: 100, height: 40 },
+    ]);
+    const { container } = render(CanvasRenderer, { props: { doc, interactive: true } });
+    expect(container.querySelector(".vc-canvas-resize-handle")).toBeTruthy();
+    // Four sides per node → 4 handles.
+    expect(container.querySelectorAll(".vc-canvas-edge-handle")).toHaveLength(4);
+    expect(container.querySelector(".vc-canvas-readonly")).toBeNull();
+  });
+
+  it("renders one <path class='vc-canvas-edge'> per resolvable edge", () => {
+    const doc = docOf(
+      [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      [
+        { id: "e1", fromNode: "a", toNode: "b" },
+        { id: "ghost", fromNode: "a", toNode: "missing" },
+      ],
+    );
+    const { container } = render(CanvasRenderer, { props: { doc, interactive: false } });
+    // Orphaned edges are dropped by resolveEdges — only 1 visible path.
+    expect(container.querySelectorAll("path.vc-canvas-edge")).toHaveLength(1);
+  });
+
+  it("applies the camera transform to the world container", () => {
+    const doc = docOf([
+      { id: "t", type: "text", text: "x", x: 0, y: 0, width: 100, height: 40 },
+    ]);
+    const { container } = render(CanvasRenderer, {
+      props: { doc, camX: 50, camY: 20, zoom: 0.5, interactive: false },
+    });
+    const world = container.querySelector<HTMLElement>(".vc-canvas-world")!;
+    expect(world.style.transform).toContain("translate(50px, 20px)");
+    expect(world.style.transform).toContain("scale(0.5)");
+  });
+
+  it("renders a group node with its label", () => {
+    const doc = docOf([
+      { id: "g", type: "group", label: "My group", x: 0, y: 0, width: 300, height: 200 },
+    ]);
+    const { container } = render(CanvasRenderer, { props: { doc, interactive: false } });
+    const label = container.querySelector(".vc-canvas-node-group-label");
+    expect(label?.textContent).toBe("My group");
+  });
+
+  it("renders the link URL inside a link node", () => {
+    const doc = docOf([
+      { id: "l", type: "link", url: "https://example.com", x: 0, y: 0, width: 160, height: 60 },
+    ]);
+    const { container } = render(CanvasRenderer, { props: { doc, interactive: false } });
+    const url = container.querySelector(".vc-canvas-node-link-url");
+    expect(url?.textContent).toBe("https://example.com");
+  });
+
+  it("file nodes pointing at an image render an <img> with the asset:// src", () => {
+    const doc = docOf([
+      { id: "f", type: "file", file: "pic.png", x: 0, y: 0, width: 200, height: 150 },
+    ]);
+    const { container } = render(CanvasRenderer, {
+      props: { doc, vaultPath: "/vault", interactive: false },
+    });
+    const img = container.querySelector<HTMLImageElement>("img.vc-canvas-node-image");
+    expect(img).toBeTruthy();
+    expect(img!.getAttribute("src")).toContain("asset://localhost/");
+    expect(img!.getAttribute("src")).toContain(encodeURIComponent("/vault/pic.png"));
+  });
+
+  it("markdown file nodes use the provided mdPreviews HTML", () => {
+    const doc = docOf([
+      { id: "f", type: "file", file: "Note.md", x: 0, y: 0, width: 240, height: 120 },
+    ]);
+    const { container } = render(CanvasRenderer, {
+      props: {
+        doc,
+        vaultPath: "/vault",
+        interactive: false,
+        mdPreviews: { "Note.md": "<h1>Heading from markdown</h1>" },
+      },
+    });
+    const md = container.querySelector(".vc-canvas-node-md.markdown-body");
+    expect(md?.innerHTML).toContain("<h1>Heading from markdown</h1>");
+  });
+});

--- a/src/components/Editor/__tests__/canvasEmbedPreview.test.ts
+++ b/src/components/Editor/__tests__/canvasEmbedPreview.test.ts
@@ -1,8 +1,7 @@
-// #147 — inline canvas embed rendering. These tests drive the SVG preview
-// helper that the CM6 embed widget calls after it fetches the .canvas file.
-// We only need a DOM (jsdom) — no Tauri runtime — to assert that nodes and
-// edges land in the SVG with auto-fit viewBox, and that empty / invalid
-// canvases surface a friendly placeholder instead of blowing up.
+// #156 — the inline canvas embed now mounts the shared CanvasRenderer
+// with a fit-to-width camera. These tests lock in the pure camera math
+// (bounding box + zoom + height cap) that the widget uses; renderer
+// output itself is covered by CanvasRenderer.test.ts and the E2E specs.
 
 import { describe, it, expect, vi } from "vitest";
 
@@ -13,62 +12,58 @@ vi.mock("../../../ipc/commands", () => ({
   readFile: vi.fn().mockResolvedValue(""),
 }));
 
-import { __renderCanvasPreviewForTests } from "../embedPlugin";
+import { __computeEmbedCameraForTests } from "../embedPlugin";
 
-function mountPreview(json: string): HTMLElement {
-  const el = document.createElement("div");
-  __renderCanvasPreviewForTests(el, json);
-  return el;
-}
-
-describe("canvas embed preview (#147)", () => {
-  it("renders one <rect> per node and one <line> per edge inside a viewBox that contains all nodes", () => {
-    const doc = {
+describe("canvas embed fit-to-width camera (#156)", () => {
+  it("zooms the bounding box to the requested width and translates to its top-left", () => {
+    const json = JSON.stringify({
       nodes: [
         { id: "a", type: "text", text: "Hello", x: 0, y: 0, width: 100, height: 40 },
         { id: "b", type: "text", text: "World", x: 200, y: 80, width: 120, height: 50 },
       ],
       edges: [{ id: "e", fromNode: "a", toNode: "b" }],
-    };
-    const el = mountPreview(JSON.stringify(doc));
-    const svg = el.querySelector("svg")!;
-    expect(svg).toBeTruthy();
-
-    const viewBox = svg.getAttribute("viewBox")!.split(/\s+/).map(Number);
-    const [vbX, vbY, vbW, vbH] = viewBox as [number, number, number, number];
-    // minX=0, minY=0, maxX=320, maxY=130 with pad=20 → viewBox -20 -20 360 170
-    expect(vbX).toBe(-20);
-    expect(vbY).toBe(-20);
-    expect(vbW).toBe(360);
-    expect(vbH).toBe(170);
-
-    expect(svg.querySelectorAll("rect")).toHaveLength(2);
-    expect(svg.querySelectorAll("line")).toHaveLength(1);
-    // Labels: first line of text for text nodes.
-    const labels = Array.from(svg.querySelectorAll("text")).map((t) => t.textContent);
-    expect(labels).toContain("Hello");
-    expect(labels).toContain("World");
+    });
+    const cam = __computeEmbedCameraForTests(json, 600)!;
+    // bbox = 0..320 × 0..130, pad=24 on both sides → 368 × 178
+    // zoom = 600 / 368, camX/camY translate the padded origin to (0,0).
+    const expectedZoom = 600 / 368;
+    expect(cam.zoom).toBeCloseTo(expectedZoom, 5);
+    expect(cam.camX).toBeCloseTo(24 * expectedZoom, 5);
+    expect(cam.camY).toBeCloseTo(24 * expectedZoom, 5);
+    // heightPx = 178 * zoom, clamped to [80, 420].
+    expect(cam.heightPx).toBeCloseTo(178 * expectedZoom, 5);
   });
 
-  it("renders an (empty canvas) placeholder when the file has no nodes", () => {
-    const el = mountPreview(JSON.stringify({ nodes: [], edges: [] }));
-    expect(el.querySelector(".cm-embed-canvas-empty")).toBeTruthy();
-    expect(el.textContent).toContain("empty canvas");
+  it("caps the height at the embed's max when the canvas is very tall", () => {
+    const json = JSON.stringify({
+      nodes: [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 50, height: 50 },
+        { id: "b", type: "text", text: "b", x: 0, y: 5000, width: 50, height: 50 },
+      ],
+      edges: [],
+    });
+    const cam = __computeEmbedCameraForTests(json, 600)!;
+    expect(cam.heightPx).toBeLessThanOrEqual(420);
   });
 
-  it("reports an invalid-canvas warning when the payload is not JSON", () => {
-    const el = mountPreview("not-json");
-    expect(el.textContent).toContain("invalid canvas file");
+  it("returns null when the canvas has no nodes (empty-placeholder path)", () => {
+    const cam = __computeEmbedCameraForTests(
+      JSON.stringify({ nodes: [], edges: [] }),
+      600,
+    );
+    expect(cam).toBeNull();
   });
 
-  it("drops edges whose endpoints reference missing nodes without throwing", () => {
-    const doc = {
-      nodes: [{ id: "a", type: "text", text: "only", x: 0, y: 0, width: 80, height: 30 }],
-      edges: [{ id: "dangling", fromNode: "a", toNode: "ghost" }],
-    };
-    const el = mountPreview(JSON.stringify(doc));
-    const svg = el.querySelector("svg")!;
-    expect(svg.querySelectorAll("rect")).toHaveLength(1);
-    expect(svg.querySelectorAll("line")).toHaveLength(0);
+  it("treats nodes with missing width/height as default-sized so bbox stays finite", () => {
+    const json = JSON.stringify({
+      nodes: [
+        { id: "a", type: "text", text: "x", x: 10, y: 20 }, // no width/height
+      ],
+      edges: [],
+    });
+    const cam = __computeEmbedCameraForTests(json, 400)!;
+    expect(Number.isFinite(cam.zoom)).toBe(true);
+    expect(Number.isFinite(cam.heightPx)).toBe(true);
+    expect(cam.heightPx).toBeGreaterThan(0);
   });
 });

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -24,6 +24,7 @@ import type { EditorState } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { get } from "svelte/store";
+import { mount, unmount } from "svelte";
 
 import { resolveAttachment } from "./embeds";
 import { resolveTarget } from "./wikiLink";
@@ -34,6 +35,7 @@ import { listenFileChange } from "../../ipc/events";
 import { parseCanvas } from "../../lib/canvas/parse";
 import type { CanvasNode } from "../../lib/canvas/types";
 import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from "../../lib/canvas/types";
+import CanvasRenderer from "../Canvas/CanvasRenderer.svelte";
 
 // ── Regex ──────────────────────────────────────────────────────────────────────
 
@@ -310,9 +312,11 @@ class NoteEmbedWidget extends WidgetType {
 }
 
 /**
- * #147 — inline read-only mini-canvas for `![[mycanvas]]`. Renders node
- * rectangles and edges as a single SVG that auto-fits all nodes into the
- * widget's box. Clicking anywhere opens the full canvas viewer via the
+ * #147 / #156 — inline read-only mini-canvas for `![[mycanvas]]`. Mounts
+ * the shared `CanvasRenderer` with `interactive={false}` so nodes render
+ * with full HTML (markdown, file previews, link cards, group labels) and
+ * edges keep their SVG bezier/arrowhead styling — pixel-identical to the
+ * main CanvasView. Clicking anywhere opens the full canvas viewer via the
  * standard tabStore path.
  */
 class CanvasEmbedWidget extends WidgetType {
@@ -345,18 +349,18 @@ class CanvasEmbedWidget extends WidgetType {
     wrap.setAttribute("role", "button");
     wrap.setAttribute("tabindex", "0");
     wrap.title = `Open ${this.relPath}`;
-    if (this.widthPx !== null) {
-      wrap.style.width = `${this.widthPx}px`;
-    }
+    const widthPx = this.widthPx ?? CANVAS_EMBED_DEFAULT_WIDTH;
+    wrap.style.width = `${widthPx}px`;
 
     const body = document.createElement("div");
     body.className = "cm-embed-canvas-body";
+    wrap.appendChild(body);
+
     if (this.content === null) {
       body.textContent = "…";
     } else {
-      renderCanvasPreviewInto(body, this.content);
+      renderCanvasEmbedBody(body, this.content, widthPx, wrap);
     }
-    wrap.appendChild(body);
 
     const abs = absFromRel(this.relPath);
     const openCanvas = (): void => {
@@ -378,6 +382,20 @@ class CanvasEmbedWidget extends WidgetType {
     return wrap;
   }
 
+  destroy(dom: HTMLElement): void {
+    // Tear down the Svelte renderer instance — without this, every embed
+    // replacement would leak reactive state until the view is destroyed.
+    const component = (dom as unknown as { _vcRenderer?: unknown })._vcRenderer;
+    if (component) {
+      try {
+        unmount(component);
+      } catch {
+        /* already unmounted */
+      }
+      (dom as unknown as { _vcRenderer?: unknown })._vcRenderer = undefined;
+    }
+  }
+
   ignoreEvent(event: Event): boolean {
     // Let click + keydown through to our own listener so the embed is
     // actionable even though CM6 otherwise swallows widget events.
@@ -385,25 +403,76 @@ class CanvasEmbedWidget extends WidgetType {
   }
 }
 
-function renderCanvasPreviewInto(el: HTMLElement, rawJson: string): void {
-  el.textContent = "";
+const CANVAS_EMBED_DEFAULT_WIDTH = 600;
+const CANVAS_EMBED_MAX_HEIGHT = 420;
+const CANVAS_EMBED_MIN_HEIGHT = 80;
+const CANVAS_EMBED_PADDING = 24;
+
+/**
+ * Populate the embed body by mounting CanvasRenderer in read-only mode.
+ * The bounding box of all nodes drives a fit-to-width camera so the whole
+ * canvas is visible. Height is capped so ridiculously tall canvases don't
+ * push the host note off the screen.
+ */
+function renderCanvasEmbedBody(
+  body: HTMLElement,
+  rawJson: string,
+  widthPx: number,
+  wrap: HTMLElement,
+): void {
   let doc;
   try {
     doc = parseCanvas(rawJson);
   } catch {
-    el.textContent = "\u26A0 invalid canvas file";
+    body.textContent = "\u26A0 invalid canvas file";
     return;
   }
-  const nodes = doc.nodes;
-  if (nodes.length === 0) {
+  if (doc.nodes.length === 0) {
     const empty = document.createElement("div");
     empty.className = "cm-embed-canvas-empty";
     empty.textContent = "(empty canvas)";
-    el.appendChild(empty);
+    body.appendChild(empty);
     return;
   }
 
-  // Compute bounding box including default sizes for nodes missing width/height.
+  const bbox = computeCanvasBBox(doc.nodes);
+  const pad = CANVAS_EMBED_PADDING;
+  const bboxW = bbox.maxX - bbox.minX + pad * 2;
+  const bboxH = bbox.maxY - bbox.minY + pad * 2;
+  const zoom = widthPx / bboxW;
+  const camX = -(bbox.minX - pad) * zoom;
+  const camY = -(bbox.minY - pad) * zoom;
+  const heightPx = Math.max(
+    CANVAS_EMBED_MIN_HEIGHT,
+    Math.min(CANVAS_EMBED_MAX_HEIGHT, bboxH * zoom),
+  );
+  body.style.position = "relative";
+  body.style.overflow = "hidden";
+  body.style.height = `${heightPx}px`;
+
+  const vaultPath = get(vaultStore).currentPath ?? null;
+  const component = mount(CanvasRenderer, {
+    target: body,
+    props: {
+      doc,
+      camX,
+      camY,
+      zoom,
+      vaultPath,
+      interactive: false,
+    },
+  });
+  // Stash the handle on the wrapper so CanvasEmbedWidget.destroy() can
+  // unmount the component when CM6 tears the widget down.
+  (wrap as unknown as { _vcRenderer?: unknown })._vcRenderer = component;
+}
+
+function computeCanvasBBox(nodes: CanvasNode[]): {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+} {
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
@@ -416,85 +485,7 @@ function renderCanvasPreviewInto(el: HTMLElement, rawJson: string): void {
     if (n.x + w > maxX) maxX = n.x + w;
     if (n.y + h > maxY) maxY = n.y + h;
   }
-  const pad = 20;
-  const vbX = minX - pad;
-  const vbY = minY - pad;
-  const vbW = maxX - minX + pad * 2;
-  const vbH = maxY - minY + pad * 2;
-
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("viewBox", `${vbX} ${vbY} ${vbW} ${vbH}`);
-  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
-  svg.setAttribute("class", "cm-embed-canvas-svg");
-
-  // Edges first, so nodes paint over.
-  const nodeMap = new Map<string, CanvasNode>(nodes.map((n) => [n.id, n]));
-  for (const edge of doc.edges) {
-    const a = nodeMap.get(edge.fromNode);
-    const b = nodeMap.get(edge.toNode);
-    if (!a || !b) continue;
-    const ax = a.x + (a.width || DEFAULT_NODE_WIDTH) / 2;
-    const ay = a.y + (a.height || DEFAULT_NODE_HEIGHT) / 2;
-    const bx = b.x + (b.width || DEFAULT_NODE_WIDTH) / 2;
-    const by = b.y + (b.height || DEFAULT_NODE_HEIGHT) / 2;
-    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
-    line.setAttribute("x1", String(ax));
-    line.setAttribute("y1", String(ay));
-    line.setAttribute("x2", String(bx));
-    line.setAttribute("y2", String(by));
-    line.setAttribute("stroke", "currentColor");
-    line.setAttribute("stroke-width", "2");
-    line.setAttribute("opacity", "0.5");
-    svg.appendChild(line);
-  }
-
-  for (const n of nodes) {
-    const w = n.width || DEFAULT_NODE_WIDTH;
-    const h = n.height || DEFAULT_NODE_HEIGHT;
-    const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-    rect.setAttribute("x", String(n.x));
-    rect.setAttribute("y", String(n.y));
-    rect.setAttribute("width", String(w));
-    rect.setAttribute("height", String(h));
-    rect.setAttribute("rx", "6");
-    rect.setAttribute("ry", "6");
-    rect.setAttribute("fill", "var(--vc-bg-secondary, #f5f5f5)");
-    rect.setAttribute("stroke", "currentColor");
-    rect.setAttribute("stroke-width", "1.5");
-    svg.appendChild(rect);
-    // Lightweight label: for text nodes we preview the first line; for other
-    // nodes we show the type so the reader sees the structure at a glance.
-    const label = nodeLabel(n);
-    if (label) {
-      const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      text.setAttribute("x", String(n.x + 8));
-      text.setAttribute("y", String(n.y + 20));
-      text.setAttribute("font-size", "14");
-      text.setAttribute("fill", "currentColor");
-      text.textContent = label;
-      svg.appendChild(text);
-    }
-  }
-
-  el.appendChild(svg);
-}
-
-function nodeLabel(n: CanvasNode): string {
-  // `CanvasUnknownNode` overlaps every other variant on the `type` discriminant,
-  // so read optional fields through a loose record to keep the union-narrowing
-  // from collapsing into the fallback branch.
-  const any = n as unknown as Record<string, unknown>;
-  if (n.type === "text") {
-    const raw = typeof any["text"] === "string" ? (any["text"] as string) : "";
-    const firstLine = raw.split("\n", 1)[0] ?? "";
-    return firstLine.length > 40 ? `${firstLine.slice(0, 37)}…` : firstLine;
-  }
-  if (n.type === "file") return typeof any["file"] === "string" ? (any["file"] as string) : "(file)";
-  if (n.type === "link") return typeof any["url"] === "string" ? (any["url"] as string) : "(link)";
-  if (n.type === "group") {
-    return typeof any["label"] === "string" ? (any["label"] as string) : "(group)";
-  }
-  return n.type;
+  return { minX, minY, maxX, maxY };
 }
 
 class BrokenEmbedWidget extends WidgetType {
@@ -728,9 +719,25 @@ export function __resetEmbedCachesForTests(): void {
   canvasContentCache.clear();
 }
 
-/** Test-only: render an SVG preview for a raw canvas JSON string into `el`. */
-export function __renderCanvasPreviewForTests(el: HTMLElement, rawJson: string): void {
-  renderCanvasPreviewInto(el, rawJson);
+/** Test-only: compute a fit-to-width camera for a raw canvas JSON (#156). */
+export function __computeEmbedCameraForTests(
+  rawJson: string,
+  widthPx: number,
+): { camX: number; camY: number; zoom: number; heightPx: number } | null {
+  const doc = parseCanvas(rawJson);
+  if (doc.nodes.length === 0) return null;
+  const bbox = computeCanvasBBox(doc.nodes);
+  const pad = CANVAS_EMBED_PADDING;
+  const bboxW = bbox.maxX - bbox.minX + pad * 2;
+  const bboxH = bbox.maxY - bbox.minY + pad * 2;
+  const zoom = widthPx / bboxW;
+  const camX = -(bbox.minX - pad) * zoom;
+  const camY = -(bbox.minY - pad) * zoom;
+  const heightPx = Math.max(
+    CANVAS_EMBED_MIN_HEIGHT,
+    Math.min(CANVAS_EMBED_MAX_HEIGHT, bboxH * zoom),
+  );
+  return { camX, camY, zoom, heightPx };
 }
 
 /** Test-only: expose the canvas-content cache for cache-invalidation tests (#154). */


### PR DESCRIPTION
## Summary
- Extracts the presentation layer of `CanvasView` into a new `CanvasRenderer.svelte` (HTML nodes + SVG edge overlay) so the inline `![[board]]` embed can mount the exact same DOM as the main canvas view.
- `CanvasEmbedWidget` (CodeMirror 6) now instantiates `CanvasRenderer` with `mount()` / `unmount()` and a fit-to-width camera instead of the old empty-rect SVG placeholder. Embeds now show real node content, labels, images, and edges.
- Keeps live-refresh behaviour (#154): the widget re-reads the `.canvas` file on `vault://file_change` and re-mounts with the new doc.

## Architecture
- `CanvasRenderer.svelte`: pure component. In read-only mode (`interactive=false`) it drops resize + edge handles and adds `.vc-canvas-readonly` so embeds can't be mutated.
- `CanvasView.svelte`: interactive wrapper. Delegates the whole world template to `CanvasRenderer`, binds textarea / edge-label refs for focus effects, and keeps gesture/edit logic co-located.
- `embedPlugin.ts`: `__computeEmbedCameraForTests` exposes the pure camera math (bbox + padding=24, zoom=width/bboxWidth, heightPx clamped to [80, 420]).

## Test plan
- [x] Unit tests: 618 passing (new `CanvasRenderer.test.ts` with 10 cases locks in DOM contract — node classes, no truncation, handle visibility per mode, camera transform, group labels, link URLs, image `asset://`, markdown previews).
- [x] Camera-math tests: 4 cases in `canvasEmbedPreview.test.ts` covering bbox zoom, height cap, empty canvas (null), and missing width/height.
- [x] E2E: 52 specs passing — canvas-specific:
  - `canvas-wiki-embed.spec.ts` (#147): asserts `.vc-canvas-node` divs ≥ 2 and verbatim "Alpha"/"Beta" text.
  - `canvas-embed-refresh.spec.ts` (#154): overwrites `Board.canvas` on disk and asserts the embed repaints from 1 → 2 nodes.
- [ ] Manual UAT: open a vault with a `![[Board]]` embed, verify it renders identical to the `.canvas` tab view.