### PR TITLE
chore(ui): increase modal surface transparency

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -15,10 +15,10 @@
   --color-success:   #059669;
   --color-code-bg:   #F3F4F6;
 
-  /* #176 — frosted-glass modal surface tokens. Light alpha 0.72 lets the
-     blurred background show through; dark mode uses 0.85 because the lower
+  /* #176 — frosted-glass modal surface tokens. Light alpha 0.55 lets the
+     blurred background show through; dark mode uses 0.72 because the lower
      surface luminance otherwise loses text contrast. Blur radius is shared. */
-  --color-modal-surface: rgba(255, 255, 255, 0.72);
+  --color-modal-surface: rgba(255, 255, 255, 0.55);
   --color-modal-scrim:   rgba(0, 0, 0, 0.35);
   --modal-blur-radius:   16px;
 
@@ -43,7 +43,7 @@
   --color-warning: #D97706;
   --color-success: #059669;
   --color-code-bg: #F3F4F6;
-  --color-modal-surface: rgba(255, 255, 255, 0.72);
+  --color-modal-surface: rgba(255, 255, 255, 0.55);
   --color-modal-scrim: rgba(0, 0, 0, 0.35);
 }
 
@@ -62,7 +62,7 @@
   --color-warning: #FCD34D;
   --color-success: #34D399;
   --color-code-bg: #252523;
-  --color-modal-surface: rgba(42, 42, 40, 0.85);
+  --color-modal-surface: rgba(42, 42, 40, 0.72);
   --color-modal-scrim: rgba(0, 0, 0, 0.45);
 }
 
@@ -82,7 +82,7 @@
     --color-warning: #FCD34D;
     --color-success: #34D399;
     --color-code-bg: #252523;
-    --color-modal-surface: rgba(42, 42, 40, 0.85);
+    --color-modal-surface: rgba(42, 42, 40, 0.72);
     --color-modal-scrim: rgba(0, 0, 0, 0.45);
   }
 }


### PR DESCRIPTION
## Summary
- Light modal surface alpha 0.72 → 0.55
- Dark modal surface alpha 0.85 → 0.72
- Blur radius, scrim alpha, @supports fallback unchanged

Macht den frosted-glass-Effekt sichtbarer, ohne Text-Kontrast im Dark Mode zu opfern.

## Test plan
- [x] `modalTheming.test.ts` läuft grün (35/35)
- [ ] Manuell: Settings / OmniSearch / CommandPalette im Light + Dark Mode öffnen und verifizieren, dass der Hintergrund durch das Modal erkennbar geblurrt ist und Text lesbar bleibt