### PR TITLE
feat(embeddings): persist HNSW index with mmap reload + corruption recovery (#199)

### DIFF
--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -13,14 +13,19 @@
 //! safely share `Arc<VectorIndex>` between the embed worker (writes)
 //! and the query IPC handlers (reads).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 // Use DistDot (not DistCosine): both give the same ranking on L2-normalised
 // vectors, but only DistDot has the AVX2/SSE2 SIMD path in anndists. The
 // distance values are mathematically identical (1 - dot product) for unit
 // inputs, which `EmbeddingService` always produces (#194).
+use hnsw_rs::api::AnnT;
+use hnsw_rs::hnswio::{HnswIo, ReloadOptions};
 use hnsw_rs::prelude::{DistDot, Hnsw};
+use serde::{Deserialize, Serialize};
+
+use super::EmbeddingError;
 
 /// Embedding dimensionality — locked by `EmbeddingService` (MiniLM-L6-v2).
 pub const DIM: usize = 384;
@@ -32,6 +37,36 @@ const EF_CONSTRUCTION: usize = 200;
 const NB_LAYER: usize = 16; // hard cap; the graph picks its own per insert
 /// Default `ef_search` — quality/latency knob exposed per query.
 pub const DEFAULT_EF_SEARCH: usize = 64;
+
+/// Filename stem used by `Hnsw::file_dump` — emits `<DUMP_BASENAME>.hnsw.graph`
+/// and `<DUMP_BASENAME>.hnsw.data` next to a sibling `<DUMP_MAPPING>` file.
+const DUMP_BASENAME: &str = "vectors";
+const DUMP_MAPPING: &str = "vectors.mapping.json";
+
+#[derive(Serialize, Deserialize)]
+struct MappingFile {
+    /// Bumped if the on-disk layout changes incompatibly.
+    version: u32,
+    entries: Vec<(PathBuf, usize)>,
+}
+
+const MAPPING_VERSION: u32 = 1;
+
+/// Magic bytes hnsw_rs writes at the start of the data file (`MAGICDATAP`)
+/// and the graph file (`MAGICDESCR_*`). We re-check them before delegating
+/// to `load_hnsw_with_dist` because that function panics via `assert_eq!`
+/// on a bad data-file magic — a corrupt dump must surface as a recoverable
+/// `Err` so `load_or_empty` can rebuild from embeddings (#199 AC #3).
+const MAGIC_DATA: u32 = 0xa67f_0000;
+const MAGIC_DESCR_VALID: [u32; 3] = [0x002a_677f, 0x002a_6771, 0x002a_6779];
+
+fn read_u32_ne(path: &Path) -> std::io::Result<u32> {
+    use std::io::Read;
+    let mut f = std::fs::File::open(path)?;
+    let mut buf = [0u8; 4];
+    f.read_exact(&mut buf)?;
+    Ok(u32::from_ne_bytes(buf))
+}
 
 /// In-memory HNSW vector index. Construct via `VectorIndex::new`,
 /// `insert(path, chunk_idx, vec)` to add, `query(vec, k)` to retrieve.
@@ -146,6 +181,111 @@ impl VectorIndex {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Persist the index to `dir` (created if missing). Writes three files:
+    /// `vectors.hnsw.graph`, `vectors.hnsw.data`, `vectors.mapping.json`.
+    /// Mapping is written atomically (tmp + rename); the hnsw_rs dump is not
+    /// atomic but `load_or_empty` rebuilds on read failure (#199 AC #3).
+    pub fn save(&self, dir: &Path) -> Result<(), EmbeddingError> {
+        std::fs::create_dir_all(dir)?;
+        self.hnsw
+            .file_dump(dir, DUMP_BASENAME)
+            .map_err(|e| EmbeddingError::Io(std::io::Error::other(format!(
+                "hnsw file_dump failed: {e}"
+            ))))?;
+        let m = self.mapping.read().expect("mapping lock");
+        let payload = MappingFile {
+            version: MAPPING_VERSION,
+            entries: m.clone(),
+        };
+        let json = serde_json::to_vec(&payload).map_err(|e| {
+            EmbeddingError::Io(std::io::Error::other(format!("mapping serialize: {e}")))
+        })?;
+        let final_path = dir.join(DUMP_MAPPING);
+        let tmp_path = dir.join(format!("{DUMP_MAPPING}.tmp"));
+        std::fs::write(&tmp_path, &json)?;
+        std::fs::rename(&tmp_path, &final_path)?;
+        Ok(())
+    }
+
+    /// Reload a previously dumped index from `dir`. Returns
+    /// `Err(EmbeddingError::Io)` if any of the three files are missing or
+    /// the dump is corrupt — callers should prefer `load_or_empty`.
+    ///
+    /// # mmap + lifetime
+    ///
+    /// `hnsw_rs::HnswIo::load_hnsw` returns `Hnsw<'b, ..>` constrained by
+    /// the `&'a mut self` it was called on (`'a: 'b`). With mmap enabled
+    /// the returned `Hnsw` holds borrowed slices into the `DataMap` owned
+    /// by `HnswIo`, so the two structs must share a lifetime. To keep
+    /// `VectorIndex.hnsw: Hnsw<'static, ..>` we `Box::leak` the `HnswIo`,
+    /// which is sound because there is at most one live `VectorIndex` per
+    /// app session (vault re-open creates a fresh process state in #201)
+    /// and `HnswIo` is a tiny struct holding the directory path and the
+    /// `DataMap`.
+    pub fn load(dir: &Path) -> Result<Self, EmbeddingError> {
+        let mapping_path = dir.join(DUMP_MAPPING);
+        let mapping_bytes = std::fs::read(&mapping_path)?;
+        let mapping: MappingFile = serde_json::from_slice(&mapping_bytes).map_err(|e| {
+            EmbeddingError::Io(std::io::Error::other(format!("mapping parse: {e}")))
+        })?;
+        if mapping.version != MAPPING_VERSION {
+            return Err(EmbeddingError::Io(std::io::Error::other(format!(
+                "mapping version mismatch: got {}, want {}",
+                mapping.version, MAPPING_VERSION
+            ))));
+        }
+
+        // Preflight magic-byte check on both dump files. hnsw_rs panics
+        // (assert_eq!) on a bad data-file magic, so without this the
+        // recovery path in `load_or_empty` would crash the app instead of
+        // rebuilding (#199 AC #3).
+        let graph_path = dir.join(format!("{DUMP_BASENAME}.hnsw.graph"));
+        let data_path = dir.join(format!("{DUMP_BASENAME}.hnsw.data"));
+        let graph_magic = read_u32_ne(&graph_path)?;
+        let data_magic = read_u32_ne(&data_path)?;
+        if !MAGIC_DESCR_VALID.contains(&graph_magic) {
+            return Err(EmbeddingError::Io(std::io::Error::other(format!(
+                "bad graph-file magic: 0x{graph_magic:08x}"
+            ))));
+        }
+        if data_magic != MAGIC_DATA {
+            return Err(EmbeddingError::Io(std::io::Error::other(format!(
+                "bad data-file magic: 0x{data_magic:08x}"
+            ))));
+        }
+
+        let io: &'static mut HnswIo = Box::leak(Box::new(HnswIo::new_with_options(
+            dir,
+            DUMP_BASENAME,
+            ReloadOptions::new(true),
+        )));
+        let hnsw: Hnsw<'static, f32, DistDot> = io.load_hnsw().map_err(|e| {
+            EmbeddingError::Io(std::io::Error::other(format!("hnsw load: {e}")))
+        })?;
+
+        Ok(Self {
+            hnsw,
+            mapping: RwLock::new(mapping.entries),
+        })
+    }
+
+    /// Try to `load(dir)`. On any failure (missing files, corruption, dim
+    /// mismatch) log a warning and return a fresh empty index sized to
+    /// `capacity_hint`. This is the recovery path the embed coordinator
+    /// uses on startup — invariant per AC #3 (Corruption-Handling: Bei
+    /// ungültigem Dump Rebuild aus Embeddings).
+    pub fn load_or_empty(dir: &Path, capacity_hint: usize) -> Self {
+        match Self::load(dir) {
+            Ok(idx) => idx,
+            Err(e) => {
+                log::warn!(
+                    "VectorIndex::load_or_empty: rebuilding empty index ({e})"
+                );
+                Self::new(capacity_hint)
+            }
+        }
     }
 }
 
@@ -329,6 +469,123 @@ mod tests {
         assert!(
             p50 < Duration::from_millis(1),
             "query p50 too slow: {p50:?}",
+        );
+    }
+
+    // ---- #199: persistence ---------------------------------------------------
+
+    #[test]
+    fn save_and_load_roundtrip_preserves_query_results() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(32);
+        for i in 0..32u64 {
+            idx.insert(PathBuf::from(format!("notes/{i}.md")), (i % 4) as usize, &unit_vec(i));
+        }
+        let probe = unit_vec(7);
+        let before = idx.query_with_paths(&probe, 5);
+
+        idx.save(tmp.path()).expect("save");
+        // Confirm the dump emitted the three expected files.
+        for f in ["vectors.hnsw.graph", "vectors.hnsw.data", "vectors.mapping.json"] {
+            assert!(
+                tmp.path().join(f).exists(),
+                "missing dump file {f}",
+            );
+        }
+
+        let loaded = VectorIndex::load(tmp.path()).expect("load");
+        assert_eq!(loaded.len(), idx.len());
+        let after = loaded.query_with_paths(&probe, 5);
+        assert_eq!(before.len(), after.len());
+        // Same id mapping → same (path, chunk) for identical ranks.
+        for (b, a) in before.iter().zip(after.iter()) {
+            assert_eq!(b.0, a.0, "path mismatch after reload");
+            assert_eq!(b.1, a.1, "chunk index mismatch after reload");
+            assert!((b.2 - a.2).abs() < 1e-5, "distance drift: {} vs {}", b.2, a.2);
+        }
+    }
+
+    #[test]
+    fn load_or_empty_returns_fresh_when_dir_is_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::load_or_empty(tmp.path(), 8);
+        assert!(idx.is_empty());
+        // Brand-new index must still be usable.
+        idx.insert(PathBuf::from("a.md"), 0, &unit_vec(1));
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn load_or_empty_recovers_from_corrupted_data_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(16);
+        for i in 0..16u64 {
+            idx.insert(PathBuf::from(format!("v-{i}.md")), 0, &unit_vec(i));
+        }
+        idx.save(tmp.path()).expect("save");
+
+        // Truncate the data file to simulate on-disk corruption (#199 AC #3).
+        let data_path = tmp.path().join("vectors.hnsw.data");
+        std::fs::write(&data_path, b"garbage").expect("truncate");
+
+        let recovered = VectorIndex::load_or_empty(tmp.path(), 16);
+        assert!(recovered.is_empty(), "expected empty index after corrupt load");
+        recovered.insert(PathBuf::from("after.md"), 0, &unit_vec(99));
+        assert_eq!(recovered.len(), 1);
+    }
+
+    #[test]
+    fn load_rejects_mismatched_mapping_version() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(4);
+        idx.insert(PathBuf::from("x.md"), 0, &unit_vec(1));
+        idx.save(tmp.path()).expect("save");
+
+        // Hand-write a mapping file with an unsupported version.
+        std::fs::write(
+            tmp.path().join("vectors.mapping.json"),
+            br#"{"version":99,"entries":[]}"#,
+        )
+        .expect("rewrite mapping");
+        match VectorIndex::load(tmp.path()) {
+            Ok(_) => panic!("expected version mismatch error"),
+            Err(e) => assert!(
+                format!("{e}").contains("version"),
+                "expected version error, got: {e}",
+            ),
+        }
+    }
+
+    /// AC #4 — load at 100k scale. Spec target is <100 ms but the
+    /// `hnsw_rs` 0.3.4 format parses every point's graph data (neighbour
+    /// lists per layer) serially during `load_hnsw`, even with mmap
+    /// enabled — mmap only defers reading the data-file vectors. On a
+    /// reference dev box (Ryzen 7, NVMe) this lands around 600–800 ms;
+    /// the regression bar here is set to 1500 ms. Squeezing further
+    /// toward the spec target would mean either a custom on-disk format
+    /// or upstream work in `hnsw_rs`, both tracked as follow-ups under
+    /// #207 (benchmark harness drives the call).
+    #[test]
+    #[ignore]
+    fn bench_load_100k_under_1500ms() {
+        const N: usize = 100_000;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = (0..N as u64)
+            .map(|i| (PathBuf::from(format!("/v/{i}.md")), 0, unit_vec(i)))
+            .collect();
+        let idx = VectorIndex::new(N);
+        idx.bulk_insert(items);
+        idx.save(tmp.path()).expect("save");
+        drop(idx);
+
+        let t0 = Instant::now();
+        let loaded = VectorIndex::load(tmp.path()).expect("load");
+        let took = t0.elapsed();
+        eprintln!("VectorIndex load {N} vectors in {took:?}");
+        assert_eq!(loaded.len(), N);
+        assert!(
+            took < Duration::from_millis(1500),
+            "load too slow: {took:?} for {N} vectors",
         );
     }
 }


### PR DESCRIPTION
Closes #199.

## Summary

- `VectorIndex::save / load / load_or_empty` over `<dir>/vectors.hnsw.{graph,data}` + `vectors.mapping.json`
- Reload uses `HnswIo::load_hnsw` with `ReloadOptions::new(true)` (mmap), `Box::leak`'d to give the resulting `Hnsw<'static, ..>` a sound parent lifetime
- Mapping file is versioned and written atomically (tmp + rename)
- Preflight magic-byte check on both dump files turns corruption into a recoverable `Err` instead of letting hnsw_rs's `assert_eq!` panic the process

## Acceptance criteria

- [x] **AC #1** — `save(dir)` writes a complete dump; the embed coordinator (#201) will call this on shutdown + periodically.
- [x] **AC #2** — Load uses `ReloadOptions::new(true)`; data-file vectors are mmap'd, not read into RAM.
- [x] **AC #3** — Truncated/garbage data file → `load_or_empty` logs a warn and returns a fresh empty index. Covered by `load_or_empty_recovers_from_corrupted_data_file`.
- [ ] **AC #4** — Spec target was load <100ms at 100k. Measured ~700 ms on Ryzen-7/NVMe. The `hnsw_rs` 0.3.4 format parses every point's graph data (per-layer neighbour lists) serially during `load_hnsw` even with mmap on — mmap only defers data-file reads. Closing the gap requires either a custom on-disk format or upstream work in `hnsw_rs`. Bench bar set to 1500ms; follow-up tracked under #207 (benchmark harness will drive the call).

## Tests

- `save_and_load_roundtrip_preserves_query_results` — same paths, chunk indices, distances after reload
- `load_or_empty_returns_fresh_when_dir_is_empty`
- `load_or_empty_recovers_from_corrupted_data_file` (AC #3)
- `load_rejects_mismatched_mapping_version`
- `bench_load_100k_under_1500ms` (`#[ignore]`, release-only)

All 36 embeddings unit tests green; no regressions in adjacent suites.

## Test plan

- [x] `cargo test --features embeddings --lib embeddings -- --test-threads=1`
- [x] `cargo test --features embeddings --release --lib embeddings::vector_index::tests::bench_load_100k_under_1500ms -- --ignored --nocapture --test-threads=1`