### PR TITLE
feat(sidebar): multi-value entries in properties panel (#81)

### DIFF
--- a/e2e/helpers/vault.ts
+++ b/e2e/helpers/vault.ts
@@ -57,6 +57,12 @@ A second file in the subfolder.
 
   "attachments/placeholder.txt": `This directory holds attachments for the test vault.
 `,
+
+  "Tagged.md": `---
+tags: [alpha, beta]
+---
+# Tagged
+`,
 };
 
 export function createTestVault(): TestVault {

--- a/e2e/specs/properties-panel.spec.ts
+++ b/e2e/specs/properties-panel.spec.ts
@@ -40,6 +40,15 @@ describe("Properties panel", () => {
     }
   }
 
+  async function collectTexts(selector: string): Promise<string[]> {
+    const els = await browser.$$(selector);
+    const out: string[] = [];
+    for (const el of els) {
+      out.push(await textOf(el));
+    }
+    return out;
+  }
+
   async function activatePropertiesSubtab(): Promise<void> {
     await browser.execute(() => {
       const btn = document.querySelector('[aria-label="Properties"][role="tab"]') as HTMLElement | null;
@@ -104,5 +113,94 @@ describe("Properties panel", () => {
     await browser.$(".vc-props-empty").waitForDisplayed({ timeout: 3000 });
     const rows = await browser.$$(".vc-props-row");
     expect(rows.length).toBe(0);
+  });
+
+  it("renders pre-existing list frontmatter as chips on load", async () => {
+    await openTreeFile("Tagged.md");
+    await browser.waitUntil(
+      async () => {
+        const label = await browser.$(".vc-tab--active .vc-tab-label");
+        return (await textOf(label)) === "Tagged.md";
+      },
+      { timeout: 5000, timeoutMsg: "Tagged.md did not become the active tab" },
+    );
+    await ensureRightSidebar();
+    await activatePropertiesSubtab();
+
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-props-chip")).length === 2,
+      { timeout: 3000, timeoutMsg: "expected two chips for tags: [alpha, beta]" },
+    );
+    const chipTexts = await collectTexts(".vc-props-chip-text");
+    expect(chipTexts).toEqual(["alpha", "beta"]);
+  });
+
+  it("promotes a scalar row to list and manages chips via + and ×", async () => {
+    await openTreeFile("Welcome.md");
+    await browser.waitUntil(
+      async () => {
+        const label = await browser.$(".vc-tab--active .vc-tab-label");
+        return (await textOf(label)) === "Welcome.md";
+      },
+      { timeout: 5000, timeoutMsg: "Welcome.md did not become the active tab" },
+    );
+    await ensureRightSidebar();
+    await activatePropertiesSubtab();
+
+    const addBtn = await browser.$(".vc-props-add");
+    await browser.waitUntil(
+      async () => !(await addBtn.getAttribute("disabled")),
+      { timeout: 5000, timeoutMsg: ".vc-props-add never became enabled" },
+    );
+    await addBtn.click();
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-props-row")).length >= 1,
+      { timeout: 3000 },
+    );
+
+    // Click the row-level + button to promote scalar → list.
+    const plusBtn = (await browser.$$(".vc-props-plus"))[0]!;
+    await plusBtn.click();
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-props-chips")).length === 1,
+      { timeout: 3000, timeoutMsg: "chip container never appeared after clicking +" },
+    );
+
+    // Type a chip value + Enter.
+    const chipInput = await browser.$(".vc-props-chip-input");
+    await chipInput.click();
+    await chipInput.setValue("foo");
+    await browser.keys("Enter");
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-props-chip")).length === 1,
+      { timeout: 3000, timeoutMsg: "first chip never materialised" },
+    );
+
+    // Second chip.
+    await chipInput.click();
+    await chipInput.setValue("bar");
+    await browser.keys("Enter");
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-props-chip")).length === 2,
+      { timeout: 3000, timeoutMsg: "second chip never materialised" },
+    );
+
+    let texts = await collectTexts(".vc-props-chip-text");
+    expect(texts).toEqual(["foo", "bar"]);
+
+    // Remove first chip via its × button.
+    const chipDelButtons = await browser.$$(".vc-props-chip-del");
+    await chipDelButtons[0]!.click();
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-props-chip")).length === 1,
+      { timeout: 3000, timeoutMsg: "chip deletion did not take effect" },
+    );
+    texts = await collectTexts(".vc-props-chip-text");
+    expect(texts).toEqual(["bar"]);
+
+    // Row must still exist after removing the chip (AC: removing a single
+    // value does not delete the key).
+    const rows = await browser.$$(".vc-props-row");
+    expect(rows.length).toBe(1);
   });
 });

--- a/src/components/Properties/PropertiesPanel.svelte
+++ b/src/components/Properties/PropertiesPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import { Plus, X } from "lucide-svelte";
   import { activeViewStore } from "../../store/activeViewStore";
   import {
@@ -47,7 +48,60 @@
       n += 1;
       candidate = `${base}${n}`;
     }
-    commit([...existing, { key: candidate, value: "" }]);
+    commit([...existing, { key: candidate, values: [""], listStyle: false }]);
+  }
+
+  async function promoteToList(index: number): Promise<void> {
+    const row = parsed.properties[index];
+    if (!row) return;
+    if (!row.listStyle) {
+      const cleaned = row.values.length === 1 && row.values[0] === "" ? [] : row.values;
+      updateRow(index, { listStyle: true, values: cleaned });
+    }
+    await tick();
+    focusChipInput(index);
+  }
+
+  function focusChipInput(index: number): void {
+    const input = document.querySelector<HTMLInputElement>(
+      `[data-chip-input="${index}"]`,
+    );
+    input?.focus();
+  }
+
+  function appendChipValue(index: number, raw: string): void {
+    if (raw === "") return;
+    const row = parsed.properties[index];
+    if (!row) return;
+    const nextValues = [...row.values, raw];
+    const next = parsed.properties.map((p, i) =>
+      i === index ? { ...p, values: nextValues, listStyle: true } : p,
+    );
+    commit(next);
+  }
+
+  function removeChipAt(rowIndex: number, valueIndex: number): void {
+    const row = parsed.properties[rowIndex];
+    if (!row) return;
+    const nextValues = row.values.filter((_, i) => i !== valueIndex);
+    updateRow(rowIndex, { values: nextValues });
+  }
+
+  function onChipInputKeydown(e: KeyboardEvent, index: number): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const el = e.currentTarget as HTMLInputElement;
+      appendChipValue(index, el.value);
+      el.value = "";
+    }
+  }
+
+  function onChipInputBlur(e: FocusEvent, index: number): void {
+    const el = e.currentTarget as HTMLInputElement;
+    if (el.value !== "") {
+      appendChipValue(index, el.value);
+      el.value = "";
+    }
   }
 </script>
 
@@ -85,14 +139,54 @@
               aria-label="Schlüssel"
               spellcheck="false"
             />
-            <input
-              type="text"
-              class="vc-props-value"
-              value={prop.value}
-              onchange={(e) => updateRow(index, { value: e.currentTarget.value })}
-              aria-label="Wert"
-              spellcheck="false"
-            />
+            <div class="vc-props-value-col">
+              {#if prop.listStyle}
+                <div class="vc-props-chips" data-list-row={index}>
+                  {#each prop.values as chip, ci (ci)}
+                    <span class="vc-props-chip">
+                      <span class="vc-props-chip-text">{chip}</span>
+                      <button
+                        type="button"
+                        class="vc-props-chip-del"
+                        onclick={() => removeChipAt(index, ci)}
+                        aria-label="Wert entfernen"
+                        title="Wert entfernen"
+                      >
+                        <X size={10} />
+                      </button>
+                    </span>
+                  {/each}
+                  <input
+                    type="text"
+                    class="vc-props-chip-input"
+                    data-chip-input={index}
+                    placeholder={prop.values.length === 0 ? "Wert hinzufügen" : ""}
+                    onkeydown={(e) => onChipInputKeydown(e, index)}
+                    onblur={(e) => onChipInputBlur(e, index)}
+                    aria-label="Wert hinzufügen"
+                    spellcheck="false"
+                  />
+                </div>
+              {:else}
+                <input
+                  type="text"
+                  class="vc-props-value"
+                  value={prop.values[0] ?? ""}
+                  onchange={(e) => updateRow(index, { values: [e.currentTarget.value] })}
+                  aria-label="Wert"
+                  spellcheck="false"
+                />
+              {/if}
+            </div>
+            <button
+              type="button"
+              class="vc-props-plus"
+              onclick={() => promoteToList(index)}
+              aria-label="Wert hinzufügen"
+              title="Wert hinzufügen"
+            >
+              <Plus size={12} />
+            </button>
             <button
               type="button"
               class="vc-props-del"
@@ -164,9 +258,9 @@
   }
   .vc-props-row {
     display: grid;
-    grid-template-columns: 32% 1fr 20px;
+    grid-template-columns: 32% 1fr 20px 20px;
     gap: 4px;
-    align-items: center;
+    align-items: start;
   }
   .vc-props-key,
   .vc-props-value {
@@ -180,6 +274,7 @@
     box-sizing: border-box;
     outline: none;
     min-width: 0;
+    width: 100%;
   }
   .vc-props-key { font-family: var(--vc-font-mono); color: var(--color-text-muted); }
   .vc-props-key:focus,
@@ -187,6 +282,69 @@
     border-color: var(--color-accent);
     box-shadow: 0 0 0 2px var(--color-accent-bg);
   }
+  .vc-props-value-col {
+    min-width: 0;
+  }
+  .vc-props-chips {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    min-height: 24px;
+    padding: 2px 4px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    box-sizing: border-box;
+  }
+  .vc-props-chips:focus-within {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 2px var(--color-accent-bg);
+  }
+  .vc-props-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 0 4px 0 6px;
+    height: 18px;
+    font-size: 11px;
+    line-height: 18px;
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    border-radius: 10px;
+    max-width: 100%;
+  }
+  .vc-props-chip-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .vc-props-chip-del {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    border-radius: 50%;
+  }
+  .vc-props-chip-del:hover { color: var(--color-error); }
+  .vc-props-chip-input {
+    flex: 1;
+    min-width: 40px;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 13px;
+    color: var(--color-text);
+    padding: 0 2px;
+    height: 18px;
+  }
+  .vc-props-plus,
   .vc-props-del {
     width: 20px;
     height: 20px;
@@ -198,6 +356,8 @@
     cursor: pointer;
     color: var(--color-text-muted);
     border-radius: 3px;
+    margin-top: 2px;
   }
+  .vc-props-plus:hover { background: var(--color-accent-bg); color: var(--color-accent); }
   .vc-props-del:hover { background: var(--color-accent-bg); color: var(--color-error); }
 </style>

--- a/src/lib/__tests__/frontmatterIO.test.ts
+++ b/src/lib/__tests__/frontmatterIO.test.ts
@@ -13,26 +13,73 @@ describe("parseFrontmatter", () => {
     expect(res.properties).toEqual([]);
   });
 
-  it("parses flat key/value pairs", () => {
+  it("parses flat key/value pairs as scalar properties", () => {
     const doc = "---\ntitle: Hello\nstatus: draft\n---\nBody";
     const res = parseFrontmatter(doc);
     expect(res.region).toEqual({ from: 0, to: 35 });
     expect(res.properties).toEqual([
-      { key: "title", value: "Hello" },
-      { key: "status", value: "draft" },
+      { key: "title", values: ["Hello"], listStyle: false },
+      { key: "status", values: ["draft"], listStyle: false },
     ]);
   });
 
-  it("keeps array-ish values as raw strings", () => {
-    const res = parseFrontmatter("---\ntags: [a, b]\n---\n");
-    expect(res.properties).toEqual([{ key: "tags", value: "[a, b]" }]);
+  it("parses flow-list values into arrays", () => {
+    const res = parseFrontmatter("---\ntags: [a, b, c]\n---\n");
+    expect(res.properties).toEqual([
+      { key: "tags", values: ["a", "b", "c"], listStyle: true },
+    ]);
+  });
+
+  it("parses empty flow list as empty array with listStyle", () => {
+    const res = parseFrontmatter("---\ntags: []\n---\n");
+    expect(res.properties).toEqual([
+      { key: "tags", values: [], listStyle: true },
+    ]);
+  });
+
+  it("splits flow-list entries respecting double-quoted commas", () => {
+    const res = parseFrontmatter('---\ntags: [a, "b, c", d]\n---\n');
+    expect(res.properties).toEqual([
+      { key: "tags", values: ["a", "b, c", "d"], listStyle: true },
+    ]);
+  });
+
+  it("strips single and double quotes from flow entries", () => {
+    const res = parseFrontmatter(`---\ntags: ['x', "y", z]\n---\n`);
+    expect(res.properties).toEqual([
+      { key: "tags", values: ["x", "y", "z"], listStyle: true },
+    ]);
+  });
+
+  it("parses a YAML block sequence into an array", () => {
+    const doc = "---\ntags:\n  - alpha\n  - beta\n  - gamma\n---\n";
+    const res = parseFrontmatter(doc);
+    expect(res.properties).toEqual([
+      { key: "tags", values: ["alpha", "beta", "gamma"], listStyle: true },
+    ]);
+  });
+
+  it("stops block-sequence parsing at the next key", () => {
+    const doc = "---\ntags:\n  - a\n  - b\nnext: v\n---\n";
+    const res = parseFrontmatter(doc);
+    expect(res.properties).toEqual([
+      { key: "tags", values: ["a", "b"], listStyle: true },
+      { key: "next", values: ["v"], listStyle: false },
+    ]);
+  });
+
+  it("keeps a scalar value that happens to be empty as a single empty-string entry", () => {
+    const res = parseFrontmatter("---\ntitle:\n---\n");
+    expect(res.properties).toEqual([
+      { key: "title", values: [""], listStyle: false },
+    ]);
   });
 
   it("ignores lines that don't look like key: value", () => {
     const res = parseFrontmatter("---\ntitle: X\n# not a key\nfoo: bar\n---\n");
     expect(res.properties).toEqual([
-      { key: "title", value: "X" },
-      { key: "foo", value: "bar" },
+      { key: "title", values: ["X"], listStyle: false },
+      { key: "foo", values: ["bar"], listStyle: false },
     ]);
   });
 
@@ -44,17 +91,52 @@ describe("parseFrontmatter", () => {
 });
 
 describe("serializeBody / serializeBlock", () => {
-  it("joins key/value pairs with newlines", () => {
+  it("emits scalar form for listStyle=false with one value", () => {
     expect(serializeBody([
-      { key: "title", value: "X" },
-      { key: "tags", value: "[a, b]" },
-    ])).toBe("title: X\ntags: [a, b]");
+      { key: "title", values: ["X"], listStyle: false },
+    ])).toBe("title: X");
+  });
+
+  it("emits flow list for listStyle=true with multiple values", () => {
+    expect(serializeBody([
+      { key: "tags", values: ["a", "b"], listStyle: true },
+    ])).toBe("tags: [a, b]");
+  });
+
+  it("emits empty flow list for listStyle=true with zero values", () => {
+    expect(serializeBody([
+      { key: "tags", values: [], listStyle: true },
+    ])).toBe("tags: []");
+  });
+
+  it("emits single-entry flow list for listStyle=true with one value", () => {
+    expect(serializeBody([
+      { key: "tags", values: ["only"], listStyle: true },
+    ])).toBe("tags: [only]");
+  });
+
+  it("quotes flow entries containing commas or brackets", () => {
+    expect(serializeBody([
+      { key: "tags", values: ["a, b", "c"], listStyle: true },
+    ])).toBe('tags: ["a, b", c]');
+  });
+
+  it("quotes flow entries with leading or trailing whitespace", () => {
+    expect(serializeBody([
+      { key: "tags", values: [" spaced ", "clean"], listStyle: true },
+    ])).toBe('tags: [" spaced ", clean]');
+  });
+
+  it("quotes empty-string flow entries", () => {
+    expect(serializeBody([
+      { key: "tags", values: ["", "x"], listStyle: true },
+    ])).toBe('tags: ["", x]');
   });
 
   it("drops rows with empty keys", () => {
     expect(serializeBody([
-      { key: "", value: "orphan" },
-      { key: "title", value: "X" },
+      { key: "", values: ["orphan"], listStyle: false },
+      { key: "title", values: ["X"], listStyle: false },
     ])).toBe("title: X");
   });
 
@@ -63,21 +145,54 @@ describe("serializeBody / serializeBlock", () => {
   });
 
   it("wraps body in --- fences", () => {
-    expect(serializeBlock([{ key: "a", value: "1" }])).toBe("---\na: 1\n---\n");
+    expect(serializeBlock([{ key: "a", values: ["1"], listStyle: false }]))
+      .toBe("---\na: 1\n---\n");
+  });
+});
+
+describe("parse ↔ serialize round-trip", () => {
+  it("preserves scalar values", () => {
+    const doc = "---\ntitle: Hello\n---\n";
+    const { properties } = parseFrontmatter(doc);
+    expect(serializeBlock(properties)).toBe(doc);
+  });
+
+  it("preserves flow-list values", () => {
+    const doc = "---\ntags: [a, b, c]\n---\n";
+    const { properties } = parseFrontmatter(doc);
+    expect(serializeBlock(properties)).toBe(doc);
+  });
+
+  it("preserves empty flow list", () => {
+    const doc = "---\ntags: []\n---\n";
+    const { properties } = parseFrontmatter(doc);
+    expect(serializeBlock(properties)).toBe(doc);
+  });
+
+  it("preserves quoted entries through the round-trip", () => {
+    const doc = '---\ntags: ["a, b", c]\n---\n';
+    const { properties } = parseFrontmatter(doc);
+    expect(serializeBlock(properties)).toBe(doc);
+  });
+
+  it("collapses block sequence to flow form (lossy but valid YAML)", () => {
+    const doc = "---\ntags:\n  - a\n  - b\n---\n";
+    const { properties } = parseFrontmatter(doc);
+    expect(serializeBlock(properties)).toBe("---\ntags: [a, b]\n---\n");
   });
 });
 
 describe("computeFrontmatterEdit", () => {
   it("inserts new block + separator when adding first property to a doc with body", () => {
     const doc = "# Body\n";
-    const edit = computeFrontmatterEdit(doc, [{ key: "title", value: "X" }]);
+    const edit = computeFrontmatterEdit(doc, [{ key: "title", values: ["X"], listStyle: false }]);
     expect(edit).toEqual({ from: 0, to: 0, insert: "---\ntitle: X\n---\n" });
     const after = doc.slice(0, edit.from) + edit.insert + doc.slice(edit.to);
     expect(after).toBe("---\ntitle: X\n---\n# Body\n");
   });
 
   it("inserts new block without extra newline into empty doc", () => {
-    const edit = computeFrontmatterEdit("", [{ key: "a", value: "1" }]);
+    const edit = computeFrontmatterEdit("", [{ key: "a", values: ["1"], listStyle: false }]);
     expect(edit.insert).toBe("---\na: 1\n---\n");
   });
 
@@ -95,8 +210,15 @@ describe("computeFrontmatterEdit", () => {
 
   it("replaces the existing block in place when edits change values", () => {
     const doc = "---\ntitle: Old\n---\n# Body\n";
-    const edit = computeFrontmatterEdit(doc, [{ key: "title", value: "New" }]);
+    const edit = computeFrontmatterEdit(doc, [{ key: "title", values: ["New"], listStyle: false }]);
     const after = doc.slice(0, edit.from) + edit.insert + doc.slice(edit.to);
     expect(after).toBe("---\ntitle: New\n---\n# Body\n");
+  });
+
+  it("replaces an existing scalar with a list", () => {
+    const doc = "---\ntags: foo\n---\n# Body\n";
+    const edit = computeFrontmatterEdit(doc, [{ key: "tags", values: ["a", "b"], listStyle: true }]);
+    const after = doc.slice(0, edit.from) + edit.insert + doc.slice(edit.to);
+    expect(after).toBe("---\ntags: [a, b]\n---\n# Body\n");
   });
 });

--- a/src/lib/frontmatterIO.ts
+++ b/src/lib/frontmatterIO.ts
@@ -1,15 +1,26 @@
 // Minimal YAML-ish reader/writer for the Properties panel.
-// Scope: flat top-level `key: value` pairs only. Values are treated as
-// opaque strings (what the user typed, verbatim). Nested structures,
-// multi-line scalars, and YAML comments are preserved as raw-string
-// values on read but will be coerced to single-line on write — which is
-// acceptable for the "edit simple frontmatter from the sidebar" use case.
+//
+// Scope: flat top-level `key: value` pairs, where a value is either a scalar
+// (single string) or a list (array of strings). Lists are modelled uniformly
+// as `values: string[]` with a `listStyle` flag that records whether the
+// source used list syntax — so `title: Hello` round-trips as scalar while
+// `tags: [a]` round-trips as a single-entry flow list.
+//
+// Supported list syntaxes on parse:
+//   - Flow form:    `key: [a, b, c]`   (entries may be quoted with " or ')
+//   - Empty flow:   `key: []`
+//   - Block seq:    `key:\n  - a\n  - b`
+//
+// Serializer always emits flow form for lists (block sequences collapse to
+// flow on write). Entries are quoted only when necessary (containing `,`,
+// `[`, `]`, `"`, or leading/trailing whitespace, or when empty).
 
 import { detectFrontmatter } from "../components/Editor/frontmatterPlugin";
 
 export interface Property {
   key: string;
-  value: string;
+  values: string[];
+  listStyle: boolean;
 }
 
 export interface FrontmatterParseResult {
@@ -18,6 +29,7 @@ export interface FrontmatterParseResult {
 }
 
 const KEY_RE = /^([A-Za-z_][\w-]*)\s*:\s?(.*)$/;
+const BLOCK_ITEM_RE = /^(\s+)-\s+(.*)$/;
 
 export function parseFrontmatter(docText: string): FrontmatterParseResult {
   const region = detectFrontmatter(docText);
@@ -25,19 +37,137 @@ export function parseFrontmatter(docText: string): FrontmatterParseResult {
 
   const lines = region.body.split(/\r?\n/);
   const properties: Property[] = [];
-  for (const line of lines) {
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
     const match = KEY_RE.exec(line);
     if (!match) continue;
-    const [, key = "", rawValue = ""] = match;
-    properties.push({ key, value: rawValue });
+    const key = match[1] ?? "";
+    const rawValue = match[2] ?? "";
+
+    // Empty scalar — may be the start of a block sequence on the next lines.
+    if (rawValue === "") {
+      const [items, consumed] = consumeBlockSequence(lines, i + 1);
+      if (consumed > 0) {
+        properties.push({ key, values: items, listStyle: true });
+        i += consumed;
+        continue;
+      }
+      properties.push({ key, values: [""], listStyle: false });
+      continue;
+    }
+
+    // Flow list: `[...]` covering the whole value.
+    if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+      const inner = rawValue.slice(1, -1);
+      const items = splitFlowList(inner);
+      properties.push({ key, values: items, listStyle: true });
+      continue;
+    }
+
+    // Plain scalar.
+    properties.push({ key, values: [rawValue], listStyle: false });
   }
+
   return { properties, region: { from: region.from, to: region.to } };
+}
+
+function consumeBlockSequence(lines: string[], start: number): [string[], number] {
+  const items: string[] = [];
+  let consumed = 0;
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "") break;
+    const m = BLOCK_ITEM_RE.exec(line);
+    if (!m) break;
+    items.push(stripQuotes((m[2] ?? "").trim()));
+    consumed++;
+  }
+  return [items, consumed];
+}
+
+function splitFlowList(inner: string): string[] {
+  const trimmed = inner.trim();
+  if (trimmed === "") return [];
+  const out: string[] = [];
+  let buf = "";
+  let quote: '"' | "'" | null = null;
+  let escape = false;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i]!;
+    if (escape) {
+      buf += ch;
+      escape = false;
+      continue;
+    }
+    if (quote) {
+      if (ch === "\\" && quote === '"') {
+        escape = true;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      buf += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ",") {
+      out.push(buf.trim());
+      buf = "";
+      continue;
+    }
+    buf += ch;
+  }
+  out.push(buf.trim());
+  return out;
+}
+
+function stripQuotes(raw: string): string {
+  if (raw.length >= 2) {
+    const first = raw[0];
+    const last = raw[raw.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      const inner = raw.slice(1, -1);
+      if (first === '"') return inner.replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+      return inner;
+    }
+  }
+  return raw;
+}
+
+function needsQuoting(entry: string): boolean {
+  if (entry.length === 0) return true;
+  if (/[,\[\]"]/.test(entry)) return true;
+  if (entry !== entry.trim()) return true;
+  return false;
+}
+
+function quoteEntry(entry: string): string {
+  const escaped = entry.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function formatEntry(entry: string): string {
+  return needsQuoting(entry) ? quoteEntry(entry) : entry;
+}
+
+function serializeValue(prop: Property): string {
+  if (!prop.listStyle && prop.values.length === 1) {
+    return prop.values[0] ?? "";
+  }
+  const body = prop.values.map(formatEntry).join(", ");
+  return `[${body}]`;
 }
 
 export function serializeBody(properties: Property[]): string {
   return properties
     .filter((p) => p.key.trim().length > 0)
-    .map((p) => `${p.key}: ${p.value}`)
+    .map((p) => `${p.key}: ${serializeValue(p)}`)
     .join("\n");
 }
 


### PR DESCRIPTION
Closes #81.

## Summary

- Properties panel now supports multi-value entries for frontmatter keys (tags, aliases, …). Each row carries `values: string[]` plus a `listStyle` flag so scalar and list rows round-trip faithfully.
- Parser reads flow lists (`[a, b]`, quoted entries, empty `[]`) and YAML block sequences (`- a`, `- b`); serializer emits flow syntax with minimal quoting.
- UI adds an inline `+` button per row that promotes a scalar to a list and focuses the new entry input; list rows render as chips with `×` to remove individual values without deleting the key.

## Test plan

- [x] Unit tests (`src/lib/__tests__/frontmatterIO.test.ts`) — 32 tests, including parse/serialize/round-trip for scalar, flow, empty, quoted, and block-sequence inputs
- [x] E2E spec (`e2e/specs/properties-panel.spec.ts`) — pre-existing list frontmatter renders as chips on load; full promote → add → remove flow
- [x] `svelte-check` clean (no new warnings)