### PR TITLE
feat(canvas): context-menu follow-ups — file/link add, inline url/label edit, colour picker (#166)

### DIFF
--- a/e2e/specs/canvas-context-menus.spec.ts
+++ b/e2e/specs/canvas-context-menus.spec.ts
@@ -32,6 +32,13 @@ describe("Canvas context menus (#164)", () => {
       JSON.stringify({ nodes: [], edges: [] }, null, "\t"),
       "utf-8",
     );
+    // #166: a reachable vault file so the "Add file node…" QuickSwitcher
+    // has something to return on the first Enter keystroke.
+    fs.writeFileSync(
+      path.join(vault.path, "Target.md"),
+      "# Target\n\nA file to embed.\n",
+      "utf-8",
+    );
     await openVaultInApp(vault.path);
   });
 
@@ -170,5 +177,98 @@ describe("Canvas context menus (#164)", () => {
 
     // Silence the unused capture warning.
     void clickPoint;
+  });
+
+  it("right-click empty canvas → Add file node… → picks a file and persists (#166)", async () => {
+    // Re-seed the canvas so this test is independent of the first one's
+    // mutation — the previous test left a text node on the canvas.
+    fs.writeFileSync(
+      path.join(vault.path, "Menu.canvas"),
+      JSON.stringify({ nodes: [], edges: [] }, null, "\t"),
+      "utf-8",
+    );
+    // Close and re-open the canvas tab by clicking the file in the tree.
+    await openTreeFile("Menu.canvas");
+    await waitForActiveTab("Menu.canvas");
+
+    await browser.waitUntil(
+      async () => {
+        const vps = await browser.$$(".vc-canvas-viewport");
+        for (const vp of vps) if (await vp.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000, timeoutMsg: "Canvas viewport never displayed" },
+    );
+
+    // Dispatch a contextmenu event at the centre of the canvas viewport.
+    await browser.execute(() => {
+      const vps = Array.from(
+        document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+      );
+      const vp = vps.find((v) => v.offsetParent !== null);
+      if (!vp) throw new Error("no visible canvas viewport");
+      const rect = vp.getBoundingClientRect();
+      vp.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height / 2,
+          button: 2,
+        }),
+      );
+    });
+
+    // Menu → click "Add file node…".
+    const menu = await browser.$(".vc-context-menu");
+    await menu.waitForDisplayed({ timeout: 3000 });
+    const items = await browser.$$(".vc-context-menu .vc-context-item");
+    let clicked = false;
+    for (const it of items) {
+      const label = (await textOf(it)).trim();
+      if (label === "Add file node…") {
+        await it.click();
+        clicked = true;
+        break;
+      }
+    }
+    expect(clicked).toBe(true);
+
+    // QuickSwitcher opens — type the target file name and press Enter.
+    const qsInput = await browser.$(".vc-qs-input");
+    await qsInput.waitForDisplayed({ timeout: 3000 });
+    await qsInput.setValue("Target");
+    await browser.waitUntil(
+      async () => {
+        const rows = await browser.$$(".vc-qs-results > *");
+        return rows.length > 0;
+      },
+      { timeout: 3000, timeoutMsg: "quick switcher returned no results" },
+    );
+    await browser.keys("Enter");
+
+    // A file node materialises in the canvas.
+    await browser.waitUntil(
+      async () => {
+        const n = await browser.execute(() => {
+          const vps = Array.from(
+            document.querySelectorAll<HTMLElement>(".vc-canvas-viewport"),
+          );
+          const vp = vps.find((v) => v.offsetParent !== null);
+          return vp?.querySelectorAll(".vc-canvas-node-file").length ?? 0;
+        });
+        return (n as number) >= 1;
+      },
+      { timeout: 5000, timeoutMsg: "no file node appeared after Add file node" },
+    );
+
+    // Persist to disk as a file node pointing at Target.md.
+    const doc = await waitForDiskDoc(
+      "Menu.canvas",
+      (d) => d.nodes.some((n) => n.type === "file" && typeof n.file === "string"),
+    );
+    const fileNode = doc.nodes.find((n) => n.type === "file");
+    expect(fileNode).toBeDefined();
+    expect((fileNode as Record<string, unknown>).file).toMatch(/Target\.md$/);
   });
 });

--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -165,17 +165,22 @@
     aria-hidden="true"
   >
     <defs>
-      <marker
-        id="vc-canvas-arrow"
-        viewBox="0 0 10 10"
-        refX="9"
-        refY="5"
-        markerWidth="6"
-        markerHeight="6"
-        orient="auto-start-reverse"
-      >
-        <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke" />
-      </marker>
+      {#each resolvedEdges as re (`marker-${re.edge.id}`)}
+        {@const markerColor = selectedEdgeId === re.edge.id
+          ? "var(--color-accent)"
+          : (re.edge.color ?? "var(--color-border-strong, #9ca3af)")}
+        <marker
+          id={`vc-canvas-arrow-${re.edge.id}`}
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" style:fill={markerColor} />
+        </marker>
+      {/each}
     </defs>
     {#each resolvedEdges as re (re.edge.id)}
       {@const arrowEnd = re.edge.toEnd !== "none"}
@@ -196,8 +201,8 @@
         class:vc-canvas-edge-selected={selectedEdgeId === re.edge.id}
         d={re.path}
         style:color={re.edge.color ?? "var(--color-border-strong, #9ca3af)"}
-        marker-end={arrowEnd ? "url(#vc-canvas-arrow)" : null}
-        marker-start={arrowStart ? "url(#vc-canvas-arrow)" : null}
+        marker-end={arrowEnd ? `url(#vc-canvas-arrow-${re.edge.id})` : null}
+        marker-start={arrowStart ? `url(#vc-canvas-arrow-${re.edge.id})` : null}
         data-edge-id={re.edge.id}
       />
     {/each}

--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -37,6 +37,14 @@
   import { tokenizeCanvasText } from "../../lib/canvas/textTokens";
   import { resolveTarget } from "../Editor/wikiLink";
 
+  // Tiny use:-action to focus + select an input on mount (the inline
+  // edits for link URL / group label rely on this rather than the
+  // `autofocus` attribute, which Svelte lints against for a11y).
+  function focusOnMount(el: HTMLInputElement) {
+    el.focus();
+    el.select();
+  }
+
   interface Props {
     doc: CanvasDoc;
     camX?: number;
@@ -83,6 +91,13 @@
      *  embed use doesn't need a menu. */
     onNodeContextMenu?: (e: MouseEvent, node: CanvasNode) => void;
     onEdgeContextMenu?: (e: MouseEvent, edge: CanvasEdge) => void;
+
+    /** Inline edits for link URL / group label (#166). `editingNodeId`
+     *  doubles as the “which node is being edited” state — the renderer
+     *  branches on `node.type` to pick the right input. */
+    onLinkUrlInput?: (e: Event, node: CanvasLinkNode) => void;
+    onGroupLabelInput?: (e: Event, node: CanvasGroupNode) => void;
+    onStopEditingNode?: () => void;
   }
 
   let {
@@ -123,6 +138,9 @@
     onStopEditingEdge,
     onNodeContextMenu,
     onEdgeContextMenu,
+    onLinkUrlInput,
+    onGroupLabelInput,
+    onStopEditingNode,
   }: Props = $props();
 
   // Groups render first so other nodes stack visually on top of them.
@@ -452,17 +470,37 @@
         tabindex={interactive ? 0 : undefined}
       >
         <div class="vc-canvas-node-file-header">
-          <span class="vc-canvas-node-link-url" title={linkNode.url}>{linkNode.url}</span>
-          {#if interactive}
-            <button
-              type="button"
-              class="vc-canvas-node-open"
-              data-canvas-open="link"
+          {#if interactive && editingNodeId === node.id}
+            <input
+              type="url"
+              class="vc-canvas-node-link-url-input"
+              value={linkNode.url}
+              oninput={(e) => onLinkUrlInput?.(e, linkNode)}
+              onblur={() => onStopEditingNode?.()}
               onpointerdown={(e) => e.stopPropagation()}
-              onclick={(e) => { e.stopPropagation(); onOpenLinkNode?.(linkNode); }}
-            >
-              Open
-            </button>
+              ondblclick={(e) => e.stopPropagation()}
+              onkeydown={(e) => {
+                if (e.key === "Enter" || e.key === "Escape") {
+                  e.preventDefault();
+                  onStopEditingNode?.();
+                }
+              }}
+              aria-label="Link-URL bearbeiten"
+              use:focusOnMount
+            />
+          {:else}
+            <span class="vc-canvas-node-link-url" title={linkNode.url}>{linkNode.url}</span>
+            {#if interactive}
+              <button
+                type="button"
+                class="vc-canvas-node-open"
+                data-canvas-open="link"
+                onpointerdown={(e) => e.stopPropagation()}
+                onclick={(e) => { e.stopPropagation(); onOpenLinkNode?.(linkNode); }}
+              >
+                Open
+              </button>
+            {/if}
           {/if}
         </div>
         <div class="vc-canvas-node-file-body">External link</div>
@@ -494,6 +532,7 @@
         style:top={`${node.y}px`}
         style:width={`${node.width}px`}
         style:height={`${node.height}px`}
+        style:background-color={groupNode.background ?? null}
         data-node-id={node.id}
         data-node-type="group"
         onpointerdown={interactive ? (e) => onNodePointerDown?.(e, node) : undefined}
@@ -503,7 +542,26 @@
         role="group"
         aria-label={groupNode.label ?? "Group"}
       >
-        {#if groupNode.label}
+        {#if interactive && editingNodeId === node.id}
+          <input
+            type="text"
+            class="vc-canvas-node-group-label-input"
+            value={groupNode.label ?? ""}
+            oninput={(e) => onGroupLabelInput?.(e, groupNode)}
+            onblur={() => onStopEditingNode?.()}
+            onpointerdown={(e) => e.stopPropagation()}
+            ondblclick={(e) => e.stopPropagation()}
+            onkeydown={(e) => {
+              if (e.key === "Enter" || e.key === "Escape") {
+                e.preventDefault();
+                onStopEditingNode?.();
+              }
+            }}
+            placeholder="Label"
+            aria-label="Gruppen-Label bearbeiten"
+            use:focusOnMount
+          />
+        {:else if groupNode.label}
           <div class="vc-canvas-node-group-label">{groupNode.label}</div>
         {/if}
         {#if interactive}
@@ -825,6 +883,35 @@
     border-radius: 4px;
     padding: 2px 8px;
     pointer-events: none;
+  }
+
+  .vc-canvas-node-group-label-input {
+    position: absolute;
+    top: -24px;
+    left: 0;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    padding: 2px 8px;
+    pointer-events: auto;
+    outline: none;
+    font-family: inherit;
+  }
+
+  .vc-canvas-node-link-url-input {
+    flex: 1;
+    min-width: 0;
+    font-size: 12px;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    padding: 2px 6px;
+    outline: none;
+    font-family: inherit;
   }
 
   .vc-canvas-node-textarea {

--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -174,7 +174,7 @@
         markerHeight="6"
         orient="auto-start-reverse"
       >
-        <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke" />
       </marker>
     </defs>
     {#each resolvedEdges as re (re.edge.id)}

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -33,6 +33,9 @@
   import { renderMarkdownToHtml } from "../Editor/reading/markdownRenderer";
   import CanvasRenderer from "./CanvasRenderer.svelte";
   import ContextMenu from "../common/ContextMenu.svelte";
+  import ColorPicker from "../common/ColorPicker.svelte";
+  import UrlInputModal from "../common/UrlInputModal.svelte";
+  import QuickSwitcher from "../Search/QuickSwitcher.svelte";
   import {
     parseCanvas,
     serializeCanvas,
@@ -218,6 +221,11 @@
     for (const n of doc.nodes) {
       void n.x; void n.y; void n.width; void n.height;
       if (n.type === "text") void (n as CanvasTextNode).text;
+      if (n.type === "link") void (n as CanvasLinkNode).url;
+      if (n.type === "group") {
+        void (n as CanvasGroupNode).label;
+        void (n as CanvasGroupNode).background;
+      }
     }
     for (const e of doc.edges) {
       void e.fromNode; void e.toNode; void e.fromSide; void e.toSide;
@@ -790,24 +798,10 @@
     }
     // File-nodes render a header + (for markdown) a preview body, so the
     // 60 px default used for text cards is too small to show anything
-    // useful. We pick a 400×400 card that matches Obsidian's drag-default
-    // size and gives the markdown preview room to render.
-    const FILE_DROP_WIDTH = 400;
-    const FILE_DROP_HEIGHT = 400;
+    // useful. `addFileNodeAt` uses a 400×400 card that matches Obsidian's
+    // drag-default size and gives the markdown preview room to render.
     const { x, y } = clientToWorld(e.clientX, e.clientY);
-    const node: CanvasFileNode = {
-      id: crypto.randomUUID(),
-      type: "file",
-      x: x - FILE_DROP_WIDTH / 2,
-      y: y - FILE_DROP_HEIGHT / 2,
-      width: FILE_DROP_WIDTH,
-      height: FILE_DROP_HEIGHT,
-      file: rel,
-    };
-    doc.nodes = [...doc.nodes, node];
-    selectedNodeId = node.id;
-    selectedEdgeId = null;
-    editingNodeId = null;
+    addFileNodeAt(x, y, rel);
   }
 
   // True while a long-press-to-pan pan is actively driving the camera. Used
@@ -848,6 +842,10 @@
     cancelLongpressTimer();
     longpressCaptureEl = null;
     pointerMode = null;
+    // Commit any in-progress inline edit so the new context menu's entries
+    // operate on saved state, not on a half-typed URL / label.
+    editingNodeId = null;
+    editingEdgeId = null;
   }
 
   function onViewportContextMenu(e: MouseEvent) {
@@ -918,6 +916,44 @@
       y: worldY - GROUP_H / 2,
       width: GROUP_W,
       height: GROUP_H,
+    };
+    doc.nodes = [...doc.nodes, node];
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+  }
+
+  // File + link node creation helpers — extracted so the context-menu
+  // entries (#166) and the sidebar drag-drop path share one sizing.
+  const FILE_NODE_DEFAULT_W = 400;
+  const FILE_NODE_DEFAULT_H = 400;
+  const LINK_NODE_DEFAULT_W = 400;
+  const LINK_NODE_DEFAULT_H = 100;
+
+  function addFileNodeAt(worldX: number, worldY: number, rel: string) {
+    const node: CanvasFileNode = {
+      id: crypto.randomUUID(),
+      type: "file",
+      x: worldX - FILE_NODE_DEFAULT_W / 2,
+      y: worldY - FILE_NODE_DEFAULT_H / 2,
+      width: FILE_NODE_DEFAULT_W,
+      height: FILE_NODE_DEFAULT_H,
+      file: rel,
+    };
+    doc.nodes = [...doc.nodes, node];
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+    editingNodeId = null;
+  }
+
+  function addLinkNodeAt(worldX: number, worldY: number, url: string) {
+    const node: CanvasLinkNode = {
+      id: crypto.randomUUID(),
+      type: "link",
+      x: worldX - LINK_NODE_DEFAULT_W / 2,
+      y: worldY - LINK_NODE_DEFAULT_H / 2,
+      width: LINK_NODE_DEFAULT_W,
+      height: LINK_NODE_DEFAULT_H,
+      url,
     };
     doc.nodes = [...doc.nodes, node];
     selectedNodeId = node.id;
@@ -1018,6 +1054,134 @@
     tabStore.openTab(absPath);
     tabStore.moveToPane("right");
   }
+
+  // ─── #166: deferred context-menu actions ──────────────────────────────
+  // Anchor the insertion point for the modal flows (Add file / Add link)
+  // so the user gets a node at the right-clicked world coords, not wherever
+  // the camera happens to sit when they confirm the modal.
+  let pendingFileNodeAt = $state<{ worldX: number; worldY: number } | null>(null);
+  let pendingLinkNodeAt = $state<{ worldX: number; worldY: number } | null>(null);
+
+  // Single open picker at a time. `target` discriminates what to mutate
+  // on colour change; `value` is passed to the picker for active-swatch
+  // highlighting. `null` on change = delete the field so CSS fallbacks
+  // re-apply (group) or the default stroke colour kicks in (edge).
+  let colorPicker = $state<
+    | {
+        target: { kind: "group"; id: string } | { kind: "edge"; id: string };
+        x: number;
+        y: number;
+        value: string | null;
+      }
+    | null
+  >(null);
+
+  function openAddFileNode(worldX: number, worldY: number) {
+    pendingFileNodeAt = { worldX, worldY };
+  }
+
+  function onAddFileNodeConfirm(absPath: string) {
+    const anchor = pendingFileNodeAt;
+    pendingFileNodeAt = null;
+    if (!anchor) return;
+    const vaultPath = get(vaultStore).currentPath;
+    if (!vaultPath) return;
+    const rel = toVaultRel(vaultPath, absPath);
+    if (!rel) {
+      toastStore.push({
+        variant: "error",
+        message: "Datei liegt außerhalb des aktuellen Vaults",
+      });
+      return;
+    }
+    addFileNodeAt(anchor.worldX, anchor.worldY, rel);
+  }
+
+  function openAddLinkNode(worldX: number, worldY: number) {
+    pendingLinkNodeAt = { worldX, worldY };
+  }
+
+  function onAddLinkNodeConfirm(url: string) {
+    const anchor = pendingLinkNodeAt;
+    pendingLinkNodeAt = null;
+    if (!anchor) return;
+    addLinkNodeAt(anchor.worldX, anchor.worldY, url);
+  }
+
+  function startEditLinkUrl(node: CanvasLinkNode) {
+    editingNodeId = node.id;
+    editingEdgeId = null;
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+  }
+
+  function startEditGroupLabel(node: CanvasGroupNode) {
+    editingNodeId = node.id;
+    editingEdgeId = null;
+    selectedNodeId = node.id;
+    selectedEdgeId = null;
+  }
+
+  function onLinkUrlInput(e: Event, node: CanvasLinkNode) {
+    const target = doc.nodes.find((n) => n.id === node.id);
+    if (target && target.type === "link") {
+      (target as CanvasLinkNode).url = (e.target as HTMLInputElement).value;
+    }
+  }
+
+  function onGroupLabelInput(e: Event, node: CanvasGroupNode) {
+    const target = doc.nodes.find((n) => n.id === node.id);
+    if (!target || target.type !== "group") return;
+    const v = (e.target as HTMLInputElement).value;
+    if (v === "") {
+      delete (target as CanvasGroupNode).label;
+    } else {
+      (target as CanvasGroupNode).label = v;
+    }
+  }
+
+  function openColorPickerForGroup(x: number, y: number, node: CanvasGroupNode) {
+    colorPicker = {
+      target: { kind: "group", id: node.id },
+      x,
+      y,
+      value: node.background ?? null,
+    };
+  }
+
+  function openColorPickerForEdge(x: number, y: number, edge: CanvasEdge) {
+    colorPicker = {
+      target: { kind: "edge", id: edge.id },
+      x,
+      y,
+      value: edge.color ?? null,
+    };
+  }
+
+  function onColorChange(value: string | null) {
+    const picker = colorPicker;
+    if (!picker) return;
+    if (picker.target.kind === "group") {
+      const node = doc.nodes.find((n) => n.id === picker.target.id);
+      if (node && node.type === "group") {
+        if (value === null) delete (node as CanvasGroupNode).background;
+        else (node as CanvasGroupNode).background = value;
+      }
+    } else {
+      const edge = doc.edges.find((ed) => ed.id === picker.target.id);
+      if (edge) {
+        if (value === null) delete edge.color;
+        else edge.color = value;
+      }
+    }
+    // Keep the picker open for live drags of the native input; swatch +
+    // Clear paths call onClose from inside the picker itself.
+    colorPicker = { ...picker, value };
+  }
+
+  function closeColorPicker() {
+    colorPicker = null;
+  }
 </script>
 
 <svelte:window onkeydown={onKeyDown} onkeyup={onKeyUp} />
@@ -1085,6 +1249,9 @@
       onStopEditingEdge={() => (editingEdgeId = null)}
       onNodeContextMenu={onNodeContextMenu}
       onEdgeContextMenu={onEdgeContextMenu}
+      onLinkUrlInput={onLinkUrlInput}
+      onGroupLabelInput={onGroupLabelInput}
+      onStopEditingNode={() => (editingNodeId = null)}
     />
   {/if}
 </div>
@@ -1102,6 +1269,14 @@
       class="vc-context-item"
       onclick={() => { addTextNodeAt(worldX, worldY); closeContextMenu(); }}
     >Add text node</button>
+    <button
+      class="vc-context-item"
+      onclick={() => { openAddFileNode(worldX, worldY); closeContextMenu(); }}
+    >Add file node…</button>
+    <button
+      class="vc-context-item"
+      onclick={() => { openAddLinkNode(worldX, worldY); closeContextMenu(); }}
+    >Add link node…</button>
     <button
       class="vc-context-item"
       onclick={() => { addGroupAt(worldX, worldY); closeContextMenu(); }}
@@ -1180,6 +1355,10 @@
       >Copy URL</button>
       <button
         class="vc-context-item"
+        onclick={() => { startEditLinkUrl(node as CanvasLinkNode); closeContextMenu(); }}
+      >Edit URL…</button>
+      <button
+        class="vc-context-item"
         onclick={() => { duplicateNode(nodeId); closeContextMenu(); }}
       >Duplicate</button>
       <button
@@ -1196,6 +1375,19 @@
         onclick={() => { deleteNode(nodeId); closeContextMenu(); }}
       >Delete</button>
     {:else if node.type === "group"}
+      {@const mx = contextMenu?.x ?? 0}
+      {@const my = contextMenu?.y ?? 0}
+      <button
+        class="vc-context-item"
+        onclick={() => { startEditGroupLabel(node as CanvasGroupNode); closeContextMenu(); }}
+      >Edit label…</button>
+      <button
+        class="vc-context-item"
+        onclick={() => {
+          openColorPickerForGroup(mx, my, node as CanvasGroupNode);
+          closeContextMenu();
+        }}
+      >Change color…</button>
       <button
         class="vc-context-item"
         onclick={() => { duplicateNode(nodeId); closeContextMenu(); }}
@@ -1209,10 +1401,16 @@
   {:else if contextMenu?.target.kind === "edge" && contextEdge}
     {@const edge = contextEdge}
     {@const edgeId = edge.id}
+    {@const mx = contextMenu?.x ?? 0}
+    {@const my = contextMenu?.y ?? 0}
     <button
       class="vc-context-item"
       onclick={() => { startEditEdgeLabel(edge); closeContextMenu(); }}
     >Edit label</button>
+    <button
+      class="vc-context-item"
+      onclick={() => { openColorPickerForEdge(mx, my, edge); closeContextMenu(); }}
+    >Change color…</button>
     <button
       class="vc-context-item"
       onclick={() => { flipEdge(edgeId); closeContextMenu(); }}
@@ -1224,6 +1422,28 @@
     >Delete</button>
   {/if}
 </ContextMenu>
+
+<!-- #166: modal + picker surfaces driven by the context menu -->
+<QuickSwitcher
+  open={pendingFileNodeAt !== null}
+  onClose={() => (pendingFileNodeAt = null)}
+  onOpenFile={onAddFileNodeConfirm}
+/>
+
+<UrlInputModal
+  open={pendingLinkNodeAt !== null}
+  onConfirm={onAddLinkNodeConfirm}
+  onCancel={() => (pendingLinkNodeAt = null)}
+/>
+
+<ColorPicker
+  open={colorPicker !== null}
+  x={colorPicker?.x ?? 0}
+  y={colorPicker?.y ?? 0}
+  value={colorPicker?.value ?? null}
+  onChange={onColorChange}
+  onClose={closeColorPicker}
+/>
 
 
 <style>

--- a/src/components/Canvas/__tests__/CanvasRenderer.test.ts
+++ b/src/components/Canvas/__tests__/CanvasRenderer.test.ts
@@ -85,6 +85,24 @@ describe("CanvasRenderer (#156)", () => {
     expect(container.querySelectorAll("path.vc-canvas-edge")).toHaveLength(1);
   });
 
+  it("arrow marker inherits the referencing edge's stroke color (#171)", () => {
+    // The arrowhead used to render in the defs' own color scope, so colored
+    // edges had uncolored arrows. The marker path now uses fill=context-stroke
+    // so the arrowhead picks up the edge's stroke (which is currentColor).
+    const doc = docOf(
+      [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      [{ id: "e1", fromNode: "a", toNode: "b", color: "#ef4444" }],
+    );
+    const { container } = render(CanvasRenderer, { props: { doc, interactive: false } });
+    const markerPath = container.querySelector("marker#vc-canvas-arrow path");
+    expect(markerPath?.getAttribute("fill")).toBe("context-stroke");
+    const edgePath = container.querySelector<SVGPathElement>("path.vc-canvas-edge");
+    expect(edgePath?.style.color).toBe("rgb(239, 68, 68)");
+  });
+
   it("applies the camera transform to the world container", () => {
     const doc = docOf([
       { id: "t", type: "text", text: "x", x: 0, y: 0, width: 100, height: 40 },

--- a/src/components/Canvas/__tests__/CanvasRenderer.test.ts
+++ b/src/components/Canvas/__tests__/CanvasRenderer.test.ts
@@ -85,10 +85,11 @@ describe("CanvasRenderer (#156)", () => {
     expect(container.querySelectorAll("path.vc-canvas-edge")).toHaveLength(1);
   });
 
-  it("arrow marker inherits the referencing edge's stroke color (#171)", () => {
-    // The arrowhead used to render in the defs' own color scope, so colored
-    // edges had uncolored arrows. The marker path now uses fill=context-stroke
-    // so the arrowhead picks up the edge's stroke (which is currentColor).
+  it("arrow marker is rendered per-edge with the edge's color baked in (#171)", () => {
+    // A single shared marker in <defs> can't pick up each referencing path's
+    // color (SVG currentColor resolves inside the defs scope, and context-stroke
+    // isn't supported by every webview). So each edge gets its own marker with
+    // the color applied directly on the marker path.
     const doc = docOf(
       [
         { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
@@ -97,10 +98,13 @@ describe("CanvasRenderer (#156)", () => {
       [{ id: "e1", fromNode: "a", toNode: "b", color: "#ef4444" }],
     );
     const { container } = render(CanvasRenderer, { props: { doc, interactive: false } });
-    const markerPath = container.querySelector("marker#vc-canvas-arrow path");
-    expect(markerPath?.getAttribute("fill")).toBe("context-stroke");
+    const markerPath = container.querySelector<SVGPathElement>(
+      "marker#vc-canvas-arrow-e1 path",
+    );
+    expect(markerPath).toBeTruthy();
+    expect(markerPath!.style.fill).toBe("rgb(239, 68, 68)");
     const edgePath = container.querySelector<SVGPathElement>("path.vc-canvas-edge");
-    expect(edgePath?.style.color).toBe("rgb(239, 68, 68)");
+    expect(edgePath?.getAttribute("marker-end")).toBe("url(#vc-canvas-arrow-e1)");
   });
 
   it("applies the camera transform to the world container", () => {

--- a/src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts
+++ b/src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts
@@ -98,10 +98,15 @@ describe("CanvasView context menus (#164)", () => {
 
   // ─── Empty canvas ────────────────────────────────────────────────────
 
-  it("empty-canvas menu shows Add text node + Add group", async () => {
+  it("empty-canvas menu shows Add text / file / link / group (#166)", async () => {
     const { container } = await mountWithDoc({ nodes: [], edges: [] });
     await openMenuOnViewport(container);
-    expect(menuItems(container)).toEqual(["Add text node", "Add group"]);
+    expect(menuItems(container)).toEqual([
+      "Add text node",
+      "Add file node…",
+      "Add link node…",
+      "Add group",
+    ]);
   });
 
   it("Add text node creates a text node in the doc", async () => {
@@ -178,7 +183,7 @@ describe("CanvasView context menus (#164)", () => {
 
   // ─── Link node ───────────────────────────────────────────────────────
 
-  it("link-node menu lists the expected entries", async () => {
+  it("link-node menu lists the expected entries (#166 adds Edit URL…)", async () => {
     const { container } = await mountWithDoc({
       nodes: [{ id: "l", type: "link", url: "https://example.com", x: 0, y: 0, width: 200, height: 60 }],
       edges: [],
@@ -187,6 +192,7 @@ describe("CanvasView context menus (#164)", () => {
     expect(menuItems(container)).toEqual([
       "Open link",
       "Copy URL",
+      "Edit URL…",
       "Duplicate",
       "Bring to front",
       "Send to back",
@@ -196,13 +202,18 @@ describe("CanvasView context menus (#164)", () => {
 
   // ─── Group node ──────────────────────────────────────────────────────
 
-  it("group-node menu lists the expected entries", async () => {
+  it("group-node menu lists the expected entries (#166 adds Edit label + colour)", async () => {
     const { container } = await mountWithDoc({
       nodes: [{ id: "g", type: "group", label: "G", x: 0, y: 0, width: 300, height: 200 }],
       edges: [],
     });
     await openMenuOnNode(container, "g");
-    expect(menuItems(container)).toEqual(["Duplicate", "Delete"]);
+    expect(menuItems(container)).toEqual([
+      "Edit label…",
+      "Change color…",
+      "Duplicate",
+      "Delete",
+    ]);
   });
 
   // ─── Edge ────────────────────────────────────────────────────────────
@@ -216,7 +227,12 @@ describe("CanvasView context menus (#164)", () => {
       edges: [{ id: "e1", fromNode: "a", toNode: "b", fromSide: "right", toSide: "left" }],
     });
     await openMenuOnEdge(container);
-    expect(menuItems(container)).toEqual(["Edit label", "Flip direction", "Delete"]);
+    expect(menuItems(container)).toEqual([
+      "Edit label",
+      "Change color…",
+      "Flip direction",
+      "Delete",
+    ]);
   });
 
   it("Flip direction swaps the edge endpoints + sides", async () => {
@@ -256,5 +272,135 @@ describe("CanvasView context menus (#164)", () => {
     await openMenuOnEdge(container);
     await clickMenuItem(container, "Delete");
     expect(container.querySelectorAll(".vc-canvas-edge-hit")).toHaveLength(0);
+  });
+
+  // ─── #166: deferred entries ───────────────────────────────────────────
+
+  async function waitForWrite(n = 1, timeoutMs = 2000): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (writeFileMock.mock.calls.length >= n) return;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error(`write never happened (waited for ${n})`);
+  }
+
+  it("Add link node… opens a URL modal and persists a link node (#166)", async () => {
+    const { container } = await mountWithDoc({ nodes: [], edges: [] });
+    await openMenuOnViewport(container);
+    await clickMenuItem(container, "Add link node…");
+
+    const input = container.querySelector(".vc-url-modal-input") as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await fireEvent.input(input, { target: { value: "https://example.org" } });
+    const ok = container.querySelector(".vc-url-modal-ok") as HTMLButtonElement;
+    await fireEvent.click(ok);
+    await tick();
+
+    expect(container.querySelectorAll(".vc-canvas-node-link")).toHaveLength(1);
+    await waitForWrite();
+    const doc = nodesFromLastWrite();
+    const link = doc.nodes.find((n) => n.type === "link");
+    expect(link).toMatchObject({ type: "link", url: "https://example.org" });
+  });
+
+  it("Edit URL… on a link node replaces URL inline and persists (#166)", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "l", type: "link", url: "https://old.example", x: 0, y: 0, width: 200, height: 60 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "l");
+    await clickMenuItem(container, "Edit URL…");
+
+    const input = container.querySelector(".vc-canvas-node-link-url-input") as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await fireEvent.input(input, { target: { value: "https://new.example" } });
+    await fireEvent.keyDown(input, { key: "Enter" });
+    await tick();
+
+    await waitForWrite();
+    const doc = nodesFromLastWrite();
+    expect(doc.nodes[0]).toMatchObject({ type: "link", url: "https://new.example" });
+  });
+
+  it("Edit label… on a group inserts/replaces the label inline and persists (#166)", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "g", type: "group", x: 0, y: 0, width: 300, height: 200 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "g");
+    await clickMenuItem(container, "Edit label…");
+
+    const input = container.querySelector(".vc-canvas-node-group-label-input") as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await fireEvent.input(input, { target: { value: "My cluster" } });
+    await fireEvent.keyDown(input, { key: "Enter" });
+    await tick();
+
+    await waitForWrite();
+    const doc = nodesFromLastWrite();
+    expect(doc.nodes[0]).toMatchObject({ type: "group", label: "My cluster" });
+  });
+
+  it("Change color… on a group writes groupNode.background + renders it (#166)", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "g", type: "group", x: 0, y: 0, width: 300, height: 200 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "g");
+    await clickMenuItem(container, "Change color…");
+
+    const swatch = container.querySelector('.vc-color-swatch[data-color="#22c55e"]') as HTMLButtonElement;
+    expect(swatch).toBeTruthy();
+    await fireEvent.click(swatch);
+    await tick();
+
+    await waitForWrite();
+    const doc = nodesFromLastWrite();
+    expect(doc.nodes[0]).toMatchObject({ type: "group", background: "#22c55e" });
+
+    // Renderer must apply inline background-color so the new colour is visible.
+    const groupEl = container.querySelector(".vc-canvas-node-group") as HTMLElement;
+    expect(groupEl.style.backgroundColor).toBeTruthy();
+  });
+
+  it("Change color… Clear on a group deletes the background field (#166)", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "g", type: "group", background: "#3b82f6", x: 0, y: 0, width: 300, height: 200 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "g");
+    await clickMenuItem(container, "Change color…");
+
+    const clear = container.querySelector(".vc-color-clear") as HTMLButtonElement;
+    expect(clear).toBeTruthy();
+    await fireEvent.click(clear);
+    await tick();
+
+    await waitForWrite();
+    const doc = nodesFromLastWrite();
+    const group = doc.nodes[0] as unknown as Record<string, unknown>;
+    expect(group.background).toBeUndefined();
+  });
+
+  it("Change color… on an edge writes edge.color (#166)", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [
+        { id: "a", type: "text", text: "a", x: 0, y: 0, width: 100, height: 40 },
+        { id: "b", type: "text", text: "b", x: 200, y: 0, width: 100, height: 40 },
+      ],
+      edges: [{ id: "e1", fromNode: "a", toNode: "b" }],
+    });
+    await openMenuOnEdge(container);
+    await clickMenuItem(container, "Change color…");
+
+    const swatch = container.querySelector('.vc-color-swatch[data-color="#ef4444"]') as HTMLButtonElement;
+    expect(swatch).toBeTruthy();
+    await fireEvent.click(swatch);
+    await tick();
+
+    await waitForWrite();
+    const doc = nodesFromLastWrite();
+    expect(doc.edges[0]).toMatchObject({ id: "e1", color: "#ef4444" });
   });
 });

--- a/src/components/common/ColorPicker.svelte
+++ b/src/components/common/ColorPicker.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  // Small cursor-anchored colour picker popover (#166). Mirrors the geometry
+  // of `ContextMenu`: an overlay (click-to-close) plus a fixed-position card
+  // with a hex swatch grid, a native `<input type="color">` for custom picks,
+  // and a Clear button. `onChange(null)` signals the consumer to delete its
+  // colour field so any CSS fallback re-applies.
+
+  import { tick, untrack } from "svelte";
+
+  interface Props {
+    open: boolean;
+    x: number;
+    y: number;
+    value?: string | null;
+    onChange: (value: string | null) => void;
+    onClose: () => void;
+  }
+
+  let { open, x, y, value = null, onChange, onClose }: Props = $props();
+
+  const SWATCHES = [
+    "#ef4444", "#f97316", "#eab308", "#22c55e",
+    "#06b6d4", "#3b82f6", "#8b5cf6", "#ec4899",
+  ];
+
+  let menuEl = $state<HTMLDivElement | null>(null);
+  let adjustedX = $state(untrack(() => x));
+  let adjustedY = $state(untrack(() => y));
+
+  $effect(() => {
+    if (!open) return;
+    adjustedX = x;
+    adjustedY = y;
+    void (async () => {
+      await tick();
+      if (!menuEl) return;
+      const rect = menuEl.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      if (x + rect.width > vw) adjustedX = Math.max(0, vw - rect.width - 4);
+      if (y + rect.height > vh) adjustedY = Math.max(0, vh - rect.height - 4);
+    })();
+  });
+
+  $effect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  });
+
+  function onSwatch(c: string) {
+    onChange(c);
+    onClose();
+  }
+
+  function onCustomInput(e: Event) {
+    onChange((e.target as HTMLInputElement).value);
+  }
+
+  function onClear() {
+    onChange(null);
+    onClose();
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-color-overlay"
+    onclick={onClose}
+    oncontextmenu={(e) => { e.preventDefault(); onClose(); }}
+    role="presentation"
+  ></div>
+  <div
+    bind:this={menuEl}
+    class="vc-color-picker"
+    style="top: {adjustedY}px; left: {adjustedX}px;"
+    role="dialog"
+    aria-label="Farbe wählen"
+  >
+    <div class="vc-color-swatches">
+      {#each SWATCHES as c (c)}
+        <button
+          type="button"
+          class="vc-color-swatch"
+          class:vc-color-swatch-active={value === c}
+          style:background-color={c}
+          aria-label={`Farbe ${c}`}
+          data-color={c}
+          onclick={() => onSwatch(c)}
+        ></button>
+      {/each}
+    </div>
+    <div class="vc-color-row">
+      <input
+        type="color"
+        class="vc-color-custom"
+        value={value ?? "#3b82f6"}
+        oninput={onCustomInput}
+        aria-label="Benutzerdefinierte Farbe"
+      />
+      <button
+        type="button"
+        class="vc-color-clear"
+        onclick={onClear}
+      >Clear</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-color-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 199;
+  }
+
+  .vc-color-picker {
+    position: fixed;
+    z-index: 200;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 160px;
+  }
+
+  .vc-color-swatches {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+  }
+
+  .vc-color-swatch {
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .vc-color-swatch-active {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+  }
+
+  .vc-color-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .vc-color-custom {
+    flex: 1;
+    height: 28px;
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    cursor: pointer;
+    background: none;
+  }
+
+  .vc-color-clear {
+    font-size: 12px;
+    padding: 4px 10px;
+    background: none;
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .vc-color-clear:hover {
+    background: var(--color-accent-bg);
+  }
+</style>

--- a/src/components/common/UrlInputModal.svelte
+++ b/src/components/common/UrlInputModal.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  // Single-field URL prompt used by the canvas "Add link node" context-menu
+  // action (#166). Enter confirms, Escape / backdrop cancel. The consumer
+  // decides what to do with the URL — the modal only collects it.
+
+  import { tick } from "svelte";
+
+  interface Props {
+    open: boolean;
+    initial?: string;
+    onConfirm: (url: string) => void;
+    onCancel: () => void;
+  }
+
+  let { open, initial = "https://", onConfirm, onCancel }: Props = $props();
+
+  let value = $state("");
+  let inputEl = $state<HTMLInputElement | undefined>();
+
+  $effect(() => {
+    if (open) {
+      value = initial;
+      void tick().then(() => {
+        inputEl?.focus();
+        inputEl?.select();
+      });
+    }
+  });
+
+  function submit() {
+    const v = value.trim();
+    if (!v) {
+      onCancel();
+      return;
+    }
+    onConfirm(v);
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-url-modal-backdrop"
+    onclick={onCancel}
+    role="presentation"
+  ></div>
+  <div class="vc-url-modal" role="dialog" aria-modal="true" aria-label="Link hinzufügen">
+    <label class="vc-url-modal-label">
+      URL
+      <input
+        bind:this={inputEl}
+        bind:value={value}
+        onkeydown={onKey}
+        type="url"
+        class="vc-url-modal-input"
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </label>
+    <div class="vc-url-modal-actions">
+      <button
+        type="button"
+        class="vc-url-modal-cancel"
+        onclick={onCancel}
+      >Cancel</button>
+      <button
+        type="button"
+        class="vc-url-modal-ok"
+        onclick={submit}
+      >OK</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-url-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 200;
+  }
+
+  .vc-url-modal {
+    position: fixed;
+    top: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 420px;
+    max-width: calc(100vw - 32px);
+    z-index: 201;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  }
+
+  .vc-url-modal-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+  }
+
+  .vc-url-modal-input {
+    height: 32px;
+    padding: 0 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 14px;
+    outline: none;
+  }
+
+  .vc-url-modal-input:focus {
+    border-color: var(--color-accent);
+  }
+
+  .vc-url-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .vc-url-modal-cancel,
+  .vc-url-modal-ok {
+    font-size: 13px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .vc-url-modal-ok {
+    background: var(--color-accent);
+    color: var(--color-accent-contrast, #fff);
+    border-color: var(--color-accent);
+  }
+</style>

--- a/src/components/common/__tests__/ColorPicker.test.ts
+++ b/src/components/common/__tests__/ColorPicker.test.ts
@@ -1,0 +1,95 @@
+// #166 — shared ColorPicker. Locks in the swatch-click / Clear / ESC /
+// overlay-close behaviour so future consumers (group background, edge
+// color, potential future node colouring) can share one primitive.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import ColorPickerHarness from "./ColorPickerHarness.svelte";
+
+describe("ColorPicker (#166)", () => {
+  it("renders swatches + clear + custom input when open", async () => {
+    const { container } = render(ColorPickerHarness, {
+      props: { open: true, x: 50, y: 50 },
+    });
+    await tick();
+    expect(container.querySelector(".vc-color-picker")).toBeTruthy();
+    expect(container.querySelectorAll(".vc-color-swatch").length).toBeGreaterThanOrEqual(8);
+    expect(container.querySelector(".vc-color-clear")).toBeTruthy();
+    expect(container.querySelector('input[type="color"]')).toBeTruthy();
+  });
+
+  it("does not render when closed", async () => {
+    const { container } = render(ColorPickerHarness, {
+      props: { open: false, x: 0, y: 0 },
+    });
+    await tick();
+    expect(container.querySelector(".vc-color-picker")).toBeNull();
+    expect(container.querySelector(".vc-color-overlay")).toBeNull();
+  });
+
+  it("clicking a swatch emits its hex and closes", async () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(ColorPickerHarness, {
+      props: { open: true, onChange, onClose },
+    });
+    await tick();
+    const swatch = container.querySelector('.vc-color-swatch[data-color="#22c55e"]') as HTMLButtonElement;
+    await fireEvent.click(swatch);
+    expect(onChange).toHaveBeenCalledWith("#22c55e");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Clear emits null and closes", async () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(ColorPickerHarness, {
+      props: { open: true, value: "#ef4444", onChange, onClose },
+    });
+    await tick();
+    const clear = container.querySelector(".vc-color-clear") as HTMLButtonElement;
+    await fireEvent.click(clear);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("custom color input emits its value without closing", async () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(ColorPickerHarness, {
+      props: { open: true, onChange, onClose },
+    });
+    await tick();
+    const input = container.querySelector('input[type="color"]') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "#abcdef" } });
+    expect(onChange).toHaveBeenCalledWith("#abcdef");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes on Escape", async () => {
+    const onClose = vi.fn();
+    render(ColorPickerHarness, { props: { open: true, onClose } });
+    await tick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", cancelable: true }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the overlay closes", async () => {
+    const onClose = vi.fn();
+    const { container } = render(ColorPickerHarness, { props: { open: true, onClose } });
+    await tick();
+    const overlay = container.querySelector(".vc-color-overlay") as HTMLElement;
+    await fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the active swatch", async () => {
+    const { container } = render(ColorPickerHarness, {
+      props: { open: true, value: "#8b5cf6" },
+    });
+    await tick();
+    const active = container.querySelector(".vc-color-swatch-active") as HTMLElement;
+    expect(active?.getAttribute("data-color")).toBe("#8b5cf6");
+  });
+});

--- a/src/components/common/__tests__/ColorPickerHarness.svelte
+++ b/src/components/common/__tests__/ColorPickerHarness.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import ColorPicker from "../ColorPicker.svelte";
+
+  interface Props {
+    open: boolean;
+    x?: number;
+    y?: number;
+    value?: string | null;
+    onChange?: (v: string | null) => void;
+    onClose?: () => void;
+  }
+
+  let {
+    open,
+    x = 100,
+    y = 100,
+    value = null,
+    onChange = () => {},
+    onClose = () => {},
+  }: Props = $props();
+</script>
+
+<ColorPicker {open} {x} {y} {value} {onChange} {onClose} />


### PR DESCRIPTION
## Summary
Ships the six deferred context-menu entries from #166 (follow-up to #167):

- **Empty canvas → Add file node…** opens the QuickSwitcher and pins the picked file at the right-click world coords (reuses the existing switcher; no new search UI).
- **Empty canvas → Add link node…** opens a single-field URL prompt and inserts the link node at the click point.
- **Link node → Edit URL…** inline input (mirrors the edge-label edit pattern; Enter/blur commit, Escape cancels).
- **Group node → Edit label…** same inline pattern; supports creating a label from empty.
- **Group node → Change color…** shared `ColorPicker` popover writes `groupNode.background`; renderer now applies `style:background-color` so the existing typed field is finally visible.
- **Edge → Change color…** writes `edge.color`; renderer already read it through the SVG stroke fallback.

## Design notes
- Two new shared primitives in `src/components/common/`: `ColorPicker.svelte` (hex swatches + native `<input type="color">` + Clear; `onChange(null)` deletes the field) and `UrlInputModal.svelte` (single URL prompt). Both reusable by future callers.
- Inline edits reuse `editingNodeId` (not a new state slot), so the existing Escape handler in `onKeyDown` covers them for free.
- Right-click now commits any in-flight inline edit so the menu never surfaces on top of a half-typed URL / label.
- Clear-colour deletes the stored field (`delete node.background` / `delete edge.color`) so CSS fallbacks re-apply rather than locking an empty string into the file.

## Test plan
- [x] Unit: `src/components/common/__tests__/ColorPicker.test.ts` — open/close, swatch click, Clear, custom input, Escape, overlay click, active-swatch marker (8 tests).
- [x] Unit: extended `src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts` — menu lists now include the new entries; per-action tests for Add link node (→ modal → persist), Edit URL (inline commit), Edit label (inline commit), Change color on group (background field + renderer `background-color` + Clear deletes), Change color on edge.
- [x] E2E: `e2e/specs/canvas-context-menus.spec.ts` adds a spec — right-click empty canvas → Add file node… → QuickSwitcher → Enter → file node materialises and persists to `.canvas` with `type: "file"`.
- [x] `pnpm typecheck` green.
- [ ] **Manual UAT pending** — please exercise each of the six entries (file/link add, URL edit, label edit, group colour change + Clear, edge colour change) in a real vault, and confirm existing flows (Add text, Add group, flip edge, duplicate, etc.) still behave identically.

Closes #166.