### PR TITLE
refactor(ipc): type getOutgoingLinks response as Promise<ParsedLink[]> (#182)

### DIFF
--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -11,7 +11,7 @@ import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
 import type { DirEntry } from "../types/tree";
 import type { SearchResult, FileMatch } from "../types/search";
-import type { BacklinkEntry, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
+import type { BacklinkEntry, ParsedLink, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
 
 function normalizeError(err: unknown): VaultError {
@@ -242,11 +242,13 @@ export async function getBacklinks(path: string): Promise<BacklinkEntry[]> {
 }
 
 /**
- * Return all outgoing wiki-links from a vault-relative source path.
+ * Return all outgoing wiki-links from a vault-relative source path — one
+ * `ParsedLink` per occurrence (duplicates preserved; deduplication, if any,
+ * is the caller's job).
  */
-export async function getOutgoingLinks(path: string): Promise<any[]> {
+export async function getOutgoingLinks(path: string): Promise<ParsedLink[]> {
   try {
-    return await invoke<any[]>("get_outgoing_links", { path });
+    return await invoke<ParsedLink[]>("get_outgoing_links", { path });
   } catch (e) {
     throw normalizeError(e);
   }

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -13,6 +13,25 @@ export interface BacklinkEntry {
   lineNumber: number;
 }
 
+/**
+ * A single wiki-link parsed out of a Markdown document — the raw record
+ * produced by the Rust indexer (mirrors `src-tauri/src/indexer/link_graph.rs::ParsedLink`).
+ *
+ * This is the per-occurrence form returned by `getOutgoingLinks`. It is
+ * distinct from `src/lib/outgoingLinks.ts#OutgoingLink`, which is the
+ * aggregated (deduplicated-by-target) shape the sidebar renders on top.
+ */
+export interface ParsedLink {
+  /** Raw link target as written (e.g. "Note", "Folder/Note", "Note.md"). */
+  targetRaw: string;
+  /** Optional alias text after `|` (e.g. `[[Note|alias]]` → `"alias"`). */
+  alias: string | null;
+  /** 0-based line number where the link appears. */
+  lineNumber: number;
+  /** Full line text (used as context in backlink-style UIs). */
+  context: string;
+}
+
 /** A wiki-link that could not be resolved to any file in the vault. */
 export interface UnresolvedLink {
   /** Vault-relative path of the file that contains the dangling link. */

--- a/tests/parsedLinkType.test.ts
+++ b/tests/parsedLinkType.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, expectTypeOf } from "vitest";
+import type { ParsedLink } from "../src/types/links";
+
+/**
+ * Guard for #182. The Rust struct `ParsedLink` (link_graph.rs) serializes as
+ * camelCase via `#[serde(rename_all = "camelCase")]`. This test anchors the
+ * TypeScript mirror so the IPC boundary stays typed: drifting either side
+ * produces a compile error here.
+ */
+describe("ParsedLink shape matches Rust serde(camelCase)", () => {
+  it("accepts the canonical wire shape", () => {
+    const wire: ParsedLink = {
+      targetRaw: "Folder/Note",
+      alias: null,
+      lineNumber: 0,
+      context: "[[Folder/Note]]",
+    };
+    expect(wire.targetRaw).toBe("Folder/Note");
+    expect(wire.alias).toBeNull();
+  });
+
+  it("accepts alias when the link is `[[target|alias]]`", () => {
+    const withAlias: ParsedLink = {
+      targetRaw: "Note",
+      alias: "display text",
+      lineNumber: 3,
+      context: "see [[Note|display text]]",
+    };
+    expect(withAlias.alias).toBe("display text");
+  });
+
+  it("is structurally identical at the type level", () => {
+    expectTypeOf<ParsedLink>().toEqualTypeOf<{
+      targetRaw: string;
+      alias: string | null;
+      lineNumber: number;
+      context: string;
+    }>();
+  });
+});


### PR DESCRIPTION
Closes #182.

## Summary

- Add `ParsedLink` interface to `src/types/links.ts`, mirroring `src-tauri/src/indexer/link_graph.rs::ParsedLink` (which serializes as camelCase).
- Replace `any[]` with `ParsedLink[]` on both sides of the `getOutgoingLinks` wrapper in `src/ipc/commands.ts`.
- Add `tests/parsedLinkType.test.ts` as a shape-anchor: uses `expectTypeOf<ParsedLink>().toEqualTypeOf<…>()` plus two runtime samples so any future drift on either side of the IPC boundary trips CI.

## Rationale

`any` on an IPC boundary is exactly where typing matters. The Rust surface can rename a field or add a variant and the TypeScript side would silently accept garbage. All other link-related wrappers in `commands.ts` already use concrete types — this was the last hold-out. Adding the type also disambiguates it from `src/lib/outgoingLinks.ts#OutgoingLink`, which is a different, frontend-aggregated shape; the new `ParsedLink` is the per-occurrence raw record from Rust.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 750 passed (was 747; +3 new shape-guard tests).
- [x] Full WDIO E2E suite — 58/58 spec files, 00:02:18 runtime. No regressions on `outgoing-links.spec.ts` or any link-related specs.