### PR TITLE
feat(embeddings): EmbeddingService for text → 384-d vectors (#194)

### DIFF
--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -23,6 +23,11 @@
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+#[cfg(feature = "embeddings")]
+mod service;
+#[cfg(feature = "embeddings")]
+pub use service::EmbeddingService;
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -1,0 +1,135 @@
+//! `EmbeddingService` (#194) — single-instance, thread-safe text → 384-d
+//! vector pipeline used by every backend caller (embed-on-save, reindex,
+//! query). The model is loaded once via fastembed and held behind a Mutex
+//! that serialises inference calls. fastembed's `TextEmbedding` is not
+//! `Sync` (it owns an `ort::Session` with interior mutability), so the
+//! Mutex wrap is required to satisfy `Send + Sync`.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use fastembed::{
+    InitOptionsUserDefined, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel,
+};
+
+use super::{ensure_runtime_initialized, model_dir, EmbeddingError};
+
+/// Bundled-model embedding pipeline. Construct once per process via
+/// `EmbeddingService::load`, then share the resulting `Arc` everywhere.
+pub struct EmbeddingService {
+    inner: Mutex<TextEmbedding>,
+}
+
+impl EmbeddingService {
+    /// Load the bundled MiniLM model. Wraps the ORT runtime initialisation
+    /// so it is safe to call before or after `embeddings::bootstrap`.
+    pub fn load(resource_dir: Option<&Path>) -> Result<Arc<Self>, EmbeddingError> {
+        ensure_runtime_initialized(resource_dir)?;
+        let dir = model_dir(resource_dir)?;
+        let read = |name: &str| std::fs::read(dir.join(name));
+        let model = UserDefinedEmbeddingModel::new(
+            read("model.onnx")?,
+            TokenizerFiles {
+                tokenizer_file: read("tokenizer.json")?,
+                config_file: read("config.json")?,
+                special_tokens_map_file: read("special_tokens_map.json")?,
+                tokenizer_config_file: read("tokenizer_config.json")?,
+            },
+        );
+        let embedder = TextEmbedding::try_new_from_user_defined(
+            model,
+            InitOptionsUserDefined::default(),
+        )
+        .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
+        Ok(Arc::new(Self {
+            inner: Mutex::new(embedder),
+        }))
+    }
+
+    /// Embed a single string. Returns a 384-dim L2-normalised vector.
+    pub fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        let mut batch = self.embed_batch(&[text])?;
+        batch.pop().ok_or_else(|| {
+            EmbeddingError::Fastembed("empty embedding batch".into())
+        })
+    }
+
+    /// Embed a batch of strings in one inference pass.
+    pub fn embed_batch(
+        &self,
+        texts: &[&str],
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| EmbeddingError::Fastembed("mutex poisoned".into()))?;
+        let owned: Vec<String> = texts.iter().map(|s| s.to_string()).collect();
+        guard
+            .embed(owned, None)
+            .map_err(|e| EmbeddingError::Fastembed(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: skip when the bundled assets aren't present yet (e.g. on a
+    /// fresh checkout where `cargo build` hasn't run).
+    fn try_load() -> Option<Arc<EmbeddingService>> {
+        EmbeddingService::load(None).ok()
+    }
+
+    #[test]
+    fn embed_returns_384_l2_normalised_vector() {
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let v = svc.embed("hello world").unwrap();
+        assert_eq!(v.len(), 384);
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 0.01, "L2 norm: {norm}");
+    }
+
+    #[test]
+    fn batch_matches_per_item() {
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let single = svc.embed("the quick brown fox").unwrap();
+        let batch = svc.embed_batch(&["the quick brown fox"]).unwrap();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0], single);
+    }
+
+    #[test]
+    fn semantically_close_strings_have_high_cosine_similarity() {
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let a = svc.embed("how do cats communicate").unwrap();
+        let b = svc.embed("feline body language").unwrap();
+        let c = svc.embed("rust async runtime internals").unwrap();
+        let cos = |x: &[f32], y: &[f32]| -> f32 {
+            x.iter().zip(y).map(|(a, b)| a * b).sum()
+        };
+        let close = cos(&a, &b);
+        let far = cos(&a, &c);
+        assert!(
+            close > far + 0.1,
+            "expected close > far + 0.1, got close={close}, far={far}"
+        );
+    }
+
+    #[test]
+    fn service_is_send_and_sync() {
+        // Compile-time assertion — if this changes, callers in tokio
+        // workers (#196) and rayon (#198) would break.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<EmbeddingService>();
+        assert_send_sync::<Arc<EmbeddingService>>();
+    }
+}


### PR DESCRIPTION
Closes #194.

## Summary
- New `EmbeddingService` wrapping fastembed's `TextEmbedding` behind a `Mutex`, exposed via `Arc` so a single model instance is shared across embed-on-save (#196), reindex (#201), and query (#202) callers.
- `load(resource_dir)` reuses the existing `ensure_runtime_initialized` + `model_dir` path-resolution from #191/#192, so dev and bundled-app paths both work.
- `embed(text) -> Vec<f32>` and `embed_batch(texts) -> Vec<Vec<f32>>` for single + batched inference.

## Why a `Mutex`
fastembed's `TextEmbedding` owns an `ort::Session` with interior mutability and isn't `Sync`. Wrapping it serialises inference calls, which is fine for v1 — ORT itself is single-threaded per session unless we pin a dedicated threadpool (#197/#205). A compile-time `assert_send_sync::<EmbeddingService>()` test guards against accidental regressions that would break `tokio` (#196) or `rayon` (#198) callers.

## Test plan
- [x] `cargo test --features embeddings --lib embeddings::service` — 4/4 pass locally
  - 384-dim vector with L2 norm ≈ 1.0
  - batch/single embedding parity
  - semantic locality: close > far cosine + 0.1 (cats vs. feline body language vs. rust async runtime)
  - `Send + Sync` compile-time assertion
- [x] full Rust suite green (`cargo test --features embeddings`): 222 passed, 0 failed
- [x] tests skip cleanly when the bundled model isn't present (fresh-checkout / CI-without-resources path)