### PR TITLE
feat(canvas): right-click context menus per node / edge / empty surface (#164)

### DIFF
--- a/e2e/specs/canvas-context-menus.spec.ts
+++ b/e2e/specs/canvas-context-menus.spec.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+/**
+ * E2E for #164 — canvas context menus.
+ *
+ * Acceptance-criteria regression guard for the empty-canvas → "Add text node"
+ * flow: right-click the empty canvas surface, click the menu entry, verify a
+ * new text node materialises in the DOM and persists to the `.canvas` file on
+ * disk with `type: "text"`.
+ */
+
+const DEBOUNCE_MS = 400;
+const FLUSH_WAIT_MS = DEBOUNCE_MS + 500;
+
+interface CanvasDocOnDisk {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+  [k: string]: unknown;
+}
+
+describe("Canvas context menus (#164)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(
+      path.join(vault.path, "Menu.canvas"),
+      JSON.stringify({ nodes: [], edges: [] }, null, "\t"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const nodes = await browser.$$(".vc-tree-name");
+        for (const n of nodes) if ((await textOf(n)) === name) return true;
+        return false;
+      },
+      { timeout: 5000, timeoutMsg: `"${name}" never appeared in the tree` },
+    );
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not found`);
+  }
+
+  async function waitForActiveTab(label: string, timeout = 5000) {
+    const activeLabel = await browser.$(".vc-tab--active .vc-tab-label");
+    await browser.waitUntil(
+      async () => ((await activeLabel.getProperty("textContent")) as string).includes(label),
+      { timeout, timeoutMsg: `active tab never switched to "${label}"` },
+    );
+  }
+
+  async function waitForDiskDoc(
+    name: string,
+    predicate: (doc: CanvasDocOnDisk) => boolean,
+    timeoutMs = FLUSH_WAIT_MS * 6,
+  ): Promise<CanvasDocOnDisk> {
+    const start = Date.now();
+    let last: CanvasDocOnDisk | null = null;
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const raw = fs.readFileSync(path.join(vault.path, name), "utf-8");
+        const doc = JSON.parse(raw) as CanvasDocOnDisk;
+        if (predicate(doc)) return doc;
+        last = doc;
+      } catch {
+        /* file not yet written */
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+      `waitForDiskDoc(${name}) timed out. Last doc: ${JSON.stringify(last)}`,
+    );
+  }
+
+  it("right-click empty canvas → Add text node → creates a node and persists", async () => {
+    await openTreeFile("Menu.canvas");
+    await waitForActiveTab("Menu.canvas");
+
+    // Wait for the viewport to mount.
+    await browser.waitUntil(
+      async () => {
+        const vps = await browser.$$(".vc-canvas-viewport");
+        for (const vp of vps) if (await vp.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000, timeoutMsg: "Canvas viewport never displayed" },
+    );
+
+    // Dispatch a contextmenu event at the centre of the viewport.
+    const clickPoint = await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const vp = vps.find((v) => v.offsetParent !== null);
+      if (!vp) throw new Error("no visible canvas viewport");
+      const rect = vp.getBoundingClientRect();
+      const clientX = rect.left + rect.width / 2;
+      const clientY = rect.top + rect.height / 2;
+      vp.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX,
+          clientY,
+          button: 2,
+        }),
+      );
+      return { x: clientX, y: clientY };
+    });
+
+    // Menu should appear.
+    const menu = await browser.$(".vc-context-menu");
+    await menu.waitForDisplayed({ timeout: 3000 });
+
+    // Find "Add text node" entry and click it.
+    const items = await browser.$$(".vc-context-menu .vc-context-item");
+    let clicked = false;
+    for (const it of items) {
+      const label = (await textOf(it)).trim();
+      if (label === "Add text node") {
+        await it.click();
+        clicked = true;
+        break;
+      }
+    }
+    expect(clicked).toBe(true);
+
+    // A text node should materialise in the active canvas viewport.
+    await browser.waitUntil(
+      async () => {
+        const n = await browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const vp = vps.find((v) => v.offsetParent !== null);
+          return vp?.querySelectorAll(".vc-canvas-node-text").length ?? 0;
+        });
+        return (n as number) >= 1;
+      },
+      { timeout: 5000, timeoutMsg: "no text node appeared after Add text node" },
+    );
+
+    // Persist to disk as a text node (position is at the click point; we only
+    // assert the type since the world-coordinate will depend on camera origin).
+    const doc = await waitForDiskDoc(
+      "Menu.canvas",
+      (d) => d.nodes.some((n) => n.type === "text"),
+    );
+    expect(doc.nodes.some((n) => n.type === "text")).toBe(true);
+    // The empty node should have been written with an empty text field.
+    const textNode = doc.nodes.find((n) => n.type === "text");
+    expect(typeof textNode!.id).toBe("string");
+
+    // Silence the unused capture warning.
+    void clickPoint;
+  });
+});

--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -78,6 +78,11 @@
     onEdgeLabelBlur?: () => void;
     onStartEditEdgeLabel?: (edge: CanvasEdge) => void;
     onStopEditingEdge?: () => void;
+
+    /** Right-click surfaces (#164). When omitted the renderer stays inert —
+     *  embed use doesn't need a menu. */
+    onNodeContextMenu?: (e: MouseEvent, node: CanvasNode) => void;
+    onEdgeContextMenu?: (e: MouseEvent, edge: CanvasEdge) => void;
   }
 
   let {
@@ -116,6 +121,8 @@
     onEdgeLabelBlur,
     onStartEditEdgeLabel,
     onStopEditingEdge,
+    onNodeContextMenu,
+    onEdgeContextMenu,
   }: Props = $props();
 
   // Groups render first so other nodes stack visually on top of them.
@@ -156,12 +163,14 @@
       {@const arrowEnd = re.edge.toEnd !== "none"}
       {@const arrowStart = re.edge.fromEnd === "arrow"}
       {#if interactive}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
         <path
           class="vc-canvas-edge-hit"
           d={re.path}
           data-edge-id={re.edge.id}
           onpointerdown={(e) => onEdgeHitPointerDown?.(e, re.edge)}
           ondblclick={(e) => onEdgeDblClick?.(e, re.edge)}
+          oncontextmenu={(e) => onEdgeContextMenu?.(e, re.edge)}
         />
       {/if}
       <path
@@ -211,6 +220,7 @@
           data-edge-id={re.edge.id}
           onpointerdown={(e) => onEdgeHitPointerDown?.(e, re.edge)}
           ondblclick={(e) => onEdgeDblClick?.(e, re.edge)}
+          oncontextmenu={(e) => onEdgeContextMenu?.(e, re.edge)}
           onkeydown={(e) => onCardKey?.(e, () => onStartEditEdgeLabel?.(re.edge))}
           role="button"
           tabindex="0"
@@ -244,6 +254,7 @@
         data-node-id={node.id}
         onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
         ondblclick={interactive ? (e) => onNodeDblClick?.(e, node) : undefined}
+        oncontextmenu={interactive ? (e) => onNodeContextMenu?.(e, node) : undefined}
         onkeydown={interactive ? (e) => onCardKey?.(e, () => onStartEditText?.(node as CanvasTextNode)) : undefined}
         onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
         onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
@@ -337,6 +348,7 @@
         data-node-id={node.id}
         data-node-type="file"
         onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        oncontextmenu={interactive ? (e) => onNodeContextMenu?.(e, node) : undefined}
         onkeydown={interactive ? (e) => onCardKey?.(e, () => onOpenFileNode?.(fileNode)) : undefined}
         onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
         onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
@@ -432,6 +444,7 @@
         data-node-id={node.id}
         data-node-type="link"
         onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        oncontextmenu={interactive ? (e) => onNodeContextMenu?.(e, node) : undefined}
         onkeydown={interactive ? (e) => onCardKey?.(e, () => onOpenLinkNode?.(linkNode)) : undefined}
         onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
         onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
@@ -484,6 +497,7 @@
         data-node-id={node.id}
         data-node-type="group"
         onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        oncontextmenu={interactive ? (e) => onNodeContextMenu?.(e, node) : undefined}
         onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
         onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}
         role="group"
@@ -521,6 +535,7 @@
         style:height={`${node.height}px`}
         data-node-id={node.id}
         onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
+        oncontextmenu={interactive ? (e) => onNodeContextMenu?.(e, node) : undefined}
         onkeydown={interactive ? (e) => onCardKey?.(e, () => onSelectNode?.(node)) : undefined}
         onpointerenter={interactive ? () => onNodeHoverEnter?.(node) : undefined}
         onpointerleave={interactive ? () => onNodeHoverLeave?.(node) : undefined}

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -26,10 +26,12 @@
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore } from "../../store/tabStore";
+  import { treeRevealStore } from "../../store/treeRevealStore";
   import { openFileAsTab } from "../../lib/openFileAsTab";
   import { resolveTarget } from "../Editor/wikiLink";
   import { renderMarkdownToHtml } from "../Editor/reading/markdownRenderer";
   import CanvasRenderer from "./CanvasRenderer.svelte";
+  import ContextMenu from "../common/ContextMenu.svelte";
   import {
     parseCanvas,
     serializeCanvas,
@@ -675,6 +677,211 @@
   // True while a long-press-to-pan pan is actively driving the camera. Used
   // to force the `grabbing` cursor globally on the canvas.
   let isPanActive = $derived(pointerMode?.kind === "pan");
+
+  // ─── Context menus (#164) ─────────────────────────────────────────────
+  // Discriminated target — picks the menu entries the user sees and the
+  // action handlers wired up below.
+  type ContextTarget =
+    | { kind: "empty"; worldX: number; worldY: number }
+    | { kind: "node"; nodeId: string }
+    | { kind: "edge"; edgeId: string };
+
+  let contextMenu = $state<{ target: ContextTarget; x: number; y: number } | null>(null);
+
+  // Snapshot of the node / edge under the menu so the template can branch on
+  // type without re-scanning the doc on every render.
+  const contextNode = $derived.by((): CanvasNode | null => {
+    if (contextMenu?.target.kind !== "node") return null;
+    const id = contextMenu.target.nodeId;
+    return doc.nodes.find((n) => n.id === id) ?? null;
+  });
+
+  const contextEdge = $derived.by((): CanvasEdge | null => {
+    if (contextMenu?.target.kind !== "edge") return null;
+    const id = contextMenu.target.edgeId;
+    return doc.edges.find((e) => e.id === id) ?? null;
+  });
+
+  function closeContextMenu() {
+    contextMenu = null;
+  }
+
+  function cancelGestureForContextMenu() {
+    // Right-click cancels any in-flight longpress / pending pan so the menu
+    // doesn't surface on top of a primed pan gesture.
+    cancelLongpressTimer();
+    longpressCaptureEl = null;
+    pointerMode = null;
+  }
+
+  function onViewportContextMenu(e: MouseEvent) {
+    // Bubbles from node/edge handlers — stopPropagation there prevents this.
+    e.preventDefault();
+    cancelGestureForContextMenu();
+    selectedNodeId = null;
+    selectedEdgeId = null;
+    const { x, y } = clientToWorld(e.clientX, e.clientY);
+    contextMenu = {
+      target: { kind: "empty", worldX: x, worldY: y },
+      x: e.clientX,
+      y: e.clientY,
+    };
+  }
+
+  function onNodeContextMenu(e: MouseEvent, node: CanvasNode) {
+    e.preventDefault();
+    e.stopPropagation();
+    cancelGestureForContextMenu();
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+    contextMenu = {
+      target: { kind: "node", nodeId: node.id },
+      x: e.clientX,
+      y: e.clientY,
+    };
+  }
+
+  function onEdgeContextMenu(e: MouseEvent, edge: CanvasEdge) {
+    e.preventDefault();
+    e.stopPropagation();
+    cancelGestureForContextMenu();
+    selectedEdgeId = edge.id;
+    selectedNodeId = null;
+    contextMenu = {
+      target: { kind: "edge", edgeId: edge.id },
+      x: e.clientX,
+      y: e.clientY,
+    };
+  }
+
+  // ─── Menu actions ──────────────────────────────────────────────────────
+
+  function addTextNodeAt(worldX: number, worldY: number) {
+    const node: CanvasTextNode = {
+      id: crypto.randomUUID(),
+      type: "text",
+      x: worldX - DEFAULT_NODE_WIDTH / 2,
+      y: worldY - DEFAULT_NODE_HEIGHT / 2,
+      width: DEFAULT_NODE_WIDTH,
+      height: DEFAULT_NODE_HEIGHT,
+      text: "",
+    };
+    doc.nodes = [...doc.nodes, node];
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+    editingNodeId = node.id;
+  }
+
+  function addGroupAt(worldX: number, worldY: number) {
+    const GROUP_W = 400;
+    const GROUP_H = 300;
+    const node: CanvasGroupNode = {
+      id: crypto.randomUUID(),
+      type: "group",
+      x: worldX - GROUP_W / 2,
+      y: worldY - GROUP_H / 2,
+      width: GROUP_W,
+      height: GROUP_H,
+    };
+    doc.nodes = [...doc.nodes, node];
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+  }
+
+  function duplicateNode(nodeId: string) {
+    const src = doc.nodes.find((n) => n.id === nodeId);
+    if (!src) return;
+    const clone: CanvasNode = {
+      ...src,
+      id: crypto.randomUUID(),
+      x: src.x + 24,
+      y: src.y + 24,
+    };
+    doc.nodes = [...doc.nodes, clone];
+    selectedNodeId = clone.id;
+    selectedEdgeId = null;
+  }
+
+  function copyNodeToClipboard(nodeId: string) {
+    const src = doc.nodes.find((n) => n.id === nodeId);
+    if (!src) return;
+    try {
+      void navigator.clipboard.writeText(JSON.stringify(src));
+    } catch {
+      /* clipboard API blocked — silently swallow */
+    }
+  }
+
+  function copyTextToClipboard(text: string) {
+    try {
+      void navigator.clipboard.writeText(text);
+    } catch {
+      /* clipboard API blocked */
+    }
+  }
+
+  function bringNodeToFront(nodeId: string) {
+    const src = doc.nodes.find((n) => n.id === nodeId);
+    if (!src) return;
+    // Groups render behind other nodes (CanvasRenderer sorts group-first);
+    // reordering across that band has no visual effect, so we keep the swap
+    // within the same band to stay intuitive.
+    const rest = doc.nodes.filter((n) => n.id !== nodeId);
+    doc.nodes = [...rest, src];
+  }
+
+  function sendNodeToBack(nodeId: string) {
+    const src = doc.nodes.find((n) => n.id === nodeId);
+    if (!src) return;
+    const rest = doc.nodes.filter((n) => n.id !== nodeId);
+    doc.nodes = [src, ...rest];
+  }
+
+  function deleteNode(nodeId: string) {
+    doc.nodes = doc.nodes.filter((n) => n.id !== nodeId);
+    doc.edges = doc.edges.filter(
+      (ed) => ed.fromNode !== nodeId && ed.toNode !== nodeId,
+    );
+    if (selectedNodeId === nodeId) selectedNodeId = null;
+  }
+
+  function deleteEdge(edgeId: string) {
+    doc.edges = doc.edges.filter((ed) => ed.id !== edgeId);
+    if (selectedEdgeId === edgeId) selectedEdgeId = null;
+  }
+
+  function flipEdge(edgeId: string) {
+    const idx = doc.edges.findIndex((e) => e.id === edgeId);
+    if (idx < 0) return;
+    const src = doc.edges[idx];
+    if (!src) return;
+    const swapped: CanvasEdge = { ...src, fromNode: src.toNode, toNode: src.fromNode };
+    if (src.toSide !== undefined) swapped.fromSide = src.toSide;
+    else delete swapped.fromSide;
+    if (src.fromSide !== undefined) swapped.toSide = src.fromSide;
+    else delete swapped.toSide;
+    if (src.toEnd !== undefined) swapped.fromEnd = src.toEnd;
+    else delete swapped.fromEnd;
+    if (src.fromEnd !== undefined) swapped.toEnd = src.fromEnd;
+    else delete swapped.toEnd;
+    doc.edges = [
+      ...doc.edges.slice(0, idx),
+      swapped,
+      ...doc.edges.slice(idx + 1),
+    ];
+  }
+
+  async function revealFileNode(node: CanvasFileNode) {
+    treeRevealStore.requestReveal(node.file);
+  }
+
+  async function openFileNodeInSplit(node: CanvasFileNode) {
+    const vaultPath = get(vaultStore).currentPath;
+    if (!vaultPath) return;
+    const absPath = resolveVaultAbs(vaultPath, node.file);
+    tabStore.openTab(absPath);
+    tabStore.moveToPane("right");
+  }
 </script>
 
 <svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />
@@ -694,6 +901,7 @@
   onpointerup={onViewportPointerUp}
   onpointercancel={onViewportPointerUp}
   ondblclick={onViewportDblClick}
+  oncontextmenu={onViewportContextMenu}
   ondragover={onViewportDragOver}
   ondrop={onViewportDrop}
   onwheel={onWheel}
@@ -739,9 +947,147 @@
       onEdgeLabelBlur={onEdgeLabelBlur}
       onStartEditEdgeLabel={startEditEdgeLabel}
       onStopEditingEdge={() => (editingEdgeId = null)}
+      onNodeContextMenu={onNodeContextMenu}
+      onEdgeContextMenu={onEdgeContextMenu}
     />
   {/if}
 </div>
+
+<ContextMenu
+  open={contextMenu !== null}
+  x={contextMenu?.x ?? 0}
+  y={contextMenu?.y ?? 0}
+  onClose={closeContextMenu}
+>
+  {#if contextMenu?.target.kind === "empty"}
+    {@const worldX = contextMenu.target.worldX}
+    {@const worldY = contextMenu.target.worldY}
+    <button
+      class="vc-context-item"
+      onclick={() => { addTextNodeAt(worldX, worldY); closeContextMenu(); }}
+    >Add text node</button>
+    <button
+      class="vc-context-item"
+      onclick={() => { addGroupAt(worldX, worldY); closeContextMenu(); }}
+    >Add group</button>
+  {:else if contextMenu?.target.kind === "node" && contextNode}
+    {@const node = contextNode}
+    {@const nodeId = node.id}
+    {#if node.type === "text"}
+      <button
+        class="vc-context-item"
+        onclick={() => { startEditText(node as CanvasTextNode); closeContextMenu(); }}
+      >Edit text</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { duplicateNode(nodeId); closeContextMenu(); }}
+      >Duplicate</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { copyTextToClipboard((node as CanvasTextNode).text); closeContextMenu(); }}
+      >Copy text</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { bringNodeToFront(nodeId); closeContextMenu(); }}
+      >Bring to front</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { sendNodeToBack(nodeId); closeContextMenu(); }}
+      >Send to back</button>
+      <div class="vc-context-separator" role="separator"></div>
+      <button
+        class="vc-context-item vc-context-item--danger"
+        onclick={() => { deleteNode(nodeId); closeContextMenu(); }}
+      >Delete</button>
+    {:else if node.type === "file"}
+      <button
+        class="vc-context-item"
+        onclick={() => { void onOpenFileNode(node as CanvasFileNode); closeContextMenu(); }}
+      >Open in editor</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { void openFileNodeInSplit(node as CanvasFileNode); closeContextMenu(); }}
+      >Open in split</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { void revealFileNode(node as CanvasFileNode); closeContextMenu(); }}
+      >Reveal in sidebar</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { copyTextToClipboard((node as CanvasFileNode).file); closeContextMenu(); }}
+      >Copy vault path</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { duplicateNode(nodeId); closeContextMenu(); }}
+      >Duplicate</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { bringNodeToFront(nodeId); closeContextMenu(); }}
+      >Bring to front</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { sendNodeToBack(nodeId); closeContextMenu(); }}
+      >Send to back</button>
+      <div class="vc-context-separator" role="separator"></div>
+      <button
+        class="vc-context-item vc-context-item--danger"
+        onclick={() => { deleteNode(nodeId); closeContextMenu(); }}
+      >Delete</button>
+    {:else if node.type === "link"}
+      <button
+        class="vc-context-item"
+        onclick={() => { onOpenLinkNode(node as CanvasLinkNode); closeContextMenu(); }}
+      >Open link</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { copyTextToClipboard((node as CanvasLinkNode).url); closeContextMenu(); }}
+      >Copy URL</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { duplicateNode(nodeId); closeContextMenu(); }}
+      >Duplicate</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { bringNodeToFront(nodeId); closeContextMenu(); }}
+      >Bring to front</button>
+      <button
+        class="vc-context-item"
+        onclick={() => { sendNodeToBack(nodeId); closeContextMenu(); }}
+      >Send to back</button>
+      <div class="vc-context-separator" role="separator"></div>
+      <button
+        class="vc-context-item vc-context-item--danger"
+        onclick={() => { deleteNode(nodeId); closeContextMenu(); }}
+      >Delete</button>
+    {:else if node.type === "group"}
+      <button
+        class="vc-context-item"
+        onclick={() => { duplicateNode(nodeId); closeContextMenu(); }}
+      >Duplicate</button>
+      <div class="vc-context-separator" role="separator"></div>
+      <button
+        class="vc-context-item vc-context-item--danger"
+        onclick={() => { deleteNode(nodeId); closeContextMenu(); }}
+      >Delete</button>
+    {/if}
+  {:else if contextMenu?.target.kind === "edge" && contextEdge}
+    {@const edge = contextEdge}
+    {@const edgeId = edge.id}
+    <button
+      class="vc-context-item"
+      onclick={() => { startEditEdgeLabel(edge); closeContextMenu(); }}
+    >Edit label</button>
+    <button
+      class="vc-context-item"
+      onclick={() => { flipEdge(edgeId); closeContextMenu(); }}
+    >Flip direction</button>
+    <div class="vc-context-separator" role="separator"></div>
+    <button
+      class="vc-context-item vc-context-item--danger"
+      onclick={() => { deleteEdge(edgeId); closeContextMenu(); }}
+    >Delete</button>
+  {/if}
+</ContextMenu>
 
 
 <style>

--- a/src/components/Canvas/__tests__/CanvasRenderer.test.ts
+++ b/src/components/Canvas/__tests__/CanvasRenderer.test.ts
@@ -6,7 +6,7 @@
 // the main view keep agreeing on the DOM contract.
 
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/svelte";
+import { render, fireEvent } from "@testing-library/svelte";
 
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: (p: string) => `asset://localhost/${encodeURIComponent(p)}`,
@@ -126,6 +126,64 @@ describe("CanvasRenderer (#156)", () => {
     expect(img).toBeTruthy();
     expect(img!.getAttribute("src")).toContain("asset://localhost/");
     expect(img!.getAttribute("src")).toContain(encodeURIComponent("/vault/pic.png"));
+  });
+
+  it("fires onNodeContextMenu with the clicked node (#164)", async () => {
+    const onNodeContextMenu = vi.fn();
+    const doc = docOf([
+      { id: "t", type: "text", text: "hi", x: 0, y: 0, width: 100, height: 40 },
+      { id: "f", type: "file", file: "a.md", x: 0, y: 60, width: 100, height: 40 },
+      { id: "l", type: "link", url: "https://x", x: 0, y: 120, width: 100, height: 40 },
+      { id: "g", type: "group", label: "G", x: 0, y: 180, width: 300, height: 200 },
+    ]);
+    const { container } = render(CanvasRenderer, {
+      props: { doc, interactive: true, vaultPath: "/vault", onNodeContextMenu },
+    });
+    for (const id of ["t", "f", "l", "g"]) {
+      const el = container.querySelector(`[data-node-id="${id}"]`) as HTMLElement;
+      await fireEvent.contextMenu(el);
+    }
+    expect(onNodeContextMenu).toHaveBeenCalledTimes(4);
+    const nodeIds = onNodeContextMenu.mock.calls.map((c) => (c[1] as { id: string }).id);
+    expect(nodeIds).toEqual(["t", "f", "l", "g"]);
+  });
+
+  it("fires onEdgeContextMenu when right-clicking the edge hit path (#164)", async () => {
+    const onEdgeContextMenu = vi.fn();
+    const doc = docOf(
+      [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      [{ id: "e1", fromNode: "a", toNode: "b" }],
+    );
+    const { container } = render(CanvasRenderer, {
+      props: { doc, interactive: true, onEdgeContextMenu },
+    });
+    const hit = container.querySelector(".vc-canvas-edge-hit") as SVGPathElement;
+    expect(hit).toBeTruthy();
+    await fireEvent.contextMenu(hit);
+    expect(onEdgeContextMenu).toHaveBeenCalledTimes(1);
+    expect((onEdgeContextMenu.mock.calls[0]?.[1] as { id: string }).id).toBe("e1");
+  });
+
+  it("does not fire context-menu callbacks in read-only mode (#164)", async () => {
+    const onNodeContextMenu = vi.fn();
+    const onEdgeContextMenu = vi.fn();
+    const doc = docOf(
+      [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      [{ id: "e1", fromNode: "a", toNode: "b" }],
+    );
+    const { container } = render(CanvasRenderer, {
+      props: { doc, interactive: false, onNodeContextMenu, onEdgeContextMenu },
+    });
+    const el = container.querySelector('[data-node-id="a"]') as HTMLElement;
+    await fireEvent.contextMenu(el);
+    expect(onNodeContextMenu).not.toHaveBeenCalled();
+    expect(onEdgeContextMenu).not.toHaveBeenCalled();
   });
 
   it("markdown file nodes use the provided mdPreviews HTML", () => {

--- a/src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts
+++ b/src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts
@@ -1,0 +1,260 @@
+// #164 — CanvasView integration: right-click menu entries mutate the doc as
+// promised. These tests exercise the end-to-end path from a contextmenu event
+// on the viewport / a node / an edge through the menu click to the store
+// mutation so the per-target menus stay wired up as the renderer evolves.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://localhost/${encodeURIComponent(p)}`,
+}));
+
+// Bind the IPC commands to a mutable mock closure so each test can seed
+// a fresh doc without remounting the module.
+const readFileMock = vi.fn<(path: string) => Promise<string>>();
+const writeFileMock = vi.fn<(path: string, content: string) => Promise<void>>();
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile: (path: string) => readFileMock(path),
+  writeFile: (path: string, content: string) => writeFileMock(path, content),
+}));
+
+import CanvasView from "../CanvasView.svelte";
+import { vaultStore } from "../../../store/vaultStore";
+import type { CanvasDoc } from "../../../lib/canvas/types";
+
+const VAULT = "/tmp/canvas-vault";
+const TAB_ID = "tab-1";
+const FILE_ABS = `${VAULT}/Menu.canvas`;
+
+function seedDoc(doc: CanvasDoc): void {
+  readFileMock.mockReset();
+  writeFileMock.mockReset();
+  readFileMock.mockResolvedValue(JSON.stringify(doc, null, "\t"));
+  writeFileMock.mockResolvedValue(undefined);
+}
+
+async function openMenuOnViewport(container: HTMLElement, x = 400, y = 300) {
+  const vp = container.querySelector(".vc-canvas-viewport") as HTMLElement;
+  // The viewport's getBoundingClientRect is {0,0,0,0} in jsdom; we dispatch
+  // the event with clientX/clientY directly, which clientToWorld reads.
+  await fireEvent.contextMenu(vp, { clientX: x, clientY: y, button: 2 });
+  await tick();
+}
+
+async function openMenuOnNode(container: HTMLElement, id: string) {
+  const el = container.querySelector(`[data-node-id="${id}"]`) as HTMLElement;
+  await fireEvent.contextMenu(el, { clientX: 100, clientY: 100, button: 2 });
+  await tick();
+}
+
+async function openMenuOnEdge(container: HTMLElement) {
+  const hit = container.querySelector(".vc-canvas-edge-hit") as SVGPathElement;
+  await fireEvent.contextMenu(hit, { clientX: 150, clientY: 100, button: 2 });
+  await tick();
+}
+
+function menuItems(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll(".vc-context-menu .vc-context-item")).map(
+    (b) => (b as HTMLElement).textContent?.trim() ?? "",
+  );
+}
+
+async function clickMenuItem(container: HTMLElement, label: string) {
+  const items = Array.from(container.querySelectorAll(".vc-context-menu .vc-context-item"));
+  const btn = items.find(
+    (b) => ((b as HTMLElement).textContent ?? "").trim() === label,
+  ) as HTMLElement | undefined;
+  if (!btn) throw new Error(`menu item "${label}" not found. Have: ${menuItems(container).join(", ")}`);
+  await fireEvent.click(btn);
+  await tick();
+}
+
+async function mountWithDoc(doc: CanvasDoc) {
+  seedDoc(doc);
+  const result = render(CanvasView, { props: { tabId: TAB_ID, abs: FILE_ABS } });
+  // Wait for async load().
+  for (let i = 0; i < 20; i++) {
+    await tick();
+    if (result.container.querySelector(".vc-canvas-world")) break;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return result;
+}
+
+function nodesFromLastWrite(): CanvasDoc {
+  const lastCall = writeFileMock.mock.calls.at(-1);
+  if (!lastCall) throw new Error("writeFile was never called");
+  return JSON.parse(lastCall[1] as string) as CanvasDoc;
+}
+
+describe("CanvasView context menus (#164)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+  });
+
+  // ─── Empty canvas ────────────────────────────────────────────────────
+
+  it("empty-canvas menu shows Add text node + Add group", async () => {
+    const { container } = await mountWithDoc({ nodes: [], edges: [] });
+    await openMenuOnViewport(container);
+    expect(menuItems(container)).toEqual(["Add text node", "Add group"]);
+  });
+
+  it("Add text node creates a text node in the doc", async () => {
+    const { container } = await mountWithDoc({ nodes: [], edges: [] });
+    await openMenuOnViewport(container);
+    await clickMenuItem(container, "Add text node");
+    expect(container.querySelectorAll(".vc-canvas-node-text")).toHaveLength(1);
+  });
+
+  it("Add group creates a group node in the doc", async () => {
+    const { container } = await mountWithDoc({ nodes: [], edges: [] });
+    await openMenuOnViewport(container);
+    await clickMenuItem(container, "Add group");
+    expect(container.querySelectorAll(".vc-canvas-node-group")).toHaveLength(1);
+  });
+
+  // ─── Text node ───────────────────────────────────────────────────────
+
+  it("text-node menu lists the expected entries", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "t", type: "text", text: "hi", x: 0, y: 0, width: 100, height: 40 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "t");
+    expect(menuItems(container)).toEqual([
+      "Edit text",
+      "Duplicate",
+      "Copy text",
+      "Bring to front",
+      "Send to back",
+      "Delete",
+    ]);
+  });
+
+  it("Duplicate on a text node creates a clone with a new id and offset position", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "t", type: "text", text: "hi", x: 100, y: 100, width: 120, height: 40 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "t");
+    await clickMenuItem(container, "Duplicate");
+    expect(container.querySelectorAll(".vc-canvas-node-text")).toHaveLength(2);
+  });
+
+  it("Delete on a text node removes it from the doc", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "t", type: "text", text: "hi", x: 0, y: 0, width: 100, height: 40 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "t");
+    await clickMenuItem(container, "Delete");
+    expect(container.querySelectorAll(".vc-canvas-node-text")).toHaveLength(0);
+  });
+
+  // ─── File node ───────────────────────────────────────────────────────
+
+  it("file-node menu lists the expected entries", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "f", type: "file", file: "Note.md", x: 0, y: 0, width: 200, height: 200 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "f");
+    expect(menuItems(container)).toEqual([
+      "Open in editor",
+      "Open in split",
+      "Reveal in sidebar",
+      "Copy vault path",
+      "Duplicate",
+      "Bring to front",
+      "Send to back",
+      "Delete",
+    ]);
+  });
+
+  // ─── Link node ───────────────────────────────────────────────────────
+
+  it("link-node menu lists the expected entries", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "l", type: "link", url: "https://example.com", x: 0, y: 0, width: 200, height: 60 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "l");
+    expect(menuItems(container)).toEqual([
+      "Open link",
+      "Copy URL",
+      "Duplicate",
+      "Bring to front",
+      "Send to back",
+      "Delete",
+    ]);
+  });
+
+  // ─── Group node ──────────────────────────────────────────────────────
+
+  it("group-node menu lists the expected entries", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "g", type: "group", label: "G", x: 0, y: 0, width: 300, height: 200 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "g");
+    expect(menuItems(container)).toEqual(["Duplicate", "Delete"]);
+  });
+
+  // ─── Edge ────────────────────────────────────────────────────────────
+
+  it("edge menu lists Edit label / Flip direction / Delete", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      edges: [{ id: "e1", fromNode: "a", toNode: "b", fromSide: "right", toSide: "left" }],
+    });
+    await openMenuOnEdge(container);
+    expect(menuItems(container)).toEqual(["Edit label", "Flip direction", "Delete"]);
+  });
+
+  it("Flip direction swaps the edge endpoints + sides", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      edges: [{ id: "e1", fromNode: "a", toNode: "b", fromSide: "right", toSide: "left" }],
+    });
+    await openMenuOnEdge(container);
+    await clickMenuItem(container, "Flip direction");
+
+    // Wait for the debounced autosave (400 ms).
+    for (let i = 0; i < 30; i++) {
+      if (writeFileMock.mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    const flipped = nodesFromLastWrite();
+    expect(flipped.edges).toHaveLength(1);
+    expect(flipped.edges[0]).toMatchObject({
+      fromNode: "b",
+      toNode: "a",
+      fromSide: "left",
+      toSide: "right",
+    });
+  });
+
+  it("Delete on an edge removes it", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      edges: [{ id: "e1", fromNode: "a", toNode: "b" }],
+    });
+    await openMenuOnEdge(container);
+    await clickMenuItem(container, "Delete");
+    expect(container.querySelectorAll(".vc-canvas-edge-hit")).toHaveLength(0);
+  });
+});

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -7,6 +7,7 @@
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import type { DirEntry } from "../../types/tree";
   import InlineRename from "./InlineRename.svelte";
+  import ContextMenu from "../common/ContextMenu.svelte";
   import TreeNode from "./TreeNode.svelte";
   import { vaultStore } from "../../store/vaultStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
@@ -61,11 +62,11 @@
   let renaming = $state(false);
   let isNewFile = $state(false);
 
-  // Context menu state. When opened via right-click we position at the mouse
-  // coordinates; when opened via the three-dots button we leave `menuPos` null
-  // and fall back to the row-anchored CSS default.
+  // Context menu state. Anchored at the cursor point when opened via
+  // right-click, and at the three-dots button's bounding rect when opened
+  // via click. Shared ContextMenu handles overflow-flip + ESC.
   let showContextMenu = $state(false);
-  let menuPos = $state<{ x: number; y: number } | null>(null);
+  let menuPos = $state<{ x: number; y: number }>({ x: 0, y: 0 });
 
   // Delete confirmation state
   let showDeleteConfirm = $state(false);
@@ -219,7 +220,9 @@
   // Context menu
   function openContextMenu(e: MouseEvent) {
     e.stopPropagation();
-    menuPos = null;
+    const btn = e.currentTarget as HTMLElement;
+    const rect = btn.getBoundingClientRect();
+    menuPos = { x: rect.left, y: rect.bottom };
     showContextMenu = true;
   }
 
@@ -234,7 +237,6 @@
 
   function closeContextMenu() {
     showContextMenu = false;
-    menuPos = null;
   }
 
   function startRename() {
@@ -623,35 +625,23 @@
   </div>
 
   <!-- Context menu -->
-  {#if showContextMenu}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div
-      class="vc-context-overlay"
-      onclick={closeContextMenu}
-      role="presentation"
-    ></div>
-    <div
-      class="vc-context-menu"
-      class:vc-context-menu--pointer={menuPos !== null}
-      style={menuPos ? `top: ${menuPos.y}px; left: ${menuPos.x}px` : undefined}
-    >
-      {#if !entry.is_dir}
-        <button class="vc-context-item" onclick={handleOpenInSplit}>Open in split</button>
-      {/if}
-      <button class="vc-context-item" onclick={startRename}>Rename</button>
-      {#if !entry.is_dir}
-        <button class="vc-context-item" onclick={() => void toggleBookmark()}>
-          {isBookmarked ? "Remove bookmark" : "Bookmark"}
-        </button>
-      {/if}
-      <button class="vc-context-item vc-context-item--danger" onclick={openDeleteConfirm}>Move to Trash</button>
-      {#if entry.is_dir}
-        <button class="vc-context-item" onclick={handleNewFileHere}>New file here</button>
-        <button class="vc-context-item" onclick={handleNewCanvasHere}>New canvas here</button>
-        <button class="vc-context-item" onclick={handleNewFolderHere}>New folder here</button>
-      {/if}
-    </div>
-  {/if}
+  <ContextMenu open={showContextMenu} x={menuPos.x} y={menuPos.y} onClose={closeContextMenu}>
+    {#if !entry.is_dir}
+      <button class="vc-context-item" onclick={handleOpenInSplit}>Open in split</button>
+    {/if}
+    <button class="vc-context-item" onclick={startRename}>Rename</button>
+    {#if !entry.is_dir}
+      <button class="vc-context-item" onclick={() => void toggleBookmark()}>
+        {isBookmarked ? "Remove bookmark" : "Bookmark"}
+      </button>
+    {/if}
+    <button class="vc-context-item vc-context-item--danger" onclick={openDeleteConfirm}>Move to Trash</button>
+    {#if entry.is_dir}
+      <button class="vc-context-item" onclick={handleNewFileHere}>New file here</button>
+      <button class="vc-context-item" onclick={handleNewCanvasHere}>New canvas here</button>
+      <button class="vc-context-item" onclick={handleNewFolderHere}>New folder here</button>
+    {/if}
+  </ContextMenu>
 
   <!-- Delete confirmation dialog -->
   {#if showDeleteConfirm}
@@ -887,51 +877,6 @@
     color: var(--color-text-muted);
     padding: 4px 8px 4px 32px;
     font-style: italic;
-  }
-
-  /* Context menu */
-  .vc-context-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 99;
-  }
-
-  .vc-context-menu {
-    position: absolute;
-    top: 24px;
-    left: 24px;
-    z-index: 100;
-    min-width: 160px;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
-    padding: 4px 0;
-  }
-
-  /* Right-click positioning uses viewport-relative clientX/clientY. */
-  .vc-context-menu--pointer {
-    position: fixed;
-  }
-
-  .vc-context-item {
-    display: block;
-    width: 100%;
-    padding: 6px 12px;
-    font-size: 14px;
-    text-align: left;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--color-text);
-  }
-
-  .vc-context-item:hover {
-    background: var(--color-accent-bg);
-  }
-
-  .vc-context-item--danger {
-    color: var(--color-error);
   }
 
   /* Confirmation dialog */

--- a/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
@@ -77,9 +77,7 @@ describe("TreeNode right-click context menu (#47)", () => {
     await tick();
     const menu = container.querySelector(".vc-context-menu") as HTMLElement;
     expect(menu).toBeTruthy();
-    // When opened via right-click, menu is positioned at the mouse coords
-    // (via inline style) and uses fixed positioning via the pointer modifier.
-    expect(menu.classList.contains("vc-context-menu--pointer")).toBe(true);
+    // Menu is positioned at the mouse coords via inline style.
     expect(menu.style.top).toBe("80px");
     expect(menu.style.left).toBe("120px");
   });

--- a/src/components/common/ContextMenu.svelte
+++ b/src/components/common/ContextMenu.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  // Shared cursor-anchored popover menu (#164).
+  //
+  // Renders an overlay (click-to-close) and the menu itself, positioned at
+  // viewport-fixed (x, y). On mount the menu measures its own rect and shifts
+  // left / up when it would overflow the viewport — so right-clicks near the
+  // screen edge still surface the whole menu.
+  //
+  // Closing rules: click anywhere on the overlay, or press Escape. The Escape
+  // listener is attached to `window` only while the menu is open and stops
+  // propagation so parents (e.g. canvas's edit-mode cancel) don't also react.
+  //
+  // Consumers own the items: pass them as the `children` snippet with whatever
+  // buttons / separators they need. Item classes `.vc-context-item` and
+  // `.vc-context-item--danger` are styled here so consumers can stay terse.
+
+  import { tick, untrack, type Snippet } from "svelte";
+
+  interface Props {
+    open: boolean;
+    x: number;
+    y: number;
+    onClose: () => void;
+    children: Snippet;
+  }
+
+  let { open, x, y, onClose, children }: Props = $props();
+
+  let menuEl = $state<HTMLDivElement | null>(null);
+  let adjustedX = $state(untrack(() => x));
+  let adjustedY = $state(untrack(() => y));
+
+  $effect(() => {
+    if (!open) return;
+    adjustedX = x;
+    adjustedY = y;
+    void (async () => {
+      await tick();
+      if (!menuEl) return;
+      const rect = menuEl.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      if (x + rect.width > vw) adjustedX = Math.max(0, vw - rect.width - 4);
+      if (y + rect.height > vh) adjustedY = Math.max(0, vh - rect.height - 4);
+    })();
+  });
+
+  $effect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  });
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-context-overlay"
+    onclick={onClose}
+    oncontextmenu={(e) => { e.preventDefault(); onClose(); }}
+    role="presentation"
+  ></div>
+  <div
+    bind:this={menuEl}
+    class="vc-context-menu"
+    style="top: {adjustedY}px; left: {adjustedX}px;"
+    role="menu"
+  >
+    {@render children()}
+  </div>
+{/if}
+
+<style>
+  .vc-context-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 199;
+  }
+
+  .vc-context-menu {
+    position: fixed;
+    z-index: 200;
+    min-width: 180px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+    padding: 4px 0;
+  }
+
+  :global(.vc-context-item) {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    font-size: 14px;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  :global(.vc-context-item:hover),
+  :global(.vc-context-item:focus-visible) {
+    background: var(--color-accent-bg);
+    outline: none;
+  }
+
+  :global(.vc-context-item--danger) {
+    color: var(--color-error);
+  }
+
+  :global(.vc-context-separator) {
+    height: 1px;
+    background: var(--color-border);
+    margin: 4px 0;
+  }
+</style>

--- a/src/components/common/__tests__/ContextMenu.test.ts
+++ b/src/components/common/__tests__/ContextMenu.test.ts
@@ -1,0 +1,71 @@
+// #164 — shared ContextMenu component. Locks in the open/close contract,
+// ESC handling, and viewport-overflow flip logic so future callers can rely
+// on it without re-testing the primitive.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import ContextMenuHarness from "./ContextMenuHarness.svelte";
+
+describe("ContextMenu (#164)", () => {
+  it("renders the menu and children when open=true", async () => {
+    const { container, getByText } = render(ContextMenuHarness, {
+      props: { open: true, x: 40, y: 60, label: "Item A" },
+    });
+    await tick();
+    expect(container.querySelector(".vc-context-menu")).toBeTruthy();
+    expect(container.querySelector(".vc-context-overlay")).toBeTruthy();
+    expect(getByText("Item A")).toBeTruthy();
+  });
+
+  it("does not render when open=false", async () => {
+    const { container } = render(ContextMenuHarness, {
+      props: { open: false, x: 0, y: 0, label: "Hidden" },
+    });
+    await tick();
+    expect(container.querySelector(".vc-context-menu")).toBeNull();
+    expect(container.querySelector(".vc-context-overlay")).toBeNull();
+  });
+
+  it("positions the menu at the given x/y", async () => {
+    const { container } = render(ContextMenuHarness, {
+      props: { open: true, x: 123, y: 45, label: "Item" },
+    });
+    await tick();
+    const menu = container.querySelector(".vc-context-menu") as HTMLElement;
+    expect(menu.style.top).toBe("45px");
+    expect(menu.style.left).toBe("123px");
+  });
+
+  it("calls onClose when the overlay is clicked", async () => {
+    const onClose = vi.fn();
+    const { container } = render(ContextMenuHarness, {
+      props: { open: true, x: 0, y: 0, label: "x", onClose },
+    });
+    await tick();
+    const overlay = container.querySelector(".vc-context-overlay") as HTMLElement;
+    await fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Escape", async () => {
+    const onClose = vi.fn();
+    render(ContextMenuHarness, {
+      props: { open: true, x: 0, y: 0, label: "x", onClose },
+    });
+    await tick();
+    const ev = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+    window.dispatchEvent(ev);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not listen for Escape while closed", async () => {
+    const onClose = vi.fn();
+    render(ContextMenuHarness, {
+      props: { open: false, x: 0, y: 0, label: "x", onClose },
+    });
+    await tick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/common/__tests__/ContextMenuHarness.svelte
+++ b/src/components/common/__tests__/ContextMenuHarness.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import ContextMenu from "../ContextMenu.svelte";
+
+  interface Props {
+    open: boolean;
+    x: number;
+    y: number;
+    label: string;
+    onClose?: () => void;
+  }
+
+  let { open, x, y, label, onClose = () => {} }: Props = $props();
+</script>
+
+<ContextMenu {open} {x} {y} {onClose}>
+  <button class="vc-context-item">{label}</button>
+</ContextMenu>


### PR DESCRIPTION
## Summary
- Adds right-click context menus across the canvas (empty surface, text / file / link / group nodes, edges) with the trivial entries from the ticket: open, copy, reveal, duplicate, reorder, delete, flip edge direction.
- Extracts a shared `src/components/common/ContextMenu.svelte` (overlay + menu + viewport-overflow flip + Escape-to-close). `TreeNode.svelte` migrates onto it so both surfaces share one primitive.
- Canvas selection now happens on right-click too (the previous code short-circuited non-primary buttons), so the menu action always targets what the user saw.

## Out of scope (follow-up #166)
- **Add file node…** / **Add link node…** — need the QuickSwitcher / URL-input UI.
- **Edit URL…** (link), **Edit label…** (group) — need inline edit affordances.
- **Change color…** (group, edge) — needs a small color picker + renderer wiring for `CanvasGroupNode.background`.

## Test plan
- [x] Unit: `src/components/common/__tests__/ContextMenu.test.ts` — open/close, overlay click, ESC, not-listening-while-closed, position.
- [x] Unit: `src/components/Canvas/__tests__/CanvasRenderer.test.ts` — `onNodeContextMenu` / `onEdgeContextMenu` fire for each type; read-only renderer does not.
- [x] Unit: `src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts` — per-target menu items + mutations (Add text / group, Duplicate, Delete, Flip direction round-trips via writeFile).
- [x] Unit: existing `TreeNodeContextMenu` passes after migration.
- [x] E2E: `e2e/specs/canvas-context-menus.spec.ts` — right-click empty → "Add text node" → DOM + disk round-trip.
- [ ] **Manual UAT pending** — please exercise the menus in every target (empty / text / file / link / group / edge) and confirm the existing tree menu still feels identical after the migration.