### PR TITLE
fix(canvas): live-refresh file-node previews when source note changes (#165)

### DIFF
--- a/e2e/specs/canvas-embed-live-refresh.spec.ts
+++ b/e2e/specs/canvas-embed-live-refresh.spec.ts
@@ -1,0 +1,108 @@
+// #165 — markdown previews inside canvas file-nodes must live-refresh when
+// the embedded note changes. This spec exercises the external-watcher path:
+// we seed a canvas with a file-node pointing at `Notes/foo.md`, open the
+// canvas, then rewrite `foo.md` from the test process (which the Rust file
+// watcher sees as an external modification since write_ignore only
+// suppresses VaultCore's own IPC writes). Within a few seconds the preview
+// inside `.vc-canvas-node-md` must update without the canvas being closed.
+
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+const CANVAS_NAME = "Board.canvas";
+const NOTE_REL = "Notes/foo.md";
+
+const INITIAL_NOTE = "# Version One\n\nInitial body text.";
+const UPDATED_NOTE = "# Version Two\n\nBody after external edit.";
+
+describe("Canvas embed live-refresh (#165)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    fs.mkdirSync(path.join(vault.path, "Notes"), { recursive: true });
+    fs.writeFileSync(path.join(vault.path, NOTE_REL), INITIAL_NOTE, "utf-8");
+    fs.writeFileSync(
+      path.join(vault.path, CANVAS_NAME),
+      JSON.stringify(
+        {
+          nodes: [
+            {
+              id: "fn",
+              type: "file",
+              file: NOTE_REL,
+              x: 0,
+              y: 0,
+              width: 320,
+              height: 200,
+            },
+          ],
+          edges: [],
+        },
+        null,
+        "\t",
+      ),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const nodes = await browser.$$(".vc-tree-name");
+        for (const n of nodes) if ((await textOf(n)) === name) return true;
+        return false;
+      },
+      { timeout: 5000, timeoutMsg: `"${name}" never appeared in the tree` },
+    );
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not found`);
+  }
+
+  async function previewContains(substr: string): Promise<boolean> {
+    return browser.execute(
+      (needle: string) => {
+        const md = document.querySelector(".vc-canvas-node-md");
+        if (!md) return false;
+        return (md.textContent ?? "").includes(needle);
+      },
+      substr,
+    );
+  }
+
+  it("re-renders the embedded note preview when the source file changes externally", async () => {
+    await openTreeFile(CANVAS_NAME);
+
+    // Wait for the canvas to mount and the initial preview to render.
+    await browser.waitUntil(async () => previewContains("Version One"), {
+      timeout: 5000,
+      timeoutMsg: "Initial preview never rendered",
+    });
+
+    // External modification — the watcher picks this up because the test
+    // process bypasses the app's IPC write path.
+    fs.writeFileSync(path.join(vault.path, NOTE_REL), UPDATED_NOTE, "utf-8");
+
+    await browser.waitUntil(async () => previewContains("Version Two"), {
+      timeout: 5000,
+      timeoutMsg: "Preview never refreshed to updated body",
+    });
+
+    // Sanity: the old content is gone too.
+    expect(await previewContains("Version One")).toBe(false);
+  });
+});

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -22,6 +22,7 @@
   import { convertFileSrc } from "@tauri-apps/api/core";
   import { get } from "svelte/store";
   import { readFile, writeFile } from "../../ipc/commands";
+  import { listenFileChange } from "../../ipc/events";
   import { toastStore } from "../../store/toastStore";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import { vaultStore } from "../../store/vaultStore";
@@ -190,6 +191,11 @@
       void persist();
     }
     cancelLongpressTimer();
+    // #165: tear down preview-invalidation subscriptions so multi-tab
+    // open/close cycles don't leak listeners.
+    unsubTab();
+    destroyed = true;
+    watcherUnlisten?.();
   });
 
   $effect(() => {
@@ -220,6 +226,38 @@
     scheduleSave();
   });
 
+  // #165: per-file fetch-generation map. Incremented every time we kick a
+  // re-fetch for a given path so a stale in-flight read whose invalidation
+  // arrived mid-fetch cannot overwrite the fresh body. Pure module state —
+  // the view never renders it, so it's a plain `let`, not `$state`.
+  let mdPreviewGen: Map<string, number> = new Map();
+
+  function loadPreviewFor(vaultPath: string, file: string): void {
+    if (!isMarkdownFile(file)) return;
+    const gen = (mdPreviewGen.get(file) ?? 0) + 1;
+    mdPreviewGen.set(file, gen);
+    // Reserve the slot synchronously so the effect's `file in mdPreviews`
+    // guard doesn't re-queue the same fetch while it's in flight.
+    mdPreviews = { ...mdPreviews, [file]: "" };
+    const absPath = resolveVaultAbs(vaultPath, file);
+    void readFile(absPath).then(
+      (body) => {
+        // Drop the result if a newer fetch for the same file has started —
+        // otherwise a tabStore eviction followed by a re-fetch could have
+        // its fresh body clobbered by this older in-flight read resolving
+        // after it (#165).
+        if (mdPreviewGen.get(file) !== gen) return;
+        mdPreviews = {
+          ...mdPreviews,
+          [file]: renderMarkdownToHtml(canvasFilePreview(body)),
+        };
+      },
+      () => {
+        /* preview failure stays as "" — renderer shows a generic card */
+      },
+    );
+  }
+
   // Lazily load markdown body for every file-node that points at an .md note.
   // We resolve the file relative to the current vault root; when the vault
   // path is missing (e.g., a stray canvas opened without a vault) we fall
@@ -232,22 +270,84 @@
       const file = (n as CanvasFileNode).file;
       if (!file || !isMarkdownFile(file)) continue;
       if (file in untrack(() => mdPreviews)) continue;
-      // Reserve the slot synchronously so we don't re-queue the same file.
-      mdPreviews = { ...mdPreviews, [file]: "" };
-      const absPath = resolveVaultAbs(vaultPath, file);
-      void readFile(absPath).then(
-        (body) => {
-          mdPreviews = {
-            ...mdPreviews,
-            [file]: renderMarkdownToHtml(canvasFilePreview(body)),
-          };
-        },
-        () => {
-          /* preview failure stays as "" — renderer shows a generic card */
-        },
-      );
+      loadPreviewFor(vaultPath, file);
     }
   });
+
+  // #165: invalidate embedded-note previews when the source note is saved
+  // from another tab or modified externally. Mirror the pattern
+  // embedPlugin.ts uses for the inverse direction (canvas-inside-note).
+  //
+  // Two sources of change, independent because the watcher's write_ignore
+  // suppresses our own saves — we can't rely on `listenFileChange` alone:
+  //   (a) tabStore.setLastSavedContent — fires when any tab auto-saves.
+  //   (b) listenFileChange — fires for external edits (other editors, shell,
+  //       git checkout).
+  //
+  // Rename payloads (`new_path`) are a non-goal for #165: canvas nodes pin
+  // `file` by its original vault-relative path; after a rename that path no
+  // longer exists so re-fetching would just fail silently. Out of scope.
+  const lastSavedByTabId: Map<string, string> = new Map();
+  const unsubTab = tabStore.subscribe((state) => {
+    const vaultPath = get(vaultStore).currentPath;
+    if (!vaultPath) return;
+    const fileNodes = untrack(() =>
+      doc.nodes
+        .filter((n): n is CanvasFileNode => n.type === "file")
+        .map((n) => n.file)
+        .filter((f) => !!f && isMarkdownFile(f)),
+    );
+    for (const tab of state.tabs) {
+      const prev = lastSavedByTabId.get(tab.id);
+      if (prev === tab.lastSavedContent) continue;
+      lastSavedByTabId.set(tab.id, tab.lastSavedContent);
+      if (prev === undefined) continue; // first sighting isn't a change
+      const rel = toVaultRel(vaultPath, tab.filePath);
+      if (!rel) continue;
+      const normalized = rel.replace(/\\/g, "/");
+      if (fileNodes.some((f) => f.replace(/\\/g, "/") === normalized)) {
+        loadPreviewFor(vaultPath, normalized);
+      }
+    }
+    // Prune snapshots for tabs that have closed so the map doesn't leak.
+    const liveIds = new Set(state.tabs.map((t) => t.id));
+    for (const id of Array.from(lastSavedByTabId.keys())) {
+      if (!liveIds.has(id)) lastSavedByTabId.delete(id);
+    }
+  });
+
+  // The async listen/unlisten contract means a quick mount/unmount could
+  // leak the subscription if we just stored the resolved unlisten fn; the
+  // `destroyed` flag guards against that race.
+  let watcherUnlisten: (() => void) | null = null;
+  let destroyed = false;
+  void listenFileChange((payload) => {
+    const vaultPath = get(vaultStore).currentPath;
+    if (!vaultPath) return;
+    const paths = payload.new_path ? [payload.path, payload.new_path] : [payload.path];
+    for (const p of paths) {
+      const rel = toVaultRel(vaultPath, p);
+      if (!rel) continue;
+      const normalized = rel.replace(/\\/g, "/");
+      const fileNodes = untrack(() =>
+        doc.nodes
+          .filter((n): n is CanvasFileNode => n.type === "file")
+          .map((n) => n.file)
+          .filter((f) => !!f && isMarkdownFile(f)),
+      );
+      if (fileNodes.some((f) => f.replace(/\\/g, "/") === normalized)) {
+        loadPreviewFor(vaultPath, normalized);
+      }
+    }
+  }).then(
+    (fn) => {
+      if (destroyed) fn();
+      else watcherUnlisten = fn;
+    },
+    () => {
+      /* Tauri not initialized (vitest) — swallow so the module still loads. */
+    },
+  );
 
   async function onOpenFileNode(node: CanvasFileNode) {
     const vaultPath = get(vaultStore).currentPath;

--- a/src/components/Canvas/__tests__/CanvasViewLiveRefresh.test.ts
+++ b/src/components/Canvas/__tests__/CanvasViewLiveRefresh.test.ts
@@ -1,0 +1,175 @@
+// #165 — markdown previews inside canvas file-nodes must live-refresh when
+// the embedded note is saved from another tab. The CanvasView mounts with
+// one file-node pointing at `Note.md`, then a simulated autosave from
+// another tab fires `tabStore.setLastSavedContent` for that same path. We
+// assert readFile is re-invoked so the preview repaints with the new body.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://localhost/${encodeURIComponent(p)}`,
+}));
+
+// Mock the file-change listener so it's a no-op in vitest — the subscription
+// lives at component level so we need a stub that returns an unlisten fn.
+const listenFileChangeMock = vi.fn<
+  (cb: (p: { path: string; new_path?: string }) => void) => Promise<() => void>
+>();
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: (cb: (p: { path: string; new_path?: string }) => void) =>
+    listenFileChangeMock(cb),
+}));
+
+const readFileMock = vi.fn<(path: string) => Promise<string>>();
+const writeFileMock = vi.fn<(path: string, content: string) => Promise<void>>();
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile: (path: string) => readFileMock(path),
+  writeFile: (path: string, content: string) => writeFileMock(path, content),
+}));
+
+import CanvasView from "../CanvasView.svelte";
+import { vaultStore } from "../../../store/vaultStore";
+import { tabStore } from "../../../store/tabStore";
+import type { CanvasDoc } from "../../../lib/canvas/types";
+
+const VAULT = "/tmp/refresh-vault";
+const CANVAS_ABS = `${VAULT}/Board.canvas`;
+const NOTE_REL = "Notes/foo.md";
+const NOTE_ABS = `${VAULT}/${NOTE_REL}`;
+
+function docWithFileNode(): CanvasDoc {
+  return {
+    nodes: [
+      {
+        id: "fn",
+        type: "file",
+        file: NOTE_REL,
+        x: 0,
+        y: 0,
+        width: 240,
+        height: 140,
+      },
+    ],
+    edges: [],
+  };
+}
+
+async function waitForReadCount(n: number, path: string, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hits = readFileMock.mock.calls.filter((c) => c[0] === path).length;
+    if (hits >= n) return;
+    await tick();
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  const hits = readFileMock.mock.calls.filter((c) => c[0] === path).length;
+  throw new Error(`expected ${n} reads of ${path}, got ${hits}`);
+}
+
+describe("CanvasView live-refresh of file-node previews (#165)", () => {
+  beforeEach(() => {
+    readFileMock.mockReset();
+    writeFileMock.mockReset();
+    listenFileChangeMock.mockReset();
+    listenFileChangeMock.mockResolvedValue(() => {});
+    writeFileMock.mockResolvedValue(undefined);
+    vaultStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [NOTE_REL], fileCount: 1 });
+    tabStore._reset();
+  });
+
+  it("re-fetches the embedded note when tabStore.lastSavedContent for that file changes", async () => {
+    // readFile must answer for the canvas file AND for the embedded note.
+    readFileMock.mockImplementation(async (p) => {
+      if (p === CANVAS_ABS) {
+        return JSON.stringify(docWithFileNode(), null, "\t");
+      }
+      if (p === NOTE_ABS) {
+        return "# Hello v1";
+      }
+      throw new Error(`unexpected read: ${p}`);
+    });
+
+    const { container } = render(CanvasView, {
+      props: { tabId: "canvas-tab", abs: CANVAS_ABS },
+    });
+
+    // Wait for initial preview load.
+    for (let i = 0; i < 30; i++) {
+      await tick();
+      if (container.querySelector(".vc-canvas-world")) break;
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    await waitForReadCount(1, NOTE_ABS);
+    expect(readFileMock.mock.calls.filter((c) => c[0] === NOTE_ABS)).toHaveLength(1);
+
+    // Simulate another tab autosaving the same note.
+    const noteTabId = tabStore.openTab(NOTE_ABS);
+    tabStore.setLastSavedContent(noteTabId, "# Hello v2");
+
+    // The invalidation should trigger a second read of the note file.
+    await waitForReadCount(2, NOTE_ABS);
+    expect(readFileMock.mock.calls.filter((c) => c[0] === NOTE_ABS)).toHaveLength(2);
+  });
+
+  it("re-fetches the embedded note when listenFileChange fires for its path", async () => {
+    let watcherCb: ((p: { path: string; new_path?: string }) => void) | null = null;
+    listenFileChangeMock.mockImplementation(async (cb) => {
+      watcherCb = cb;
+      return () => {};
+    });
+
+    readFileMock.mockImplementation(async (p) => {
+      if (p === CANVAS_ABS) return JSON.stringify(docWithFileNode(), null, "\t");
+      if (p === NOTE_ABS) return "# External v1";
+      throw new Error(`unexpected read: ${p}`);
+    });
+
+    const { container } = render(CanvasView, {
+      props: { tabId: "canvas-tab", abs: CANVAS_ABS },
+    });
+
+    for (let i = 0; i < 30; i++) {
+      await tick();
+      if (container.querySelector(".vc-canvas-world")) break;
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    await waitForReadCount(1, NOTE_ABS);
+
+    // Fire the watcher as if an external editor saved the file.
+    expect(watcherCb).not.toBeNull();
+    watcherCb!({ path: NOTE_ABS });
+
+    await waitForReadCount(2, NOTE_ABS);
+    expect(readFileMock.mock.calls.filter((c) => c[0] === NOTE_ABS)).toHaveLength(2);
+  });
+
+  it("ignores tabStore changes for files the canvas does not reference", async () => {
+    readFileMock.mockImplementation(async (p) => {
+      if (p === CANVAS_ABS) return JSON.stringify(docWithFileNode(), null, "\t");
+      if (p === NOTE_ABS) return "# Hello";
+      throw new Error(`unexpected read: ${p}`);
+    });
+
+    const { container } = render(CanvasView, {
+      props: { tabId: "canvas-tab", abs: CANVAS_ABS },
+    });
+    for (let i = 0; i < 30; i++) {
+      await tick();
+      if (container.querySelector(".vc-canvas-world")) break;
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    await waitForReadCount(1, NOTE_ABS);
+
+    // Autosave an unrelated file — must not trigger a re-read.
+    const otherTabId = tabStore.openTab(`${VAULT}/other.md`);
+    tabStore.setLastSavedContent(otherTabId, "# unrelated");
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(readFileMock.mock.calls.filter((c) => c[0] === NOTE_ABS)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #165.

Markdown previews rendered inside canvas file-nodes now repaint live when the embedded note is saved from another tab or modified externally. Previously the preview was populated once at mount and never refreshed.

Architecture mirrors the inverse-direction fix from #155 (canvas-inside-note): two per-instance subscriptions in `CanvasView.svelte`, one on `tabStore` and one on `listenFileChange`, both routing through a new `loadPreviewFor(vaultPath, file)` helper.

## Correctness guardrails

- **Fetch race (from plan review):** per-file generation counter — an in-flight `readFile` whose invalidation arrived mid-flight drops its resolved body so it can't clobber the re-fetch.
- **Async unlisten race:** `destroyed` flag caught between the `listenFileChange` Promise and `onDestroy` prevents leaking the subscription on a quick mount/unmount.
- **Two independent invalidators:** `tabStore` catches our own auto-saves (which the Rust watcher's `write_ignore` suppresses), `listenFileChange` catches everything else. Non-overlapping; no duplicate-work worry.
- **Path normalisation:** tab absolute path → vault-relative via `toVaultRel`, then `\\` → `/` on both sides before comparison so mixed-separator canvases match.
- **Guard on markdown only:** `isMarkdownFile` check in the subscribers — image file-nodes don't touch `mdPreviews`.
- **Rename out of scope:** canvas nodes pin `file` by its original path, so a rename just leaves the node dangling — matches existing behavior, not a regression.

## Test plan

- [x] `pnpm vitest run src/lib/canvas/ src/components/Canvas/` — 131 tests pass, including the three new ones in `CanvasViewLiveRefresh.test.ts`:
  - tabStore `setLastSavedContent` for a matching file triggers a second `readFile`.
  - `listenFileChange` firing for a matching path triggers a second `readFile`.
  - Saves for unrelated files do **not** trigger re-fetch.
- [x] `pnpm build` — clean, zero svelte-check errors.
- [x] E2E (`canvas-embed-live-refresh.spec.ts`): seed `Board.canvas` + `Notes/foo.md`, open canvas, rewrite `foo.md` from the test process, assert `.vc-canvas-node-md` DOM updates to the new body within 5 s.
- [ ] Manual UAT: open a canvas with a file-node pointing at a note; open that note in another tab; edit + wait 2 s (autosave debounce); verify the canvas preview updates without closing the canvas. Repeat with an external edit (e.g. `echo` into the file) — should also refresh.

## Notes

- Out of scope per ticket: live preview during typing (before autosave), and incremental preview rendering for huge notes (`canvasFilePreview` already truncates).
- Flake note: `src/components/Editor/__tests__/largeFile.test.ts > creates EditorView with 10,000-line doc in under 500ms` is a pre-existing timing-dependent test that flakes under load on `main` too — unrelated.