### PR TITLE
chore(canvas): silence noninteractive-tabindex warnings (#181)

### DIFF
--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -265,6 +265,7 @@
 
   {#each orderedNodes as node (node.id)}
     {#if node.type === "text"}
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex (role and tabindex co-vary on `interactive`) -->
       <div
         class="vc-canvas-node vc-canvas-node-text"
         class:vc-canvas-node-selected={selectedNodeId === node.id}
@@ -360,6 +361,7 @@
     {:else if node.type === "file"}
       {@const fileNode = node as CanvasFileNode}
       {@const abs = vaultPath ? resolveVaultAbs(vaultPath, fileNode.file) : null}
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex (role and tabindex co-vary on `interactive`) -->
       <div
         class="vc-canvas-node vc-canvas-node-file"
         class:vc-canvas-node-selected={selectedNodeId === node.id}
@@ -456,6 +458,7 @@
       </div>
     {:else if node.type === "link"}
       {@const linkNode = node as CanvasLinkNode}
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex (role and tabindex co-vary on `interactive`) -->
       <div
         class="vc-canvas-node vc-canvas-node-link"
         class:vc-canvas-node-selected={selectedNodeId === node.id}
@@ -588,6 +591,7 @@
         {/if}
       </div>
     {:else}
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex (role and tabindex co-vary on `interactive`) -->
       <div
         class="vc-canvas-node vc-canvas-node-placeholder"
         class:vc-canvas-node-selected={selectedNodeId === node.id}

--- a/tests/canvasRendererA11y.test.ts
+++ b/tests/canvasRendererA11y.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Guard for #181: every `svelte-ignore a11y_no_noninteractive_tabindex`
+ * in CanvasRenderer.svelte must be immediately followed — within the next
+ * ~20 lines — by a `<div>` whose `role` AND `tabindex` both bind to the
+ * same `interactive` flag. If someone drops `role={interactive ? ...}`
+ * but keeps the ignore, the suppression becomes a real a11y regression;
+ * this test fails before it merges.
+ */
+
+const SRC = resolve(__dirname, "../src/components/Canvas/CanvasRenderer.svelte");
+const WINDOW = 25;
+const DIRECTIVE = "svelte-ignore a11y_no_noninteractive_tabindex";
+
+describe("CanvasRenderer a11y ignore directives", () => {
+  const text = readFileSync(SRC, "utf8");
+  const lines = text.split("\n");
+
+  it("every a11y_no_noninteractive_tabindex ignore is co-located with conditional role + tabindex", () => {
+    const occurrences: number[] = [];
+    lines.forEach((line, idx) => {
+      if (line.includes(DIRECTIVE)) occurrences.push(idx);
+    });
+
+    expect(occurrences.length).toBeGreaterThan(0);
+
+    for (const idx of occurrences) {
+      const window = lines.slice(idx, idx + WINDOW).join("\n");
+      expect(
+        window,
+        `ignore at line ${idx + 1} has no "role={interactive ?" within ${WINDOW} lines`,
+      ).toMatch(/role=\{interactive\s*\?/);
+      expect(
+        window,
+        `ignore at line ${idx + 1} has no "tabindex={interactive ?" within ${WINDOW} lines`,
+      ).toMatch(/tabindex=\{interactive\s*\?/);
+    }
+  });
+});


### PR DESCRIPTION
Closes #181.

## Summary

- Add `<!-- svelte-ignore a11y_no_noninteractive_tabindex -->` at each of the four CanvasRenderer node sites where `role` and `tabindex` co-vary on the `interactive` prop. Comment-only; zero runtime change.
- Add `tests/canvasRendererA11y.test.ts` as a regression guard: every ignore directive in `CanvasRenderer.svelte` must be followed within 25 lines by both `role={interactive ?` and `tabindex={interactive ?` — if someone removes the conditional role later without also removing the ignore, CI fails.

## Rationale

The four warnings were background radiation in `pnpm test` output. The sites are semantically correct (role and tabindex bind to the same flag) — Svelte's static analyzer just can't prove co-occurrence. Converting the divs to `<button>` or `<svelte:element>` would double markup branches and touch hot-path CSS selectors; a scoped suppression plus a drift-guard test is the right weight.

## Test plan

- [x] `pnpm test` — 747 passed (was 746; +1 new guard test). All four `a11y_no_noninteractive_tabindex` warnings gone from output.
- [x] `pnpm typecheck` — clean.
- [x] Full WDIO E2E suite — 58/58 spec files passed, 00:02:17 runtime. No regressions on Canvas specs (`canvas.spec.ts`, `canvas-a11y.spec.ts`, `canvas-context-menus.spec.ts`, etc.).