### PR TITLE
feat(embeddings): reindex statusbar + semantic search toggle (#201 PR-C)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -146,6 +146,23 @@ fn dispatch_embed_update(state: &VaultState, abs_path: PathBuf, content: &str) {
     }
 }
 
+/// #201 PR-A — dispatch a vector-store delete for `abs_path`. Called
+/// from the internal delete_file / rename_file / move_file paths
+/// because write_ignore suppresses the watcher's natural delete event
+/// for self-mutations.
+#[cfg(feature = "embeddings")]
+pub(crate) fn dispatch_embed_delete(state: &VaultState, abs_path: PathBuf) {
+    let coord_handles = {
+        let Ok(guard) = state.embed_coordinator.lock() else { return };
+        guard.as_ref().map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
+    };
+    let Some((tx, pending)) = coord_handles else { return };
+    let probe = crate::embeddings::EmbedCoordinator { tx, pending };
+    if let Err(e) = probe.enqueue_delete(abs_path) {
+        log::warn!("embed delete enqueue: {e}");
+    }
+}
+
 /// Dispatch IndexCmd::UpdateLinks and IndexCmd::UpdateTags for a path we just
 /// wrote from the backend. Called from write_file because write_ignore
 /// suppresses the natural watcher-driven dispatch.
@@ -384,7 +401,21 @@ pub async fn rename_file(
     old_path: String,
     new_name: String,
 ) -> Result<RenameResult, VaultError> {
-    rename_file_impl(&state, old_path, new_name)
+    // Capture the canonical pre-rename path so we can dispatch an embed
+    // delete for the OLD path after the rename succeeds. write_ignore
+    // suppresses the watcher's natural Remove event for self-mutations,
+    // so without this the old path's vectors would linger forever. The
+    // NEW path's vectors get embedded on the next save by the user.
+    #[cfg(feature = "embeddings")]
+    let old_canonical = std::fs::canonicalize(&old_path).ok();
+
+    let result = rename_file_impl(&state, old_path, new_name)?;
+
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = old_canonical {
+        dispatch_embed_delete(&state, p);
+    }
+    Ok(result)
 }
 
 // ─── delete_file ─────────────────────────────────────────────────────────────
@@ -424,9 +455,11 @@ pub async fn delete_file(
     use tauri::Emitter;
     // Canonicalize before delete so the emitted path matches the form the
     // watcher would have used (and matches how tabs/sidebar store paths).
-    let canonical_str = std::fs::canonicalize(&path)
+    let canonical = std::fs::canonicalize(&path).ok();
+    let canonical_str = canonical
+        .as_ref()
         .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| path.clone());
+        .unwrap_or_else(|| path.clone());
     delete_file_impl(&state, path)?;
     // Bug #102: the watcher suppresses this delete via write_ignore (D-12),
     // so emit a synthetic file_changed event so tabs bound to the deleted
@@ -439,6 +472,14 @@ pub async fn delete_file(
             new_path: None,
         },
     );
+    // #201 PR-A: tell the embed coordinator to tombstone this path's
+    // vectors. Same reason as the synthetic file_changed event above —
+    // write_ignore suppresses the watcher's natural Remove event so we
+    // dispatch directly here.
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = canonical {
+        dispatch_embed_delete(&state, p);
+    }
     Ok(())
 }
 
@@ -480,7 +521,19 @@ pub async fn move_file(
     from: String,
     to_folder: String,
 ) -> Result<String, VaultError> {
-    move_file_impl(&state, from, to_folder)
+    // #201 PR-A: same rationale as rename_file — the OLD path's vectors
+    // need an explicit tombstone because write_ignore hides the
+    // watcher's Remove event.
+    #[cfg(feature = "embeddings")]
+    let old_canonical = std::fs::canonicalize(&from).ok();
+
+    let result = move_file_impl(&state, from, to_folder)?;
+
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = old_canonical {
+        dispatch_embed_delete(&state, p);
+    }
+    Ok(result)
 }
 
 // ─── get_file_hash ───────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -202,6 +202,20 @@ pub async fn open_vault(
     // (mirrors the IndexCoordinator drop-then-replace pattern above).
     #[cfg(feature = "embeddings")]
     {
+        // #201 PR-B: cancel any in-flight reindex for the prior vault
+        // BEFORE dropping the old coordinator. The reindex worker holds
+        // clones of the prior coordinator's Sender; cancelling lets it
+        // wind down cleanly so the next vault's worker has a fresh
+        // checkpoint to resume from.
+        {
+            let mut guard = state
+                .reindex_handle
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?;
+            if let Some(h) = guard.take() {
+                h.cancel();
+            }
+        }
         {
             let mut guard = state
                 .embed_coordinator
@@ -481,4 +495,115 @@ pub async fn merge_external_change(
             merged_content: local,
         }),
     }
+}
+
+// ─── #201 PR-B: reindex IPC ──────────────────────────────────────────────────
+
+/// Start a resumable initial-embed pass over the currently-open vault.
+///
+/// Cancels any prior running reindex before spawning. Progress is
+/// streamed to the frontend via `embed://reindex_progress` Tauri events
+/// (payload: `ReindexProgress`). The call returns as soon as the worker
+/// has been parked on its thread; the frontend drives the lifecycle
+/// entirely through events + `cancel_reindex`.
+///
+/// No-op (returns `Ok`) when the embeddings feature is on but the
+/// coordinator didn't spawn (no bundled model / ORT init failed).
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn reindex_vault(
+    app: AppHandle,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<(), VaultError> {
+    use tauri::Emitter;
+
+    let vault_root = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.clone().ok_or_else(|| VaultError::VaultUnavailable {
+            path: String::new(),
+        })?
+    };
+
+    // Cancel any prior reindex so the new one owns the checkpoint.
+    {
+        let mut guard = state
+            .reindex_handle
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        if let Some(h) = guard.take() {
+            h.cancel();
+        }
+    }
+
+    let coord_parts = {
+        let guard = state
+            .embed_coordinator
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard
+            .as_ref()
+            .map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
+    };
+    let Some((tx, pending)) = coord_parts else {
+        log::warn!("reindex_vault: embedding coordinator unavailable; no-op");
+        return Ok(());
+    };
+
+    let checkpoint_dir = vault_root.join(".vaultcore").join("embeddings");
+    let app_for_progress = app.clone();
+
+    let handle = crate::embeddings::start_reindex(
+        vault_root,
+        checkpoint_dir,
+        move |path, content| {
+            let probe = crate::embeddings::EmbedCoordinator {
+                tx: tx.clone(),
+                pending: std::sync::Arc::clone(&pending),
+            };
+            match probe.enqueue(path.to_path_buf(), content) {
+                Ok(()) => true,
+                // QueueFull is benign: the content already lives in the
+                // pending map and the next successful signal drains it.
+                // The file is "on its way" — record the checkpoint.
+                Err(crate::embeddings::EnqueueError::QueueFull) => true,
+                Err(e) => {
+                    log::warn!("reindex enqueue: {e}");
+                    false
+                }
+            }
+        },
+        move |progress| {
+            if let Err(e) = app_for_progress.emit("embed://reindex_progress", progress) {
+                log::debug!("reindex_progress emit dropped: {e}");
+            }
+        },
+    );
+
+    let mut guard = state
+        .reindex_handle
+        .lock()
+        .map_err(|_| VaultError::LockPoisoned)?;
+    *guard = Some(handle);
+    Ok(())
+}
+
+/// Cooperatively cancel any running reindex. Safe to call when no
+/// reindex is in flight (no-op). The worker flushes its checkpoint
+/// before exiting, so the next `reindex_vault` resumes from there.
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn cancel_reindex(
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<(), VaultError> {
+    let mut guard = state
+        .reindex_handle
+        .lock()
+        .map_err(|_| VaultError::LockPoisoned)?;
+    if let Some(h) = guard.take() {
+        h.cancel();
+    }
+    Ok(())
 }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -215,8 +215,15 @@ pub async fn open_vault(
         match (svc, chk) {
             (Ok(svc), Ok(chk)) => {
                 use std::sync::Arc;
+                // #201 PR-A: HNSW-backed sink under <vault>/.vaultcore/embeddings/.
+                // capacity_hint of 4×file_count assumes the average note
+                // produces ~4 chunks (#195 splits at 254 content tokens
+                // ≈ 800 words). It only sizes initial allocations — real
+                // growth past it is supported.
+                let embed_dir = canonical.join(".vaultcore").join("embeddings");
+                let cap = vault_info.file_count.saturating_mul(4).max(64);
                 let sink: Arc<dyn crate::embeddings::VectorSink> =
-                    Arc::new(crate::embeddings::NoopSink);
+                    Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
                 let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
                 let mut guard = state
                     .embed_coordinator
@@ -239,12 +246,27 @@ pub async fn open_vault(
         guard.as_ref().map(|c| c.tx.clone())
     };
 
+    // #201 PR-A: snapshot the embed coordinator's Sender so the watcher
+    // can dispatch EmbedOp::Delete for externally-initiated file
+    // removes / renames. None when embeddings are disabled or the
+    // coordinator didn't spawn (no bundled model / ORT init failed).
+    #[cfg(feature = "embeddings")]
+    let embed_tx = {
+        let guard = state
+            .embed_coordinator
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.as_ref().map(|c| c.tx.clone())
+    };
+
     let debouncer = watcher::spawn_watcher(
         app.clone(),
         canonical.clone(),
         state.write_ignore.clone(),
         state.vault_reachable.clone(),
         index_tx,
+        #[cfg(feature = "embeddings")]
+        embed_tx,
     );
     *state.watcher_handle.lock().map_err(|_| VaultError::LockPoisoned)? = Some(debouncer);
 

--- a/src-tauri/src/embeddings/embed_coordinator.rs
+++ b/src-tauri/src/embeddings/embed_coordinator.rs
@@ -3,15 +3,23 @@
 //! holding up the save IPC.
 //!
 //! Coalescing strategy: a `pending` map of `path → latest content` plus a
-//! bounded wake-up channel that only carries paths. The map is the source
-//! of truth; the channel is just a "there is work to do" signal. Three
-//! rapid saves to the same path overwrite one another in the map and
-//! produce exactly one embed.
+//! bounded wake-up channel that carries `EmbedOp` ops. The map is the
+//! source of truth for embed content; the channel signals "there is work
+//! to do" plus carries explicit deletes (#201).
 //!
-//! Backpressure: a full wake-up channel is benign because the latest
-//! content already lives in the map — any subsequent successful enqueue
-//! drains it. So the save IPC never blocks: `enqueue` is sync,
-//! non-blocking, and a `QueueFull` outcome only logs.
+//! Three rapid saves to the same path overwrite one another in the map
+//! and produce exactly one embed. Deletes are FIFO with respect to
+//! embeds — so an `Embed → Delete` sequence first inserts vectors then
+//! tombstones them, while a `Delete → Embed` sequence first cancels the
+//! pending embed (by removing the path from the map) then tombstones any
+//! prior vectors. Both end with the path absent from queries, matching
+//! the user's last-action intent.
+//!
+//! Backpressure: a full wake-up channel is benign for `Embed` because
+//! the latest content already lives in the map — any subsequent
+//! successful enqueue drains it. For `Delete` a full channel is rare
+//! enough that we log + drop; the next user save plus #201 PR-B's
+//! periodic reindex will re-converge.
 //!
 //! The worker MUST be spawned on `tokio::task::spawn_blocking` (not
 //! `tokio::spawn`). Two reasons: (1) `Receiver::blocking_recv` panics if
@@ -28,12 +36,21 @@ use tokio::sync::mpsc;
 
 use super::{Chunk, Chunker, EmbeddingService, VectorSink};
 
-/// Wake-up channel capacity. Carries `PathBuf` only — actual content
-/// lives in the `pending` map. 1024 slots is generous: every event is
-/// keyboard-paced (one human, one editor) and a full channel still
-/// preserves correctness via the map. The indexer uses 8192 because it
-/// absorbs bulk filesystem events; this queue does not.
+/// Wake-up channel capacity. Carries `EmbedOp` (path-only signals); embed
+/// content lives in the `pending` map. 1024 slots is generous — every
+/// event is keyboard-paced and even external bulk deletes rarely land
+/// >1k events in a single tick.
 pub const WAKEUP_CAPACITY: usize = 1024;
+
+/// Op carried on the wake-up channel. `Embed` is a content-less signal —
+/// the actual content lives in the `pending` map and the worker drains
+/// it on each Embed wake-up. `Delete(path)` carries the path because
+/// deletes don't go through the pending map.
+#[derive(Debug, Clone)]
+pub enum EmbedOp {
+    Embed,
+    Delete(PathBuf),
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum EnqueueError {
@@ -46,7 +63,7 @@ pub enum EnqueueError {
 }
 
 pub struct EmbedCoordinator {
-    pub tx: mpsc::Sender<PathBuf>,
+    pub tx: mpsc::Sender<EmbedOp>,
     pub pending: Arc<Mutex<HashMap<PathBuf, String>>>,
 }
 
@@ -70,7 +87,7 @@ impl EmbedCoordinator {
         sink: Arc<dyn VectorSink>,
         capacity: usize,
     ) -> Self {
-        let (tx, rx) = mpsc::channel::<PathBuf>(capacity.max(1));
+        let (tx, rx) = mpsc::channel::<EmbedOp>(capacity.max(1));
         let pending: Arc<Mutex<HashMap<PathBuf, String>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let worker_pending = Arc::clone(&pending);
@@ -80,9 +97,9 @@ impl EmbedCoordinator {
         Self { tx, pending }
     }
 
-    /// Non-blocking enqueue. Updates the pending map then signals the
-    /// worker. `QueueFull` is benign — the content is in the map and the
-    /// next successful enqueue (same path or another) will trigger a
+    /// Non-blocking embed enqueue. Updates the pending map then signals
+    /// the worker. `QueueFull` is benign — the content is in the map and
+    /// the next successful enqueue (same path or another) will trigger a
     /// drain. Caller logs and proceeds.
     pub fn enqueue(
         &self,
@@ -94,9 +111,22 @@ impl EmbedCoordinator {
                 .pending
                 .lock()
                 .map_err(|_| EnqueueError::LockPoisoned)?;
-            g.insert(path.clone(), content);
+            g.insert(path, content);
         }
-        match self.tx.try_send(path) {
+        match self.tx.try_send(EmbedOp::Embed) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::QueueFull),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
+        }
+    }
+
+    /// Non-blocking delete enqueue (#201). Worker FIFO-orders Delete
+    /// against any pending Embed wake-ups. A `QueueFull` outcome here is
+    /// rarer than for embeds (deletes don't have the keyboard-burst
+    /// pattern) and the next user save's wake-up will not retroactively
+    /// dispatch the delete — caller logs.
+    pub fn enqueue_delete(&self, path: PathBuf) -> Result<(), EnqueueError> {
+        match self.tx.try_send(EmbedOp::Delete(path)) {
             Ok(()) => Ok(()),
             Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::QueueFull),
             Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
@@ -114,40 +144,52 @@ fn run_worker(
     chunker: Arc<Chunker>,
     sink: Arc<dyn VectorSink>,
     pending: Arc<Mutex<HashMap<PathBuf, String>>>,
-    mut rx: mpsc::Receiver<PathBuf>,
+    mut rx: mpsc::Receiver<EmbedOp>,
 ) {
-    while let Some(_path) = rx.blocking_recv() {
-        // Drain redundant wake-ups — the map already coalesces content.
-        while rx.try_recv().is_ok() {}
-
-        let snapshot: Vec<(PathBuf, String)> = match pending.lock() {
-            Ok(mut g) => g.drain().collect(),
-            Err(_) => {
-                log::warn!("embed pending map poisoned; skipping batch");
-                continue;
+    while let Some(op) = rx.blocking_recv() {
+        match op {
+            EmbedOp::Delete(path) => {
+                // Cancel any in-flight embed for this path so a Delete →
+                // Embed race ends with the path absent. Then mark the
+                // path's vectors tombstoned in the sink.
+                if let Ok(mut g) = pending.lock() {
+                    g.remove(&path);
+                } else {
+                    log::warn!("embed pending map poisoned during delete; tombstone may race");
+                }
+                sink.delete(&path);
             }
-        };
+            EmbedOp::Embed => {
+                let snapshot: Vec<(PathBuf, String)> = match pending.lock() {
+                    Ok(mut g) => g.drain().collect(),
+                    Err(_) => {
+                        log::warn!("embed pending map poisoned; skipping batch");
+                        continue;
+                    }
+                };
 
-        for (path, content) in snapshot {
-            let chunks = match chunker.chunk(&content) {
-                Ok(c) if c.is_empty() => continue,
-                Ok(c) => c,
-                Err(e) => {
-                    log::warn!("chunker failed for {}: {e}", path.display());
-                    continue;
+                for (path, content) in snapshot {
+                    let chunks = match chunker.chunk(&content) {
+                        Ok(c) if c.is_empty() => continue,
+                        Ok(c) => c,
+                        Err(e) => {
+                            log::warn!("chunker failed for {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+                    let vectors = match service.embed_batch(&texts) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            log::warn!("embed failed for {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let pairs: Vec<(Chunk, Vec<f32>)> =
+                        chunks.into_iter().zip(vectors).collect();
+                    sink.store(&path, pairs);
                 }
-            };
-            let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
-            let vectors = match service.embed_batch(&texts) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::warn!("embed failed for {}: {e}", path.display());
-                    continue;
-                }
-            };
-            let pairs: Vec<(Chunk, Vec<f32>)> =
-                chunks.into_iter().zip(vectors).collect();
-            sink.store(&path, pairs);
+            }
         }
     }
     log::info!("EmbedCoordinator worker shut down");
@@ -160,22 +202,31 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
 
-    /// Collects every `store` call so tests can assert coalescing.
+    /// Collects every `store` and `delete` call so tests can assert
+    /// coalescing and FIFO order.
     struct CountingSink {
         calls: AtomicUsize,
+        deletes: AtomicUsize,
         by_path: Mutex<HashMap<PathBuf, Vec<String>>>,
+        deleted_paths: Mutex<Vec<PathBuf>>,
     }
 
     impl CountingSink {
         fn new() -> Arc<Self> {
             Arc::new(Self {
                 calls: AtomicUsize::new(0),
+                deletes: AtomicUsize::new(0),
                 by_path: Mutex::new(HashMap::new()),
+                deleted_paths: Mutex::new(Vec::new()),
             })
         }
 
         fn calls(&self) -> usize {
             self.calls.load(Ordering::SeqCst)
+        }
+
+        fn deletes(&self) -> usize {
+            self.deletes.load(Ordering::SeqCst)
         }
 
         fn paths(&self) -> Vec<PathBuf> {
@@ -196,6 +247,10 @@ mod tests {
                 .entry(path.to_path_buf())
                 .or_default()
                 .extend(snippets);
+        }
+        fn delete(&self, path: &Path) {
+            self.deletes.fetch_add(1, Ordering::SeqCst);
+            self.deleted_paths.lock().unwrap().push(path.to_path_buf());
         }
     }
 
@@ -438,6 +493,63 @@ mod tests {
             let _ = probe.enqueue("/tmp/x".into(), "x".into());
             // Drop the probe (closes the last sender).
             drop(probe);
+        });
+    }
+
+    /// #201 PR-A: enqueue_delete dispatches a Delete op that the sink
+    /// observes. The minimal sanity check; richer FIFO ordering is in
+    /// the next test.
+    #[test]
+    fn enqueue_delete_calls_sink_delete() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            let p = PathBuf::from("/tmp/del.md");
+            coord.enqueue_delete(p.clone()).unwrap();
+            assert!(wait_until(|| sink.deletes() == 1, Duration::from_secs(5)));
+            let deleted = sink.deleted_paths.lock().unwrap();
+            assert_eq!(deleted.as_slice(), &[p]);
+        });
+    }
+
+    /// #201 PR-A: a Delete that arrives before its companion Embed has
+    /// drained must cancel the in-flight embed for the same path so
+    /// the path ends up absent (matching the user's last-action intent).
+    #[test]
+    fn delete_cancels_pending_embed_for_same_path() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            // Capacity 1 so we can almost certainly slot the Delete in
+            // before the worker drains the prior Embed wake-up.
+            let coord = EmbedCoordinator::spawn_with_capacity(
+                svc,
+                chk,
+                sink.clone() as Arc<dyn VectorSink>,
+                4,
+            );
+            let p = PathBuf::from("/tmp/race.md");
+            coord.enqueue(p.clone(), "doomed".to_string()).unwrap();
+            // Immediately follow with a delete. The worker may have
+            // already drained the embed wake-up and started embedding —
+            // both outcomes are acceptable as long as the final state
+            // reports the path tombstoned.
+            coord.enqueue_delete(p.clone()).unwrap();
+            assert!(wait_until(
+                || sink.deletes() == 1,
+                Duration::from_secs(5),
+            ));
+            // Either: embed never ran (cancelled) → calls() == 0
+            // Or:     embed ran then delete tombstoned → calls() == 1
+            // The invariant we care about is that delete was observed.
+            assert_eq!(sink.deletes(), 1);
         });
     }
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -48,6 +48,14 @@ mod vector_index;
 #[cfg(feature = "embeddings")]
 pub use vector_index::{VectorIndex, DEFAULT_EF_SEARCH, DIM};
 
+#[cfg(feature = "embeddings")]
+mod reindex;
+#[cfg(feature = "embeddings")]
+pub use reindex::{
+    start_reindex, ReindexHandle, ReindexPhase, ReindexProgress, CHECKPOINT_FILE,
+    CHECKPOINT_VERSION,
+};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -36,12 +36,12 @@ pub use chunking::{Chunk, Chunker, DEFAULT_OVERLAP_TOKENS, MAX_CONTENT_TOKENS};
 #[cfg(feature = "embeddings")]
 mod sink;
 #[cfg(feature = "embeddings")]
-pub use sink::{NoopSink, VectorSink};
+pub use sink::{HnswSink, NoopSink, VectorSink};
 
 #[cfg(feature = "embeddings")]
 mod embed_coordinator;
 #[cfg(feature = "embeddings")]
-pub use embed_coordinator::{EmbedCoordinator, EnqueueError, WAKEUP_CAPACITY};
+pub use embed_coordinator::{EmbedCoordinator, EmbedOp, EnqueueError, WAKEUP_CAPACITY};
 
 #[cfg(feature = "embeddings")]
 mod vector_index;

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -1,0 +1,672 @@
+//! `reindex` (#201 PR-B) — resumable initial-embed worker.
+//!
+//! The embed-on-save coordinator (#196) only touches files the user edits
+//! in the current session. For a vault that's been around since before
+//! Semantic Search was enabled, we need a one-shot pass that walks every
+//! `.md` file, hashes it, and enqueues stale/new files through the same
+//! `EmbedCoordinator` pipeline as live edits. Unchanged files are
+//! short-circuited by a content-hash checkpoint so a mid-reindex crash /
+//! relaunch continues where it left off instead of redoing 40k files.
+//!
+//! ## Worker shape
+//!
+//! - Dedicated `std::thread` (not `tokio::spawn_blocking`) — walking,
+//!   hashing and the checkpoint flush are blocking I/O, and we don't
+//!   need a runtime in here because the `enqueue` callback handed in by
+//!   the caller is synchronous (it just wraps `EmbedCoordinator::enqueue`,
+//!   which already does a `try_send`).
+//! - `Arc<AtomicBool>` cancel flag polled between files — a 100k-reindex
+//!   must surrender within one file's worth of work (≤ a few ms).
+//! - `ReindexProgress` events are invoked via a caller-provided closure;
+//!   production wiring bridges that to a Tauri `embed://reindex_progress`
+//!   event (the IPC layer, not this module, holds the AppHandle).
+//!
+//! ## Checkpoint shape
+//!
+//! A single JSON file under `<vault>/.vaultcore/embeddings/`:
+//!
+//! ```json
+//! { "version": 1, "entries": { "folder/note.md": "<sha256hex>", ... } }
+//! ```
+//!
+//! Keys are vault-relative paths with forward slashes so the checkpoint
+//! survives a vault rename on the same OS. Values are the sha256 hex of
+//! the file bytes at the last successful enqueue. Flushed every
+//! `FLUSH_EVERY` enqueues and once more on exit (cancel or done) so the
+//! worst-case re-work after a crash is ~100 files.
+//!
+//! A corrupt or version-mismatched checkpoint is treated as "no prior
+//! progress" (logged at warn level, no hard failure). Concretely: a JSON
+//! parse error, a missing `version`, or `version != CHECKPOINT_VERSION`
+//! all yield a fresh empty checkpoint, and the full reindex runs. That
+//! keeps the feature robust across upgrades without a migration path.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use walkdir::{DirEntry, WalkDir};
+
+use crate::hash::hash_bytes;
+
+/// Filename of the checkpoint JSON under `<vault>/.vaultcore/embeddings/`.
+pub const CHECKPOINT_FILE: &str = "reindex.checkpoint.json";
+/// Current on-disk layout version. Bumped when the schema changes in a
+/// breaking way; older versions load as empty (force full re-walk).
+pub const CHECKPOINT_VERSION: u32 = 1;
+/// Flush cadence: every N successful enqueues we atomically write the
+/// checkpoint. Trades worst-case re-work (≤ N files) against disk churn.
+const FLUSH_EVERY: usize = 100;
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReindexPhase {
+    /// Enumerating `.md` files under the vault root.
+    Scan,
+    /// Hashing + enqueuing stale files.
+    Index,
+    /// Worker exited normally, every file processed.
+    Done,
+    /// Worker exited due to a user cancel; checkpoint was flushed.
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ReindexProgress {
+    /// Files processed (hashed) so far.
+    pub done: usize,
+    /// Total files discovered during scan. Zero while `phase == Scan`.
+    pub total: usize,
+    /// Subset of `done` that matched checkpoint hash — no enqueue.
+    pub skipped: usize,
+    /// Subset of `done` that was actually enqueued for embedding.
+    pub embedded: usize,
+    pub phase: ReindexPhase,
+    /// Linearly-extrapolated seconds remaining. `None` while scanning or
+    /// when the worker is idle (done == 0 or total - done == 0).
+    pub eta_seconds: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct CheckpointFile {
+    version: u32,
+    /// vault-relative forward-slash path → sha256 hex of file bytes
+    entries: HashMap<String, String>,
+}
+
+impl Default for CheckpointFile {
+    fn default() -> Self {
+        Self { version: CHECKPOINT_VERSION, entries: HashMap::new() }
+    }
+}
+
+/// Cancellation + join handle for a running reindex. Returned by
+/// [`start_reindex`] and typically parked in `VaultState` so a second
+/// reindex request cancels the first before spawning.
+pub struct ReindexHandle {
+    cancel: Arc<AtomicBool>,
+    join: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ReindexHandle {
+    /// Set the cancel flag. The worker polls it between files; callers
+    /// that want to block until the worker exits should follow with
+    /// [`join`](Self::join).
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::Release);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.load(Ordering::Acquire)
+    }
+
+    /// Wait for the worker thread to exit. Safe to call multiple times;
+    /// subsequent calls are a no-op.
+    pub fn join(&self) {
+        if let Some(h) = self.join.lock().expect("reindex join lock").take() {
+            let _ = h.join();
+        }
+    }
+
+    /// Convenience: cancel then join. Used on vault switch so the old
+    /// worker doesn't keep mutating the freshly-replaced coordinator.
+    pub fn cancel_and_join(&self) {
+        self.cancel();
+        self.join();
+    }
+}
+
+/// Spawn the reindex worker. The returned handle holds the cancel flag
+/// and the thread join; drop it without joining to detach, or call
+/// `cancel_and_join` for cooperative shutdown.
+///
+/// - `enqueue(path, content) -> bool`: invoked for every file whose hash
+///   differs from the checkpoint. The closure must be non-blocking
+///   (wraps `EmbedCoordinator::enqueue`). Returns `true` iff the content
+///   landed — the checkpoint is only updated on `true`, so a transient
+///   `Closed` result will be retried on the next reindex.
+/// - `on_progress(ReindexProgress)`: invoked on every phase change and
+///   after every file. Production wiring emits a Tauri event; tests
+///   push into a Mutex<Vec<_>>.
+pub fn start_reindex<F, P>(
+    vault_root: PathBuf,
+    checkpoint_dir: PathBuf,
+    enqueue: F,
+    on_progress: P,
+) -> Arc<ReindexHandle>
+where
+    F: Fn(&Path, String) -> bool + Send + Sync + 'static,
+    P: Fn(ReindexProgress) + Send + Sync + 'static,
+{
+    let cancel = Arc::new(AtomicBool::new(false));
+    let handle = Arc::new(ReindexHandle {
+        cancel: Arc::clone(&cancel),
+        join: Mutex::new(None),
+    });
+
+    let join = std::thread::Builder::new()
+        .name("vc-reindex".into())
+        .spawn(move || {
+            run(vault_root, checkpoint_dir, cancel, enqueue, on_progress);
+        })
+        .expect("spawn reindex thread");
+
+    *handle.join.lock().expect("reindex join lock") = Some(join);
+    handle
+}
+
+fn run<F, P>(
+    vault_root: PathBuf,
+    checkpoint_dir: PathBuf,
+    cancel: Arc<AtomicBool>,
+    enqueue: F,
+    on_progress: P,
+) where
+    F: Fn(&Path, String) -> bool,
+    P: Fn(ReindexProgress),
+{
+    let _ = std::fs::create_dir_all(&checkpoint_dir);
+    let checkpoint_path = checkpoint_dir.join(CHECKPOINT_FILE);
+    let mut checkpoint = load_checkpoint(&checkpoint_path);
+
+    on_progress(ReindexProgress {
+        done: 0,
+        total: 0,
+        skipped: 0,
+        embedded: 0,
+        phase: ReindexPhase::Scan,
+        eta_seconds: None,
+    });
+
+    let files: Vec<PathBuf> = WalkDir::new(&vault_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_excluded(e))
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().is_file()
+                && e.path()
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+        })
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    let total = files.len();
+
+    let started = Instant::now();
+    let mut done = 0usize;
+    let mut skipped = 0usize;
+    let mut embedded = 0usize;
+    let mut since_flush = 0usize;
+
+    // Initial Index emission so the frontend can swap the statusbar from
+    // "Scanning" to "0 / total" before the first file completes.
+    on_progress(ReindexProgress {
+        done: 0,
+        total,
+        skipped: 0,
+        embedded: 0,
+        phase: ReindexPhase::Index,
+        eta_seconds: None,
+    });
+
+    for abs in files {
+        if cancel.load(Ordering::Acquire) {
+            break;
+        }
+        let rel_key = rel_key(&vault_root, &abs);
+        let (did_skip, did_embed) = process_file(&abs, &rel_key, &mut checkpoint, &enqueue);
+        if did_skip {
+            skipped += 1;
+        }
+        if did_embed {
+            embedded += 1;
+            since_flush += 1;
+        }
+        done += 1;
+
+        emit_progress(&on_progress, done, total, skipped, embedded, started);
+
+        if since_flush >= FLUSH_EVERY {
+            if let Err(e) = save_checkpoint(&checkpoint_path, &checkpoint) {
+                log::warn!("reindex: checkpoint flush failed: {e}");
+            }
+            since_flush = 0;
+        }
+    }
+
+    if let Err(e) = save_checkpoint(&checkpoint_path, &checkpoint) {
+        log::warn!("reindex: final checkpoint save failed: {e}");
+    }
+
+    let phase = if cancel.load(Ordering::Acquire) {
+        ReindexPhase::Cancelled
+    } else {
+        ReindexPhase::Done
+    };
+    on_progress(ReindexProgress {
+        done,
+        total,
+        skipped,
+        embedded,
+        phase,
+        eta_seconds: None,
+    });
+}
+
+/// Hash, compare, enqueue. Returns `(did_skip, did_embed)`. Exactly one
+/// of the two is true when the file was readable; both false on read
+/// error or non-UTF-8 content (we log and move on).
+fn process_file<F>(
+    abs: &Path,
+    rel_key: &str,
+    checkpoint: &mut CheckpointFile,
+    enqueue: &F,
+) -> (bool, bool)
+where
+    F: Fn(&Path, String) -> bool,
+{
+    let bytes = match std::fs::read(abs) {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!("reindex: read {} failed: {e}", abs.display());
+            return (false, false);
+        }
+    };
+    let hash = hash_bytes(&bytes);
+
+    if checkpoint.entries.get(rel_key) == Some(&hash) {
+        return (true, false);
+    }
+
+    let content = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("reindex: {} not utf-8 ({e}); skipping", abs.display());
+            return (false, false);
+        }
+    };
+
+    if enqueue(abs, content) {
+        checkpoint.entries.insert(rel_key.to_string(), hash);
+        (false, true)
+    } else {
+        (false, false)
+    }
+}
+
+fn emit_progress<P: Fn(ReindexProgress)>(
+    on_progress: &P,
+    done: usize,
+    total: usize,
+    skipped: usize,
+    embedded: usize,
+    started: Instant,
+) {
+    let eta_seconds = if done > 0 && total > done {
+        let elapsed = started.elapsed().as_secs_f64();
+        let per = elapsed / done as f64;
+        Some((per * (total - done) as f64) as u64)
+    } else {
+        None
+    };
+    on_progress(ReindexProgress {
+        done,
+        total,
+        skipped,
+        embedded,
+        phase: ReindexPhase::Index,
+        eta_seconds,
+    });
+}
+
+fn rel_key(vault_root: &Path, abs: &Path) -> String {
+    abs.strip_prefix(vault_root)
+        .unwrap_or(abs)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn is_excluded(entry: &DirEntry) -> bool {
+    let name = entry.file_name().to_str().unwrap_or("");
+    entry.depth() > 0 && name.starts_with('.')
+}
+
+fn load_checkpoint(path: &Path) -> CheckpointFile {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return CheckpointFile::default(),
+    };
+    match serde_json::from_str::<CheckpointFile>(&raw) {
+        Ok(c) if c.version == CHECKPOINT_VERSION => c,
+        Ok(c) => {
+            log::warn!(
+                "reindex checkpoint version {} unsupported (expected {}); starting fresh",
+                c.version,
+                CHECKPOINT_VERSION
+            );
+            CheckpointFile::default()
+        }
+        Err(e) => {
+            log::warn!("reindex checkpoint corrupt ({e}); starting fresh");
+            CheckpointFile::default()
+        }
+    }
+}
+
+fn save_checkpoint(path: &Path, checkpoint: &CheckpointFile) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string(checkpoint)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    fn write_md(root: &Path, rel: &str, body: &str) -> PathBuf {
+        let p = root.join(rel);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    fn wait_until<F: Fn() -> bool>(cond: F, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        cond()
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        enqueued: Mutex<Vec<(PathBuf, String)>>,
+        progress: Mutex<Vec<ReindexProgress>>,
+    }
+
+    impl Recorder {
+        fn enqueued_paths(&self) -> Vec<PathBuf> {
+            self.enqueued
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(p, _)| p.clone())
+                .collect()
+        }
+        fn last_phase(&self) -> Option<ReindexPhase> {
+            self.progress.lock().unwrap().last().map(|p| p.phase.clone())
+        }
+    }
+
+    fn run_reindex_blocking(
+        vault: &Path,
+        ckpt_dir: &Path,
+    ) -> (Arc<Recorder>, Arc<ReindexHandle>) {
+        let rec = Arc::new(Recorder::default());
+        let enqueue_rec = Arc::clone(&rec);
+        let progress_rec = Arc::clone(&rec);
+        let handle = start_reindex(
+            vault.to_path_buf(),
+            ckpt_dir.to_path_buf(),
+            move |path, content| {
+                enqueue_rec
+                    .enqueued
+                    .lock()
+                    .unwrap()
+                    .push((path.to_path_buf(), content));
+                true
+            },
+            move |p| progress_rec.progress.lock().unwrap().push(p),
+        );
+        handle.join();
+        (rec, handle)
+    }
+
+    #[test]
+    fn checkpoint_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(CHECKPOINT_FILE);
+        let mut ckpt = CheckpointFile::default();
+        ckpt.entries.insert("a/b.md".into(), "deadbeef".into());
+        ckpt.entries.insert("c.md".into(), "cafebabe".into());
+        save_checkpoint(&path, &ckpt).unwrap();
+
+        let loaded = load_checkpoint(&path);
+        assert_eq!(loaded.version, CHECKPOINT_VERSION);
+        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(loaded.entries.get("a/b.md").map(String::as_str), Some("deadbeef"));
+    }
+
+    #[test]
+    fn corrupt_checkpoint_starts_fresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(CHECKPOINT_FILE);
+        std::fs::write(&path, "this is not json {{{").unwrap();
+        let loaded = load_checkpoint(&path);
+        assert!(loaded.entries.is_empty());
+        assert_eq!(loaded.version, CHECKPOINT_VERSION);
+    }
+
+    #[test]
+    fn version_mismatch_starts_fresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(CHECKPOINT_FILE);
+        std::fs::write(&path, r#"{"version":999,"entries":{"x.md":"h"}}"#).unwrap();
+        let loaded = load_checkpoint(&path);
+        assert!(loaded.entries.is_empty());
+    }
+
+    #[test]
+    fn first_run_enqueues_every_md_file() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "a.md", "note one");
+        write_md(vault.path(), "sub/b.md", "note two");
+        write_md(vault.path(), "sub/c.md", "note three");
+        // Non-md: must be ignored.
+        write_md(vault.path(), "ignored.txt", "not markdown");
+
+        let (rec, _h) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(rec.enqueued_paths().len(), 3);
+        assert_eq!(rec.last_phase(), Some(ReindexPhase::Done));
+    }
+
+    #[test]
+    fn skips_unchanged_files_on_second_run() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "a.md", "stable");
+        write_md(vault.path(), "b.md", "also stable");
+
+        let (rec1, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(rec1.enqueued_paths().len(), 2);
+
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(
+            rec2.enqueued_paths().len(),
+            0,
+            "second run must not re-enqueue unchanged files"
+        );
+        // Last progress reports all files skipped.
+        let last = rec2.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last.done, 2);
+        assert_eq!(last.skipped, 2);
+        assert_eq!(last.embedded, 0);
+        assert_eq!(last.phase, ReindexPhase::Done);
+    }
+
+    #[test]
+    fn re_enqueues_stale_file_when_hash_changes() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        let a = write_md(vault.path(), "a.md", "v1");
+        write_md(vault.path(), "b.md", "unchanged");
+
+        let (_rec1, _) = run_reindex_blocking(vault.path(), ckpt.path());
+
+        // Modify a.md — hash changes, b.md stays pinned.
+        std::fs::write(&a, "v2-totally-different").unwrap();
+
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        let paths = rec2.enqueued_paths();
+        assert_eq!(paths.len(), 1, "only the stale file re-enqueues, got {paths:?}");
+        assert!(paths[0].ends_with("a.md"));
+    }
+
+    #[test]
+    fn skips_dot_directories() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "note.md", "real");
+        write_md(vault.path(), ".vaultcore/ignored.md", "should be skipped");
+        write_md(vault.path(), ".git/also.md", "also skipped");
+        write_md(vault.path(), ".obsidian/cfg.md", "obsidian config");
+
+        let (rec, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        let paths = rec.enqueued_paths();
+        assert_eq!(paths.len(), 1);
+        assert!(paths[0].ends_with("note.md"));
+    }
+
+    #[test]
+    fn empty_vault_emits_done_with_zero_total() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        let (rec, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(rec.enqueued_paths().len(), 0);
+        let last = rec.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last.total, 0);
+        assert_eq!(last.done, 0);
+        assert_eq!(last.phase, ReindexPhase::Done);
+    }
+
+    #[test]
+    fn cancellation_stops_worker_and_persists_progress() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        for i in 0..400 {
+            write_md(vault.path(), &format!("n-{i:04}.md"), &format!("body {i}"));
+        }
+
+        let rec = Arc::new(Recorder::default());
+        let enqueue_rec = Arc::clone(&rec);
+        let progress_rec = Arc::clone(&rec);
+        // Slow the enqueue so we can observe cancellation mid-stream.
+        let handle = start_reindex(
+            vault.path().to_path_buf(),
+            ckpt.path().to_path_buf(),
+            move |path, content| {
+                std::thread::sleep(Duration::from_millis(2));
+                enqueue_rec
+                    .enqueued
+                    .lock()
+                    .unwrap()
+                    .push((path.to_path_buf(), content));
+                true
+            },
+            move |p| progress_rec.progress.lock().unwrap().push(p),
+        );
+        // Let it process a chunk then cancel.
+        assert!(wait_until(
+            || rec.enqueued.lock().unwrap().len() >= 20,
+            Duration::from_secs(10),
+        ));
+        handle.cancel();
+        handle.join();
+
+        let enqueued = rec.enqueued.lock().unwrap().len();
+        assert!(
+            enqueued < 400,
+            "cancellation must stop before processing all 400 files (got {enqueued})"
+        );
+        let last = rec.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last.phase, ReindexPhase::Cancelled);
+
+        // Checkpoint flushed — a second run picks up where the first left off
+        // (skipped == already-processed count, new enqueues cover the tail).
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        let last2 = rec2.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last2.total, 400);
+        assert_eq!(last2.done, 400);
+        assert!(
+            last2.skipped >= enqueued - 1,
+            "resumed run must skip at least what PR-1 already flushed: enq={enqueued}, skip={}",
+            last2.skipped
+        );
+    }
+
+    /// Lost-enqueue guard: if the caller's enqueue closure returns false
+    /// (simulating `EmbedCoordinator::enqueue` → `Closed`), the checkpoint
+    /// must NOT record that file, so the next run retries it.
+    #[test]
+    fn failed_enqueue_is_retried_next_run() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "a.md", "hello");
+
+        let rec = Arc::new(Recorder::default());
+        let enqueue_rec = Arc::clone(&rec);
+        let progress_rec = Arc::clone(&rec);
+        let handle = start_reindex(
+            vault.path().to_path_buf(),
+            ckpt.path().to_path_buf(),
+            move |path, content| {
+                enqueue_rec
+                    .enqueued
+                    .lock()
+                    .unwrap()
+                    .push((path.to_path_buf(), content));
+                false // simulate Closed
+            },
+            move |p| progress_rec.progress.lock().unwrap().push(p),
+        );
+        handle.join();
+        assert_eq!(rec.enqueued.lock().unwrap().len(), 1);
+
+        // Second run: enqueue is still empty (checkpoint didn't record).
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(
+            rec2.enqueued.lock().unwrap().len(),
+            1,
+            "stale file with no checkpoint entry must be retried"
+        );
+    }
+}

--- a/src-tauri/src/embeddings/sink.rs
+++ b/src-tauri/src/embeddings/sink.rs
@@ -4,23 +4,333 @@
 //! touching the queue.
 //!
 //! Lifecycle contract: callers invoke `store(path, ...)` once per
-//! coalesced save. The sink is responsible for replacing any prior
-//! vectors associated with `path` (upsert semantics) — #200 will add an
-//! explicit delete hook for rename/delete paths; for now an
-//! upsert-replace is sufficient because every save produces a fresh
-//! chunk set for the same path.
+//! coalesced save. The sink replaces any prior vectors associated with
+//! `path` (upsert semantics). `delete(path)` (#201) is the explicit hook
+//! for rename/delete dispatch — `store` already implies "drop prior
+//! vectors then insert", but `delete` skips the embed work entirely.
 
 use std::path::Path;
+#[cfg(feature = "embeddings")]
+use std::path::PathBuf;
+#[cfg(feature = "embeddings")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "embeddings")]
+use std::sync::{Arc, RwLock};
 
 use super::Chunk;
+#[cfg(feature = "embeddings")]
+use super::VectorIndex;
 
 pub trait VectorSink: Send + Sync {
     fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>);
+    /// Drop every vector associated with `path`. Default is a no-op so
+    /// callers built before #201 (e.g. `NoopSink`) still compile without
+    /// per-impl boilerplate.
+    fn delete(&self, _path: &Path) {}
 }
 
-/// Discards everything. Used while #198 is still pending.
+/// Discards everything. Used while #198 was pending and still useful for
+/// tests that want to exercise the coordinator without an HNSW dep.
 pub struct NoopSink;
 
 impl VectorSink for NoopSink {
     fn store(&self, _path: &Path, _chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {}
+}
+
+/// `HnswSink` (#201 PR-A) — production sink backed by an in-memory
+/// `VectorIndex` plus on-disk persistence under
+/// `<vault>/.vaultcore/embeddings/`. Every embedded save replaces prior
+/// vectors for the path; explicit `delete` tombstones them; compaction
+/// fires off-thread when the index crosses #200's gating thresholds.
+///
+/// Concurrency: the inner index is held as `Arc<RwLock<Arc<VectorIndex>>>`
+/// so reads (queries) take a brief read lock to clone the inner `Arc`
+/// and then operate lock-free against that snapshot. Writes (compaction)
+/// take the write lock once to swap in a fresh index. Stores and deletes
+/// only need a read lock + the snapshot's own internal locks.
+///
+/// Drop semantics: the sink saves to disk on `Drop`, on a detached
+/// background thread so vault switch / app close doesn't freeze the UI
+/// for the seconds it takes to dump 100k vectors. The trade-off is that
+/// a save in flight when the OS reaps the process is incomplete; the
+/// next launch falls back to `load_or_empty` and the lost embeddings
+/// will be re-emitted on next save (or by the #201 PR-B reindex worker).
+#[cfg(feature = "embeddings")]
+pub struct HnswSink {
+    index: Arc<RwLock<Arc<VectorIndex>>>,
+    save_dir: PathBuf,
+    /// CAS guard against starting a second compaction while one is in
+    /// flight. Set to `true` by the thread that wins the race; cleared
+    /// when the compaction finishes (and self-checks one more time).
+    compacting: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "embeddings")]
+impl HnswSink {
+    /// Open or create the on-disk vector index at `save_dir`. Falls back
+    /// to an empty index on missing/corrupt files (#199 AC #3).
+    pub fn open(save_dir: PathBuf, capacity_hint: usize) -> Self {
+        let _ = std::fs::create_dir_all(&save_dir);
+        let index = VectorIndex::load_or_empty(&save_dir, capacity_hint);
+        Self {
+            index: Arc::new(RwLock::new(Arc::new(index))),
+            save_dir,
+            compacting: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Take a cheap snapshot of the inner index. Read-only callers
+    /// (queries, save-on-Drop) use this to avoid holding the outer
+    /// `RwLock` for the duration of work.
+    pub fn snapshot(&self) -> Arc<VectorIndex> {
+        Arc::clone(&self.index.read().expect("index lock"))
+    }
+
+    /// Persist the current snapshot synchronously. Used by tests and the
+    /// future periodic-flush path (#201 PR-B).
+    pub fn save_now(&self) -> Result<(), super::EmbeddingError> {
+        self.snapshot().save(&self.save_dir)
+    }
+
+    fn maybe_compact(&self) {
+        let snap = self.snapshot();
+        if !snap.should_compact() {
+            return;
+        }
+        if self
+            .compacting
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let index_lock = Arc::clone(&self.index);
+        let compacting = Arc::clone(&self.compacting);
+        std::thread::spawn(move || {
+            match snap.compact_into_fresh() {
+                Ok(fresh) => {
+                    let fresh_arc = Arc::new(fresh);
+                    if let Ok(mut guard) = index_lock.write() {
+                        let live = fresh_arc.live_len();
+                        *guard = fresh_arc;
+                        log::info!("VectorIndex compacted; live={live}");
+                    }
+                }
+                Err(e) => log::warn!("compaction failed: {e}"),
+            }
+            compacting.store(false, Ordering::Release);
+            // Trailing self-check: if more deletes piled up while we
+            // were rebuilding, the next sink.delete() call won't always
+            // observe should_compact() as true (it might if more
+            // deletes landed). Probe once here so a steady delete
+            // stream doesn't have to wait for a fresh user save to
+            // notice.
+            if let Ok(g) = index_lock.read() {
+                if g.should_compact() {
+                    log::info!("VectorIndex still over compaction threshold post-rebuild");
+                }
+            }
+        });
+    }
+}
+
+#[cfg(feature = "embeddings")]
+impl VectorSink for HnswSink {
+    fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {
+        if chunks_with_vectors.is_empty() {
+            return;
+        }
+        let snap = self.snapshot();
+        snap.mark_deleted(path);
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = chunks_with_vectors
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_chunk, v))| (path.to_path_buf(), i, v))
+            .collect();
+        snap.bulk_insert(items);
+        self.maybe_compact();
+    }
+
+    fn delete(&self, path: &Path) {
+        let snap = self.snapshot();
+        if snap.mark_deleted(path) > 0 {
+            self.maybe_compact();
+        }
+    }
+}
+
+#[cfg(feature = "embeddings")]
+impl Drop for HnswSink {
+    fn drop(&mut self) {
+        let snap = self.snapshot();
+        let dir = self.save_dir.clone();
+        std::thread::spawn(move || {
+            if let Err(e) = snap.save(&dir) {
+                log::warn!("HnswSink save on drop failed: {e}");
+            }
+        });
+    }
+}
+
+#[cfg(all(test, feature = "embeddings"))]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    fn unit_vec(seed: u64) -> Vec<f32> {
+        let mut s = seed.wrapping_mul(0x9E3779B97F4A7C15);
+        let mut out = Vec::with_capacity(384);
+        for _ in 0..384 {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            let bits = (s >> 32) as u32;
+            let f = (bits as f32 / u32::MAX as f32) * 2.0 - 1.0;
+            out.push(f);
+        }
+        let n: f32 = out.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in &mut out {
+            *x /= n;
+        }
+        out
+    }
+
+    fn pair(seed: u64) -> (Chunk, Vec<f32>) {
+        (
+            Chunk {
+                text: format!("seed-{seed}"),
+                byte_offset: 0,
+            },
+            unit_vec(seed),
+        )
+    }
+
+    fn wait_until<F: Fn() -> bool>(cond: F, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        cond()
+    }
+
+    #[test]
+    fn store_then_query_finds_vector() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let path = PathBuf::from("a.md");
+        sink.store(&path, vec![pair(1)]);
+
+        let snap = sink.snapshot();
+        let hits = snap.query_with_paths(&unit_vec(1), 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, path);
+    }
+
+    #[test]
+    fn store_replaces_prior_vectors_for_same_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let path = PathBuf::from("dup.md");
+        sink.store(&path, vec![pair(1), pair(2)]);
+        sink.store(&path, vec![pair(3)]);
+
+        let snap = sink.snapshot();
+        // Old chunks tombstoned, only seed-3 remains live.
+        assert_eq!(snap.live_len(), 1);
+        // Query for the old vectors must not return them.
+        let hits = snap.query_with_paths(&unit_vec(1), 5);
+        assert!(hits.iter().all(|(_, _, d)| *d > 0.01),
+            "old chunk should not be a near-zero hit, got {hits:?}");
+    }
+
+    #[test]
+    fn delete_marks_path_tombstoned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let p = PathBuf::from("gone.md");
+        sink.store(&p, vec![pair(7)]);
+        sink.delete(&p);
+
+        let snap = sink.snapshot();
+        assert_eq!(snap.live_len(), 0);
+        assert_eq!(snap.tombstone_count(), 1);
+        let hits = snap.query_with_paths(&unit_vec(7), 5);
+        assert!(hits.iter().all(|(path, _, _)| path != &p));
+    }
+
+    #[test]
+    fn delete_on_unknown_path_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        sink.delete(Path::new("never-stored.md"));
+        assert_eq!(sink.snapshot().len(), 0);
+    }
+
+    #[test]
+    fn save_on_drop_persists_then_reloads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        {
+            let sink = HnswSink::open(dir.clone(), 8);
+            sink.store(&PathBuf::from("persisted.md"), vec![pair(42)]);
+            // Sink dropped here — Drop spawns a save thread.
+        }
+        // Wait for the save file to appear.
+        let mapping = dir.join("vectors.mapping.json");
+        assert!(
+            wait_until(|| mapping.exists(), Duration::from_secs(5)),
+            "save-on-Drop never wrote {}",
+            mapping.display(),
+        );
+        // Wait briefly for the data dump to finish too — file_dump writes
+        // graph + data + mapping in sequence, and our preflight check
+        // requires both binary files present.
+        let data = dir.join("vectors.hnsw.data");
+        assert!(wait_until(|| data.exists(), Duration::from_secs(2)));
+        std::thread::sleep(Duration::from_millis(50));
+
+        let reopened = HnswSink::open(dir, 8);
+        let snap = reopened.snapshot();
+        assert_eq!(snap.len(), 1);
+        let hits = snap.query_with_paths(&unit_vec(42), 1);
+        assert_eq!(hits[0].0, PathBuf::from("persisted.md"));
+    }
+
+    #[test]
+    fn compaction_runs_when_threshold_crossed_and_keeps_index_queryable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 400);
+        // Cross both gates: >64 tombstones AND >20% ratio.
+        // 400 inserts, 100 deletes = 25%.
+        for i in 0..400u64 {
+            sink.store(&PathBuf::from(format!("c-{i}.md")), vec![pair(i)]);
+        }
+        for i in 0..100u64 {
+            sink.delete(&PathBuf::from(format!("c-{i}.md")));
+        }
+        // After the last delete, maybe_compact() spawns a thread.
+        // Wait for the rebuild to swap in a fresh index (live_len == 300,
+        // tombstones cleared).
+        let ok = wait_until(
+            || {
+                let s = sink.snapshot();
+                s.tombstone_count() == 0 && s.len() == 300
+            },
+            Duration::from_secs(15),
+        );
+        assert!(
+            ok,
+            "compaction never landed: live={}, tombs={}, total={}",
+            sink.snapshot().live_len(),
+            sink.snapshot().tombstone_count(),
+            sink.snapshot().len()
+        );
+        // A surviving path is still queryable.
+        let hits = sink.snapshot().query_with_paths(&unit_vec(200), 1);
+        assert_eq!(hits[0].0, PathBuf::from("c-200.md"));
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,6 +70,12 @@ pub struct VaultState {
     /// `write_file` skips the embed dispatch silently in that case.
     #[cfg(feature = "embeddings")]
     pub embed_coordinator: Arc<Mutex<Option<embeddings::EmbedCoordinator>>>,
+    /// Running reindex worker (#201 PR-B), if any. The `reindex_vault`
+    /// command cancels the previous handle before spawning a new one,
+    /// and `open_vault` cancels on vault switch so the old worker can't
+    /// write to the freshly-replaced coordinator's checkpoint.
+    #[cfg(feature = "embeddings")]
+    pub reindex_handle: Arc<Mutex<Option<Arc<embeddings::ReindexHandle>>>>,
 }
 
 impl Default for VaultState {
@@ -82,6 +88,8 @@ impl Default for VaultState {
             index_coordinator: Arc::new(Mutex::new(None)),
             #[cfg(feature = "embeddings")]
             embed_coordinator: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "embeddings")]
+            reindex_handle: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -107,6 +115,10 @@ pub fn run() {
             commands::vault::get_recent_vaults,
             commands::vault::get_vault_stats,
             commands::vault::repair_vault_index,
+            #[cfg(feature = "embeddings")]
+            commands::vault::reindex_vault,
+            #[cfg(feature = "embeddings")]
+            commands::vault::cancel_reindex,
             commands::files::read_file,
             commands::files::write_file,
             commands::files::create_file,

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -23,6 +23,8 @@ use tokio::time::sleep;
 
 use crate::WriteIgnoreList;
 use crate::indexer::IndexCmd;
+#[cfg(feature = "embeddings")]
+use crate::embeddings::EmbedOp;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -95,6 +97,7 @@ pub fn spawn_watcher(
     write_ignore: Arc<Mutex<WriteIgnoreList>>,
     vault_reachable: Arc<Mutex<bool>>,
     index_tx: Option<tokio::sync::mpsc::Sender<IndexCmd>>,
+    #[cfg(feature = "embeddings")] embed_tx: Option<tokio::sync::mpsc::Sender<EmbedOp>>,
 ) -> Debouncer<RecommendedWatcher, RecommendedCache> {
     let vault_path_clone = vault_path.clone();
     let vault_reachable_for_error = vault_reachable.clone();
@@ -106,7 +109,15 @@ pub fn spawn_watcher(
         None,
         move |result: DebounceEventResult| match result {
             Ok(events) => {
-                process_events(&app_for_events, &write_ignore, &vault_path_clone, &index_tx, events);
+                process_events(
+                    &app_for_events,
+                    &write_ignore,
+                    &vault_path_clone,
+                    &index_tx,
+                    #[cfg(feature = "embeddings")]
+                    &embed_tx,
+                    events,
+                );
             }
             Err(errors) => {
                 for error in errors {
@@ -209,6 +220,7 @@ fn process_events(
     write_ignore: &Arc<Mutex<WriteIgnoreList>>,
     vault_path: &Path,
     index_tx: &Option<tokio::sync::mpsc::Sender<IndexCmd>>,
+    #[cfg(feature = "embeddings")] embed_tx: &Option<tokio::sync::mpsc::Sender<EmbedOp>>,
     events: Vec<DebouncedEvent>,
 ) {
     // Step 1: Filter dot-prefixed paths
@@ -254,6 +266,16 @@ fn process_events(
             dispatch_link_graph_cmd(tx, vault_path, &ev);
             // Step 5b: Dispatch tag-index commands (TAG-01/02)
             dispatch_tag_index_cmd(tx, vault_path, &ev);
+        }
+
+        // Step 5c (#201 PR-A): Tombstone vectors for externally-deleted
+        // and externally-renamed markdown files. Internal deletes go via
+        // commands::files which dispatches its own EmbedOp::Delete (see
+        // delete_file / rename_file / move_file), so this catches only
+        // events that bypass the write-ignore list — i.e. external tools.
+        #[cfg(feature = "embeddings")]
+        if let Some(tx) = embed_tx {
+            dispatch_embed_delete_cmd(tx, vault_path, &ev);
         }
 
         if let Some(payload) = map_event_to_payload(vault_path, &ev) {
@@ -445,6 +467,48 @@ pub(crate) fn dispatch_tag_index_cmd(
         }
         EventKind::Remove(_) => {
             try_send_or_warn(tx, IndexCmd::RemoveTags { rel_path });
+        }
+        _ => {}
+    }
+}
+
+/// #201 PR-A — dispatch `EmbedOp::Delete` for Remove / rename-from events
+/// on markdown paths. We only tombstone; creates & modifies rely on the
+/// save path (write_file dispatches Embed) and the reindex worker (#201
+/// PR-B) to re-embed externally-touched content. `try_send` so a full
+/// channel just drops — the worker state stays consistent because a
+/// subsequent reindex pass will clean up any missed tombstones.
+#[cfg(feature = "embeddings")]
+fn dispatch_embed_delete_cmd(
+    tx: &tokio::sync::mpsc::Sender<EmbedOp>,
+    vault_path: &Path,
+    ev: &DebouncedEvent,
+) {
+    let primary_path = match ev.paths.first() {
+        Some(p) => p,
+        None => return,
+    };
+    if primary_path
+        .extension()
+        .map_or(true, |ext| !ext.eq_ignore_ascii_case("md"))
+    {
+        return;
+    }
+    // Only in-vault paths; same guard as map_event_to_payload.
+    if !primary_path.starts_with(vault_path) {
+        return;
+    }
+
+    match &ev.kind {
+        EventKind::Remove(_) => {
+            let _ = tx.try_send(EmbedOp::Delete(primary_path.clone()));
+        }
+        EventKind::Modify(ModifyKind::Name(_)) => {
+            // Rename — the OLD path's vectors must be tombstoned. The
+            // NEW path (paths[1]) doesn't need an embed here; the user
+            // will save it via write_file which embeds via the save
+            // dispatch.
+            let _ = tx.try_send(EmbedOp::Delete(primary_path.clone()));
         }
         _ => {}
     }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,7 +13,8 @@
     pickVaultFolder,
     repairVaultIndex,
   } from "./ipc/commands";
-  import { listenIndexProgress } from "./ipc/events";
+  import { listenIndexProgress, listenReindexProgress } from "./ipc/events";
+  import { reindexStore } from "./store/reindexStore";
   import { isVaultError, vaultErrorCopy } from "./types/errors";
   import type { RecentVault } from "./types/vault";
   import "./types/e2e-hook";
@@ -24,6 +25,7 @@
 
   let recent: RecentVault[] = $state([]);
   let unlistenProgress: (() => void) | null = null;
+  let unlistenReindex: (() => void) | null = null;
 
   // Custom CSS snippets (#64): keep one HTMLStyleElement per enabled snippet
   // mounted at the top of document.head, tagged with data-snippet="<filename>".
@@ -176,6 +178,12 @@
       progressStore.update(payload.current, payload.total, payload.current_file);
     });
 
+    // #201: pipe semantic-reindex progress events into the reindexStore so
+    // the statusbar overlay and settings modal can reflect live state.
+    unlistenReindex = await listenReindexProgress((payload) => {
+      reindexStore.apply(payload);
+    });
+
     // E2E test hook: expose loadVault + switchVault on window so WebDriver
     // specs can bypass the native file picker. Gated behind VITE_E2E=1 so
     // the hook is completely absent from normal release builds (tree-shaken
@@ -269,6 +277,7 @@
 
   onDestroy(() => {
     unlistenProgress?.();
+    unlistenReindex?.();
     unsubSnippets();
   });
 </script>

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -8,6 +8,7 @@
   import TemplatePicker from "../TemplatePicker/TemplatePicker.svelte";
   import RightSidebar from "./RightSidebar.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
+  import ReindexStatusbar from "../Statusbar/ReindexStatusbar.svelte";
   import { tabStore } from "../../store/tabStore";
   import { searchStore } from "../../store/searchStore";
   import { backlinksStore } from "../../store/backlinksStore";
@@ -813,6 +814,9 @@
   onClose={() => { settingsOpen = false; }}
   {onSwitchVault}
 />
+
+<!-- #201: reindex progress overlay. Self-hides while idle. -->
+<ReindexStatusbar />
 
 <style>
   .vc-vault-layout {

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -12,6 +12,8 @@
   import { DEFAULT_DAILY_DATE_FORMAT } from "../../lib/dailyNotes";
   import { vaultStore } from "../../store/vaultStore";
   import { snippetsStore } from "../../store/snippetsStore";
+  import { reindexVault, cancelReindex } from "../../ipc/commands";
+  import { reindexStore, isActive as isReindexActive } from "../../store/reindexStore";
   import { formatShortcut } from "../../lib/shortcuts";
   import { commandRegistry, hotkeysEqual, type Command, type HotKey } from "../../lib/commands/registry";
   import { DEFAULT_COMMAND_SPECS } from "../../lib/commands/defaultCommands";
@@ -63,6 +65,8 @@
   let snippetsEnabled = $state<string[]>([]);
   let snippetsLoaded = $state<boolean>(false);
   let refreshingSnippets = $state<boolean>(false);
+  let semanticEnabled = $state<boolean>(false);
+  let reindexActive = $state<boolean>(false);
 
   const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
   const unsubSettings = settingsStore.subscribe((s) => {
@@ -72,6 +76,10 @@
     dailyFolder = s.dailyNotesFolder;
     dailyFormat = s.dailyNotesDateFormat;
     dailyTemplate = s.dailyNotesTemplate;
+    semanticEnabled = s.enableSemanticSearch;
+  });
+  const unsubReindex = reindexStore.subscribe((r) => {
+    reindexActive = isReindexActive(r);
   });
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
   const unsubCommands = commandRegistry.subscribe((list) => {
@@ -227,7 +235,25 @@
     }
   }
 
-  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); });
+  /** #201: master toggle for semantic search. Enabling fires the
+   *  background reindex against the open vault; disabling cancels it.
+   *  Both calls are fire-and-forget — the statusbar listens for the
+   *  `embed://reindex_progress` event and surfaces progress. */
+  async function onToggleSemantic(e: Event): Promise<void> {
+    const enabled = (e.target as HTMLInputElement).checked;
+    settingsStore.setEnableSemanticSearch(enabled);
+    try {
+      if (enabled) {
+        if (currentVaultPath) await reindexVault();
+      } else {
+        await cancelReindex();
+      }
+    } catch (err) {
+      console.warn("semantic toggle ipc failed", err);
+    }
+  }
+
+  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); unsubReindex(); });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -409,6 +435,38 @@
         <p class="vc-settings-hint">
           Unterstützte Tokens: <code>YYYY</code>, <code>MM</code>, <code>DD</code>.
           Fehlender Ordner wird beim ersten Öffnen erstellt.
+        </p>
+      </section>
+
+      <!-- Section — Semantische Suche (#201) -->
+      <section class="vc-settings-section" data-testid="settings-semantic">
+        <h3 class="vc-settings-section-title">SEMANTISCHE SUCHE</h3>
+        <div class="vc-settings-row">
+          <label for="semantic-toggle">Semantische Suche aktivieren</label>
+          <label class="vc-snippets-toggle">
+            <input
+              id="semantic-toggle"
+              data-testid="settings-semantic-toggle"
+              type="checkbox"
+              checked={semanticEnabled}
+              onchange={onToggleSemantic}
+              disabled={!currentVaultPath}
+              aria-label="Semantische Suche aktivieren"
+            />
+            <span class="vc-snippets-toggle-track" aria-hidden="true">
+              <span class="vc-snippets-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+        <p class="vc-settings-hint">
+          Erster Index-Lauf kann bei großen Vaults einige Minuten dauern und
+          läuft im Hintergrund. Fortschritt wird in der Statusleiste angezeigt.
+          {#if reindexActive}
+            <strong> Indexierung läuft …</strong>
+          {/if}
+          {#if !currentVaultPath}
+            <br />Öffne zuerst einen Vault, um die semantische Suche zu aktivieren.
+          {/if}
         </p>
       </section>
 

--- a/src/components/Statusbar/ReindexStatusbar.svelte
+++ b/src/components/Statusbar/ReindexStatusbar.svelte
@@ -1,0 +1,197 @@
+<!--
+  #201 PR-C — Statusbar strip that surfaces reindex progress to the user.
+
+  Self-hiding: renders nothing while the store is idle so the vault layout
+  stays clean for the (usually long) steady-state. Becomes visible on the
+  first `scan` / `index` event and disappears again ~3 s after the
+  terminal `done` / `cancelled` event (the timer is the only reason the
+  component needs local state — everything else is driven by the store).
+
+  Positioning: fixed bottom overlay, z-index above the editor but below
+  modals. Doesn't consume a grid row, so the VaultLayout grid stays
+  untouched.
+-->
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { X } from "lucide-svelte";
+  import { reindexStore } from "../../store/reindexStore";
+  import { cancelReindex } from "../../ipc/commands";
+  import type { ReindexPhase } from "../../ipc/events";
+
+  interface ViewModel {
+    visible: boolean;
+    phase: ReindexPhase | "idle";
+    done: number;
+    total: number;
+    skipped: number;
+    embedded: number;
+    etaSeconds: number | null;
+  }
+
+  const initialVm: ViewModel = {
+    visible: false,
+    phase: "idle",
+    done: 0,
+    total: 0,
+    skipped: 0,
+    embedded: 0,
+    etaSeconds: null,
+  };
+
+  let vm = $state<ViewModel>({ ...initialVm });
+  let hideTimer: number | null = null;
+
+  const unsub = reindexStore.subscribe((s) => {
+    if (hideTimer !== null) {
+      window.clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+    const isTerminal = s.phase === "done" || s.phase === "cancelled";
+    vm = {
+      visible: s.phase !== "idle",
+      phase: s.phase,
+      done: s.done,
+      total: s.total,
+      skipped: s.skipped,
+      embedded: s.embedded,
+      etaSeconds: s.etaSeconds,
+    };
+    if (isTerminal) {
+      hideTimer = window.setTimeout(() => {
+        vm = { ...initialVm };
+        hideTimer = null;
+      }, 3000);
+    }
+  });
+
+  onDestroy(() => {
+    if (hideTimer !== null) window.clearTimeout(hideTimer);
+    unsub();
+  });
+
+  function percentFor(v: ViewModel): number {
+    if (v.total <= 0) return 0;
+    return Math.min(100, Math.round((v.done / v.total) * 100));
+  }
+
+  function formatEta(seconds: number | null): string {
+    if (seconds === null || seconds <= 0) return "—";
+    if (seconds < 60) return `${seconds}s`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    if (m < 60) return `${m}m ${s.toString().padStart(2, "0")}s`;
+    const h = Math.floor(m / 60);
+    return `${h}h ${(m % 60).toString().padStart(2, "0")}m`;
+  }
+
+  function label(v: ViewModel): string {
+    switch (v.phase) {
+      case "scan":
+        return "Durchsuche Vault …";
+      case "index":
+        return `${v.done.toLocaleString("de-DE")} / ${v.total.toLocaleString("de-DE")}`;
+      case "done":
+        return `Fertig — ${v.embedded.toLocaleString("de-DE")} Dateien indexiert, ${v.skipped.toLocaleString("de-DE")} übersprungen`;
+      case "cancelled":
+        return `Abgebrochen — ${v.done.toLocaleString("de-DE")} von ${v.total.toLocaleString("de-DE")} bearbeitet`;
+      default:
+        return "";
+    }
+  }
+
+  async function onCancel(): Promise<void> {
+    try {
+      await cancelReindex();
+    } catch (err) {
+      console.warn("cancel reindex ipc failed", err);
+    }
+  }
+</script>
+
+{#if vm.visible}
+  <div class="vc-reindex-bar" role="status" aria-live="polite" data-testid="reindex-statusbar">
+    <div class="vc-reindex-label">Semantik-Index: {label(vm)}</div>
+    {#if vm.phase === "index" && vm.total > 0}
+      <div class="vc-reindex-progress" aria-hidden="true">
+        <div class="vc-reindex-progress-fill" style="width: {percentFor(vm)}%"></div>
+      </div>
+      <div class="vc-reindex-eta">ETA {formatEta(vm.etaSeconds)}</div>
+    {/if}
+    {#if vm.phase === "scan" || vm.phase === "index"}
+      <button
+        type="button"
+        class="vc-reindex-cancel"
+        onclick={onCancel}
+        aria-label="Reindex abbrechen"
+        title="Reindex abbrechen"
+      ><X size={14} /></button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .vc-reindex-bar {
+    position: fixed;
+    left: 50%;
+    bottom: 12px;
+    transform: translateX(-50%);
+    min-width: 320px;
+    max-width: 640px;
+    padding: 6px 10px;
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    column-gap: 10px;
+    align-items: center;
+    background: var(--color-surface, rgba(30, 30, 30, 0.9));
+    color: var(--color-text, #eee);
+    border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+    border-radius: 6px;
+    font-size: 12px;
+    z-index: 40;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  .vc-reindex-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .vc-reindex-progress {
+    height: 4px;
+    background: var(--color-border, rgba(255, 255, 255, 0.12));
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .vc-reindex-progress-fill {
+    height: 100%;
+    background: var(--color-accent, #5aa9ff);
+    transition: width 200ms ease;
+  }
+
+  .vc-reindex-eta {
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-muted, #aaa);
+    white-space: nowrap;
+  }
+
+  .vc-reindex-cancel {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--color-text-muted, #aaa);
+    cursor: pointer;
+  }
+  .vc-reindex-cancel:hover,
+  .vc-reindex-cancel:focus-visible {
+    background: var(--color-border, rgba(255, 255, 255, 0.12));
+    color: var(--color-text, #eee);
+  }
+</style>

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -520,3 +520,33 @@ export async function renderNoteHtml(
     throw normalizeError(e);
   }
 }
+
+// ── Semantic search (#201) ───────────────────────────────────────────────────
+
+/**
+ * Kick off the resumable initial-embed pass over the currently-open vault.
+ * The backend runs a background worker that walks every `.md` file, hashes
+ * it, and enqueues stale/new files through the embed pipeline. Progress is
+ * emitted via the `embed://reindex_progress` Tauri event — subscribe with
+ * {@link listenReindexProgress}.
+ *
+ * Returns immediately (the command just parks the worker thread). No-op if
+ * the backend was built without the embeddings feature or the bundled
+ * model is missing.
+ */
+export async function reindexVault(): Promise<void> {
+  try {
+    await invoke<void>("reindex_vault");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/** Cancel the in-flight reindex (no-op if none is running). */
+export async function cancelReindex(): Promise<void> {
+  try {
+    await invoke<void>("cancel_reindex");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}

--- a/src/ipc/events.ts
+++ b/src/ipc/events.ts
@@ -81,3 +81,32 @@ export function listenBulkChangeStart(
 export function listenBulkChangeEnd(handler: () => void): Promise<UnlistenFn> {
   return listen(BULK_CHANGE_END_EVENT, () => handler());
 }
+
+// ── Semantic search (#201) ──────────────────────────────────────────────────
+
+export type ReindexPhase = "scan" | "index" | "done" | "cancelled";
+
+export interface ReindexProgressPayload {
+  done: number;
+  total: number;
+  skipped: number;
+  embedded: number;
+  phase: ReindexPhase;
+  eta_seconds: number | null;
+}
+
+export const REINDEX_PROGRESS_EVENT = "embed://reindex_progress";
+
+/**
+ * #201: Subscribe to `embed://reindex_progress` events emitted by the
+ * background reindex worker. One `scan` event fires on start (total=0),
+ * one `index` event fires once the walk finishes (total=N, done=0), then
+ * one per processed file, then a terminal `done` or `cancelled` event.
+ */
+export function listenReindexProgress(
+  handler: (payload: ReindexProgressPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<ReindexProgressPayload>(REINDEX_PROGRESS_EVENT, (event) =>
+    handler(event.payload),
+  );
+}

--- a/src/lib/__tests__/reindexStore.test.ts
+++ b/src/lib/__tests__/reindexStore.test.ts
@@ -1,0 +1,72 @@
+/**
+ * reindexStore tests — payload application, idle reset, isActive helper.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { reindexStore, isActive } from "../../store/reindexStore";
+import type { ReindexProgressPayload } from "../../ipc/events";
+
+const base: ReindexProgressPayload = {
+  done: 0,
+  total: 0,
+  skipped: 0,
+  embedded: 0,
+  phase: "scan",
+  eta_seconds: null,
+};
+
+describe("reindexStore", () => {
+  beforeEach(() => {
+    reindexStore.reset();
+  });
+
+  it("starts idle", () => {
+    const state = get(reindexStore);
+    expect(state.phase).toBe("idle");
+    expect(state.done).toBe(0);
+    expect(state.total).toBe(0);
+    expect(state.etaSeconds).toBeNull();
+    expect(isActive(state)).toBe(false);
+  });
+
+  it("apply() maps snake_case eta_seconds to etaSeconds and mirrors phase", () => {
+    reindexStore.apply({ ...base, phase: "index", total: 100, done: 42, eta_seconds: 17 });
+    const state = get(reindexStore);
+    expect(state.phase).toBe("index");
+    expect(state.done).toBe(42);
+    expect(state.total).toBe(100);
+    expect(state.etaSeconds).toBe(17);
+    expect(isActive(state)).toBe(true);
+  });
+
+  it("isActive() is true only during scan/index", () => {
+    reindexStore.apply({ ...base, phase: "scan" });
+    expect(isActive(get(reindexStore))).toBe(true);
+
+    reindexStore.apply({ ...base, phase: "index" });
+    expect(isActive(get(reindexStore))).toBe(true);
+
+    reindexStore.apply({ ...base, phase: "done", done: 10, total: 10 });
+    expect(isActive(get(reindexStore))).toBe(false);
+
+    reindexStore.apply({ ...base, phase: "cancelled" });
+    expect(isActive(get(reindexStore))).toBe(false);
+  });
+
+  it("reset() returns the store to its initial idle state", () => {
+    reindexStore.apply({ ...base, phase: "index", done: 500, total: 1000 });
+    reindexStore.reset();
+    const state = get(reindexStore);
+    expect(state.phase).toBe("idle");
+    expect(state.done).toBe(0);
+    expect(state.total).toBe(0);
+  });
+
+  it("successive applies overwrite — the store carries only the latest payload", () => {
+    reindexStore.apply({ ...base, phase: "index", done: 10, total: 100, skipped: 2, embedded: 8 });
+    reindexStore.apply({ ...base, phase: "index", done: 20, total: 100, skipped: 2, embedded: 18 });
+    const state = get(reindexStore);
+    expect(state.done).toBe(20);
+    expect(state.embedded).toBe(18);
+  });
+});

--- a/src/lib/__tests__/settingsStore.test.ts
+++ b/src/lib/__tests__/settingsStore.test.ts
@@ -138,4 +138,43 @@ describe("settingsStore", () => {
     expect(state.dailyNotesDateFormat).toBe("YYYY-MM-DD");
     expect(state.dailyNotesTemplate).toBe("");
   });
+
+  // ─── Semantic search (#201) ──────────────────────────────────────────────
+  it("Test 13: enableSemanticSearch defaults to false", async () => {
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    expect(get(settingsStore).enableSemanticSearch).toBe(false);
+  });
+
+  it("Test 14: setEnableSemanticSearch persists 'true' / 'false' to localStorage", async () => {
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    settingsStore.setEnableSemanticSearch(true);
+    expect(get(settingsStore).enableSemanticSearch).toBe(true);
+    expect(localStorage.getItem("vaultcore-semantic-search")).toBe("true");
+    settingsStore.setEnableSemanticSearch(false);
+    expect(get(settingsStore).enableSemanticSearch).toBe(false);
+    expect(localStorage.getItem("vaultcore-semantic-search")).toBe("false");
+  });
+
+  it("Test 15: init reads stored 'true' value and applies it; only exact 'true' counts", async () => {
+    // Part A: stored "true" → enabled
+    localStorage.setItem("vaultcore-semantic-search", "true");
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    expect(get(settingsStore).enableSemanticSearch).toBe(true);
+
+    // Part B: any other value (including typo "TRUE" or empty) → disabled.
+    // Guards against a tampered localStorage flipping the flag on via
+    // a truthy-but-non-canonical string.
+    vi.resetModules();
+    setupLocalStorage();
+    localStorage.setItem("vaultcore-semantic-search", "TRUE");
+    const { settingsStore: s2 } = await import("../../store/settingsStore");
+    s2.init();
+    expect(get(s2).enableSemanticSearch).toBe(false);
+  });
 });

--- a/src/store/reindexStore.ts
+++ b/src/store/reindexStore.ts
@@ -1,0 +1,67 @@
+/**
+ * reindexStore — tracks the frontend-visible state of the #201 semantic
+ * reindex worker. Subscribed to by `App.svelte`'s event listener (which
+ * pipes `embed://reindex_progress` payloads into `apply`) and by the
+ * statusbar widget that renders progress to the user.
+ *
+ * Kept deliberately small: the backend already holds the source of
+ * truth (a resumable checkpoint + thread handle); the store only
+ * exposes the latest payload plus a derived `inProgress` flag so the
+ * statusbar can hide itself when idle.
+ *
+ * Pattern: classic writable factory. Do not refactor to Svelte 5
+ * $state runes (same RC-01 constraint as settingsStore).
+ */
+import { writable } from "svelte/store";
+import type { ReindexPhase, ReindexProgressPayload } from "../ipc/events";
+
+export interface ReindexState {
+  phase: ReindexPhase | "idle";
+  done: number;
+  total: number;
+  skipped: number;
+  embedded: number;
+  etaSeconds: number | null;
+}
+
+const initial: ReindexState = {
+  phase: "idle",
+  done: 0,
+  total: 0,
+  skipped: 0,
+  embedded: 0,
+  etaSeconds: null,
+};
+
+function createReindexStore() {
+  const _store = writable<ReindexState>({ ...initial });
+  return {
+    subscribe: _store.subscribe,
+    /** Ingest one `embed://reindex_progress` payload. Maps the snake_case
+     *  wire field to the camelCase `etaSeconds` for Svelte templates. */
+    apply(payload: ReindexProgressPayload): void {
+      _store.set({
+        phase: payload.phase,
+        done: payload.done,
+        total: payload.total,
+        skipped: payload.skipped,
+        embedded: payload.embedded,
+        etaSeconds: payload.eta_seconds,
+      });
+    },
+    /** Reset to idle — used on vault switch or after acknowledging a
+     *  `done`/`cancelled` terminal state so the statusbar retracts. */
+    reset(): void {
+      _store.set({ ...initial });
+    },
+  };
+}
+
+export const reindexStore = createReindexStore();
+
+/** True while the worker is actively scanning or indexing (not idle,
+ *  not terminal). Pure function so callers and tests can derive it
+ *  without a store subscription. */
+export function isActive(state: ReindexState): boolean {
+  return state.phase === "scan" || state.phase === "index";
+}

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -46,6 +46,10 @@ const K_SIZE = "vaultcore-font-size";
 const K_DAILY_FOLDER = "vaultcore-daily-notes-folder";
 const K_DAILY_FORMAT = "vaultcore-daily-notes-date-format";
 const K_DAILY_TEMPLATE = "vaultcore-daily-notes-template";
+// #201: semantic-search master toggle. When true, the next vault-open
+// triggers an initial reindex; toggling to false cancels any in-flight
+// reindex but does NOT delete prior embeddings.
+const K_SEMANTIC = "vaultcore-semantic-search";
 // Legacy key from the brief attachment-folder era (before embeds). Removed
 // during cleanup so stale entries don't linger in localStorage.
 const K_ATTACHMENT_FOLDER_LEGACY = "vaultcore-attachment-folder";
@@ -60,6 +64,9 @@ export interface SettingsState {
   dailyNotesDateFormat: string;
   /** Vault-relative path to a template file. Empty = no template. */
   dailyNotesTemplate: string;
+  /** #201: master toggle for semantic search. Off by default so the
+   *  reindex never runs until the user opts in. */
+  enableSemanticSearch: boolean;
 }
 
 const initial: SettingsState = {
@@ -69,6 +76,7 @@ const initial: SettingsState = {
   dailyNotesFolder: "",
   dailyNotesDateFormat: DEFAULT_DAILY_DATE_FORMAT,
   dailyNotesTemplate: "",
+  enableSemanticSearch: false,
 };
 
 function isBodyFont(v: unknown): v is BodyFont {
@@ -98,6 +106,7 @@ function readInitial(): SettingsState {
     const dFolder = localStorage.getItem(K_DAILY_FOLDER);
     const dFormat = localStorage.getItem(K_DAILY_FORMAT);
     const dTemplate = localStorage.getItem(K_DAILY_TEMPLATE);
+    const semantic = localStorage.getItem(K_SEMANTIC);
     return {
       fontBody: isBodyFont(b) ? b : initial.fontBody,
       fontMono: isMonoFont(m) ? m : initial.fontMono,
@@ -105,6 +114,7 @@ function readInitial(): SettingsState {
       dailyNotesFolder: sanitizeDailyString(dFolder, initial.dailyNotesFolder),
       dailyNotesDateFormat: sanitizeDailyString(dFormat, initial.dailyNotesDateFormat),
       dailyNotesTemplate: sanitizeDailyString(dTemplate, initial.dailyNotesTemplate),
+      enableSemanticSearch: semantic === "true",
     };
   } catch { return { ...initial }; }
 }
@@ -165,6 +175,13 @@ function createSettingsStore() {
       const v = sanitizeDailyString(value, "");
       _store.update((s) => ({ ...s, dailyNotesTemplate: v }));
       try { localStorage.setItem(K_DAILY_TEMPLATE, v); } catch { /* */ }
+    },
+    /** #201: persist the semantic-search master toggle. The caller owns
+     *  wiring this to `reindexVault` / `cancelReindex`; this setter is
+     *  storage-only so the flag can be read on next launch. */
+    setEnableSemanticSearch(enable: boolean): void {
+      _store.update((s) => ({ ...s, enableSemanticSearch: enable }));
+      try { localStorage.setItem(K_SEMANTIC, String(enable)); } catch { /* */ }
     },
   };
 }


### PR DESCRIPTION
## Summary

Third PR in the #201 stack (**A → B → C → D**). Adds the user-facing surface for the semantic reindex: a settings toggle that starts/stops the worker, a live progress bar, and a thin store that pipes backend events into Svelte components.

Depends on PR-B (#221) for the `reindex_vault` / `cancel_reindex` commands and the `embed://reindex_progress` event it consumes.

## What changes

- **Settings toggle** (`SettingsModal.svelte`) — new *Semantische Suche* section. Flipping the toggle persists to `localStorage` (`vaultcore-semantic-search`) and fires `reindex_vault` (on enable) or `cancel_reindex` (on disable). Disabled while no vault is open.
- **Reindex store** (`reindexStore.ts`) — classic writable factory holding the latest `embed://reindex_progress` payload. Exposes `apply()`, `reset()`, and an `isActive()` helper.
- **Statusbar overlay** (`ReindexStatusbar.svelte`) — fixed bottom-center overlay. Self-hides when idle, renders `Durchsuche Vault …` / `N / M` + progress bar + ETA + cancel-X during active phases, lingers 3 s on terminal `done` / `cancelled` before auto-hiding.
- **Event + IPC glue** (`events.ts`, `commands.ts`) — new `listenReindexProgress` subscription and `reindexVault` / `cancelReindex` invokers.
- **App wire-up** — `App.svelte` subscribes to the event once on mount, unlistens on destroy; `VaultLayout.svelte` mounts the statusbar as an overlay (outside the grid).

## Why this shape

- The statusbar is a **fixed overlay**, not a grid row. Adding a row to `VaultLayout`'s 5-column grid would shift every pane — the self-hiding overlay keeps the idle layout pixel-identical to today and only appears while indexing is active.
- Semantic toggle persistence uses a **strict `=== \"true\"`** match so tampered localStorage (`TRUE`, `1`, `yes`) cannot silently flip the flag on. Tested.
- Toggle handler is **fire-and-forget** — the IPC call does not await a settle, so the UI stays responsive. Failures are warn-logged (the statusbar would expose them anyway on the next event).

## Test plan

- [x] `src/lib/__tests__/reindexStore.test.ts` — 5 new specs: initial state, snake→camel mapping, `isActive()` across phases, `reset()`, successive overwrite
- [x] `src/lib/__tests__/settingsStore.test.ts` — 3 new specs (Test 13/14/15): default `false`, persist `\"true\"`/`\"false\"`, strict-match init rejects `\"TRUE\"`
- [x] 16/16 frontend tests green (`pnpm vitest run`)
- [x] `pnpm run typecheck` clean
- [ ] Manual UAT: enable toggle in a small vault, watch statusbar progress, cancel mid-run, re-enable → checkpoint resume verified