### PR TITLE
refactor(tag_index): remove BUG-05.1 dead extract_yaml_tags wrapper (#183)

### DIFF
--- a/src-tauri/src/indexer/tag_index.rs
+++ b/src-tauri/src/indexer/tag_index.rs
@@ -87,23 +87,13 @@ pub fn extract_inline_tag_occurrences(content: &str) -> Vec<String> {
         .collect()
 }
 
-// ── extract_yaml_tags ──────────────────────────────────────────────────────────
-
-/// Extract YAML frontmatter `tags` (list OR scalar).
-///
-/// Returns `[]` if:
-/// - The document has no frontmatter (`---` header)
-/// - Frontmatter has no `tags` key
-/// - The YAML is malformed (T-05-01-01 mitigation: `from_str` returns Err → `[]`)
-///
-/// Delegates to the shared frontmatter reader (`super::frontmatter`). Public
-/// contract is semantically identical to the pre-refactor implementation —
-/// existing tag tests still exercise this code path.
-pub fn extract_yaml_tags(content: &str) -> Vec<String> {
-    super::frontmatter::extract_yaml_tags(content)
-}
-
 // ── TagIndex ───────────────────────────────────────────────────────────────────
+//
+// YAML frontmatter tag extraction was descoped per user UAT (BUG-05.1). The
+// implementation lives in `super::frontmatter` — `parse_frontmatter().tags` /
+// `extract_yaml_tags()` — where aliases also come from; it is deliberately
+// not called from this module, and there is no wrapper here to re-enable it
+// by accident. See `TagIndex::update_file` below for the rationale.
 
 /// In-memory tag adjacency index.
 ///
@@ -130,8 +120,9 @@ impl TagIndex {
     /// Idempotent: calling twice for the same file replaces the previous entries.
     /// BUG-05.1 FIXES:
     /// - YAML frontmatter tag extraction (TAG-02) descoped per user UAT feedback.
-    ///   Only inline `#tag` / `#parent/child` tags are collected. `extract_yaml_tags`
-    ///   remains in the module as dead code for future re-enablement.
+    ///   Only inline `#tag` / `#parent/child` tags are collected. The YAML helper
+    ///   lives in `super::frontmatter`; re-enabling it here would require an
+    ///   explicit follow-up ticket (see tests/tag_index.rs regression guard).
     /// - Counts are now total-occurrence (not per-file unique). Writing `#test` three
     ///   times in one file yields `test (3)` in the tag panel — matches user expectation.
     pub fn update_file(&mut self, rel_path: &str, content: &str) {

--- a/src-tauri/src/tests/tag_index.rs
+++ b/src-tauri/src/tests/tag_index.rs
@@ -1,9 +1,10 @@
 // Unit tests for the tag_index module (Tasks 1 + 2, Plan 05-01).
 //
-// Tests 1–11: extract_inline_tags, extract_yaml_tags, TagIndex update/remove/list.
-// Tests 12–15 (Task 2): watcher dispatch + serde shape.
+// Tests 1–5: extract_inline_tags (YAML tests live in `indexer::frontmatter`).
+// Tests 10–11: TagIndex update/remove/list semantics.
+// Tests 12–15: watcher dispatch + serde shape.
 
-use crate::indexer::tag_index::{extract_inline_tags, extract_yaml_tags, TagIndex, TagUsage};
+use crate::indexer::tag_index::{extract_inline_tags, TagIndex, TagUsage};
 
 // ── Test 1: inline flat tags ───────────────────────────────────────────────────
 
@@ -48,40 +49,30 @@ fn test_inline_case_fold_dedupe() {
     assert_eq!(tags, vec!["rust"]);
 }
 
-// ── Test 6: YAML list tags ─────────────────────────────────────────────────────
+// Tests 6–9 (pure `extract_yaml_tags`) moved to `src-tauri/src/indexer/frontmatter.rs`
+// (same assertions live in that module's `#[cfg(test)] mod tests`) — the wrapper in
+// `tag_index.rs` was removed per BUG-05.1 so the duplicate assertions no longer
+// have a stable import path here.
+
+// ── Test 9a: TagIndex ignores YAML frontmatter tags (BUG-05.1 regression guard) ─
 
 #[test]
-fn test_yaml_list_tags() {
-    let content = "---\ntags: [a, b, nested/tag]\n---\nbody";
-    let tags = extract_yaml_tags(content);
-    assert_eq!(tags, vec!["a", "b", "nested/tag"]);
-}
+fn test_tag_index_does_not_surface_yaml_tags() {
+    // Content has BOTH a YAML `tags:` list AND an inline #hash tag. Per BUG-05.1
+    // the YAML tags must NOT be reflected in list_tags(); only the inline tag
+    // should surface.
+    let mut idx = TagIndex::new();
+    idx.update_file(
+        "note.md",
+        "---\ntags: [yaml_one, yaml_two]\n---\nbody with #inline_only",
+    );
 
-// ── Test 7: YAML scalar tag ────────────────────────────────────────────────────
-
-#[test]
-fn test_yaml_scalar_tag() {
-    let content = "---\ntags: single\n---\n...";
-    let tags = extract_yaml_tags(content);
-    assert_eq!(tags, vec!["single"]);
-}
-
-// ── Test 8: YAML absent tags key ──────────────────────────────────────────────
-
-#[test]
-fn test_yaml_absent_tags() {
-    let content = "---\ntitle: foo\n---\n...";
-    let tags = extract_yaml_tags(content);
-    assert_eq!(tags, Vec::<String>::new());
-}
-
-// ── Test 9: no frontmatter ────────────────────────────────────────────────────
-
-#[test]
-fn test_yaml_no_frontmatter() {
-    let content = "no dashes\ntags: [a]";
-    let tags = extract_yaml_tags(content);
-    assert_eq!(tags, Vec::<String>::new());
+    let names: Vec<String> = idx.list_tags().into_iter().map(|u| u.tag).collect();
+    assert_eq!(
+        names,
+        vec!["inline_only".to_string()],
+        "YAML frontmatter tags must not leak into TagIndex (BUG-05.1)"
+    );
 }
 
 // ── Test 10: TagIndex update + remove ─────────────────────────────────────────


### PR DESCRIPTION
Closes #183.

## Summary

- Delete the pass-through `extract_yaml_tags` wrapper in `src-tauri/src/indexer/tag_index.rs`. The real implementation (and its test coverage) stays in `indexer/frontmatter.rs`, which is still used via `parse_frontmatter` for alias extraction.
- Drop four duplicate YAML tests from `src-tauri/src/tests/tag_index.rs` — identical assertions already live in `frontmatter.rs#[cfg(test)] mod tests`.
- Add `test_tag_index_does_not_surface_yaml_tags` as a BUG-05.1 regression guard: with content carrying both a YAML `tags:` list and an inline `#tag`, `TagIndex::update_file` must produce only the inline tag.
- Tighten the BUG-05.1 comment block to explain the decision and point at `frontmatter` for the descoped helper.

## Rationale

The wrapper was a zombie public surface: unreachable from production, easy to re-wire by accident, and it duplicated the same four test cases already present in `frontmatter.rs`. Removing it narrows the public API and adds a real regression test for the BUG-05.1 behavior that was previously only enforced by "don't call that function."

## Test plan

- [x] `cargo test` (src-tauri): 216 passed / 0 failed (was 219 — 3 removed, 1 new regression).
- [x] `pnpm test`: 747 passed / 0 failed.
- [x] `pnpm typecheck`: clean.
- [x] Full WDIO E2E suite: 58/58 spec files, 00:02:18 runtime. No regressions on `tags-panel.spec.ts`, `tag-autocomplete.spec.ts`, alias-related specs.