### PR TITLE
feat(embeddings): cap ORT thread pool at intra=2/inter=1 (#197)

### DIFF
--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -152,14 +152,36 @@ pub fn ensure_runtime_initialized(
         };
         #[cfg(feature = "embeddings")]
         {
+            use ort::environment::GlobalThreadPoolOptions;
             let builder = match ort::init_from(path.to_string_lossy().into_owned()) {
                 Ok(b) => b,
                 Err(e) => return Err(format!("ort::init_from failed: {e}")),
             };
+            // #197: cap ORT inference at 2 intra-op + 1 inter-op threads
+            // and route through a dedicated ORT-managed pool. Once the
+            // env owns a global thread pool, fastembed's per-session
+            // `with_intra_threads(available_parallelism())` is silently
+            // overridden (`DisablePerSessionThreads` runs in the session
+            // commit path), so we get the cap without patching fastembed.
+            // The cap keeps embed-on-save from contending with Tantivy's
+            // rayon pool for cores under bulk-save bursts.
+            let pool_opts = match GlobalThreadPoolOptions::default()
+                .with_intra_threads(2)
+                .and_then(|o| o.with_inter_threads(1))
+            {
+                Ok(o) => o,
+                Err(e) => return Err(format!("ORT thread-pool config failed: {e}")),
+            };
+            let builder = builder.with_global_thread_pool(pool_opts);
             // `commit` returns `false` if a global environment already exists.
             // That is not a hard error for us (idempotent init across tests
-            // and Tauri setup callbacks), so we don't fail the OnceLock.
-            let _ = builder.commit();
+            // and Tauri setup callbacks), so we don't fail the OnceLock —
+            // the cached config still applies for the env that did win.
+            if !builder.commit() {
+                log::warn!(
+                    "ORT environment already committed; #197 thread-pool caps may not apply"
+                );
+            }
             Ok(())
         }
         #[cfg(not(feature = "embeddings"))]

--- a/src-tauri/src/tests/files.rs
+++ b/src-tauri/src/tests/files.rs
@@ -214,6 +214,66 @@ fn embed_hook_does_not_regress_save_rtt() {
     });
 }
 
+/// AC for #197 ("Bulk-Write-Stresstest, 100 Saves in 10 s, no p99
+/// keystroke-latency regression"). Spreads 100 saves over ~10 s with a
+/// **real** EmbeddingService so the ORT thread-pool cap (`intra=2,
+/// inter=1`) is genuinely exercised under sustained inference load. The
+/// assertion is a comfortable absolute p99 bound rather than a delta —
+/// 50 ms is well below the spec's 100 ms "open note" budget and gives
+/// CI noise plenty of headroom while still tripping on a real
+/// regression (e.g. fastembed defaulting back to per-session unbounded
+/// threads).
+///
+/// `#[ignore]` because real ML inference is slow and CPU-heavy — opt
+/// into it explicitly with `cargo test -- --ignored`.
+#[cfg(feature = "embeddings")]
+#[test]
+#[ignore]
+fn save_rtt_p99_under_bulk_embed_pressure() {
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    tokio_test_block_on(async {
+        let Some(svc) = crate::embeddings::EmbeddingService::load(None).ok() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let Some(chk) = crate::embeddings::Chunker::load(None).ok() else {
+            eprintln!("SKIP: tokenizer not bundled");
+            return;
+        };
+        let dir = tempdir().unwrap();
+        let state = state_with_vault(dir.path());
+        {
+            let sink: Arc<dyn crate::embeddings::VectorSink> =
+                Arc::new(crate::embeddings::NoopSink);
+            let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
+            *state.embed_coordinator.lock().unwrap() = Some(coord);
+        }
+
+        const N: usize = 100;
+        const TOTAL: Duration = Duration::from_secs(10);
+        let inter_save = TOTAL / N as u32;
+        let mut samples = Vec::with_capacity(N);
+        for i in 0..N {
+            let path = dir.path().join(format!("bulk-{i}.md"));
+            let body = format!("bulk save {i}\n").repeat(40);
+            let t0 = Instant::now();
+            write_file_impl(&state, path.to_string_lossy().into_owned(), body)
+                .await
+                .unwrap();
+            samples.push(t0.elapsed());
+            tokio::time::sleep(inter_save).await;
+        }
+        samples.sort();
+        let p99 = samples[(N as f64 * 0.99) as usize - 1];
+        assert!(
+            p99 < Duration::from_millis(50),
+            "save RTT p99 = {p99:?} exceeded 50 ms budget under sustained embed pressure",
+        );
+    });
+}
+
 // --- _impl helpers: mirror the tauri::command bodies ---------------------
 //
 // Keep these byte-for-byte logically identical to commands/files.rs.


### PR DESCRIPTION
Closes #197.

## Summary
- Wires `EnvironmentBuilder::with_global_thread_pool(GlobalThreadPoolOptions::default().with_intra_threads(2).with_inter_threads(1))` into `ensure_runtime_initialized`. Once the env owns a global thread pool, ORT's session commit path runs `DisablePerSessionThreads`, which silently overrides fastembed's `with_intra_threads(available_parallelism())` — no fastembed patching needed.
- Keeps embed-on-save inference from contending with Tantivy's rayon pool for cores under bulk-save bursts (the keystroke-jank regression flagged by #188 research).

## AC mapping
- [x] **\`intra_op_num_threads = 2, inter_op_num_threads = 1\`** — `with_intra_threads(2)`, `with_inter_threads(1)` in `embeddings/mod.rs::ensure_runtime_initialized`.
- [x] **Thread-Pool getrennt von Tantivys Rayon-Pool** — ORT now owns a dedicated managed pool (separate from rayon) and the cap prevents core contention.
- [x] **Bulk-Write-Stresstest (100 Saves in 10 s) zeigt keine p99-Keystroke-Latency-Regression** — new `save_rtt_p99_under_bulk_embed_pressure` test asserts p99 < 50 ms (well under the 100 ms note-open spec budget). Verified locally: passed in 10.5 s.

## Test plan
- [x] `cargo test --features embeddings` — 244 passed, 0 failed, 4 ignored
- [x] `cargo test --features embeddings -- --ignored save_rtt_p99_under_bulk_embed_pressure` — passed