### PR TITLE
feat(embeddings): bundle MiniLM-L6-v2 INT8 ONNX model (#192)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -76,49 +76,41 @@ fn ensure_assets(resources_dir: &Path) -> Result<(), AssetError> {
         ("windows", "x86_64") => "windows-x86_64",
         _ => {
             return Err(AssetError(format!(
-                "no onnxruntime asset pinned for {target_os}/{target_arch}"
+                "no asset pinned for {target_os}/{target_arch}"
             )));
         }
     };
 
+    ensure_onnxruntime(&manifest, resources_dir, platform)?;
+    ensure_model(&manifest, resources_dir, platform)?;
+    Ok(())
+}
+
+fn ensure_onnxruntime(
+    manifest: &toml::Value,
+    resources_dir: &Path,
+    platform: &str,
+) -> Result<(), AssetError> {
     let entry = manifest
         .get("onnxruntime")
         .and_then(|v| v.get(platform))
         .ok_or_else(|| AssetError(format!("missing onnxruntime.{platform}")))?;
 
-    let url = entry
-        .get("url")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing url".into()))?;
-    let sha256 = entry
-        .get("sha256")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing sha256".into()))?;
-    let archive_path = entry
-        .get("archive_path")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing archive_path".into()))?;
-    let dylib_name = entry
-        .get("dylib_name")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing dylib_name".into()))?;
+    let url = required_str(entry, "url")?;
+    let sha256 = required_str(entry, "sha256")?;
+    let archive_path = required_str(entry, "archive_path")?;
+    let dylib_name = required_str(entry, "dylib_name")?;
 
     let dest_dir = resources_dir.join("onnxruntime");
     fs::create_dir_all(&dest_dir)?;
     let dest = dest_dir.join(dylib_name);
-
     if dest.exists() {
-        // Already extracted — accept as-is. We don't re-hash the dylib here
-        // because the archive SHA does not equal the dylib SHA, and dylib
-        // SHA varies across upstream rebuilds. The trust anchor is the
-        // archive SHA at download time.
         return Ok(());
     }
 
     println!("cargo:warning=fetching {url}");
     let archive_bytes = http_get(url)?;
     verify_sha256(&archive_bytes, sha256)?;
-
     if url.ends_with(".tgz") || url.ends_with(".tar.gz") {
         extract_from_tgz(&archive_bytes, archive_path, &dest)?;
     } else if url.ends_with(".zip") {
@@ -128,6 +120,80 @@ fn ensure_assets(resources_dir: &Path) -> Result<(), AssetError> {
     }
     Ok(())
 }
+
+fn ensure_model(
+    manifest: &toml::Value,
+    resources_dir: &Path,
+    platform: &str,
+) -> Result<(), AssetError> {
+    let model_block = match manifest.get("model") {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let id = required_str(model_block, "id")?;
+    let dest_dir = resources_dir.join("models").join(id);
+    fs::create_dir_all(&dest_dir)?;
+
+    // Per-arch ONNX file (renamed to model.onnx so embeddings code stays
+    // architecture-agnostic).
+    let arch_entry = model_block
+        .get(platform)
+        .ok_or_else(|| AssetError(format!("missing model.{platform}")))?;
+    fetch_one_file(arch_entry, &dest_dir)?;
+
+    // Architecture-shared tokenizer + config files.
+    if let Some(shared) = model_block.get("shared").and_then(|v| v.as_table()) {
+        for entry in shared.values() {
+            fetch_one_file(entry, &dest_dir)?;
+        }
+    }
+
+    // Bundle Apache-2.0 LICENSE + NOTICE next to the model files. Both are
+    // required to satisfy the upstream Apache-2.0 attribution clause.
+    write_if_missing(&dest_dir.join("LICENSE"), APACHE_2_0_LICENSE)?;
+    write_if_missing(&dest_dir.join("NOTICE"), MODEL_NOTICE)?;
+    Ok(())
+}
+
+fn fetch_one_file(entry: &toml::Value, dest_dir: &Path) -> Result<(), AssetError> {
+    let url = required_str(entry, "url")?;
+    let sha256 = required_str(entry, "sha256")?;
+    let dest_name = required_str(entry, "dest_name")?;
+    let dest = dest_dir.join(dest_name);
+    if dest.exists() {
+        return Ok(());
+    }
+    println!("cargo:warning=fetching {url}");
+    let bytes = http_get(url)?;
+    verify_sha256(&bytes, sha256)?;
+    write_atomic(&dest, |f| f.write_all(&bytes))?;
+    Ok(())
+}
+
+fn required_str<'a>(v: &'a toml::Value, key: &str) -> Result<&'a str, AssetError> {
+    v.get(key)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError(format!("missing field: {key}")))
+}
+
+fn write_if_missing(path: &Path, contents: &str) -> Result<(), AssetError> {
+    if path.exists() {
+        return Ok(());
+    }
+    write_atomic(path, |f| f.write_all(contents.as_bytes()))
+}
+
+const MODEL_NOTICE: &str = "all-MiniLM-L6-v2 (sentence-transformers)\n\
+Copyright sentence-transformers contributors\n\
+Licensed under the Apache License, Version 2.0.\n\
+\n\
+Source: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2\n\
+\n\
+This product bundles the architecture-specific INT8 / UINT8 ONNX export\n\
+of the model (`model_quint8_avx2.onnx` for x86_64,\n`model_qint8_arm64.onnx`\n\
+for aarch64). The original model card and license live upstream.\n";
+
+const APACHE_2_0_LICENSE: &str = include_str!("resources/LICENSE-APACHE-2.0");
 
 fn http_get(url: &str) -> Result<Vec<u8>, AssetError> {
     let resp = ureq::get(url)

--- a/src-tauri/resources/.gitignore
+++ b/src-tauri/resources/.gitignore
@@ -1,5 +1,8 @@
 # Binary assets fetched by build.rs are pinned via checksums.toml and
-# kept out of git. Only this file and checksums.toml are tracked.
+# kept out of git. Only this file, checksums.toml, and the upstream
+# Apache-2.0 LICENSE template (used by build.rs to populate model
+# resource directories) are tracked.
 *
 !.gitignore
 !checksums.toml
+!LICENSE-APACHE-2.0

--- a/src-tauri/resources/LICENSE-APACHE-2.0
+++ b/src-tauri/resources/LICENSE-APACHE-2.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src-tauri/resources/checksums.toml
+++ b/src-tauri/resources/checksums.toml
@@ -34,3 +34,52 @@ url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxru
 sha256 = "0b38df9af21834e41e73d602d90db5cb06dbd1ca618948b8f1d66d607ac9f3cd"
 archive_path = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
 dylib_name = "onnxruntime.dll"
+
+# MiniLM-L6-v2 INT8 ONNX, Apache-2.0 (sentence-transformers).
+# Sources: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+#
+# The ONNX file is per CPU-architecture because the upstream Optimum exports
+# bake architecture-specific quantization kernels into the model graph
+# (avx2 / avx512 / arm64). Tokenizer + config files are architecture-agnostic.
+[model]
+id = "all-MiniLM-L6-v2-int8"
+
+[model.shared.tokenizer_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
+sha256 = "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037"
+dest_name = "tokenizer.json"
+
+[model.shared.config_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json"
+sha256 = "953f9c0d463486b10a6871cc2fd59f223b2c70184f49815e7efbcab5d8908b41"
+dest_name = "config.json"
+
+[model.shared.tokenizer_config_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer_config.json"
+sha256 = "acb92769e8195aabd29b7b2137a9e6d6e25c476a4f15aa4355c233426c61576b"
+dest_name = "tokenizer_config.json"
+
+[model.shared.special_tokens_map_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/special_tokens_map.json"
+sha256 = "303df45a03609e4ead04bc3dc1536d0ab19b5358db685b6f3da123d05ec200e3"
+dest_name = "special_tokens_map.json"
+
+[model.linux-x86_64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
+sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+dest_name = "model.onnx"
+
+[model.macos-x86_64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
+sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+dest_name = "model.onnx"
+
+[model.macos-aarch64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx"
+sha256 = "4278337fd0ff3c68bfb6291042cad8ab363e1d9fbc43dcb499fe91c871902474"
+dest_name = "model.onnx"
+
+[model.windows-x86_64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
+sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+dest_name = "model.onnx"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,8 @@
     "active": true,
     "targets": "all",
     "resources": {
-      "resources/onnxruntime/": "onnxruntime/"
+      "resources/onnxruntime/": "onnxruntime/",
+      "resources/models/": "models/"
     },
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
Closes #192. Part of epic #189.

## Summary

- `checksums.toml` adds a per-architecture ONNX model entry (`model_quint8_avx2.onnx` for x86_64, `model_qint8_arm64.onnx` for aarch64) plus the architecture-shared tokenizer/config files. Each pinned by SHA-256.
- `build.rs::ensure_model()` downloads the host-arch ONNX file, renames it to `model.onnx` so backend code stays platform-agnostic, fetches the shared tokenizer files, and writes Apache-2.0 LICENSE + NOTICE next to the model so installed builds carry the upstream attribution.
- `tauri.conf.json` re-enables `resources/models/` so the model bundles into installer artefacts.
- The smoke test from #190 now exercises the full path end-to-end (load runtime → load model → embed → assert 384-dim L2-normalised vector). Verified locally on linux-x86_64.

## Acceptance criteria — installer size

- `model.onnx` (avx2 x86_64): ~22 MB
- `tokenizer.json + config.json + tokenizer_config.json + special_tokens_map.json`: ~0.5 MB
- `LICENSE + NOTICE`: ~12 KB

Raw model assets total ~22.5 MB; combined with the 22 MB libonnxruntime from #191 the raw resource block is ~44 MB. After AppImage / DMG / MSI compression (typical 50–60 % gzip ratio for binary + text) the installer size delta lands around 22–26 MB, within the **≤ 30 MB** target. **macOS Universal builds** that bundle both arm64 and x86_64 ONNX would breach the cap (≈ 45 MB compressed); deferred to the macOS notarization ticket.

## Risks

- The shared tokenizer files are fetched from the upstream repo without a pinned revision (HuggingFace doesn't expose immutable per-file commits via the resolver URL). SHA-256 still gates contents — a silent upstream change would just fail the build.
- Apache-2.0 §4(d) requires the LICENSE + NOTICE to ship in *one* of (source, docs, app UI). Shipping them as resource files alongside the model satisfies this; an "About → Third-party licenses" UI panel can land later.

## Test plan

- [x] `cargo check --features embeddings --tests` — green; build.rs fetches model + tokenizer on first invoke.
- [x] `cargo test --features embeddings tests::embeddings::embedding_smoke_test` — green (full embed path).
- [x] `cargo test --features embeddings` — full suite green, no regressions.
- [ ] `cargo tauri build` size validation deferred to the macOS notarization ticket.