### PR TITLE
feat(embeddings): add fastembed + ort load-dynamic deps (#190)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +174,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -243,7 +263,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -378,6 +398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +483,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -632,12 +676,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -655,13 +723,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -678,6 +766,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -925,10 +1044,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
+name = "fastembed"
+version = "5.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f54fc1188b7f7eac8f47be2ab7b3a79ffd842cc8ff2e38316dd59ba4858890e"
+dependencies = [
+ "anyhow",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
 
 [[package]]
 name = "fastrand"
@@ -1480,6 +1620,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2079,7 +2221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2097,6 +2239,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2167,6 +2319,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2375,16 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "measure_time"
@@ -2276,6 +2454,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2501,21 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "ndk"
@@ -2405,10 +2620,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2584,6 +2817,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2852,25 @@ checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+dependencies = [
+ "libloading 0.9.0",
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 
 [[package]]
 name = "ownedbytes"
@@ -2654,6 +2928,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -3084,6 +3364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3119,6 +3419,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3146,6 +3455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3468,17 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
 ]
 
 [[package]]
@@ -3341,6 +3667,17 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -3575,7 +3912,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3761,10 +4098,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -4480,6 +4835,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4805,6 +5193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4821,6 +5218,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"
@@ -4889,9 +5292,11 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "env_logger",
+ "fastembed",
  "log",
  "notify-debouncer-full",
  "nucleo-matcher",
+ "ort",
  "pulldown-cmark",
  "rayon",
  "regex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,5 +39,18 @@ pulldown-cmark = "0.13"
 serde_yml = "0.0.12"
 base64 = "0.22"
 
+# Embeddings stack — gated behind `embeddings` feature.
+# fastembed re-exports `ort` with the `load-dynamic` feature, so libonnxruntime
+# is dlopen'd at runtime from a Tauri-bundled resource (#191) instead of being
+# linked statically. Default features are disabled to suppress the binary
+# downloader (`ort-download-binaries-native-tls`) and unused candle backends.
+fastembed = { version = "5", default-features = false, features = ["ort-load-dynamic"], optional = true }
+# Pin must match fastembed's exact `ort` requirement — fastembed 5.13.2 needs rc.11.
+ort = { version = "=2.0.0-rc.11", default-features = false, features = ["load-dynamic", "ndarray"], optional = true }
+
+[features]
+default = ["embeddings"]
+embeddings = ["dep:fastembed", "dep:ort"]
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -1,0 +1,172 @@
+//! Local embeddings stack — gated behind the `embeddings` Cargo feature.
+//!
+//! This module owns the dlopen'd ONNX Runtime lifecycle and the discovery of
+//! the bundled MiniLM model. Higher-level services (#194 EmbeddingService,
+//! #198 VectorIndex, #203 hybrid search) build on top of `init_runtime` +
+//! `model_dir`.
+//!
+//! Path resolution order for both the runtime dylib and the model directory:
+//!
+//! 1. Explicit env override (`ORT_DYLIB_PATH`, `VAULTCORE_MODEL_DIR`) — used
+//!    by the smoke test and by developers running against a non-bundled
+//!    runtime.
+//! 2. The Tauri `resource_dir()` (production install).
+//! 3. `CARGO_MANIFEST_DIR/resources/...` as a dev fallback for `cargo run`
+//!    and `cargo test`, since `resource_dir()` is unreliable in dev builds
+//!    (tauri-apps/tauri#13654) and undefined for unit tests with no AppHandle.
+//!
+//! ORT's `init_from(path).commit()` is global per process and silently
+//! returns `false` on the second call — we wrap it in a `OnceLock` so any
+//! number of test entry points can call `ensure_runtime_initialized()` without
+//! racing or double-initializing.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EmbeddingError {
+    #[error("ONNX Runtime dylib not found at any candidate path")]
+    RuntimeMissing,
+    #[error("Model directory not found at any candidate path")]
+    ModelMissing,
+    #[error("ONNX Runtime init failed: {0}")]
+    OrtInit(String),
+    #[error("fastembed error: {0}")]
+    Fastembed(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+const ENV_DYLIB: &str = "ORT_DYLIB_PATH";
+const ENV_MODEL_DIR: &str = "VAULTCORE_MODEL_DIR";
+
+/// Platform-specific dylib filename. Bundled under `resources/onnxruntime/`.
+fn dylib_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "onnxruntime.dll"
+    } else if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    }
+}
+
+/// Resolve the libonnxruntime path. See module docs for resolution order.
+///
+/// `resource_dir` may be `None` when called outside a Tauri AppHandle context
+/// (e.g. `cargo test`) — the dev fallback then takes over.
+pub fn runtime_path(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingError> {
+    if let Some(p) = std::env::var_os(ENV_DYLIB) {
+        return Ok(PathBuf::from(p));
+    }
+    let name = dylib_name();
+    if let Some(dir) = resource_dir {
+        let p = dir.join("onnxruntime").join(name);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    let dev = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join("onnxruntime")
+        .join(name);
+    if dev.exists() {
+        return Ok(dev);
+    }
+    Err(EmbeddingError::RuntimeMissing)
+}
+
+/// Resolve the bundled model directory. Same resolution semantics as
+/// `runtime_path`. The directory must contain `model.onnx`,
+/// `tokenizer.json`, `config.json`, `tokenizer_config.json`, and
+/// `special_tokens_map.json` (#192).
+pub fn model_dir(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingError> {
+    if let Some(p) = std::env::var_os(ENV_MODEL_DIR) {
+        return Ok(PathBuf::from(p));
+    }
+    let leaf = Path::new("models").join("all-MiniLM-L6-v2-int8");
+    if let Some(dir) = resource_dir {
+        let p = dir.join(&leaf);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    let dev = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join(&leaf);
+    if dev.exists() {
+        return Ok(dev);
+    }
+    Err(EmbeddingError::ModelMissing)
+}
+
+static RUNTIME_INIT: OnceLock<Result<(), String>> = OnceLock::new();
+
+/// Idempotent global ORT init. The first caller wins; subsequent callers
+/// see the same outcome. Safe across threads and across multiple test entry
+/// points within a single `cargo test` process.
+pub fn ensure_runtime_initialized(
+    resource_dir: Option<&Path>,
+) -> Result<(), EmbeddingError> {
+    let result = RUNTIME_INIT.get_or_init(|| {
+        let path = match runtime_path(resource_dir) {
+            Ok(p) => p,
+            Err(e) => return Err(e.to_string()),
+        };
+        #[cfg(feature = "embeddings")]
+        {
+            let builder = match ort::init_from(path.to_string_lossy().into_owned()) {
+                Ok(b) => b,
+                Err(e) => return Err(format!("ort::init_from failed: {e}")),
+            };
+            // `commit` returns `false` if a global environment already exists.
+            // That is not a hard error for us (idempotent init across tests
+            // and Tauri setup callbacks), so we don't fail the OnceLock.
+            let _ = builder.commit();
+            Ok(())
+        }
+        #[cfg(not(feature = "embeddings"))]
+        {
+            let _ = path;
+            Err("embeddings feature not enabled".to_string())
+        }
+    });
+    result.clone().map_err(EmbeddingError::OrtInit)
+}
+
+/// Smoke-test entry point used by tests/embeddings.rs. Loads the bundled
+/// MiniLM model, embeds a fixed string, and returns the raw 384-dim vector.
+///
+/// The caller (the test) asserts vector length and L2 norm. Returns
+/// `Err(ModelMissing)` cleanly if the model isn't bundled yet (#192 not
+/// done) so the test can skip rather than fail.
+#[cfg(feature = "embeddings")]
+pub fn smoke_test(resource_dir: Option<&Path>) -> Result<Vec<f32>, EmbeddingError> {
+    use fastembed::{
+        InitOptionsUserDefined, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel,
+    };
+
+    ensure_runtime_initialized(resource_dir)?;
+    let dir = model_dir(resource_dir)?;
+    let read = |name: &str| std::fs::read(dir.join(name));
+    let model = UserDefinedEmbeddingModel::new(
+        read("model.onnx")?,
+        TokenizerFiles {
+            tokenizer_file: read("tokenizer.json")?,
+            config_file: read("config.json")?,
+            special_tokens_map_file: read("special_tokens_map.json")?,
+            tokenizer_config_file: read("tokenizer_config.json")?,
+        },
+    );
+    let mut embedder = TextEmbedding::try_new_from_user_defined(
+        model,
+        InitOptionsUserDefined::default(),
+    )
+    .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
+    let mut out = embedder
+        .embed(vec!["VaultCore semantic search smoke test"], None)
+        .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
+    out.pop().ok_or_else(|| {
+        EmbeddingError::Fastembed("empty embedding batch".into())
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,9 @@ pub mod watcher;
 pub mod merge;
 pub mod indexer;
 
+#[cfg(feature = "embeddings")]
+pub mod embeddings;
+
 #[cfg(test)]
 mod tests;
 

--- a/src-tauri/src/tests/embeddings.rs
+++ b/src-tauri/src/tests/embeddings.rs
@@ -1,0 +1,31 @@
+//! Smoke test for the embeddings stack (#190).
+//!
+//! Skipped silently when the runtime dylib (#191) or the bundled model (#192)
+//! is not yet present; runs end-to-end once both ship.
+
+#[cfg(feature = "embeddings")]
+#[test]
+fn embedding_smoke_test() {
+    use crate::embeddings;
+
+    // Best-effort discovery via the same paths the runtime would use in dev
+    // (`CARGO_MANIFEST_DIR/resources/...`). No AppHandle in unit tests.
+    let runtime = embeddings::runtime_path(None);
+    let model = embeddings::model_dir(None);
+    if runtime.is_err() || model.is_err() {
+        eprintln!(
+            "SKIP embedding_smoke_test: runtime={:?} model={:?}",
+            runtime.is_ok(),
+            model.is_ok()
+        );
+        return;
+    }
+
+    let v = embeddings::smoke_test(None).expect("smoke test failed");
+    assert_eq!(v.len(), 384, "MiniLM-L6-v2 must yield 384-dim vectors");
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        (norm - 1.0).abs() < 0.01,
+        "expected L2-normalized embedding, got norm {norm}"
+    );
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -16,3 +16,5 @@ mod aliases;
 mod snippets;
 mod file_index_contention;
 mod vault_walk;
+#[cfg(feature = "embeddings")]
+mod embeddings;


### PR DESCRIPTION
Closes #190. Part of epic #189.

## Summary

- Add `fastembed = 5` (default-features off) + `ort = =2.0.0-rc.11` with `load-dynamic` to `src-tauri/Cargo.toml`.
- Introduce a new `embeddings` Cargo feature (default on) so contributors who want a fast non-ML build can opt out via `--no-default-features`.
- New `src-tauri/src/embeddings/mod.rs`: path discovery (env → Tauri `resource_dir` → `CARGO_MANIFEST_DIR/resources`) for both the runtime dylib and the bundled model. ORT init is wrapped in a `OnceLock` because `ort::init_from(...).commit()` is global per process and not idempotent.
- Smoke test in `tests/embeddings.rs` is gated by feature flag and skips silently when the runtime (#191) or the model (#192) aren't bundled yet, so this PR lands green.

## Notes

- `ort` pin must stay at `=2.0.0-rc.11` until fastembed bumps; rc.12 is out but fastembed 5.13.2 still pins rc.11.
- No CI changes — the repo currently has no GitHub Actions workflow. Cross-platform validation will happen manually via `cargo tauri build` on macOS, Windows, Linux during #191 / #192.
- Dev-fallback in `runtime_path` / `model_dir` falls back to `CARGO_MANIFEST_DIR/resources/...` because `app.path().resource_dir()` is unreliable for `cargo run` and undefined for unit tests.

## Test plan

- [x] `cargo check --features embeddings --tests` — green.
- [x] `cargo check --no-default-features --tests` — green (feature gating works).
- [x] `cargo test --features embeddings` — 219 passed (1 new smoke test logs SKIP and exits ok because resources aren't bundled yet).