### PR TITLE
refactor(indexer): unify markdown walkers into a single walk_md_files (#180)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -21,11 +21,10 @@
 
 use crate::error::VaultError;
 use crate::hash::hash_bytes;
-use crate::indexer::IndexCmd;
+use crate::indexer::{walk_md_files, IndexCmd};
 use crate::VaultState;
 use regex::Regex;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
 /// T-02 mitigation: canonicalize `target` and confirm it sits inside the
 /// currently-open vault.
@@ -250,23 +249,6 @@ fn find_available_dir_name(dir: &Path, base_name: &str) -> PathBuf {
         }
         n += 1;
     }
-}
-
-/// Helper: walk all .md files in vault, excluding dot-prefixed directories.
-fn walk_md_files(vault: &Path) -> impl Iterator<Item = PathBuf> {
-    WalkDir::new(vault)
-        .follow_links(false)
-        .into_iter()
-        .filter_entry(|e| {
-            let name = e.file_name().to_str().unwrap_or("");
-            e.depth() == 0 || !name.starts_with('.')
-        })
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_type().is_file()
-                && e.path().extension().is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
-        })
-        .map(|e| e.path().to_path_buf())
 }
 
 // ─── create_file ─────────────────────────────────────────────────────────────

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -591,9 +591,16 @@ async fn acquire_writer_with_retry(index: &Index) -> Result<IndexWriter, VaultEr
 
 // ── Walk helper ───────────────────────────────────────────────────────────────
 
-/// Collect all `.md` paths under `vault_path`, skipping dot-directories
-/// (including `.obsidian`, `.vaultcore`, `.trash`).
-fn collect_md_paths(vault_path: &Path) -> Vec<PathBuf> {
+/// Walk all `.md` files under `vault_path`, skipping every dot-prefixed
+/// directory (`.obsidian`, `.vaultcore`, `.trash`, `sub/.nested/…`, …).
+///
+/// Shared by the indexer's cold-start + rebuild paths and by the
+/// user-interactive rename / count-wiki-links commands (#180).
+///
+/// Contract — keep the `filter_entry` *before* `filter_map(Result::ok)`:
+/// that ordering is what prunes the whole dot-subtree rather than walking
+/// into it and surfacing errors per entry.
+pub(crate) fn walk_md_files(vault_path: &Path) -> impl Iterator<Item = PathBuf> {
     walkdir::WalkDir::new(vault_path)
         .follow_links(false)
         .into_iter()
@@ -613,7 +620,13 @@ fn collect_md_paths(vault_path: &Path) -> Vec<PathBuf> {
                     .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
         })
         .map(|e| e.into_path())
-        .collect()
+}
+
+/// Convenience: `walk_md_files(p).collect()`. Kept for call sites that want
+/// an owned `Vec` — the indexer's cold-start pass needs the total count up
+/// front for progress throttling.
+fn collect_md_paths(vault_path: &Path) -> Vec<PathBuf> {
+    walk_md_files(vault_path).collect()
 }
 
 /// Collect all `.canvas` relative paths (forward-slash, vault-relative) under

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -15,3 +15,4 @@ mod bookmarks;
 mod aliases;
 mod snippets;
 mod file_index_contention;
+mod vault_walk;

--- a/src-tauri/src/tests/vault_walk.rs
+++ b/src-tauri/src/tests/vault_walk.rs
@@ -1,0 +1,49 @@
+// Tests for the unified `walk_md_files` helper (#180).
+//
+// Validates the dot-prefix subtree-pruning contract: once a directory name
+// starts with `.`, neither it nor any of its descendants may surface —
+// relying on `filter_entry` ordered BEFORE `filter_map(Result::ok)`.
+// Case-insensitive `.md` extension filter is likewise asserted.
+
+use std::collections::HashSet;
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::indexer::walk_md_files;
+
+#[test]
+fn walk_md_files_skips_dot_dirs_and_is_case_insensitive() {
+    let dir = tempdir().expect("tempdir");
+    let vault = dir.path();
+
+    // Expected to surface:
+    fs::write(vault.join("top.md"), "").unwrap();
+    fs::write(vault.join("SUB.MD"), "").unwrap(); // case-insensitive extension
+    fs::create_dir_all(vault.join("subdir")).unwrap();
+    fs::write(vault.join("subdir/inner.md"), "").unwrap();
+
+    // Must NOT surface — dot-prefixed subtree must be pruned whole.
+    fs::create_dir_all(vault.join(".obsidian/cache")).unwrap();
+    fs::write(vault.join(".obsidian/cache/x.md"), "").unwrap();
+    fs::create_dir_all(vault.join("sub/.nested")).unwrap();
+    fs::write(vault.join("sub/.nested/deep.md"), "").unwrap();
+
+    // Must NOT surface — wrong extension.
+    fs::write(vault.join("readme.txt"), "").unwrap();
+    fs::write(vault.join("no_ext_file"), "").unwrap();
+
+    let found: HashSet<String> = walk_md_files(vault)
+        .map(|p| {
+            p.strip_prefix(vault)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect();
+
+    let expected: HashSet<String> =
+        ["top.md", "SUB.MD", "subdir/inner.md"].iter().map(|s| s.to_string()).collect();
+
+    assert_eq!(found, expected, "walk_md_files mismatch");
+}


### PR DESCRIPTION
Closes #180.

## Summary

- Promote the md-walk primitive to `pub(crate) fn indexer::walk_md_files` returning `impl Iterator<Item = PathBuf>`. Document the `filter_entry` → `filter_map` ordering invariant that keeps the dot-subtree prune whole (the non-obvious bit a naive simplification would break).
- Reduce `indexer::collect_md_paths` to a one-line `walk_md_files(p).collect()` wrapper so existing call sites (`index_vault`, `rebuild_index`) keep their owned-Vec return shape without repeating filter logic.
- Delete `commands/files.rs::walk_md_files`; `rename_file` and `count_wiki_links` import the shared iterator.
- Add `src-tauri/src/tests/vault_walk.rs` — a temp-vault integration test with explicit coverage for root-level dot-dirs (`.obsidian/cache/x.md`), **nested** dot-dirs (`sub/.nested/deep.md`), the case-insensitive `.md` extension filter (`SUB.MD`), and non-`.md` rejection (`readme.txt`, `no_ext_file`).

## Rationale

Two walk implementations is exactly the maintenance footgun CLAUDE.md warns about: a future change to the ignore rules (add `.trash` by name, alter follow-links policy, etc.) has to happen in both places or the indexer and the user-facing commands drift. Consolidating also gives us one place to profile at 100k-note scale.

## Test plan

- [x] `cargo test` (src-tauri): 217 passed / 0 failed (was 216 — +1 new `vault_walk` integration test).
- [x] `pnpm test`: 750 passed / 0 failed.
- [x] `pnpm typecheck`: clean.
- [x] Full WDIO E2E suite: 58/58 spec files, 00:02:18 runtime. No regressions on `rename-cascade.spec.ts` (which is the real end-to-end coverage for the two affected commands) or adjacent specs.