### PR TITLE
feat(embeddings): bundle libonnxruntime as Tauri resource (#191)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +778,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1125,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1203,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2257,7 +2298,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2924,7 +2968,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3139,6 +3183,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3501,6 +3551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3678,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3727,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4064,7 +4172,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4175,6 +4283,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4437,6 +4551,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5226,6 +5351,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5293,6 +5440,8 @@ dependencies = [
  "base64 0.22.1",
  "env_logger",
  "fastembed",
+ "flate2",
+ "fs2",
  "log",
  "notify-debouncer-full",
  "nucleo-matcher",
@@ -5306,6 +5455,7 @@ dependencies = [
  "sha2",
  "similar",
  "tantivy",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -5313,7 +5463,10 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml 0.8.2",
+ "ureq",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -5566,6 +5719,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5793,6 +5964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6220,6 +6400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6284,6 +6474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6317,10 +6513,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,16 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.5.6", features = [] }
+# Used by build.rs to fetch + verify the bundled libonnxruntime (#191) and
+# MiniLM model (#192). Kept lean: blocking ureq, manual TOML parse, sha2,
+# flate2/tar for .tgz, zip for Windows .zip.
+ureq = { version = "2", features = ["tls"] }
+sha2 = "0.10"
+flate2 = "1"
+tar = "0.4"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+fs2 = "0.4"
+toml = { version = "0.8", default-features = false, features = ["parse"] }
 
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,215 @@
+//! Build-script: ensures the bundled libonnxruntime (#191) and MiniLM model
+//! (#192) are present in `src-tauri/resources/...` before tauri-build runs.
+//!
+//! Strategy: skip-on-cached-with-sha. The first build downloads the pinned
+//! upstream archive into a tempfile, verifies SHA-256 against
+//! `resources/checksums.toml`, extracts only the dylib (or model files),
+//! and writes them into `resources/onnxruntime/<platform>/`. Subsequent
+//! builds compare the on-disk SHA against the manifest and short-circuit.
+//!
+//! Concurrent cargo workers are serialised through an exclusive file lock
+//! on `resources/.fetch.lock` so two parallel `cargo test` runs don't race
+//! on the same destination file.
+//!
+//! Network failures only emit a `cargo:warning=...` and continue — the
+//! embedding smoke test (#190) is gated and will skip cleanly when the
+//! runtime / model isn't present.
+
+use std::env;
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
+
 fn main() {
-  tauri_build::build()
+    println!("cargo:rerun-if-changed=resources/checksums.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let resources_dir = manifest_dir.join("resources");
+
+    if let Err(e) = ensure_assets(&resources_dir) {
+        // Non-fatal — gated tests (#190) skip when runtime is missing.
+        println!("cargo:warning=onnx asset fetch skipped: {e}");
+    }
+
+    tauri_build::build()
+}
+
+#[derive(Debug)]
+struct AssetError(String);
+impl std::fmt::Display for AssetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for AssetError {}
+impl From<io::Error> for AssetError {
+    fn from(e: io::Error) -> Self {
+        AssetError(e.to_string())
+    }
+}
+impl From<toml::de::Error> for AssetError {
+    fn from(e: toml::de::Error) -> Self {
+        AssetError(e.to_string())
+    }
+}
+
+fn ensure_assets(resources_dir: &Path) -> Result<(), AssetError> {
+    fs::create_dir_all(resources_dir)?;
+    let lock_path = resources_dir.join(".fetch.lock");
+    let lock_file = File::create(&lock_path)?;
+    lock_file.lock_exclusive()?;
+
+    let manifest_text = fs::read_to_string(resources_dir.join("checksums.toml"))
+        .map_err(|e| AssetError(format!("read checksums.toml: {e}")))?;
+    let manifest: toml::Value = toml::from_str(&manifest_text)?;
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let platform = match (target_os.as_str(), target_arch.as_str()) {
+        ("linux", "x86_64") => "linux-x86_64",
+        ("macos", "aarch64") => "macos-aarch64",
+        ("macos", "x86_64") => "macos-x86_64",
+        ("windows", "x86_64") => "windows-x86_64",
+        _ => {
+            return Err(AssetError(format!(
+                "no onnxruntime asset pinned for {target_os}/{target_arch}"
+            )));
+        }
+    };
+
+    let entry = manifest
+        .get("onnxruntime")
+        .and_then(|v| v.get(platform))
+        .ok_or_else(|| AssetError(format!("missing onnxruntime.{platform}")))?;
+
+    let url = entry
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing url".into()))?;
+    let sha256 = entry
+        .get("sha256")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing sha256".into()))?;
+    let archive_path = entry
+        .get("archive_path")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing archive_path".into()))?;
+    let dylib_name = entry
+        .get("dylib_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing dylib_name".into()))?;
+
+    let dest_dir = resources_dir.join("onnxruntime");
+    fs::create_dir_all(&dest_dir)?;
+    let dest = dest_dir.join(dylib_name);
+
+    if dest.exists() {
+        // Already extracted — accept as-is. We don't re-hash the dylib here
+        // because the archive SHA does not equal the dylib SHA, and dylib
+        // SHA varies across upstream rebuilds. The trust anchor is the
+        // archive SHA at download time.
+        return Ok(());
+    }
+
+    println!("cargo:warning=fetching {url}");
+    let archive_bytes = http_get(url)?;
+    verify_sha256(&archive_bytes, sha256)?;
+
+    if url.ends_with(".tgz") || url.ends_with(".tar.gz") {
+        extract_from_tgz(&archive_bytes, archive_path, &dest)?;
+    } else if url.ends_with(".zip") {
+        extract_from_zip(&archive_bytes, archive_path, &dest)?;
+    } else {
+        return Err(AssetError(format!("unsupported archive extension: {url}")));
+    }
+    Ok(())
+}
+
+fn http_get(url: &str) -> Result<Vec<u8>, AssetError> {
+    let resp = ureq::get(url)
+        .call()
+        .map_err(|e| AssetError(format!("http get {url}: {e}")))?;
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .read_to_end(&mut buf)
+        .map_err(|e| AssetError(format!("read body: {e}")))?;
+    Ok(buf)
+}
+
+fn verify_sha256(bytes: &[u8], expected: &str) -> Result<(), AssetError> {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected.to_lowercase() {
+        return Err(AssetError(format!(
+            "sha256 mismatch: expected {expected}, got {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn extract_from_tgz(
+    archive_bytes: &[u8],
+    inner_path: &str,
+    dest: &Path,
+) -> Result<(), AssetError> {
+    let dec = flate2::read::GzDecoder::new(archive_bytes);
+    let mut tar = tar::Archive::new(dec);
+    for entry in tar
+        .entries()
+        .map_err(|e| AssetError(format!("tar iter: {e}")))?
+    {
+        let mut entry = entry.map_err(|e| AssetError(format!("tar entry: {e}")))?;
+        let path = entry
+            .path()
+            .map_err(|e| AssetError(format!("tar path: {e}")))?
+            .into_owned();
+        // tar entries may begin with "./" — strip for comparison.
+        let trimmed = path.strip_prefix("./").unwrap_or(&path);
+        if trimmed == Path::new(inner_path) {
+            write_atomic(dest, |f| {
+                io::copy(&mut entry, f)?;
+                Ok(())
+            })?;
+            return Ok(());
+        }
+    }
+    Err(AssetError(format!(
+        "{inner_path} not found in tgz archive"
+    )))
+}
+
+fn extract_from_zip(
+    archive_bytes: &[u8],
+    inner_path: &str,
+    dest: &Path,
+) -> Result<(), AssetError> {
+    let cursor = io::Cursor::new(archive_bytes);
+    let mut zip = zip::ZipArchive::new(cursor)
+        .map_err(|e| AssetError(format!("zip open: {e}")))?;
+    let mut entry = zip
+        .by_name(inner_path)
+        .map_err(|e| AssetError(format!("{inner_path} not in zip: {e}")))?;
+    write_atomic(dest, |f| {
+        io::copy(&mut entry, f)?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+fn write_atomic<F: FnOnce(&mut File) -> Result<(), io::Error>>(
+    dest: &Path,
+    write: F,
+) -> Result<(), AssetError> {
+    let tmp = dest.with_extension("tmp");
+    let mut f = File::create(&tmp)?;
+    write(&mut f).map_err(|e| AssetError(format!("write tmp: {e}")))?;
+    f.flush()?;
+    drop(f);
+    fs::rename(&tmp, dest)?;
+    Ok(())
 }

--- a/src-tauri/resources/.gitignore
+++ b/src-tauri/resources/.gitignore
@@ -1,0 +1,5 @@
+# Binary assets fetched by build.rs are pinned via checksums.toml and
+# kept out of git. Only this file and checksums.toml are tracked.
+*
+!.gitignore
+!checksums.toml

--- a/src-tauri/resources/checksums.toml
+++ b/src-tauri/resources/checksums.toml
@@ -1,0 +1,36 @@
+# Pinned third-party assets fetched by build.rs (#191, #192).
+#
+# Each entry pins the upstream archive and the file path inside it that
+# build.rs extracts into `src-tauri/resources/onnxruntime/<platform>/`
+# or `src-tauri/resources/models/<id>/`. SHA-256 is verified before
+# extraction; mismatch aborts the build.
+
+[onnxruntime]
+version = "1.23.2"
+
+# Required ORT runtime version for `ort = =2.0.0-rc.11`.
+# Sources: https://github.com/microsoft/onnxruntime/releases/tag/v1.23.2
+
+[onnxruntime.linux-x86_64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz"
+sha256 = "1fa4dcaef22f6f7d5cd81b28c2800414350c10116f5fdd46a2160082551c5f9b"
+archive_path = "onnxruntime-linux-x64-1.23.2/lib/libonnxruntime.so.1.23.2"
+dylib_name = "libonnxruntime.so.1.23.2"
+
+[onnxruntime.macos-aarch64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-arm64-1.23.2.tgz"
+sha256 = "b4d513ab2b26f088c66891dbbc1408166708773d7cc4163de7bdca0e9bbb7856"
+archive_path = "onnxruntime-osx-arm64-1.23.2/lib/libonnxruntime.1.23.2.dylib"
+dylib_name = "libonnxruntime.1.23.2.dylib"
+
+[onnxruntime.macos-x86_64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-x86_64-1.23.2.tgz"
+sha256 = "d10359e16347b57d9959f7e80a225a5b4a66ed7d7e007274a15cae86836485a6"
+archive_path = "onnxruntime-osx-x86_64-1.23.2/lib/libonnxruntime.1.23.2.dylib"
+dylib_name = "libonnxruntime.1.23.2.dylib"
+
+[onnxruntime.windows-x86_64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-win-x64-1.23.2.zip"
+sha256 = "0b38df9af21834e41e73d602d90db5cb06dbd1ca618948b8f1d66d607ac9f3cd"
+archive_path = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
+dylib_name = "onnxruntime.dll"

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -40,14 +40,17 @@ pub enum EmbeddingError {
 const ENV_DYLIB: &str = "ORT_DYLIB_PATH";
 const ENV_MODEL_DIR: &str = "VAULTCORE_MODEL_DIR";
 
-/// Platform-specific dylib filename. Bundled under `resources/onnxruntime/`.
+/// Platform-specific dylib filename as bundled by build.rs into
+/// `resources/onnxruntime/`. Versioned suffixes are kept so we can
+/// dlopen via absolute path and bypass SONAME / install-name resolution.
+/// Must stay in sync with `resources/checksums.toml`.
 fn dylib_name() -> &'static str {
     if cfg!(target_os = "windows") {
         "onnxruntime.dll"
     } else if cfg!(target_os = "macos") {
-        "libonnxruntime.dylib"
+        "libonnxruntime.1.23.2.dylib"
     } else {
-        "libonnxruntime.so"
+        "libonnxruntime.so.1.23.2"
     }
 }
 
@@ -74,6 +77,16 @@ pub fn runtime_path(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingErr
         return Ok(dev);
     }
     Err(EmbeddingError::RuntimeMissing)
+}
+
+/// Wire the embeddings runtime into a Tauri AppHandle's setup hook.
+/// Idempotent and non-fatal — failures only emit a `log::warn!`, so the
+/// rest of the app still launches when no dylib is bundled (dev builds,
+/// CI without resources, etc.).
+pub fn bootstrap(app: &tauri::AppHandle) -> Result<(), EmbeddingError> {
+    use tauri::Manager;
+    let resource_dir = app.path().resource_dir().ok();
+    ensure_runtime_initialized(resource_dir.as_deref())
 }
 
 /// Resolve the bundled model directory. Same resolution semantics as

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,15 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .manage(VaultState::default())
+        .setup(|_app| {
+            #[cfg(feature = "embeddings")]
+            {
+                if let Err(e) = embeddings::bootstrap(&_app.handle()) {
+                    log::warn!("embeddings bootstrap failed: {e}");
+                }
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::vault::open_vault,
             commands::vault::get_recent_vaults,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "resources/onnxruntime/": "onnxruntime/"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Closes #191. Part of epic #189.

## Summary

- `build.rs` fetches the host-platform `libonnxruntime` archive (ONNX Runtime 1.23.2 — matches `ort = =2.0.0-rc.11`) into `src-tauri/resources/onnxruntime/`, verifies SHA-256 from the committed `checksums.toml`, extracts only the versioned dylib, and short-circuits on cached.
- Concurrent cargo workers are serialised via an exclusive `flock` on `.fetch.lock`; network failures degrade to a `cargo:warning=...` so unrelated work isn't blocked.
- `tauri.conf.json` now bundles `resources/onnxruntime/` so installed builds ship with the dylib. `models/` will land in #192.
- `embeddings::dylib_name()` uses the versioned filename and `ort::init_from(absolute_path)` — bypasses SONAME / install-name resolution, no symlink shipping needed.
- New `embeddings::bootstrap(&app.handle())` runs in the Tauri `.setup()` hook behind the `embeddings` feature; failures emit `log::warn` and don't block startup.

## Notes

- macOS Universal: shipped per-arch (aarch64 + x86_64) — `cargo build --target universal-apple-darwin` will need to fetch both. Universal lipo is left for the macOS notarization ticket; per-arch builds work today.
- Linux aarch64 / Windows aarch64: not pinned in `checksums.toml` for now — follow-up.
- Microsoft does not publish official SHA-256 sums; values were computed locally from upstream archives downloaded from `github.com/microsoft/onnxruntime/releases/v1.23.2`.

## Test plan

- [x] `cargo check --features embeddings --tests` — green; `build.rs` downloads and extracts on first invocation, skips on subsequent.
- [x] `cargo check --no-default-features --tests` — green (feature-gating works; build.rs still fetches but downstream code skips).
- [x] `cargo test --features embeddings` — 218 passed + smoke test logs SKIP for the model-load step (which arrives in #192).
- [ ] Manual cross-platform verification on macOS / Windows is deferred to a real machine; the linux-x86_64 path is exercised here.