### PR TITLE
fix(canvas): remove 16:9 aspect-ratio clip on canvas embed wrap (#158)

### DIFF
--- a/e2e/specs/canvas-embed-fit-contain.spec.ts
+++ b/e2e/specs/canvas-embed-fit-contain.spec.ts
@@ -72,37 +72,39 @@ describe("Canvas embed fit-contain (#158)", () => {
       { timeout: 8000, timeoutMsg: "Embed did not render 2 canvas nodes" },
     );
 
-    // The key assertion: every node's bounding rect must sit inside the
-    // embed body's clip rect (within a 1px tolerance). With the old
-    // fit-to-width camera the bottom node was cropped; with fit-contain
-    // it scales down and stays visible.
+    // Key assertion: every node's bounding rect must sit inside the
+    // embed *wrap*'s visible rect (not just the body — the wrap is what
+    // clips visually; a prior aspect-ratio CSS forced the wrap to 16:9
+    // even though the body was sized by fit-contain, so the body rect
+    // looked fine but the wrap was cropping). The wrap's visible area
+    // should grow to match the body so the whole canvas is shown.
     const result = await browser.execute(() => {
       const panes = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
       const active = panes.find((el) => el.offsetParent !== null);
       if (!active) return { ok: false, reason: "no active pane" };
-      const body = active.querySelector<HTMLElement>(".cm-embed-canvas-body");
-      if (!body) return { ok: false, reason: "no embed body" };
-      const bodyRect = body.getBoundingClientRect();
+      const wrap = active.querySelector<HTMLElement>(".cm-embed-canvas");
+      if (!wrap) return { ok: false, reason: "no embed wrap" };
+      const wrapRect = wrap.getBoundingClientRect();
       const nodes = Array.from(
-        body.querySelectorAll<HTMLElement>(".vc-canvas-node"),
+        wrap.querySelectorAll<HTMLElement>(".vc-canvas-node"),
       );
       const out: Array<{ id: string | null; top: number; bottom: number }> = [];
       for (const n of nodes) {
         const r = n.getBoundingClientRect();
         out.push({
           id: n.getAttribute("data-node-id"),
-          top: r.top - bodyRect.top,
-          bottom: r.bottom - bodyRect.top,
+          top: r.top - wrapRect.top,
+          bottom: r.bottom - wrapRect.top,
         });
       }
-      const bodyHeight = bodyRect.height;
-      const allInside = out.every((n) => n.top >= -1 && n.bottom <= bodyHeight + 1);
-      return { ok: allInside, bodyHeight, nodes: out };
+      const wrapHeight = wrapRect.height;
+      const allInside = out.every((n) => n.top >= -1 && n.bottom <= wrapHeight + 1);
+      return { ok: allInside, wrapHeight, nodes: out };
     });
 
     if (!result.ok) {
       throw new Error(
-        `Nodes outside embed body: ${JSON.stringify(result)}`,
+        `Nodes outside embed wrap: ${JSON.stringify(result)}`,
       );
     }
   });

--- a/src/components/Editor/theme.ts
+++ b/src/components/Editor/theme.ts
@@ -250,29 +250,25 @@ export const markdownTheme = EditorView.theme({
   ".cm-embed-canvas": {
     display: "block",
     width: "100%",
-    aspectRatio: "16 / 9",
     margin: "8px 0",
     border: "1px solid var(--color-border)",
     borderRadius: "6px",
     backgroundColor: "var(--color-surface-2, var(--color-bg))",
     cursor: "pointer",
-    overflow: "hidden",
     color: "var(--color-text)",
   },
+  // Body height is set inline by renderCanvasEmbedBody to the content-
+  // scaled height from the fit-contain camera (#158). We only own the
+  // width here; height and overflow are inline so the wrap grows to
+  // contain the whole canvas — no 16:9 clip.
   ".cm-embed-canvas-body": {
     width: "100%",
-    height: "100%",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  ".cm-embed-canvas-svg": {
-    width: "100%",
-    height: "100%",
   },
   ".cm-embed-canvas-empty": {
     color: "var(--color-text-muted)",
     fontStyle: "italic",
+    padding: "16px",
+    textAlign: "center",
   },
 
   // ── Inline HTML rendering (#70) ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removes the `aspect-ratio: 16/9` + `overflow: hidden` CSS on the embed wrap, plus the \`display: flex; align/justify center\` on the body. These were a holdover from the SVG-placeholder era and conflicted with the fit-contain camera that #158 introduced.
- With the fit-contain camera, the body's inline \`height: \${contentH}px\` now drives the wrap's height. The wrap grows to match the real, scaled canvas size — no more cropping the lower part.

## Why
After shipping #158, a user-visible canvas embed still cropped its bottom nodes and edges. The camera was correct (body was sized right) but the wrap was locked to \`9/16 × widthPx\` and had \`overflow: hidden\`, so everything the body tried to show below that was cut off visually.

## Test plan
- [x] Full E2E suite (53 specs) passes.
- [x] \`canvas-embed-fit-contain.spec.ts\` updated to measure the \`.cm-embed-canvas\` **wrap**'s bounding rect rather than the body's — the body was always sized correctly under the old bug, so only the wrap rect reveals the clip regression.
- [x] Existing canvas specs (#147, #154) green — width-driven branch and live-refresh unchanged.
- [ ] Manual UAT: open a tall canvas via \`![[…]]\` and verify every node is visible with margin on all sides; open a wide canvas and verify it fills the available width.

## Related
- #156 / #158 — Shared CanvasRenderer and fit-contain camera. This PR is the CSS follow-up that makes the camera's computed size actually visible on screen.