### PR TITLE
feat(canvas): group drag translates contained nodes (#168)

### DIFF
--- a/e2e/specs/canvas-group-movement.spec.ts
+++ b/e2e/specs/canvas-group-movement.spec.ts
@@ -1,0 +1,198 @@
+// #168 — spatial group membership. Dragging a group node also translates
+// every node whose bounding box was fully inside the group rect at the
+// moment the drag started. Containment is geometric only — no persisted
+// parent field — matching Obsidian's behavior.
+//
+// This spec exercises the end-to-end path: seed a canvas with a group +
+// two fully-contained members + one outsider, drag the group, and verify
+// on disk that the group + both members shifted by the same delta while
+// the outsider stayed put.
+
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf, textsOf } from "../helpers/text.js";
+
+const DEBOUNCE_MS = 400;
+const FLUSH_WAIT_MS = DEBOUNCE_MS + 500;
+
+// Far-apart coordinates so the test is insensitive to camera / zoom details:
+// we only check relative deltas, not absolute on-screen positions.
+const GROUP_SEED = {
+  nodes: [
+    {
+      id: "grp",
+      type: "group",
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 400,
+      label: "G",
+    },
+    { id: "inA", type: "text", x: 40, y: 40, width: 100, height: 40, text: "inA" },
+    { id: "inB", type: "text", x: 240, y: 320, width: 100, height: 40, text: "inB" },
+    { id: "out", type: "text", x: 600, y: 600, width: 100, height: 40, text: "out" },
+  ],
+  edges: [],
+};
+
+describe("Canvas group movement (#168)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.writeFileSync(
+      path.join(vault.path, "Group.canvas"),
+      JSON.stringify(GROUP_SEED, null, "\t"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const names = await textsOf(await browser.$$(".vc-tree-name"));
+        return names.includes(name);
+      },
+      { timeout: 5000, timeoutMsg: `"${name}" never appeared in the tree` },
+    );
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not found`);
+  }
+
+  async function waitForCanvas(): Promise<void> {
+    await browser.waitUntil(
+      async () =>
+        browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const visible = vps.find((v) => v.offsetParent !== null);
+          return !!visible?.querySelector(".vc-canvas-world");
+        }),
+      { timeout: 5000, timeoutMsg: "Canvas world never mounted" },
+    );
+  }
+
+  async function readDoc(): Promise<{ nodes: Array<Record<string, unknown>> }> {
+    const raw = fs.readFileSync(path.join(vault.path, "Group.canvas"), "utf-8");
+    return JSON.parse(raw);
+  }
+
+  async function waitForGroupAtOrigin(x0: number, y0: number): Promise<void> {
+    const deadline = Date.now() + FLUSH_WAIT_MS * 6;
+    let last: Array<Record<string, unknown>> | null = null;
+    while (Date.now() < deadline) {
+      try {
+        const doc = await readDoc();
+        const grp = doc.nodes.find((n) => n.id === "grp")!;
+        if (grp.x !== x0 || grp.y !== y0) return;
+        last = doc.nodes;
+      } catch {
+        /* file race */
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+      `group never moved from (${x0}, ${y0}). Last nodes: ${JSON.stringify(last)}`,
+    );
+  }
+
+  // Drag the group node by (dx, dy) pixels. We start the pointer on the
+  // group's top-left quadrant — well clear of inner text nodes — so the
+  // event fires on the group element rather than a child card.
+  async function dragGroup(dx: number, dy: number): Promise<void> {
+    await browser.execute(
+      (mx: number, my: number) => {
+        const vps = Array.from(
+          document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+        );
+        const visible = vps.find((v) => v.offsetParent !== null)!;
+        const grp = visible.querySelector<HTMLElement>(
+          '[data-node-id="grp"]',
+        )!;
+        const rect = grp.getBoundingClientRect();
+        // 15% in from the top-left corner — guaranteed to miss inA at (40,40)
+        // relative to group origin (which maps to ~10% of the 400-wide rect).
+        const startX = rect.left + rect.width * 0.05;
+        const startY = rect.top + rect.height * 0.05;
+        const opts = (x: number, y: number): PointerEventInit => ({
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          pointerId: 1,
+          pointerType: "mouse",
+          button: 0,
+          buttons: 1,
+          isPrimary: true,
+        });
+        grp.dispatchEvent(new PointerEvent("pointerdown", opts(startX, startY)));
+        // Move past the long-press threshold so we fall into move mode rather
+        // than waiting for the 300ms pan-timer.
+        grp.dispatchEvent(
+          new PointerEvent("pointermove", opts(startX + mx, startY + my)),
+        );
+        grp.dispatchEvent(
+          new PointerEvent("pointerup", opts(startX + mx, startY + my)),
+        );
+      },
+      dx,
+      dy,
+    );
+  }
+
+  it("translates contained nodes with the group and leaves outsiders alone", async () => {
+    await openTreeFile("Group.canvas");
+    await waitForCanvas();
+
+    // Sanity: pre-drag positions on disk match the seed.
+    const before = await readDoc();
+    const grpB = before.nodes.find((n) => n.id === "grp")!;
+    const inAB = before.nodes.find((n) => n.id === "inA")!;
+    const inBB = before.nodes.find((n) => n.id === "inB")!;
+    const outB = before.nodes.find((n) => n.id === "out")!;
+    expect(grpB.x).toBe(0);
+    expect(grpB.y).toBe(0);
+    expect(inAB.x).toBe(40);
+    expect(inBB.x).toBe(240);
+    expect(outB.x).toBe(600);
+
+    await dragGroup(60, 30);
+
+    // Wait for any change before diffing.
+    await waitForGroupAtOrigin(0, 0);
+    const after = await readDoc();
+    const grpA = after.nodes.find((n) => n.id === "grp")!;
+    const inAA = after.nodes.find((n) => n.id === "inA")!;
+    const inBA = after.nodes.find((n) => n.id === "inB")!;
+    const outA = after.nodes.find((n) => n.id === "out")!;
+
+    const dx = (grpA.x as number) - 0;
+    const dy = (grpA.y as number) - 0;
+    // Sanity: the group actually moved.
+    expect(dx).not.toBe(0);
+
+    // Both members tracked the group by the same delta.
+    expect((inAA.x as number) - 40).toBe(dx);
+    expect((inAA.y as number) - 40).toBe(dy);
+    expect((inBA.x as number) - 240).toBe(dx);
+    expect((inBA.y as number) - 320).toBe(dy);
+
+    // Outsider stayed put.
+    expect(outA.x).toBe(600);
+    expect(outA.y).toBe(600);
+  });
+});

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -60,6 +60,7 @@
   import {
     type PointerMode,
     type DraftEdge,
+    type MoveMember,
     LONGPRESS_HOLD_MS,
     beginPan,
     beginMove,
@@ -71,10 +72,12 @@
     longpressFallback,
     panPosition,
     movePosition,
+    memberPositions,
     resizeSize,
     updateDraftOnMove,
     resolvePointerUp,
   } from "../../lib/canvas/pointerMode";
+  import { nodesInsideGroup } from "../../lib/canvas/group";
 
   interface Props {
     tabId: string;
@@ -325,7 +328,15 @@
 
   function startLongpress(
     e: PointerEvent,
-    fallback: { kind: "none" } | { kind: "move"; nodeId: string; nodeStartX: number; nodeStartY: number },
+    fallback:
+      | { kind: "none" }
+      | {
+          kind: "move";
+          nodeId: string;
+          nodeStartX: number;
+          nodeStartY: number;
+          members: MoveMember[];
+        },
   ) {
     pointerMode = beginPendingLongpress(e, fallback);
     const el = e.currentTarget as HTMLElement;
@@ -375,6 +386,18 @@
       if (node) {
         node.x = p.x;
         node.y = p.y;
+      }
+      // Group drags (#168): translate each snapshotted member by the same
+      // zoom-scaled delta so the contained nodes move with the group.
+      if (mode.members.length > 0) {
+        const positions = memberPositions(mode, e, zoom);
+        for (const mp of positions) {
+          const m = doc.nodes.find((n) => n.id === mp.nodeId);
+          if (m) {
+            m.x = mp.x;
+            m.y = mp.y;
+          }
+        }
       }
     } else if (mode.kind === "resize") {
       const s = resizeSize(mode, e, zoom);
@@ -458,6 +481,18 @@
     e.stopPropagation();
     selectedNodeId = node.id;
     selectedEdgeId = null;
+    // For group nodes, snapshot every node fully inside the group at this
+    // instant so a subsequent drag translates them together (#168).
+    // Containment is evaluated here (pointer-down) — not on every mousemove —
+    // so the set is stable even if the doc is reordered mid-drag.
+    const members: MoveMember[] =
+      node.type === "group"
+        ? nodesInsideGroup(doc, node).map((m) => ({
+            nodeId: m.id,
+            startX: m.x,
+            startY: m.y,
+          }))
+        : [];
     // Enter pending-longpress — if the user keeps the pointer still for
     // LONGPRESS_HOLD_MS we flip to pan; if they move past the threshold
     // first, we fall through to beginMove (the original gesture).
@@ -466,6 +501,7 @@
       nodeId: node.id,
       nodeStartX: node.x,
       nodeStartY: node.y,
+      members,
     });
   }
 

--- a/src/lib/canvas/__tests__/group.test.ts
+++ b/src/lib/canvas/__tests__/group.test.ts
@@ -1,0 +1,89 @@
+// #168 — spatial group membership. Pure containment helper so moving a
+// group translates every node whose bounding box fully lies inside the
+// group's rect at the moment the drag starts. Matches Obsidian behavior —
+// no persisted parent field, purely geometric at beginMove time.
+
+import { describe, it, expect } from "vitest";
+import { nodesInsideGroup } from "../group";
+import type { CanvasDoc, CanvasGroupNode, CanvasNode } from "../types";
+
+const group = (over: Partial<CanvasGroupNode> = {}): CanvasGroupNode => ({
+  id: "g",
+  type: "group",
+  x: 0,
+  y: 0,
+  width: 400,
+  height: 300,
+  ...over,
+});
+
+const text = (over: Partial<CanvasNode> & { id: string }): CanvasNode => ({
+  type: "text",
+  text: "",
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 40,
+  ...over,
+} as CanvasNode);
+
+const docOf = (nodes: CanvasNode[]): CanvasDoc => ({ nodes, edges: [] });
+
+describe("nodesInsideGroup (#168)", () => {
+  it("returns nodes whose bounding box lies fully inside the group rect", () => {
+    const g = group({ x: 0, y: 0, width: 400, height: 300 });
+    const inside = text({ id: "in", x: 50, y: 50, width: 100, height: 40 });
+    const outside = text({ id: "out", x: 500, y: 500, width: 100, height: 40 });
+    const doc = docOf([g, inside, outside]);
+
+    const members = nodesInsideGroup(doc, g).map((n) => n.id);
+    expect(members).toEqual(["in"]);
+  });
+
+  it("excludes nodes that overlap the group boundary but are not fully inside", () => {
+    const g = group({ x: 0, y: 0, width: 200, height: 200 });
+    const straddling = text({ id: "half", x: 150, y: 150, width: 100, height: 100 });
+    const doc = docOf([g, straddling]);
+
+    expect(nodesInsideGroup(doc, g)).toHaveLength(0);
+  });
+
+  it("excludes the group itself from its own membership list", () => {
+    const g = group({ x: 0, y: 0, width: 400, height: 300 });
+    const doc = docOf([g]);
+    expect(nodesInsideGroup(doc, g)).toHaveLength(0);
+  });
+
+  it("excludes other group nodes so moving a group does not drag nested groups", () => {
+    const outer = group({ id: "outer", x: 0, y: 0, width: 500, height: 500 });
+    const inner = group({ id: "inner", x: 50, y: 50, width: 100, height: 100 });
+    const doc = docOf([outer, inner]);
+    // Per acceptance criteria in #168: groups don't nest-move. The decision
+    // lives in this helper so the callers stay simple.
+    expect(nodesInsideGroup(doc, outer)).toHaveLength(0);
+  });
+
+  it("includes a node whose edges touch the group rect exactly (inclusive bounds)", () => {
+    const g = group({ x: 0, y: 0, width: 200, height: 200 });
+    const flush = text({ id: "flush", x: 0, y: 0, width: 200, height: 200 });
+    const doc = docOf([g, flush]);
+    expect(nodesInsideGroup(doc, g).map((n) => n.id)).toEqual(["flush"]);
+  });
+
+  it("works for non-zero group origin (translated group rect)", () => {
+    const g = group({ x: 100, y: 200, width: 300, height: 300 });
+    const inside = text({ id: "in", x: 150, y: 250, width: 100, height: 40 });
+    const outside = text({ id: "out", x: 50, y: 250, width: 100, height: 40 });
+    const doc = docOf([g, inside, outside]);
+    expect(nodesInsideGroup(doc, g).map((n) => n.id)).toEqual(["in"]);
+  });
+
+  it("returns every fully-inside node when many are present (preserves doc order)", () => {
+    const g = group({ x: 0, y: 0, width: 1000, height: 1000 });
+    const a = text({ id: "a", x: 10, y: 10 });
+    const b = text({ id: "b", x: 100, y: 100 });
+    const c = text({ id: "c", x: 200, y: 200 });
+    const doc = docOf([g, a, b, c]);
+    expect(nodesInsideGroup(doc, g).map((n) => n.id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/lib/canvas/__tests__/pointerMode.test.ts
+++ b/src/lib/canvas/__tests__/pointerMode.test.ts
@@ -23,6 +23,7 @@ import {
   resizeSize,
   updateDraftOnMove,
   resolvePointerUp,
+  memberPositions,
   type DraftEdge,
   type PointerMode,
 } from "../pointerMode";
@@ -53,7 +54,7 @@ describe("beginPan", () => {
 });
 
 describe("beginMove", () => {
-  it("snapshots pointer + node origin", () => {
+  it("snapshots pointer + node origin with empty members by default", () => {
     const n = node({ x: 100, y: 200 });
     const mode = beginMove(n, { clientX: 5, clientY: 6 });
     expect(mode).toEqual({
@@ -63,7 +64,22 @@ describe("beginMove", () => {
       startClientY: 6,
       startX: 100,
       startY: 200,
+      members: [],
     });
+  });
+
+  it("carries a members snapshot so group-drag can translate contained nodes (#168)", () => {
+    const g = node({ id: "g", x: 0, y: 0, width: 400, height: 300 });
+    const members = [
+      { nodeId: "m1", startX: 50, startY: 50 },
+      { nodeId: "m2", startX: 200, startY: 100 },
+    ];
+    const mode = beginMove(g, { clientX: 5, clientY: 6 }, members);
+    if (mode.kind !== "move") throw new Error("unreachable");
+    expect(mode.members).toEqual(members);
+    // And the leader's own origin is still captured independently.
+    expect(mode.startX).toBe(0);
+    expect(mode.startY).toBe(0);
   });
 });
 
@@ -141,6 +157,45 @@ describe("movePosition", () => {
       x: 40,
       y: 60,
     });
+  });
+});
+
+describe("memberPositions (#168 — group drag)", () => {
+  it("applies the same zoom-scaled delta to every member", () => {
+    const g = node({ id: "g", x: 0, y: 0 });
+    const mode = beginMove(
+      g,
+      { clientX: 0, clientY: 0 },
+      [
+        { nodeId: "a", startX: 50, startY: 50 },
+        { nodeId: "b", startX: 200, startY: 100 },
+      ],
+    );
+    if (mode.kind !== "move") throw new Error("unreachable");
+    expect(memberPositions(mode, { clientX: 20, clientY: 10 }, 1)).toEqual([
+      { nodeId: "a", x: 70, y: 60 },
+      { nodeId: "b", x: 220, y: 110 },
+    ]);
+  });
+
+  it("divides the client delta by zoom so members track the cursor under zoom", () => {
+    const g = node({ id: "g", x: 0, y: 0 });
+    const mode = beginMove(
+      g,
+      { clientX: 0, clientY: 0 },
+      [{ nodeId: "a", startX: 100, startY: 100 }],
+    );
+    if (mode.kind !== "move") throw new Error("unreachable");
+    expect(memberPositions(mode, { clientX: 200, clientY: 100 }, 2)).toEqual([
+      { nodeId: "a", x: 200, y: 150 },
+    ]);
+  });
+
+  it("returns an empty array when there are no members (leaf node drag)", () => {
+    const n = node({ x: 0, y: 0 });
+    const mode = beginMove(n, { clientX: 0, clientY: 0 });
+    if (mode.kind !== "move") throw new Error("unreachable");
+    expect(memberPositions(mode, { clientX: 50, clientY: 50 }, 1)).toEqual([]);
   });
 });
 
@@ -431,7 +486,20 @@ describe("longpressFallback", () => {
       startClientY: 40,
       startX: 100,
       startY: 200,
+      members: [],
     });
+  });
+
+  it("threads fallback.members through so group-drag survives long-press fall-through (#168)", () => {
+    const members = [{ nodeId: "a", startX: 10, startY: 20 }];
+    const pending = beginPendingLongpress(
+      { clientX: 1, clientY: 2 },
+      { kind: "move", nodeId: "g", nodeStartX: 0, nodeStartY: 0, members },
+    );
+    if (pending.kind !== "pending-longpress") throw new Error("unreachable");
+    const fallback = longpressFallback(pending);
+    if (fallback?.kind !== "move") throw new Error("expected move");
+    expect(fallback.members).toEqual(members);
   });
 
   it("returns null if the fallback metadata is incomplete (defensive)", () => {

--- a/src/lib/canvas/group.ts
+++ b/src/lib/canvas/group.ts
@@ -1,0 +1,36 @@
+// #168 — spatial group membership. Pure helpers for deciding which nodes
+// "belong" to a group at a moment in time so moving the group can drag
+// its children with it (Obsidian-compatible: no persisted `parent` field,
+// containment is evaluated at drag-start only).
+//
+// Rule: a node is inside a group iff its bounding box is *fully contained*
+// by the group's bounding box. Nodes that straddle the boundary are not
+// dragged. Group nodes are excluded from the membership list so nested
+// groups do not cascade — this matches Obsidian and keeps the interaction
+// predictable.
+
+import type { CanvasDoc, CanvasNode } from "./types";
+
+function rect(n: CanvasNode): { x0: number; y0: number; x1: number; y1: number } {
+  return { x0: n.x, y0: n.y, x1: n.x + n.width, y1: n.y + n.height };
+}
+
+function fullyInside(inner: CanvasNode, outer: CanvasNode): boolean {
+  const i = rect(inner);
+  const o = rect(outer);
+  return i.x0 >= o.x0 && i.y0 >= o.y0 && i.x1 <= o.x1 && i.y1 <= o.y1;
+}
+
+/**
+ * Returns every non-group node whose bounding box is fully contained by the
+ * given group's bounding box. The `group` param is typed as `CanvasNode` so
+ * callers can pass the narrowed leader of a drag without round-tripping
+ * through a more specific variant (CanvasUnknownNode's `type: string` makes
+ * strict narrowing fight the caller). Evaluation is purely geometric; nested
+ * groups are intentionally excluded so cascading group-drag does not happen.
+ */
+export function nodesInsideGroup(doc: CanvasDoc, group: CanvasNode): CanvasNode[] {
+  return doc.nodes.filter(
+    (n) => n.id !== group.id && n.type !== "group" && fullyInside(n, group),
+  );
+}

--- a/src/lib/canvas/pointerMode.ts
+++ b/src/lib/canvas/pointerMode.ts
@@ -31,14 +31,30 @@ export const MIN_NODE_HEIGHT = 40;
 export const LONGPRESS_HOLD_MS = 300;
 export const LONGPRESS_MOVE_THRESHOLD = 4;
 
+/**
+ * Snapshot of another node that should translate with the leader during a
+ * move (#168). Populated at `beginMove` for group nodes and left empty for
+ * regular node drags. Capturing start positions here — rather than walking
+ * the doc on every mousemove — keeps the drag math stable if the doc array
+ * is re-ordered mid-drag and avoids re-running containment each frame.
+ */
+export interface MoveMember {
+  nodeId: string;
+  startX: number;
+  startY: number;
+}
+
 // Snapshot of where a node started so pending-longpress can fall through to
 // beginMove without losing the pointer-down origin (otherwise the first
-// `threshold` pixels of drag would be dropped).
+// `threshold` pixels of drag would be dropped). For group drags (#168) the
+// members array is also captured at pointer-down so containment is evaluated
+// against the doc as it existed *before* any drift.
 export interface PendingLongpressFallback {
   kind: "none" | "move";
   nodeId?: string;
   nodeStartX?: number;
   nodeStartY?: number;
+  members?: MoveMember[];
 }
 
 export type PointerMode =
@@ -56,6 +72,7 @@ export type PointerMode =
       startClientY: number;
       startX: number;
       startY: number;
+      members: MoveMember[];
     }
   | {
       kind: "resize";
@@ -107,7 +124,11 @@ export function beginPan(e: ClientPoint, cam: { x: number; y: number }): Pointer
   };
 }
 
-export function beginMove(node: CanvasNode, e: ClientPoint): PointerMode {
+export function beginMove(
+  node: CanvasNode,
+  e: ClientPoint,
+  members: MoveMember[] = [],
+): PointerMode {
   return {
     kind: "move",
     nodeId: node.id,
@@ -115,6 +136,7 @@ export function beginMove(node: CanvasNode, e: ClientPoint): PointerMode {
     startClientY: e.clientY,
     startX: node.x,
     startY: node.y,
+    members,
   };
 }
 
@@ -195,6 +217,7 @@ export function longpressFallback(
     startClientY: mode.startClientY,
     startX: mode.fallback.nodeStartX,
     startY: mode.fallback.nodeStartY,
+    members: mode.fallback.members ?? [],
   };
 }
 
@@ -219,6 +242,26 @@ export function movePosition(
     x: mode.startX + (e.clientX - mode.startClientX) / zoom,
     y: mode.startY + (e.clientY - mode.startClientY) / zoom,
   };
+}
+
+/**
+ * Compute new positions for each member node using the same zoom-scaled
+ * client delta as the leader. Members move as a rigid translation — their
+ * relative offset to the leader is frozen at beginMove — so a group drag
+ * preserves the internal layout inside the group. (#168)
+ */
+export function memberPositions(
+  mode: Extract<PointerMode, { kind: "move" }>,
+  e: ClientPoint,
+  zoom: number,
+): Array<{ nodeId: string; x: number; y: number }> {
+  const dx = (e.clientX - mode.startClientX) / zoom;
+  const dy = (e.clientY - mode.startClientY) / zoom;
+  return mode.members.map((m) => ({
+    nodeId: m.nodeId,
+    x: m.startX + dx,
+    y: m.startY + dy,
+  }));
 }
 
 export function resizeSize(


### PR DESCRIPTION
## Summary

Closes #168.

- Dragging a group now translates every node fully contained by the group rect at the moment of pointer-down (Obsidian-compatible; no schema change).
- Containment evaluated **once at drag-start**, not every frame, so the membership set is stable under any mid-drag doc reorder.
- Nested groups are intentionally excluded from the membership list so cascading group-drag cannot happen.

## Architecture

- New pure helper `nodesInsideGroup(doc, group)` in `src/lib/canvas/group.ts`.
- `PointerMode.move` gains a `members: MoveMember[]` snapshot. New pure `memberPositions()` applies the same zoom-scaled delta as the leader.
- `CanvasView.onNodePointerDown` snapshots members when the leader is a group and threads them through the long-press fallback so the gesture survives the longpress-to-pan fallthrough.
- `CanvasView.onViewportPointerMove` applies each member position alongside the leader.

## What is NOT in scope (per #168 non-goals)

- Duplicate on a group does not clone members.
- Resize on a group does not resize members.
- Delete on a group does not delete members.
- No persisted `parent` field (stays purely geometric).

## Test plan

- [x] Unit — `src/lib/canvas/__tests__/group.test.ts` covers full/partial containment, edge-touching, nested groups excluded, translated origin, preserves doc order.
- [x] Unit — `src/lib/canvas/__tests__/pointerMode.test.ts` extended for `beginMove` members, `memberPositions` (zoom scaling, empty), long-press fallback threading.
- [x] E2E — `e2e/specs/canvas-group-movement.spec.ts` seeds a group with 2 inside + 1 outside, drags the group, asserts disk positions track the leader's delta and the outsider is untouched.
- [x] `pnpm vitest run src/lib/canvas/ src/components/Canvas/` — 113 tests pass.
- [x] `pnpm build` — clean (`svelte-check` zero errors).
- [ ] Manual UAT: open a canvas with a group containing cards; drag the group; verify cards move with it; verify cards that merely overlap the group boundary stay put; verify nested groups don't drag their inner group; verify resize/duplicate/delete on a group still only affect the group.

## Notes

- Feature-branched off `main` so it runs parallel to the still-open #167 (context menus). They touch different parts of `CanvasView` — small overlap is only the `beginMove` signature change, which this PR owns end-to-end.
- Pre-existing flake `src/components/Editor/__tests__/largeFile.test.ts > creates EditorView with 10,000-line doc in under 500ms` is unrelated (reproduces on `main` under load).