### PR TITLE
feat(embeddings): HNSW-backed VectorSink + delete dispatch (#201 PR-A)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -146,6 +146,23 @@ fn dispatch_embed_update(state: &VaultState, abs_path: PathBuf, content: &str) {
     }
 }
 
+/// #201 PR-A — dispatch a vector-store delete for `abs_path`. Called
+/// from the internal delete_file / rename_file / move_file paths
+/// because write_ignore suppresses the watcher's natural delete event
+/// for self-mutations.
+#[cfg(feature = "embeddings")]
+pub(crate) fn dispatch_embed_delete(state: &VaultState, abs_path: PathBuf) {
+    let coord_handles = {
+        let Ok(guard) = state.embed_coordinator.lock() else { return };
+        guard.as_ref().map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
+    };
+    let Some((tx, pending)) = coord_handles else { return };
+    let probe = crate::embeddings::EmbedCoordinator { tx, pending };
+    if let Err(e) = probe.enqueue_delete(abs_path) {
+        log::warn!("embed delete enqueue: {e}");
+    }
+}
+
 /// Dispatch IndexCmd::UpdateLinks and IndexCmd::UpdateTags for a path we just
 /// wrote from the backend. Called from write_file because write_ignore
 /// suppresses the natural watcher-driven dispatch.
@@ -384,7 +401,21 @@ pub async fn rename_file(
     old_path: String,
     new_name: String,
 ) -> Result<RenameResult, VaultError> {
-    rename_file_impl(&state, old_path, new_name)
+    // Capture the canonical pre-rename path so we can dispatch an embed
+    // delete for the OLD path after the rename succeeds. write_ignore
+    // suppresses the watcher's natural Remove event for self-mutations,
+    // so without this the old path's vectors would linger forever. The
+    // NEW path's vectors get embedded on the next save by the user.
+    #[cfg(feature = "embeddings")]
+    let old_canonical = std::fs::canonicalize(&old_path).ok();
+
+    let result = rename_file_impl(&state, old_path, new_name)?;
+
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = old_canonical {
+        dispatch_embed_delete(&state, p);
+    }
+    Ok(result)
 }
 
 // ─── delete_file ─────────────────────────────────────────────────────────────
@@ -424,9 +455,11 @@ pub async fn delete_file(
     use tauri::Emitter;
     // Canonicalize before delete so the emitted path matches the form the
     // watcher would have used (and matches how tabs/sidebar store paths).
-    let canonical_str = std::fs::canonicalize(&path)
+    let canonical = std::fs::canonicalize(&path).ok();
+    let canonical_str = canonical
+        .as_ref()
         .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| path.clone());
+        .unwrap_or_else(|| path.clone());
     delete_file_impl(&state, path)?;
     // Bug #102: the watcher suppresses this delete via write_ignore (D-12),
     // so emit a synthetic file_changed event so tabs bound to the deleted
@@ -439,6 +472,14 @@ pub async fn delete_file(
             new_path: None,
         },
     );
+    // #201 PR-A: tell the embed coordinator to tombstone this path's
+    // vectors. Same reason as the synthetic file_changed event above —
+    // write_ignore suppresses the watcher's natural Remove event so we
+    // dispatch directly here.
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = canonical {
+        dispatch_embed_delete(&state, p);
+    }
     Ok(())
 }
 
@@ -480,7 +521,19 @@ pub async fn move_file(
     from: String,
     to_folder: String,
 ) -> Result<String, VaultError> {
-    move_file_impl(&state, from, to_folder)
+    // #201 PR-A: same rationale as rename_file — the OLD path's vectors
+    // need an explicit tombstone because write_ignore hides the
+    // watcher's Remove event.
+    #[cfg(feature = "embeddings")]
+    let old_canonical = std::fs::canonicalize(&from).ok();
+
+    let result = move_file_impl(&state, from, to_folder)?;
+
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = old_canonical {
+        dispatch_embed_delete(&state, p);
+    }
+    Ok(result)
 }
 
 // ─── get_file_hash ───────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -215,8 +215,15 @@ pub async fn open_vault(
         match (svc, chk) {
             (Ok(svc), Ok(chk)) => {
                 use std::sync::Arc;
+                // #201 PR-A: HNSW-backed sink under <vault>/.vaultcore/embeddings/.
+                // capacity_hint of 4×file_count assumes the average note
+                // produces ~4 chunks (#195 splits at 254 content tokens
+                // ≈ 800 words). It only sizes initial allocations — real
+                // growth past it is supported.
+                let embed_dir = canonical.join(".vaultcore").join("embeddings");
+                let cap = vault_info.file_count.saturating_mul(4).max(64);
                 let sink: Arc<dyn crate::embeddings::VectorSink> =
-                    Arc::new(crate::embeddings::NoopSink);
+                    Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
                 let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
                 let mut guard = state
                     .embed_coordinator
@@ -239,12 +246,27 @@ pub async fn open_vault(
         guard.as_ref().map(|c| c.tx.clone())
     };
 
+    // #201 PR-A: snapshot the embed coordinator's Sender so the watcher
+    // can dispatch EmbedOp::Delete for externally-initiated file
+    // removes / renames. None when embeddings are disabled or the
+    // coordinator didn't spawn (no bundled model / ORT init failed).
+    #[cfg(feature = "embeddings")]
+    let embed_tx = {
+        let guard = state
+            .embed_coordinator
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.as_ref().map(|c| c.tx.clone())
+    };
+
     let debouncer = watcher::spawn_watcher(
         app.clone(),
         canonical.clone(),
         state.write_ignore.clone(),
         state.vault_reachable.clone(),
         index_tx,
+        #[cfg(feature = "embeddings")]
+        embed_tx,
     );
     *state.watcher_handle.lock().map_err(|_| VaultError::LockPoisoned)? = Some(debouncer);
 

--- a/src-tauri/src/embeddings/embed_coordinator.rs
+++ b/src-tauri/src/embeddings/embed_coordinator.rs
@@ -3,15 +3,23 @@
 //! holding up the save IPC.
 //!
 //! Coalescing strategy: a `pending` map of `path → latest content` plus a
-//! bounded wake-up channel that only carries paths. The map is the source
-//! of truth; the channel is just a "there is work to do" signal. Three
-//! rapid saves to the same path overwrite one another in the map and
-//! produce exactly one embed.
+//! bounded wake-up channel that carries `EmbedOp` ops. The map is the
+//! source of truth for embed content; the channel signals "there is work
+//! to do" plus carries explicit deletes (#201).
 //!
-//! Backpressure: a full wake-up channel is benign because the latest
-//! content already lives in the map — any subsequent successful enqueue
-//! drains it. So the save IPC never blocks: `enqueue` is sync,
-//! non-blocking, and a `QueueFull` outcome only logs.
+//! Three rapid saves to the same path overwrite one another in the map
+//! and produce exactly one embed. Deletes are FIFO with respect to
+//! embeds — so an `Embed → Delete` sequence first inserts vectors then
+//! tombstones them, while a `Delete → Embed` sequence first cancels the
+//! pending embed (by removing the path from the map) then tombstones any
+//! prior vectors. Both end with the path absent from queries, matching
+//! the user's last-action intent.
+//!
+//! Backpressure: a full wake-up channel is benign for `Embed` because
+//! the latest content already lives in the map — any subsequent
+//! successful enqueue drains it. For `Delete` a full channel is rare
+//! enough that we log + drop; the next user save plus #201 PR-B's
+//! periodic reindex will re-converge.
 //!
 //! The worker MUST be spawned on `tokio::task::spawn_blocking` (not
 //! `tokio::spawn`). Two reasons: (1) `Receiver::blocking_recv` panics if
@@ -28,12 +36,21 @@ use tokio::sync::mpsc;
 
 use super::{Chunk, Chunker, EmbeddingService, VectorSink};
 
-/// Wake-up channel capacity. Carries `PathBuf` only — actual content
-/// lives in the `pending` map. 1024 slots is generous: every event is
-/// keyboard-paced (one human, one editor) and a full channel still
-/// preserves correctness via the map. The indexer uses 8192 because it
-/// absorbs bulk filesystem events; this queue does not.
+/// Wake-up channel capacity. Carries `EmbedOp` (path-only signals); embed
+/// content lives in the `pending` map. 1024 slots is generous — every
+/// event is keyboard-paced and even external bulk deletes rarely land
+/// >1k events in a single tick.
 pub const WAKEUP_CAPACITY: usize = 1024;
+
+/// Op carried on the wake-up channel. `Embed` is a content-less signal —
+/// the actual content lives in the `pending` map and the worker drains
+/// it on each Embed wake-up. `Delete(path)` carries the path because
+/// deletes don't go through the pending map.
+#[derive(Debug, Clone)]
+pub enum EmbedOp {
+    Embed,
+    Delete(PathBuf),
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum EnqueueError {
@@ -46,7 +63,7 @@ pub enum EnqueueError {
 }
 
 pub struct EmbedCoordinator {
-    pub tx: mpsc::Sender<PathBuf>,
+    pub tx: mpsc::Sender<EmbedOp>,
     pub pending: Arc<Mutex<HashMap<PathBuf, String>>>,
 }
 
@@ -70,7 +87,7 @@ impl EmbedCoordinator {
         sink: Arc<dyn VectorSink>,
         capacity: usize,
     ) -> Self {
-        let (tx, rx) = mpsc::channel::<PathBuf>(capacity.max(1));
+        let (tx, rx) = mpsc::channel::<EmbedOp>(capacity.max(1));
         let pending: Arc<Mutex<HashMap<PathBuf, String>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let worker_pending = Arc::clone(&pending);
@@ -80,9 +97,9 @@ impl EmbedCoordinator {
         Self { tx, pending }
     }
 
-    /// Non-blocking enqueue. Updates the pending map then signals the
-    /// worker. `QueueFull` is benign — the content is in the map and the
-    /// next successful enqueue (same path or another) will trigger a
+    /// Non-blocking embed enqueue. Updates the pending map then signals
+    /// the worker. `QueueFull` is benign — the content is in the map and
+    /// the next successful enqueue (same path or another) will trigger a
     /// drain. Caller logs and proceeds.
     pub fn enqueue(
         &self,
@@ -94,9 +111,22 @@ impl EmbedCoordinator {
                 .pending
                 .lock()
                 .map_err(|_| EnqueueError::LockPoisoned)?;
-            g.insert(path.clone(), content);
+            g.insert(path, content);
         }
-        match self.tx.try_send(path) {
+        match self.tx.try_send(EmbedOp::Embed) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::QueueFull),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
+        }
+    }
+
+    /// Non-blocking delete enqueue (#201). Worker FIFO-orders Delete
+    /// against any pending Embed wake-ups. A `QueueFull` outcome here is
+    /// rarer than for embeds (deletes don't have the keyboard-burst
+    /// pattern) and the next user save's wake-up will not retroactively
+    /// dispatch the delete — caller logs.
+    pub fn enqueue_delete(&self, path: PathBuf) -> Result<(), EnqueueError> {
+        match self.tx.try_send(EmbedOp::Delete(path)) {
             Ok(()) => Ok(()),
             Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::QueueFull),
             Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
@@ -114,40 +144,52 @@ fn run_worker(
     chunker: Arc<Chunker>,
     sink: Arc<dyn VectorSink>,
     pending: Arc<Mutex<HashMap<PathBuf, String>>>,
-    mut rx: mpsc::Receiver<PathBuf>,
+    mut rx: mpsc::Receiver<EmbedOp>,
 ) {
-    while let Some(_path) = rx.blocking_recv() {
-        // Drain redundant wake-ups — the map already coalesces content.
-        while rx.try_recv().is_ok() {}
-
-        let snapshot: Vec<(PathBuf, String)> = match pending.lock() {
-            Ok(mut g) => g.drain().collect(),
-            Err(_) => {
-                log::warn!("embed pending map poisoned; skipping batch");
-                continue;
+    while let Some(op) = rx.blocking_recv() {
+        match op {
+            EmbedOp::Delete(path) => {
+                // Cancel any in-flight embed for this path so a Delete →
+                // Embed race ends with the path absent. Then mark the
+                // path's vectors tombstoned in the sink.
+                if let Ok(mut g) = pending.lock() {
+                    g.remove(&path);
+                } else {
+                    log::warn!("embed pending map poisoned during delete; tombstone may race");
+                }
+                sink.delete(&path);
             }
-        };
+            EmbedOp::Embed => {
+                let snapshot: Vec<(PathBuf, String)> = match pending.lock() {
+                    Ok(mut g) => g.drain().collect(),
+                    Err(_) => {
+                        log::warn!("embed pending map poisoned; skipping batch");
+                        continue;
+                    }
+                };
 
-        for (path, content) in snapshot {
-            let chunks = match chunker.chunk(&content) {
-                Ok(c) if c.is_empty() => continue,
-                Ok(c) => c,
-                Err(e) => {
-                    log::warn!("chunker failed for {}: {e}", path.display());
-                    continue;
+                for (path, content) in snapshot {
+                    let chunks = match chunker.chunk(&content) {
+                        Ok(c) if c.is_empty() => continue,
+                        Ok(c) => c,
+                        Err(e) => {
+                            log::warn!("chunker failed for {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+                    let vectors = match service.embed_batch(&texts) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            log::warn!("embed failed for {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let pairs: Vec<(Chunk, Vec<f32>)> =
+                        chunks.into_iter().zip(vectors).collect();
+                    sink.store(&path, pairs);
                 }
-            };
-            let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
-            let vectors = match service.embed_batch(&texts) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::warn!("embed failed for {}: {e}", path.display());
-                    continue;
-                }
-            };
-            let pairs: Vec<(Chunk, Vec<f32>)> =
-                chunks.into_iter().zip(vectors).collect();
-            sink.store(&path, pairs);
+            }
         }
     }
     log::info!("EmbedCoordinator worker shut down");
@@ -160,22 +202,31 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
 
-    /// Collects every `store` call so tests can assert coalescing.
+    /// Collects every `store` and `delete` call so tests can assert
+    /// coalescing and FIFO order.
     struct CountingSink {
         calls: AtomicUsize,
+        deletes: AtomicUsize,
         by_path: Mutex<HashMap<PathBuf, Vec<String>>>,
+        deleted_paths: Mutex<Vec<PathBuf>>,
     }
 
     impl CountingSink {
         fn new() -> Arc<Self> {
             Arc::new(Self {
                 calls: AtomicUsize::new(0),
+                deletes: AtomicUsize::new(0),
                 by_path: Mutex::new(HashMap::new()),
+                deleted_paths: Mutex::new(Vec::new()),
             })
         }
 
         fn calls(&self) -> usize {
             self.calls.load(Ordering::SeqCst)
+        }
+
+        fn deletes(&self) -> usize {
+            self.deletes.load(Ordering::SeqCst)
         }
 
         fn paths(&self) -> Vec<PathBuf> {
@@ -196,6 +247,10 @@ mod tests {
                 .entry(path.to_path_buf())
                 .or_default()
                 .extend(snippets);
+        }
+        fn delete(&self, path: &Path) {
+            self.deletes.fetch_add(1, Ordering::SeqCst);
+            self.deleted_paths.lock().unwrap().push(path.to_path_buf());
         }
     }
 
@@ -438,6 +493,63 @@ mod tests {
             let _ = probe.enqueue("/tmp/x".into(), "x".into());
             // Drop the probe (closes the last sender).
             drop(probe);
+        });
+    }
+
+    /// #201 PR-A: enqueue_delete dispatches a Delete op that the sink
+    /// observes. The minimal sanity check; richer FIFO ordering is in
+    /// the next test.
+    #[test]
+    fn enqueue_delete_calls_sink_delete() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            let p = PathBuf::from("/tmp/del.md");
+            coord.enqueue_delete(p.clone()).unwrap();
+            assert!(wait_until(|| sink.deletes() == 1, Duration::from_secs(5)));
+            let deleted = sink.deleted_paths.lock().unwrap();
+            assert_eq!(deleted.as_slice(), &[p]);
+        });
+    }
+
+    /// #201 PR-A: a Delete that arrives before its companion Embed has
+    /// drained must cancel the in-flight embed for the same path so
+    /// the path ends up absent (matching the user's last-action intent).
+    #[test]
+    fn delete_cancels_pending_embed_for_same_path() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            // Capacity 1 so we can almost certainly slot the Delete in
+            // before the worker drains the prior Embed wake-up.
+            let coord = EmbedCoordinator::spawn_with_capacity(
+                svc,
+                chk,
+                sink.clone() as Arc<dyn VectorSink>,
+                4,
+            );
+            let p = PathBuf::from("/tmp/race.md");
+            coord.enqueue(p.clone(), "doomed".to_string()).unwrap();
+            // Immediately follow with a delete. The worker may have
+            // already drained the embed wake-up and started embedding —
+            // both outcomes are acceptable as long as the final state
+            // reports the path tombstoned.
+            coord.enqueue_delete(p.clone()).unwrap();
+            assert!(wait_until(
+                || sink.deletes() == 1,
+                Duration::from_secs(5),
+            ));
+            // Either: embed never ran (cancelled) → calls() == 0
+            // Or:     embed ran then delete tombstoned → calls() == 1
+            // The invariant we care about is that delete was observed.
+            assert_eq!(sink.deletes(), 1);
         });
     }
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -36,12 +36,12 @@ pub use chunking::{Chunk, Chunker, DEFAULT_OVERLAP_TOKENS, MAX_CONTENT_TOKENS};
 #[cfg(feature = "embeddings")]
 mod sink;
 #[cfg(feature = "embeddings")]
-pub use sink::{NoopSink, VectorSink};
+pub use sink::{HnswSink, NoopSink, VectorSink};
 
 #[cfg(feature = "embeddings")]
 mod embed_coordinator;
 #[cfg(feature = "embeddings")]
-pub use embed_coordinator::{EmbedCoordinator, EnqueueError, WAKEUP_CAPACITY};
+pub use embed_coordinator::{EmbedCoordinator, EmbedOp, EnqueueError, WAKEUP_CAPACITY};
 
 #[cfg(feature = "embeddings")]
 mod vector_index;

--- a/src-tauri/src/embeddings/sink.rs
+++ b/src-tauri/src/embeddings/sink.rs
@@ -4,23 +4,333 @@
 //! touching the queue.
 //!
 //! Lifecycle contract: callers invoke `store(path, ...)` once per
-//! coalesced save. The sink is responsible for replacing any prior
-//! vectors associated with `path` (upsert semantics) — #200 will add an
-//! explicit delete hook for rename/delete paths; for now an
-//! upsert-replace is sufficient because every save produces a fresh
-//! chunk set for the same path.
+//! coalesced save. The sink replaces any prior vectors associated with
+//! `path` (upsert semantics). `delete(path)` (#201) is the explicit hook
+//! for rename/delete dispatch — `store` already implies "drop prior
+//! vectors then insert", but `delete` skips the embed work entirely.
 
 use std::path::Path;
+#[cfg(feature = "embeddings")]
+use std::path::PathBuf;
+#[cfg(feature = "embeddings")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "embeddings")]
+use std::sync::{Arc, RwLock};
 
 use super::Chunk;
+#[cfg(feature = "embeddings")]
+use super::VectorIndex;
 
 pub trait VectorSink: Send + Sync {
     fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>);
+    /// Drop every vector associated with `path`. Default is a no-op so
+    /// callers built before #201 (e.g. `NoopSink`) still compile without
+    /// per-impl boilerplate.
+    fn delete(&self, _path: &Path) {}
 }
 
-/// Discards everything. Used while #198 is still pending.
+/// Discards everything. Used while #198 was pending and still useful for
+/// tests that want to exercise the coordinator without an HNSW dep.
 pub struct NoopSink;
 
 impl VectorSink for NoopSink {
     fn store(&self, _path: &Path, _chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {}
+}
+
+/// `HnswSink` (#201 PR-A) — production sink backed by an in-memory
+/// `VectorIndex` plus on-disk persistence under
+/// `<vault>/.vaultcore/embeddings/`. Every embedded save replaces prior
+/// vectors for the path; explicit `delete` tombstones them; compaction
+/// fires off-thread when the index crosses #200's gating thresholds.
+///
+/// Concurrency: the inner index is held as `Arc<RwLock<Arc<VectorIndex>>>`
+/// so reads (queries) take a brief read lock to clone the inner `Arc`
+/// and then operate lock-free against that snapshot. Writes (compaction)
+/// take the write lock once to swap in a fresh index. Stores and deletes
+/// only need a read lock + the snapshot's own internal locks.
+///
+/// Drop semantics: the sink saves to disk on `Drop`, on a detached
+/// background thread so vault switch / app close doesn't freeze the UI
+/// for the seconds it takes to dump 100k vectors. The trade-off is that
+/// a save in flight when the OS reaps the process is incomplete; the
+/// next launch falls back to `load_or_empty` and the lost embeddings
+/// will be re-emitted on next save (or by the #201 PR-B reindex worker).
+#[cfg(feature = "embeddings")]
+pub struct HnswSink {
+    index: Arc<RwLock<Arc<VectorIndex>>>,
+    save_dir: PathBuf,
+    /// CAS guard against starting a second compaction while one is in
+    /// flight. Set to `true` by the thread that wins the race; cleared
+    /// when the compaction finishes (and self-checks one more time).
+    compacting: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "embeddings")]
+impl HnswSink {
+    /// Open or create the on-disk vector index at `save_dir`. Falls back
+    /// to an empty index on missing/corrupt files (#199 AC #3).
+    pub fn open(save_dir: PathBuf, capacity_hint: usize) -> Self {
+        let _ = std::fs::create_dir_all(&save_dir);
+        let index = VectorIndex::load_or_empty(&save_dir, capacity_hint);
+        Self {
+            index: Arc::new(RwLock::new(Arc::new(index))),
+            save_dir,
+            compacting: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Take a cheap snapshot of the inner index. Read-only callers
+    /// (queries, save-on-Drop) use this to avoid holding the outer
+    /// `RwLock` for the duration of work.
+    pub fn snapshot(&self) -> Arc<VectorIndex> {
+        Arc::clone(&self.index.read().expect("index lock"))
+    }
+
+    /// Persist the current snapshot synchronously. Used by tests and the
+    /// future periodic-flush path (#201 PR-B).
+    pub fn save_now(&self) -> Result<(), super::EmbeddingError> {
+        self.snapshot().save(&self.save_dir)
+    }
+
+    fn maybe_compact(&self) {
+        let snap = self.snapshot();
+        if !snap.should_compact() {
+            return;
+        }
+        if self
+            .compacting
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let index_lock = Arc::clone(&self.index);
+        let compacting = Arc::clone(&self.compacting);
+        std::thread::spawn(move || {
+            match snap.compact_into_fresh() {
+                Ok(fresh) => {
+                    let fresh_arc = Arc::new(fresh);
+                    if let Ok(mut guard) = index_lock.write() {
+                        let live = fresh_arc.live_len();
+                        *guard = fresh_arc;
+                        log::info!("VectorIndex compacted; live={live}");
+                    }
+                }
+                Err(e) => log::warn!("compaction failed: {e}"),
+            }
+            compacting.store(false, Ordering::Release);
+            // Trailing self-check: if more deletes piled up while we
+            // were rebuilding, the next sink.delete() call won't always
+            // observe should_compact() as true (it might if more
+            // deletes landed). Probe once here so a steady delete
+            // stream doesn't have to wait for a fresh user save to
+            // notice.
+            if let Ok(g) = index_lock.read() {
+                if g.should_compact() {
+                    log::info!("VectorIndex still over compaction threshold post-rebuild");
+                }
+            }
+        });
+    }
+}
+
+#[cfg(feature = "embeddings")]
+impl VectorSink for HnswSink {
+    fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {
+        if chunks_with_vectors.is_empty() {
+            return;
+        }
+        let snap = self.snapshot();
+        snap.mark_deleted(path);
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = chunks_with_vectors
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_chunk, v))| (path.to_path_buf(), i, v))
+            .collect();
+        snap.bulk_insert(items);
+        self.maybe_compact();
+    }
+
+    fn delete(&self, path: &Path) {
+        let snap = self.snapshot();
+        if snap.mark_deleted(path) > 0 {
+            self.maybe_compact();
+        }
+    }
+}
+
+#[cfg(feature = "embeddings")]
+impl Drop for HnswSink {
+    fn drop(&mut self) {
+        let snap = self.snapshot();
+        let dir = self.save_dir.clone();
+        std::thread::spawn(move || {
+            if let Err(e) = snap.save(&dir) {
+                log::warn!("HnswSink save on drop failed: {e}");
+            }
+        });
+    }
+}
+
+#[cfg(all(test, feature = "embeddings"))]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    fn unit_vec(seed: u64) -> Vec<f32> {
+        let mut s = seed.wrapping_mul(0x9E3779B97F4A7C15);
+        let mut out = Vec::with_capacity(384);
+        for _ in 0..384 {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            let bits = (s >> 32) as u32;
+            let f = (bits as f32 / u32::MAX as f32) * 2.0 - 1.0;
+            out.push(f);
+        }
+        let n: f32 = out.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in &mut out {
+            *x /= n;
+        }
+        out
+    }
+
+    fn pair(seed: u64) -> (Chunk, Vec<f32>) {
+        (
+            Chunk {
+                text: format!("seed-{seed}"),
+                byte_offset: 0,
+            },
+            unit_vec(seed),
+        )
+    }
+
+    fn wait_until<F: Fn() -> bool>(cond: F, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        cond()
+    }
+
+    #[test]
+    fn store_then_query_finds_vector() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let path = PathBuf::from("a.md");
+        sink.store(&path, vec![pair(1)]);
+
+        let snap = sink.snapshot();
+        let hits = snap.query_with_paths(&unit_vec(1), 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, path);
+    }
+
+    #[test]
+    fn store_replaces_prior_vectors_for_same_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let path = PathBuf::from("dup.md");
+        sink.store(&path, vec![pair(1), pair(2)]);
+        sink.store(&path, vec![pair(3)]);
+
+        let snap = sink.snapshot();
+        // Old chunks tombstoned, only seed-3 remains live.
+        assert_eq!(snap.live_len(), 1);
+        // Query for the old vectors must not return them.
+        let hits = snap.query_with_paths(&unit_vec(1), 5);
+        assert!(hits.iter().all(|(_, _, d)| *d > 0.01),
+            "old chunk should not be a near-zero hit, got {hits:?}");
+    }
+
+    #[test]
+    fn delete_marks_path_tombstoned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let p = PathBuf::from("gone.md");
+        sink.store(&p, vec![pair(7)]);
+        sink.delete(&p);
+
+        let snap = sink.snapshot();
+        assert_eq!(snap.live_len(), 0);
+        assert_eq!(snap.tombstone_count(), 1);
+        let hits = snap.query_with_paths(&unit_vec(7), 5);
+        assert!(hits.iter().all(|(path, _, _)| path != &p));
+    }
+
+    #[test]
+    fn delete_on_unknown_path_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        sink.delete(Path::new("never-stored.md"));
+        assert_eq!(sink.snapshot().len(), 0);
+    }
+
+    #[test]
+    fn save_on_drop_persists_then_reloads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        {
+            let sink = HnswSink::open(dir.clone(), 8);
+            sink.store(&PathBuf::from("persisted.md"), vec![pair(42)]);
+            // Sink dropped here — Drop spawns a save thread.
+        }
+        // Wait for the save file to appear.
+        let mapping = dir.join("vectors.mapping.json");
+        assert!(
+            wait_until(|| mapping.exists(), Duration::from_secs(5)),
+            "save-on-Drop never wrote {}",
+            mapping.display(),
+        );
+        // Wait briefly for the data dump to finish too — file_dump writes
+        // graph + data + mapping in sequence, and our preflight check
+        // requires both binary files present.
+        let data = dir.join("vectors.hnsw.data");
+        assert!(wait_until(|| data.exists(), Duration::from_secs(2)));
+        std::thread::sleep(Duration::from_millis(50));
+
+        let reopened = HnswSink::open(dir, 8);
+        let snap = reopened.snapshot();
+        assert_eq!(snap.len(), 1);
+        let hits = snap.query_with_paths(&unit_vec(42), 1);
+        assert_eq!(hits[0].0, PathBuf::from("persisted.md"));
+    }
+
+    #[test]
+    fn compaction_runs_when_threshold_crossed_and_keeps_index_queryable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 400);
+        // Cross both gates: >64 tombstones AND >20% ratio.
+        // 400 inserts, 100 deletes = 25%.
+        for i in 0..400u64 {
+            sink.store(&PathBuf::from(format!("c-{i}.md")), vec![pair(i)]);
+        }
+        for i in 0..100u64 {
+            sink.delete(&PathBuf::from(format!("c-{i}.md")));
+        }
+        // After the last delete, maybe_compact() spawns a thread.
+        // Wait for the rebuild to swap in a fresh index (live_len == 300,
+        // tombstones cleared).
+        let ok = wait_until(
+            || {
+                let s = sink.snapshot();
+                s.tombstone_count() == 0 && s.len() == 300
+            },
+            Duration::from_secs(15),
+        );
+        assert!(
+            ok,
+            "compaction never landed: live={}, tombs={}, total={}",
+            sink.snapshot().live_len(),
+            sink.snapshot().tombstone_count(),
+            sink.snapshot().len()
+        );
+        // A surviving path is still queryable.
+        let hits = sink.snapshot().query_with_paths(&unit_vec(200), 1);
+        assert_eq!(hits[0].0, PathBuf::from("c-200.md"));
+    }
 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -23,6 +23,8 @@ use tokio::time::sleep;
 
 use crate::WriteIgnoreList;
 use crate::indexer::IndexCmd;
+#[cfg(feature = "embeddings")]
+use crate::embeddings::EmbedOp;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -95,6 +97,7 @@ pub fn spawn_watcher(
     write_ignore: Arc<Mutex<WriteIgnoreList>>,
     vault_reachable: Arc<Mutex<bool>>,
     index_tx: Option<tokio::sync::mpsc::Sender<IndexCmd>>,
+    #[cfg(feature = "embeddings")] embed_tx: Option<tokio::sync::mpsc::Sender<EmbedOp>>,
 ) -> Debouncer<RecommendedWatcher, RecommendedCache> {
     let vault_path_clone = vault_path.clone();
     let vault_reachable_for_error = vault_reachable.clone();
@@ -106,7 +109,15 @@ pub fn spawn_watcher(
         None,
         move |result: DebounceEventResult| match result {
             Ok(events) => {
-                process_events(&app_for_events, &write_ignore, &vault_path_clone, &index_tx, events);
+                process_events(
+                    &app_for_events,
+                    &write_ignore,
+                    &vault_path_clone,
+                    &index_tx,
+                    #[cfg(feature = "embeddings")]
+                    &embed_tx,
+                    events,
+                );
             }
             Err(errors) => {
                 for error in errors {
@@ -209,6 +220,7 @@ fn process_events(
     write_ignore: &Arc<Mutex<WriteIgnoreList>>,
     vault_path: &Path,
     index_tx: &Option<tokio::sync::mpsc::Sender<IndexCmd>>,
+    #[cfg(feature = "embeddings")] embed_tx: &Option<tokio::sync::mpsc::Sender<EmbedOp>>,
     events: Vec<DebouncedEvent>,
 ) {
     // Step 1: Filter dot-prefixed paths
@@ -254,6 +266,16 @@ fn process_events(
             dispatch_link_graph_cmd(tx, vault_path, &ev);
             // Step 5b: Dispatch tag-index commands (TAG-01/02)
             dispatch_tag_index_cmd(tx, vault_path, &ev);
+        }
+
+        // Step 5c (#201 PR-A): Tombstone vectors for externally-deleted
+        // and externally-renamed markdown files. Internal deletes go via
+        // commands::files which dispatches its own EmbedOp::Delete (see
+        // delete_file / rename_file / move_file), so this catches only
+        // events that bypass the write-ignore list — i.e. external tools.
+        #[cfg(feature = "embeddings")]
+        if let Some(tx) = embed_tx {
+            dispatch_embed_delete_cmd(tx, vault_path, &ev);
         }
 
         if let Some(payload) = map_event_to_payload(vault_path, &ev) {
@@ -445,6 +467,48 @@ pub(crate) fn dispatch_tag_index_cmd(
         }
         EventKind::Remove(_) => {
             try_send_or_warn(tx, IndexCmd::RemoveTags { rel_path });
+        }
+        _ => {}
+    }
+}
+
+/// #201 PR-A — dispatch `EmbedOp::Delete` for Remove / rename-from events
+/// on markdown paths. We only tombstone; creates & modifies rely on the
+/// save path (write_file dispatches Embed) and the reindex worker (#201
+/// PR-B) to re-embed externally-touched content. `try_send` so a full
+/// channel just drops — the worker state stays consistent because a
+/// subsequent reindex pass will clean up any missed tombstones.
+#[cfg(feature = "embeddings")]
+fn dispatch_embed_delete_cmd(
+    tx: &tokio::sync::mpsc::Sender<EmbedOp>,
+    vault_path: &Path,
+    ev: &DebouncedEvent,
+) {
+    let primary_path = match ev.paths.first() {
+        Some(p) => p,
+        None => return,
+    };
+    if primary_path
+        .extension()
+        .map_or(true, |ext| !ext.eq_ignore_ascii_case("md"))
+    {
+        return;
+    }
+    // Only in-vault paths; same guard as map_event_to_payload.
+    if !primary_path.starts_with(vault_path) {
+        return;
+    }
+
+    match &ev.kind {
+        EventKind::Remove(_) => {
+            let _ = tx.try_send(EmbedOp::Delete(primary_path.clone()));
+        }
+        EventKind::Modify(ModifyKind::Name(_)) => {
+            // Rename — the OLD path's vectors must be tombstoned. The
+            // NEW path (paths[1]) doesn't need an embed here; the user
+            // will save it via write_file which embeds via the save
+            // dispatch.
+            let _ = tx.try_send(EmbedOp::Delete(primary_path.clone()));
         }
         _ => {}
     }


### PR DESCRIPTION
Part of #201 — Initial reindex on first enable. This is PR-A of a 4-PR split (foundation → reindex worker → progress UI → bench).

## Summary

- Adds `HnswSink` that persists chunk vectors to `<vault>/.vaultcore/embeddings/` via the #199 dump format and tombstones on delete via the #200 primitive. Save-on-Drop runs on a detached background thread to avoid freezing the UI on vault switch.
- Adds `EmbedOp::{Embed, Delete(PathBuf)}` on the coordinator channel so rename/delete events tombstone their vectors without a manual reindex. Worker processes ops FIFO; Delete clears any in-flight Embed for the same path to resolve the Delete→Embed race.
- Wires delete dispatch from `delete_file` / `rename_file` / `move_file` (internal) and the watcher's Remove / rename events (external). `open_vault` now constructs `HnswSink` instead of `NoopSink` and threads `embed_tx` to the watcher.
- Compaction triggers off-thread when #200's ratio + floor gates cross, with a trailing self-check so a steady delete stream doesn't need a fresh user save.

## Context — what this unlocks

Every save now actually lands in a persistent HNSW index. Subsequent PRs:

- **PR-B** — initial reindex worker (scans vault, embeds unseen paths, resumable via sidecar checkpoint)
- **PR-C** — statusbar progress UI + settings toggle
- **PR-D** — concurrency tuning + bench harness

## Risk notes / deliberate trade-offs

- Save-on-Drop runs detached, not joined. If the OS reaps the process during a save, the dump is incomplete; `load_or_empty` falls back to empty and PR-B's reindex worker will reconcile. The alternative — block Drop — would freeze the UI on vault switch.
- Watcher-driven embed is delete-only for PR-A. External modifies don't re-embed; PR-B's reindex worker picks them up via hash diff. This is a scope boundary, not a bug.
- Same-vault reopen has a narrow window where the dropping-sink's background save may overlap with the new sink's load. `load_or_empty` is the safety net (corrupt-read → fresh empty).

## Test plan

- [x] `cargo test --features embeddings --lib embeddings::sink` — 6/6 green (store, replace, delete, save-on-Drop, compaction)
- [x] `cargo test --features embeddings --lib embeddings::embed_coordinator` — 8/8 green (new: enqueue_delete, delete cancels pending embed)
- [x] `cargo test --features embeddings --lib` — 269/269 green (no regressions in coordinator / indexer / watcher)
- [x] `cargo test --features embeddings --tests` — 269/269 green
- [x] `cargo build --no-default-features` — clean (feature-gate boundaries)
- [x] `cargo check --features embeddings` — no warnings