### PR TITLE
fix(canvas): embed uses fit-contain camera so all nodes stay visible (#158)

### DIFF
--- a/e2e/specs/canvas-embed-fit-contain.spec.ts
+++ b/e2e/specs/canvas-embed-fit-contain.spec.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+/**
+ * E2E coverage for #158 — an embedded canvas must render *all* of its
+ * nodes inside the embed viewport, never cropping at the max-height
+ * edge. The old fit-to-width camera sized the body at 420 px but left
+ * the world-transform width-driven, so tall canvases lost their
+ * bottom nodes. The fit-contain camera (#158) scales the bbox to fit
+ * both axes and centers horizontally when height is the limit.
+ */
+
+const TALL_CANVAS = {
+  nodes: [
+    { id: "top", type: "text", text: "TopNode", x: 0, y: 0, width: 100, height: 40 },
+    { id: "bot", type: "text", text: "BottomNode", x: 0, y: 900, width: 100, height: 40 },
+  ],
+  edges: [],
+};
+
+describe("Canvas embed fit-contain (#158)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(
+      path.join(vault.path, "Tall.canvas"),
+      JSON.stringify(TALL_CANVAS, null, "\t"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(vault.path, "Host.md"),
+      "# Host\n\n![[Tall]]\n",
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not in tree`);
+  }
+
+  it("renders both top and bottom nodes inside the embed's vertical bounds", async () => {
+    await openTreeFile("Host.md");
+
+    await browser.waitUntil(
+      async () => {
+        const count = await browser.execute(() => {
+          const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+          const active = panes.find((el) => el.offsetParent !== null);
+          if (!active) return 0;
+          const embed = active.querySelector(".cm-embed-canvas");
+          if (!embed) return 0;
+          return embed.querySelectorAll(".vc-canvas-node").length;
+        });
+        return count === 2;
+      },
+      { timeout: 8000, timeoutMsg: "Embed did not render 2 canvas nodes" },
+    );
+
+    // The key assertion: every node's bounding rect must sit inside the
+    // embed body's clip rect (within a 1px tolerance). With the old
+    // fit-to-width camera the bottom node was cropped; with fit-contain
+    // it scales down and stays visible.
+    const result = await browser.execute(() => {
+      const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+      const active = panes.find((el) => el.offsetParent !== null);
+      if (!active) return { ok: false, reason: "no active pane" };
+      const body = active.querySelector<HTMLElement>(".cm-embed-canvas-body");
+      if (!body) return { ok: false, reason: "no embed body" };
+      const bodyRect = body.getBoundingClientRect();
+      const nodes = Array.from(
+        body.querySelectorAll<HTMLElement>(".vc-canvas-node"),
+      );
+      const out: Array<{ id: string | null; top: number; bottom: number }> = [];
+      for (const n of nodes) {
+        const r = n.getBoundingClientRect();
+        out.push({
+          id: n.getAttribute("data-node-id"),
+          top: r.top - bodyRect.top,
+          bottom: r.bottom - bodyRect.top,
+        });
+      }
+      const bodyHeight = bodyRect.height;
+      const allInside = out.every((n) => n.top >= -1 && n.bottom <= bodyHeight + 1);
+      return { ok: allInside, bodyHeight, nodes: out };
+    });
+
+    if (!result.ok) {
+      throw new Error(
+        `Nodes outside embed body: ${JSON.stringify(result)}`,
+      );
+    }
+  });
+});

--- a/src/components/Editor/__tests__/canvasEmbedPreview.test.ts
+++ b/src/components/Editor/__tests__/canvasEmbedPreview.test.ts
@@ -1,7 +1,8 @@
-// #156 — the inline canvas embed now mounts the shared CanvasRenderer
-// with a fit-to-width camera. These tests lock in the pure camera math
-// (bounding box + zoom + height cap) that the widget uses; renderer
-// output itself is covered by CanvasRenderer.test.ts and the E2E specs.
+// #156/#158 — the inline canvas embed mounts the shared CanvasRenderer
+// with a fit-contain camera: the padded bbox scales to fit inside both
+// the requested width and the max embed height, then centers horizontally
+// when the height constraint wins. These tests lock in the pure camera
+// math; renderer output is covered by CanvasRenderer.test.ts and E2E.
 
 import { describe, it, expect, vi } from "vitest";
 
@@ -14,8 +15,8 @@ vi.mock("../../../ipc/commands", () => ({
 
 import { __computeEmbedCameraForTests } from "../embedPlugin";
 
-describe("canvas embed fit-to-width camera (#156)", () => {
-  it("zooms the bounding box to the requested width and translates to its top-left", () => {
+describe("canvas embed fit-contain camera (#156/#158)", () => {
+  it("width-driven branch: wide canvas fills the requested width and translates to its top-left", () => {
     const json = JSON.stringify({
       nodes: [
         { id: "a", type: "text", text: "Hello", x: 0, y: 0, width: 100, height: 40 },
@@ -24,17 +25,17 @@ describe("canvas embed fit-to-width camera (#156)", () => {
       edges: [{ id: "e", fromNode: "a", toNode: "b" }],
     });
     const cam = __computeEmbedCameraForTests(json, 600)!;
-    // bbox = 0..320 × 0..130, pad=24 on both sides → 368 × 178
-    // zoom = 600 / 368, camX/camY translate the padded origin to (0,0).
+    // bbox = 0..320 × 0..130, pad=24 → 368 × 178.
+    // widthZoom = 600/368 ≈ 1.63, heightZoom = 420/178 ≈ 2.36 → width wins.
     const expectedZoom = 600 / 368;
     expect(cam.zoom).toBeCloseTo(expectedZoom, 5);
+    // No horizontal centering when width wins.
     expect(cam.camX).toBeCloseTo(24 * expectedZoom, 5);
     expect(cam.camY).toBeCloseTo(24 * expectedZoom, 5);
-    // heightPx = 178 * zoom, clamped to [80, 420].
     expect(cam.heightPx).toBeCloseTo(178 * expectedZoom, 5);
   });
 
-  it("caps the height at the embed's max when the canvas is very tall", () => {
+  it("height-driven branch: tall canvas scales to fit MAX_HEIGHT and centers horizontally (#158)", () => {
     const json = JSON.stringify({
       nodes: [
         { id: "a", type: "text", text: "a", x: 0, y: 0, width: 50, height: 50 },
@@ -43,7 +44,35 @@ describe("canvas embed fit-to-width camera (#156)", () => {
       edges: [],
     });
     const cam = __computeEmbedCameraForTests(json, 600)!;
-    expect(cam.heightPx).toBeLessThanOrEqual(420);
+    // bbox = 0..50 × 0..5050, pad=24 → 98 × 5098.
+    // widthZoom = 600/98 ≈ 6.12, heightZoom = 420/5098 ≈ 0.0824 → height wins.
+    const expectedZoom = 420 / 5098;
+    expect(cam.zoom).toBeCloseTo(expectedZoom, 5);
+    // heightPx must equal MAX_HEIGHT — nothing gets cropped.
+    expect(cam.heightPx).toBeCloseTo(420, 5);
+    // Content width < widthPx, so it should be centered horizontally.
+    const contentW = 98 * expectedZoom;
+    const expectedOffsetX = (600 - contentW) / 2;
+    expect(cam.camX).toBeCloseTo(24 * expectedZoom + expectedOffsetX, 5);
+    expect(cam.camY).toBeCloseTo(24 * expectedZoom, 5);
+  });
+
+  it("never crops: a very tall canvas fits entirely inside [0, heightPx]", () => {
+    const json = JSON.stringify({
+      nodes: [
+        { id: "top", type: "text", text: "t", x: 0, y: 0, width: 100, height: 40 },
+        { id: "bot", type: "text", text: "b", x: 0, y: 900, width: 100, height: 40 },
+      ],
+      edges: [],
+    });
+    const cam = __computeEmbedCameraForTests(json, 600)!;
+    // After transform: worldY = camY + nodeY * zoom. The bottom node's far
+    // edge must still be within the body height.
+    const bottomFarEdgeY = cam.camY + (900 + 40) * cam.zoom;
+    expect(bottomFarEdgeY).toBeLessThanOrEqual(cam.heightPx + 1e-6);
+    // And the top node's top edge stays non-negative (padding above).
+    const topEdgeY = cam.camY + 0 * cam.zoom;
+    expect(topEdgeY).toBeGreaterThanOrEqual(0);
   });
 
   it("returns null when the canvas has no nodes (empty-placeholder path)", () => {

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -408,11 +408,34 @@ const CANVAS_EMBED_MAX_HEIGHT = 420;
 const CANVAS_EMBED_MIN_HEIGHT = 80;
 const CANVAS_EMBED_PADDING = 24;
 
+type EmbedCamera = { camX: number; camY: number; zoom: number; heightPx: number };
+
+// #158 — fit-contain camera: scale so the padded bbox fits inside both the
+// requested width and the max embed height, then center horizontally when
+// the height constraint wins. Returns null for empty canvases.
+function computeEmbedCamera(nodes: CanvasNode[], widthPx: number): EmbedCamera | null {
+  if (nodes.length === 0) return null;
+  const bbox = computeCanvasBBox(nodes);
+  const pad = CANVAS_EMBED_PADDING;
+  const bboxW = bbox.maxX - bbox.minX + pad * 2;
+  const bboxH = bbox.maxY - bbox.minY + pad * 2;
+  const zoomW = widthPx / bboxW;
+  const zoomH = CANVAS_EMBED_MAX_HEIGHT / bboxH;
+  const zoom = Math.min(zoomW, zoomH);
+  const contentW = bboxW * zoom;
+  const contentH = bboxH * zoom;
+  const offsetX = Math.max(0, (widthPx - contentW) / 2);
+  const camX = -(bbox.minX - pad) * zoom + offsetX;
+  const camY = -(bbox.minY - pad) * zoom;
+  const heightPx = Math.max(CANVAS_EMBED_MIN_HEIGHT, contentH);
+  return { camX, camY, zoom, heightPx };
+}
+
 /**
  * Populate the embed body by mounting CanvasRenderer in read-only mode.
- * The bounding box of all nodes drives a fit-to-width camera so the whole
- * canvas is visible. Height is capped so ridiculously tall canvases don't
- * push the host note off the screen.
+ * The bounding box of all nodes drives a fit-contain camera so the whole
+ * canvas is always visible with a margin on every side (#158) — we never
+ * crop; tall canvases scale down instead of being clipped.
  */
 function renderCanvasEmbedBody(
   body: HTMLElement,
@@ -435,29 +458,19 @@ function renderCanvasEmbedBody(
     return;
   }
 
-  const bbox = computeCanvasBBox(doc.nodes);
-  const pad = CANVAS_EMBED_PADDING;
-  const bboxW = bbox.maxX - bbox.minX + pad * 2;
-  const bboxH = bbox.maxY - bbox.minY + pad * 2;
-  const zoom = widthPx / bboxW;
-  const camX = -(bbox.minX - pad) * zoom;
-  const camY = -(bbox.minY - pad) * zoom;
-  const heightPx = Math.max(
-    CANVAS_EMBED_MIN_HEIGHT,
-    Math.min(CANVAS_EMBED_MAX_HEIGHT, bboxH * zoom),
-  );
+  const cam = computeEmbedCamera(doc.nodes, widthPx)!;
   body.style.position = "relative";
   body.style.overflow = "hidden";
-  body.style.height = `${heightPx}px`;
+  body.style.height = `${cam.heightPx}px`;
 
   const vaultPath = get(vaultStore).currentPath ?? null;
   const component = mount(CanvasRenderer, {
     target: body,
     props: {
       doc,
-      camX,
-      camY,
-      zoom,
+      camX: cam.camX,
+      camY: cam.camY,
+      zoom: cam.zoom,
       vaultPath,
       interactive: false,
     },
@@ -719,25 +732,13 @@ export function __resetEmbedCachesForTests(): void {
   canvasContentCache.clear();
 }
 
-/** Test-only: compute a fit-to-width camera for a raw canvas JSON (#156). */
+/** Test-only: compute the fit-contain camera for a raw canvas JSON (#156/#158). */
 export function __computeEmbedCameraForTests(
   rawJson: string,
   widthPx: number,
-): { camX: number; camY: number; zoom: number; heightPx: number } | null {
+): EmbedCamera | null {
   const doc = parseCanvas(rawJson);
-  if (doc.nodes.length === 0) return null;
-  const bbox = computeCanvasBBox(doc.nodes);
-  const pad = CANVAS_EMBED_PADDING;
-  const bboxW = bbox.maxX - bbox.minX + pad * 2;
-  const bboxH = bbox.maxY - bbox.minY + pad * 2;
-  const zoom = widthPx / bboxW;
-  const camX = -(bbox.minX - pad) * zoom;
-  const camY = -(bbox.minY - pad) * zoom;
-  const heightPx = Math.max(
-    CANVAS_EMBED_MIN_HEIGHT,
-    Math.min(CANVAS_EMBED_MAX_HEIGHT, bboxH * zoom),
-  );
-  return { camX, camY, zoom, heightPx };
+  return computeEmbedCamera(doc.nodes, widthPx);
 }
 
 /** Test-only: expose the canvas-content cache for cache-invalidation tests (#154). */


### PR DESCRIPTION
## Summary
- Replaces the fit-to-width camera with fit-contain: `zoom = min(widthPx/bboxW, MAX_HEIGHT/bboxH)`. The embed now always shows the full padded bbox with a margin, never crops.
- When the height constraint wins, content is narrower than `widthPx`; the camera is translated by `(widthPx - contentW) / 2` so the canvas is centered horizontally inside the embed body.
- `heightPx` becomes the scaled content height (bounded from below by `MIN_HEIGHT` for degenerate cases) instead of a hard clamp at `MAX_HEIGHT`.

## Why
Before this fix, a canvas with nodes at `y=0` and `y=900` embedded into a note rendered only the top ~420px — the bottom node was clipped by the body's `overflow: hidden`. The camera was correct on the x axis but indifferent to y, so natural canvas aspect ratios taller than `420/widthPx` silently lost content.

## Test plan
- [x] Unit tests (619 pass): `canvasEmbedPreview.test.ts` now covers both branches — wide canvas (width-driven zoom), tall canvas (height-driven zoom, horizontal centering, `heightPx == MAX_HEIGHT`), and a "never crops" assertion on a `(0,0)..(0,940)` canvas.
- [x] E2E (53 pass): new `canvas-embed-fit-contain.spec.ts` opens a tall canvas embed and verifies each `.vc-canvas-node`'s `getBoundingClientRect()` sits within the embed body's clip rect.
- [x] Existing canvas specs (#147, #154) still pass — width-driven branch unchanged.
- [ ] Manual UAT: open a canvas with a tall layout (`![[…]]`) and verify the bottom nodes are visible with a margin below them.

## Related
- #156 — Introduced the shared `CanvasRenderer` + the fit-to-width camera this PR supersedes.