### PR TITLE
feat(ui): frosted-glass modal surfaces (#176)

### DIFF
--- a/src/components/CommandPalette/CommandPalette.svelte
+++ b/src/components/CommandPalette/CommandPalette.svelte
@@ -124,12 +124,12 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="vc-command-palette-backdrop"
+    class="vc-command-palette-backdrop vc-modal-scrim"
     onclick={handleBackdropClick}
     data-testid="command-palette-backdrop"
   >
     <div
-      class="vc-command-palette-modal"
+      class="vc-command-palette-modal vc-modal-surface"
       role="dialog"
       aria-modal="true"
       aria-label="Befehlspalette"
@@ -185,9 +185,6 @@
 
 <style>
   .vc-command-palette-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
     z-index: 200;
   }
   .vc-command-palette-modal {
@@ -197,7 +194,6 @@
     top: 15%;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);

--- a/src/components/Search/OmniSearch.svelte
+++ b/src/components/Search/OmniSearch.svelte
@@ -349,11 +349,11 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="vc-quick-switcher-backdrop"
+    class="vc-quick-switcher-backdrop vc-modal-scrim"
     onmousedown={backdropClick}
   >
     <div
-      class="vc-quick-switcher-modal"
+      class="vc-quick-switcher-modal vc-modal-surface"
       role="dialog"
       aria-modal="true"
       aria-label="Suche"
@@ -458,9 +458,6 @@
 
 <style>
   .vc-quick-switcher-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
     z-index: 200;
   }
 
@@ -471,7 +468,6 @@
     top: 12%;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -234,8 +234,8 @@
 
 {#if open}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="vc-settings-backdrop" onclick={onBackdropClick} role="presentation"></div>
-  <div class="vc-settings-modal" role="dialog" aria-modal="true" aria-labelledby="settings-title" data-testid="settings-modal">
+  <div class="vc-settings-backdrop vc-modal-scrim" onclick={onBackdropClick} role="presentation"></div>
+  <div class="vc-settings-modal vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="settings-title" data-testid="settings-modal">
     <header class="vc-settings-header">
       <h2 id="settings-title" class="vc-settings-title">Einstellungen</h2>
       <button
@@ -470,13 +470,13 @@
   {#if pendingConflict}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
-      class="vc-conflict-backdrop"
+      class="vc-conflict-backdrop vc-modal-scrim"
       role="presentation"
       onclick={resolveConflictCancel}
       data-testid="shortcut-conflict-backdrop"
     ></div>
     <div
-      class="vc-conflict-modal"
+      class="vc-conflict-modal vc-modal-surface"
       role="alertdialog"
       aria-modal="true"
       aria-labelledby="shortcut-conflict-title"
@@ -509,8 +509,6 @@
 
 <style>
   .vc-settings-backdrop {
-    position: fixed; inset: 0;
-    background: rgba(0, 0, 0, 0.4);
     z-index: 300;
   }
   .vc-settings-modal {
@@ -519,7 +517,6 @@
     /* BUG-05.1: previously flat (min-height not set), sections crowded.
        Give the modal a generous default size so all three sections breathe. */
     width: 600px; min-height: 560px; max-height: 85vh;
-    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     box-shadow: 0 8px 32px rgba(0,0,0,0.2);
@@ -793,15 +790,12 @@
 
   /* Conflict modal (#65) */
   .vc-conflict-backdrop {
-    position: fixed; inset: 0;
-    background: rgba(0, 0, 0, 0.4);
     z-index: 310;
   }
   .vc-conflict-modal {
     position: fixed; top: 50%; left: 50%;
     transform: translate(-50%, -50%);
     width: 420px;
-    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     box-shadow: 0 8px 32px rgba(0,0,0,0.2);

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -647,11 +647,11 @@
   {#if showDeleteConfirm}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
-      class="vc-confirm-overlay"
+      class="vc-confirm-overlay vc-modal-scrim"
       onclick={cancelDelete}
       role="presentation"
     ></div>
-    <div class="vc-confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="delete-heading">
+    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="delete-heading">
       <h2 id="delete-heading" class="vc-confirm-heading">Move to Trash?</h2>
       <p class="vc-confirm-body">
         "{entry.name}" will be moved to .trash/ and can be recovered from there.
@@ -667,11 +667,11 @@
   {#if pendingRename}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
-      class="vc-confirm-overlay"
+      class="vc-confirm-overlay vc-modal-scrim"
       onclick={cancelRenameWithLinks}
       role="presentation"
     ></div>
-    <div class="vc-confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="rename-heading">
+    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="rename-heading">
       <h2 id="rename-heading" class="vc-confirm-heading">Links aktualisieren?</h2>
       <p class="vc-confirm-body">
         {pendingRename.linkCount} Links in {pendingRename.fileCount} Dateien werden aktualisiert. Fortfahren?
@@ -687,11 +687,11 @@
   {#if pendingMove}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
-      class="vc-confirm-overlay"
+      class="vc-confirm-overlay vc-modal-scrim"
       onclick={cancelMoveWithLinks}
       role="presentation"
     ></div>
-    <div class="vc-confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="move-heading">
+    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="move-heading">
       <h2 id="move-heading" class="vc-confirm-heading">Links aktualisieren?</h2>
       <p class="vc-confirm-body">
         {pendingMove.linkCount} Links in {pendingMove.fileCount} Dateien werden aktualisiert. Fortfahren?
@@ -881,10 +881,7 @@
 
   /* Confirmation dialog */
   .vc-confirm-overlay {
-    position: fixed;
-    inset: 0;
     z-index: 199;
-    background: rgba(0, 0, 0, 0.1);
   }
 
   .vc-confirm-dialog {
@@ -894,7 +891,6 @@
     transform: translate(-50%, -50%);
     z-index: 200;
     width: 280px;
-    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);

--- a/src/components/TemplatePicker/TemplatePicker.svelte
+++ b/src/components/TemplatePicker/TemplatePicker.svelte
@@ -128,11 +128,11 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="vc-tp-backdrop"
+    class="vc-tp-backdrop vc-modal-scrim"
     onclick={(e) => { if (e.target === e.currentTarget) onClose(); }}
   >
     <div
-      class="vc-tp-modal"
+      class="vc-tp-modal vc-modal-surface"
       role="dialog"
       aria-modal="true"
       aria-label="Vorlage einfügen"
@@ -180,9 +180,6 @@
 
 <style>
   .vc-tp-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
     z-index: 200;
   }
 
@@ -193,7 +190,6 @@
     top: 15%;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);

--- a/src/components/common/UrlInputModal.svelte
+++ b/src/components/common/UrlInputModal.svelte
@@ -50,11 +50,11 @@
 {#if open}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="vc-url-modal-backdrop"
+    class="vc-url-modal-backdrop vc-modal-scrim"
     onclick={onCancel}
     role="presentation"
   ></div>
-  <div class="vc-url-modal" role="dialog" aria-modal="true" aria-label="Link hinzufügen">
+  <div class="vc-url-modal vc-modal-surface" role="dialog" aria-modal="true" aria-label="Link hinzufügen">
     <label class="vc-url-modal-label">
       URL
       <input
@@ -84,9 +84,6 @@
 
 <style>
   .vc-url-modal-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
     z-index: 200;
   }
 
@@ -98,7 +95,6 @@
     width: 420px;
     max-width: calc(100vw - 32px);
     z-index: 201;
-    background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 16px;

--- a/src/styles/__tests__/modalTheming.test.ts
+++ b/src/styles/__tests__/modalTheming.test.ts
@@ -1,0 +1,176 @@
+// #176 — frosted-glass modal surfaces.
+//
+// The ticket's core contract: every top-level dialog shares a SINGLE pair of
+// utility classes (`.vc-modal-scrim`, `.vc-modal-surface`) so the blur +
+// translucency aren't duplicated per component. These tests guard that
+// contract at the source level — that's stronger than runtime-classList
+// assertions for a pure CSS refactor and doesn't require bringing up eight
+// different component render fixtures with their respective stores.
+//
+// Three things are verified:
+//   1. The global tokens + utility classes exist in tailwind.css.
+//   2. Every modal component's markup applies the utility alongside the
+//      existing `.vc-*-backdrop` / `.vc-*-modal` class.
+//   3. No modal component's scoped <style> block still sets `background`,
+//      `position: fixed`, or `inset: 0` on the scrim / surface selector —
+//      those now come exclusively from the shared utility.
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+const ROOT = path.resolve(__dirname, "../../..");
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(ROOT, rel), "utf-8");
+}
+
+/**
+ * Extract the declaration block for a single CSS selector. We only match the
+ * exact selector (no descendant combinators like `.vc-settings-modal :global`)
+ * so the check doesn't bleed into unrelated rules in the same file.
+ */
+function extractRuleBlock(css: string, selector: string): string | null {
+  // Match "selector {...}" where selector stands on its own at the start of a
+  // rule. Escape dots for the regex.
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`(?:^|[}\\s])(${escaped})\\s*\\{([^}]*)\\}`, "m");
+  const m = re.exec(css);
+  return m ? m[2] ?? null : null;
+}
+
+// Scrim + surface pairs per modal file.
+const MODAL_PAIRS: Array<{
+  file: string;
+  scrim: string;
+  surface: string;
+}> = [
+  {
+    file: "src/components/Search/OmniSearch.svelte",
+    scrim: ".vc-quick-switcher-backdrop",
+    surface: ".vc-quick-switcher-modal",
+  },
+  {
+    file: "src/components/CommandPalette/CommandPalette.svelte",
+    scrim: ".vc-command-palette-backdrop",
+    surface: ".vc-command-palette-modal",
+  },
+  {
+    file: "src/components/Settings/SettingsModal.svelte",
+    scrim: ".vc-settings-backdrop",
+    surface: ".vc-settings-modal",
+  },
+  {
+    file: "src/components/Settings/SettingsModal.svelte",
+    scrim: ".vc-conflict-backdrop",
+    surface: ".vc-conflict-modal",
+  },
+  {
+    file: "src/components/TemplatePicker/TemplatePicker.svelte",
+    scrim: ".vc-tp-backdrop",
+    surface: ".vc-tp-modal",
+  },
+  {
+    file: "src/components/common/UrlInputModal.svelte",
+    scrim: ".vc-url-modal-backdrop",
+    surface: ".vc-url-modal",
+  },
+  {
+    file: "src/components/Sidebar/TreeNode.svelte",
+    scrim: ".vc-confirm-overlay",
+    surface: ".vc-confirm-dialog",
+  },
+];
+
+describe("frosted-glass modal theming (#176)", () => {
+  describe("tailwind.css defines the shared tokens and utility classes", () => {
+    const css = read("src/styles/tailwind.css");
+
+    it("defines --color-modal-surface in both light and dark themes", () => {
+      // Token must appear at least twice — once in the light block, once in
+      // the dark override. A single definition means one theme is untuned.
+      const matches = css.match(/--color-modal-surface\s*:/g) ?? [];
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("defines --color-modal-scrim", () => {
+      expect(css).toMatch(/--color-modal-scrim\s*:/);
+    });
+
+    it("defines --modal-blur-radius", () => {
+      expect(css).toMatch(/--modal-blur-radius\s*:/);
+    });
+
+    it("declares the .vc-modal-scrim utility with the scrim bg", () => {
+      const block = extractRuleBlock(css, ".vc-modal-scrim");
+      expect(block).not.toBeNull();
+      expect(block!).toMatch(/background\s*:\s*var\(--color-modal-scrim\)/);
+      expect(block!).toMatch(/position\s*:\s*fixed/);
+      expect(block!).toMatch(/inset\s*:\s*0/);
+    });
+
+    it("declares the .vc-modal-surface utility with backdrop-filter blur", () => {
+      const block = extractRuleBlock(css, ".vc-modal-surface");
+      expect(block).not.toBeNull();
+      expect(block!).toMatch(/background\s*:\s*var\(--color-modal-surface\)/);
+      expect(block!).toMatch(
+        /backdrop-filter\s*:\s*blur\(var\(--modal-blur-radius\)\)/,
+      );
+      // Vendor prefix for older WebKit is load-bearing on Linux/Safari.
+      expect(block!).toMatch(/-webkit-backdrop-filter/);
+    });
+
+    it("includes an @supports fallback for browsers without backdrop-filter", () => {
+      expect(css).toMatch(
+        /@supports\s+not\s*\(\s*backdrop-filter\s*:/,
+      );
+    });
+
+    it("does NOT put backdrop-filter on the scrim (avoids double-blur through the surface)", () => {
+      const block = extractRuleBlock(css, ".vc-modal-scrim");
+      expect(block).not.toBeNull();
+      expect(block!).not.toMatch(/backdrop-filter/);
+    });
+  });
+
+  describe.each(MODAL_PAIRS)(
+    "modal contract: $file [$scrim / $surface]",
+    ({ file, scrim, surface }) => {
+      const src = read(file);
+
+      it(`${scrim} element carries the vc-modal-scrim utility class`, () => {
+        const needle = scrim.slice(1); // strip leading "."
+        const re = new RegExp(
+          `class=\\"[^\\"]*\\b${needle}\\b[^\\"]*\\bvc-modal-scrim\\b` +
+            `|class=\\"[^\\"]*\\bvc-modal-scrim\\b[^\\"]*\\b${needle}\\b`,
+        );
+        expect(src).toMatch(re);
+      });
+
+      it(`${surface} element carries the vc-modal-surface utility class`, () => {
+        const needle = surface.slice(1);
+        const re = new RegExp(
+          `class=\\"[^\\"]*\\b${needle}\\b[^\\"]*\\bvc-modal-surface\\b` +
+            `|class=\\"[^\\"]*\\bvc-modal-surface\\b[^\\"]*\\b${needle}\\b`,
+        );
+        expect(src).toMatch(re);
+      });
+
+      it(`scoped style for ${scrim} no longer redeclares background / position / inset`, () => {
+        const block = extractRuleBlock(src, scrim);
+        expect(block).not.toBeNull();
+        expect(block!).not.toMatch(/background\s*:/);
+        expect(block!).not.toMatch(/position\s*:\s*fixed/);
+        expect(block!).not.toMatch(/inset\s*:\s*0/);
+      });
+
+      it(`scoped style for ${surface} no longer redeclares background`, () => {
+        const block = extractRuleBlock(src, surface);
+        expect(block).not.toBeNull();
+        // Surface keeps its own layout (top/left/width/shadow) — only
+        // background is off-limits, since it now comes from the utility.
+        expect(block!).not.toMatch(/background\s*:\s*var\(--color-surface\)/);
+      });
+    },
+  );
+});

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -15,6 +15,13 @@
   --color-success:   #059669;
   --color-code-bg:   #F3F4F6;
 
+  /* #176 — frosted-glass modal surface tokens. Light alpha 0.72 lets the
+     blurred background show through; dark mode uses 0.85 because the lower
+     surface luminance otherwise loses text contrast. Blur radius is shared. */
+  --color-modal-surface: rgba(255, 255, 255, 0.72);
+  --color-modal-scrim:   rgba(0, 0, 0, 0.35);
+  --modal-blur-radius:   16px;
+
   --vc-font-body: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --vc-font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
   --vc-font-size: 14px;
@@ -36,6 +43,8 @@
   --color-warning: #D97706;
   --color-success: #059669;
   --color-code-bg: #F3F4F6;
+  --color-modal-surface: rgba(255, 255, 255, 0.72);
+  --color-modal-scrim: rgba(0, 0, 0, 0.35);
 }
 
 /* Dark theme (locked palette per UI-SPEC D-06). */
@@ -53,6 +62,8 @@
   --color-warning: #FCD34D;
   --color-success: #34D399;
   --color-code-bg: #252523;
+  --color-modal-surface: rgba(42, 42, 40, 0.85);
+  --color-modal-scrim: rgba(0, 0, 0, 0.45);
 }
 
 /* Auto — follow OS preference when data-theme="auto". */
@@ -71,6 +82,8 @@
     --color-warning: #FCD34D;
     --color-success: #34D399;
     --color-code-bg: #252523;
+    --color-modal-surface: rgba(42, 42, 40, 0.85);
+    --color-modal-scrim: rgba(0, 0, 0, 0.45);
   }
 }
 
@@ -82,6 +95,31 @@ html, body, #app {
   font-family: var(--vc-font-body);
   font-size: 14px;
   line-height: 1.5;
+}
+
+/* #176 — frosted-glass modal utilities.
+   The scrim is intentionally solid (no backdrop-filter) to avoid double-blur
+   when the surface sits on top: the surface would otherwise sample the scrim's
+   already-blurred buffer and look muddy, plus waste a compositor pass.
+   The surface owns the blur + saturation for the frosted-glass look. */
+.vc-modal-scrim {
+  position: fixed;
+  inset: 0;
+  background: var(--color-modal-scrim);
+}
+
+.vc-modal-surface {
+  background: var(--color-modal-surface);
+  backdrop-filter: blur(var(--modal-blur-radius)) saturate(140%);
+  -webkit-backdrop-filter: blur(var(--modal-blur-radius)) saturate(140%);
+}
+
+/* Opaque fallback for webviews without backdrop-filter (none of Tauri 2's
+   targets actually lack it today, but keep it cheap). */
+@supports not (backdrop-filter: blur(1px)) {
+  .vc-modal-surface {
+    background: var(--color-surface);
+  }
 }
 
 /* Phase 3 — Sidebar tabs */
@@ -124,30 +162,6 @@ html, body, #app {
 
 .vc-spin {
   animation: vc-spin 1s linear infinite;
-}
-
-/* Phase 3 — Quick Switcher */
-.vc-quick-switcher-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 200;
-}
-.vc-quick-switcher-modal {
-  width: 560px;
-  max-height: 480px;
-  position: fixed;
-  top: 15%;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-  z-index: 201;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
 }
 
 /* Phase 3 — Flash highlight for scroll-to-match */


### PR DESCRIPTION
Closes #176.

## Summary

Every top-level dialog (OmniSearch, Command Palette, Settings + its conflict sub-modal, Template Picker, URL Input, TreeNode confirm dialogs) now shares **one** pair of utility classes — `.vc-modal-scrim` + `.vc-modal-surface` — that produce a translucent, blurred frosted-glass surface. Tuned per theme (0.72 alpha light / 0.85 dark so text contrast holds).

## What changed

- **New tokens** in `src/styles/tailwind.css`: `--color-modal-surface`, `--color-modal-scrim`, `--modal-blur-radius`, tuned per light/dark.
- **Two global utilities**: `.vc-modal-scrim` (solid bg, fixed, inset 0) and `.vc-modal-surface` (translucent bg + `backdrop-filter: blur(16px) saturate(140%)` + `-webkit-` prefix + `@supports not` opaque fallback).
- **Refactored 7 scrim+surface pairs** to compose the utility alongside their existing class, e.g. `class=\"vc-quick-switcher-backdrop vc-modal-scrim\"`. All WDIO selectors (`.vc-*-backdrop`, `.vc-*-modal`) stay unchanged.
- **Removed per-component duplicates** of `background`, `position: fixed`, `inset: 0` on scrim/surface — the utility is now load-bearing. Svelte 5's `:where()`-scoped rules have the same specificity as the global utility, so without this deletion the per-component rule would silently override.

## Design decisions

- **Scrim is solid, only the surface is blurred.** Blurring both causes double-blur (the surface re-samples the scrim's already-blurred output) plus a wasted compositor pass. Surface-only blur gives the cleanest frosted look.
- **`0.72` light / `0.85` dark alpha.** Dark editor content at mid-luminance bled through a lower alpha — 0.85 keeps body text readable through the surface.
- **TreeNode scrim tone unified.** Confirm dialogs used `rgba(0,0,0,0.1)` before — an outlier. They now match the rest of the app at `rgba(0,0,0,0.35)`. Intentional visual change.

## Test plan

- [x] `npx vitest run src/styles/__tests__/modalTheming.test.ts` — 35 assertions: tokens present, utility declarations present, every modal composes the utility, no component redeclares `background`.
- [x] `npx vitest run src/components/Search src/components/CommandPalette src/components/Sidebar src/styles` — 75/75 green.
- [x] `npx tsc --noEmit` — clean.
- [x] Full vitest suite — 742/743 (one unrelated pre-existing perf flake in `largeFile.test.ts`, 536ms > 500ms budget).
- [ ] Manual UAT: open each modal in light + dark theme, confirm the frosted look and text contrast. Editor content behind OmniSearch/CommandPalette should read as visibly blurred but still recognisable.