### PR TITLE
feat(embeddings): semantic_search IPC endpoint (#202)

### DIFF
--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -277,6 +277,69 @@ pub async fn search_filename(
     Ok(matches)
 }
 
+// ── semantic_search ───────────────────────────────────────────────────────────
+
+/// Semantic (vector) search over the HNSW index (#202).
+///
+/// Returns up to `k` nearest chunks to `query` as `SemanticHit`s sorted
+/// by descending similarity. Feature-gated: when the `embeddings` crate
+/// feature is disabled, the bundled model is missing, or the coordinator
+/// failed to initialise, the command returns an empty list rather than
+/// erroring — matches the tolerant contract of the existing full-text
+/// commands.
+///
+/// `k` is clamped to `[1, 100]` at the boundary to bound worst-case query
+/// cost; the HNSW overshoot for tombstone filtering (#200) scales with `k`.
+///
+/// The embed + ANN search is wrapped in `spawn_blocking` so it does not
+/// stall the tokio runtime thread — a typical MiniLM embed is ~15 ms,
+/// which would block other async IPC traffic otherwise.
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn semantic_search(
+    query: String,
+    k: usize,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<crate::embeddings::SemanticHit>, VaultError> {
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let k = k.clamp(1, 100);
+
+    let handles = {
+        let guard = state
+            .query_handles
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(h) => std::sync::Arc::clone(h),
+            None => return Ok(Vec::new()),
+        }
+    };
+
+    tokio::task::spawn_blocking(move || {
+        crate::embeddings::semantic_search_query(&handles, &query, k)
+    })
+    .await
+    .map_err(|_| VaultError::IndexCorrupt)?
+    .map_err(|e| {
+        log::warn!("semantic_search failed: {e}");
+        VaultError::IndexCorrupt
+    })
+}
+
+/// Stub command exposed when the `embeddings` feature is off so the
+/// frontend IPC call always resolves. Returns an empty list.
+#[cfg(not(feature = "embeddings"))]
+#[tauri::command]
+pub async fn semantic_search(
+    _query: String,
+    _k: usize,
+    _state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<serde_json::Value>, VaultError> {
+    Ok(Vec::new())
+}
+
 // ── rebuild_index ─────────────────────────────────────────────────────────────
 
 /// Trigger a full index rebuild.

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -223,6 +223,13 @@ pub async fn open_vault(
                 .map_err(|_| VaultError::LockPoisoned)?;
             *guard = None;
         }
+        {
+            let mut guard = state
+                .query_handles
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?;
+            *guard = None;
+        }
         let resource_dir = app.path().resource_dir().ok();
         let svc = crate::embeddings::EmbeddingService::load(resource_dir.as_deref());
         let chk = crate::embeddings::Chunker::load(resource_dir.as_deref());
@@ -236,14 +243,31 @@ pub async fn open_vault(
                 // growth past it is supported.
                 let embed_dir = canonical.join(".vaultcore").join("embeddings");
                 let cap = vault_info.file_count.saturating_mul(4).max(64);
+                // #202: keep a concrete `Arc<HnswSink>` alongside the
+                // `Arc<dyn VectorSink>` handed to the coordinator so the
+                // `semantic_search` IPC handler can call `snapshot()`
+                // without widening the trait. Both Arcs share one alloc.
+                let sink_concrete = Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
                 let sink: Arc<dyn crate::embeddings::VectorSink> =
-                    Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
+                    Arc::clone(&sink_concrete) as Arc<dyn crate::embeddings::VectorSink>;
+                let svc_for_query = Arc::clone(&svc);
                 let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
+                {
+                    let mut guard = state
+                        .embed_coordinator
+                        .lock()
+                        .map_err(|_| VaultError::LockPoisoned)?;
+                    *guard = Some(coord);
+                }
+                let handles = Arc::new(crate::embeddings::QueryHandles {
+                    service: svc_for_query,
+                    sink: sink_concrete,
+                });
                 let mut guard = state
-                    .embed_coordinator
+                    .query_handles
                     .lock()
                     .map_err(|_| VaultError::LockPoisoned)?;
-                *guard = Some(coord);
+                *guard = Some(handles);
             }
             (Err(e), _) | (_, Err(e)) => {
                 log::warn!("embed-on-save disabled: {e}");

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -56,6 +56,11 @@ pub use reindex::{
     ReindexProgress, CHECKPOINT_FILE, CHECKPOINT_VERSION,
 };
 
+#[cfg(feature = "embeddings")]
+mod query;
+#[cfg(feature = "embeddings")]
+pub use query::{semantic_search_query, QueryHandles, SemanticHit};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -1,0 +1,316 @@
+//! `query` (#202) — text-input top-k search composing `EmbeddingService`
+//! (#194) and `VectorIndex` (#198). Sits one layer above the raw HNSW so
+//! IPC handlers (and the future hybrid-search fusion in #203) can ask
+//! "find the nearest k chunks to this query string" without touching the
+//! embed / index plumbing themselves.
+//!
+//! Concurrency: the returned `QueryHandles` is `Send + Sync` and cheap to
+//! clone (two `Arc`s). The embed call serialises through
+//! `EmbeddingService`'s internal `Mutex` — see #205 for ORT session
+//! tuning that addresses the contention with the embed-on-save / reindex
+//! workers under bursty queries.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use super::{EmbeddingError, EmbeddingService, HnswSink};
+
+/// Combined handle the IPC layer needs to answer `semantic_search` —
+/// the embedder for the query text plus the sink that owns the live
+/// `VectorIndex` snapshot. Wrapped together so `VaultState` only adds
+/// one new `Mutex<Option<_>>` field rather than two parallel ones.
+pub struct QueryHandles {
+    pub service: Arc<EmbeddingService>,
+    pub sink: Arc<HnswSink>,
+}
+
+/// One ranked semantic-search hit. Path + chunk-index identifies the
+/// span; `score` is cosine similarity in `[-1, 1]` (≈ `[0, 1]` for
+/// real English prose) — higher = more similar. `id` is intentionally
+/// omitted: HNSW internal u32 ids are reassigned on compaction (#200),
+/// so leaking them across an async IPC boundary is a footgun.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticHit {
+    pub path: String,
+    pub chunk_index: usize,
+    pub score: f32,
+}
+
+/// Embed `text`, query the index for the top `k` nearest chunks, and
+/// convert distances to similarity scores. Returns an empty vec for an
+/// empty query or empty index — never errors on either; that case is
+/// expected during reindex bring-up before any chunks have landed.
+///
+/// Distance → score: `score = 1.0 - distance` because `DistDot` returns
+/// `1 - cos_sim` on L2-normalised vectors. The score is left in its raw
+/// `[-1, 1]` range so downstream RRF fusion (#203) can keep the
+/// "0 = orthogonal" reading.
+pub fn semantic_search_query(
+    handles: &QueryHandles,
+    text: &str,
+    k: usize,
+) -> Result<Vec<SemanticHit>, EmbeddingError> {
+    if text.trim().is_empty() || k == 0 {
+        return Ok(Vec::new());
+    }
+    let snap = handles.sink.snapshot();
+    if snap.is_empty() {
+        return Ok(Vec::new());
+    }
+    let vec = handles.service.embed(text)?;
+    if vec.len() != super::DIM {
+        return Err(EmbeddingError::InvalidArgument(format!(
+            "embedding dim mismatch: got {}, expected {}",
+            vec.len(),
+            super::DIM
+        )));
+    }
+    let hits = snap.query_with_paths(&vec, k);
+    Ok(hits
+        .into_iter()
+        .map(|(p, idx, dist)| SemanticHit {
+            path: p.to_string_lossy().into_owned(),
+            chunk_index: idx,
+            score: 1.0 - dist,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embeddings::{Chunker, VectorIndex};
+    use std::path::PathBuf;
+
+    fn try_load() -> Option<(Arc<EmbeddingService>, Arc<Chunker>)> {
+        let svc = EmbeddingService::load(None).ok()?;
+        let chk = Chunker::load(None).ok()?;
+        Some((svc, chk))
+    }
+
+    fn handles_with(sink: Arc<HnswSink>, svc: Arc<EmbeddingService>) -> QueryHandles {
+        QueryHandles { service: svc, sink }
+    }
+
+    #[test]
+    fn empty_query_returns_empty_without_embedding() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let h = handles_with(sink, svc);
+        assert!(semantic_search_query(&h, "", 5).unwrap().is_empty());
+        assert!(semantic_search_query(&h, "   ", 5).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_index_returns_empty_not_panic() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let h = handles_with(sink, svc);
+        let hits = semantic_search_query(&h, "anything at all", 10).unwrap();
+        assert!(hits.is_empty(), "expected no hits on empty index, got {hits:?}");
+    }
+
+    #[test]
+    fn k_zero_returns_empty() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let h = handles_with(sink, svc);
+        assert!(semantic_search_query(&h, "anything", 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn semantically_close_text_outranks_unrelated() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 16));
+
+        // Seed the index with several small notes via the live embedder so
+        // the test exercises the real embedding pipeline end-to-end.
+        // HNSW graph traversal can return fewer than k hits on very small
+        // indices (< ~5 points) due to layer-entry sparsity — seeding 6
+        // puts us safely past that floor.
+        let snap = sink.snapshot();
+        let docs = [
+            ("cats.md", "Cats are independent creatures that purr when content."),
+            ("dogs.md", "Dogs are loyal pack animals that wag their tails when happy."),
+            ("rust.md", "Rust async runtimes use cooperative scheduling and futures."),
+            ("recipe.md", "Bake the sourdough at 240 degrees for forty minutes."),
+            ("music.md", "Jazz improvisation builds on cycling chord progressions."),
+            ("math.md", "Eigenvalues of a symmetric matrix are always real numbers."),
+        ];
+        for (path, text) in docs {
+            let v = svc.embed(text).unwrap();
+            snap.insert(PathBuf::from(path), 0, &v);
+        }
+        drop(snap);
+
+        let h = handles_with(sink, svc);
+        let hits = semantic_search_query(&h, "feline body language", 3).unwrap();
+        assert!(!hits.is_empty(), "expected at least one hit");
+        // The cat note must rank first for a feline-related query.
+        assert_eq!(hits[0].path, "cats.md", "expected cats first, got {hits:?}");
+        // Scores must be non-increasing.
+        for w in hits.windows(2) {
+            assert!(
+                w[0].score >= w[1].score - 1e-6,
+                "scores not non-increasing: {} < {}",
+                w[0].score,
+                w[1].score
+            );
+        }
+        // Top score for a related query should be clearly positive.
+        assert!(
+            hits[0].score > 0.3,
+            "top score suspiciously low: {} for {}",
+            hits[0].score,
+            hits[0].path
+        );
+    }
+
+    #[test]
+    fn k_caps_result_count() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let snap = sink.snapshot();
+        for i in 0..5u64 {
+            let v = svc.embed(&format!("note number {i} with unique content")).unwrap();
+            snap.insert(PathBuf::from(format!("n-{i}.md")), 0, &v);
+        }
+        drop(snap);
+
+        let h = handles_with(sink, svc);
+        for k in [1usize, 3, 5] {
+            let hits = semantic_search_query(&h, "note", k).unwrap();
+            assert!(hits.len() <= k, "k={k} returned {} hits", hits.len());
+        }
+    }
+
+    #[test]
+    fn handles_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<QueryHandles>();
+        assert_send_sync::<Arc<QueryHandles>>();
+    }
+
+    #[test]
+    fn semantic_hit_serializes_to_camel_case() {
+        let h = SemanticHit {
+            path: "a/b.md".into(),
+            chunk_index: 3,
+            score: 0.42,
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains("\"chunkIndex\":3"), "got: {json}");
+        assert!(json.contains("\"score\":0.42"), "got: {json}");
+    }
+
+    /// Ensure VectorIndex is queryable via the helper — exercises the
+    /// path/sink composition without involving the live embedder. Uses
+    /// hand-crafted unit vectors so the test runs even without the
+    /// bundled model.
+    #[test]
+    fn helper_composes_sink_snapshot_correctly() {
+        // We can't construct an EmbeddingService without the model, so
+        // this test only verifies the snapshot-query side of the pipeline
+        // by calling VectorIndex directly. The text→embed→query pipeline
+        // is covered by `semantically_close_text_outranks_unrelated`.
+        let idx = VectorIndex::new(4);
+        let mut v = vec![0f32; super::super::DIM];
+        v[0] = 1.0;
+        idx.insert(PathBuf::from("only.md"), 0, &v);
+        let hits = idx.query_with_paths(&v, 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, PathBuf::from("only.md"));
+    }
+
+    /// AC #4 for #202 — p50 query latency under 5 ms at 100k vectors
+    /// (pre-fusion, i.e. HNSW + mapping-lookup only, no BM25 / RRF).
+    /// The per-query breakdown measured here is:
+    ///   - `service.embed` (~15 ms on cold ORT, ~2–5 ms warm)
+    ///   - `VectorIndex::query_with_paths` with k=10, ef_search=64
+    ///     (~100–500 µs against real-clustered data)
+    ///
+    /// The bench is `#[ignore]` because it builds 100k vectors and loads
+    /// the full MiniLM model. Run with
+    /// `cargo test --release --features embeddings -- --ignored bench_semantic_query`.
+    #[test]
+    #[ignore]
+    fn bench_semantic_query_p50_under_5ms() {
+        use std::time::{Duration, Instant};
+        const N: usize = 100_000;
+        const Q: usize = 100;
+
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), N));
+
+        // Synthetic corpus — unit vectors derived from a simple hash.
+        // Real embedding distributions cluster tighter than uniform noise,
+        // so this is the pessimistic case for HNSW recall + traversal.
+        let snap = sink.snapshot();
+        let mut items: Vec<(PathBuf, usize, Vec<f32>)> = Vec::with_capacity(N);
+        for i in 0..N as u64 {
+            let mut s = i.wrapping_mul(0x9E3779B97F4A7C15);
+            let mut v = Vec::with_capacity(super::super::DIM);
+            for _ in 0..super::super::DIM {
+                s ^= s << 13;
+                s ^= s >> 7;
+                s ^= s << 17;
+                let bits = (s >> 32) as u32;
+                v.push((bits as f32 / u32::MAX as f32) * 2.0 - 1.0);
+            }
+            let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in &mut v {
+                *x /= n;
+            }
+            items.push((PathBuf::from(format!("/v/{i}.md")), 0, v));
+        }
+        snap.bulk_insert(items);
+        drop(snap);
+
+        let h = handles_with(sink, svc);
+        // Warm-up: one embed + one query to prime ORT + HNSW caches.
+        let _ = semantic_search_query(&h, "warm up the embedder", 10).unwrap();
+
+        let probes: Vec<String> = (0..Q)
+            .map(|i| format!("query number {i} about various topics"))
+            .collect();
+        let mut samples = Vec::with_capacity(Q);
+        for p in &probes {
+            let t0 = Instant::now();
+            let _ = semantic_search_query(&h, p, 10).unwrap();
+            samples.push(t0.elapsed());
+        }
+        samples.sort();
+        let p50 = samples[Q / 2];
+        eprintln!("semantic_search p50 over {Q} queries @ {N} vectors: {p50:?}");
+        assert!(
+            p50 < Duration::from_millis(5),
+            "p50 latency too slow: {p50:?}",
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,12 @@ pub struct VaultState {
     /// write to the freshly-replaced coordinator's checkpoint.
     #[cfg(feature = "embeddings")]
     pub reindex_handle: Arc<Mutex<Option<Arc<embeddings::ReindexHandle>>>>,
+    /// Embed service + HNSW sink pair (#202) used by the `semantic_search`
+    /// IPC command. The sink Arc here aliases the one held by
+    /// `embed_coordinator` (upcast as `Arc<dyn VectorSink>`), so queries
+    /// see the same live `VectorIndex` the embed worker writes to.
+    #[cfg(feature = "embeddings")]
+    pub query_handles: Arc<Mutex<Option<Arc<embeddings::QueryHandles>>>>,
 }
 
 impl Default for VaultState {
@@ -90,6 +96,8 @@ impl Default for VaultState {
             embed_coordinator: Arc::new(Mutex::new(None)),
             #[cfg(feature = "embeddings")]
             reindex_handle: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "embeddings")]
+            query_handles: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -133,6 +141,7 @@ pub fn run() {
             commands::vault::merge_external_change,
             commands::search::search_fulltext,
             commands::search::search_filename,
+            commands::search::semantic_search,
             commands::search::rebuild_index,
             commands::links::get_backlinks,
             commands::links::get_outgoing_links,

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -10,7 +10,7 @@ import type { VaultError } from "../types/errors";
 import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
 import type { DirEntry } from "../types/tree";
-import type { SearchResult, FileMatch } from "../types/search";
+import type { SearchResult, FileMatch, SemanticHit } from "../types/search";
 import type { BacklinkEntry, ParsedLink, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
 
@@ -210,6 +210,23 @@ export async function searchFilename(
 ): Promise<FileMatch[]> {
   try {
     return await invoke<FileMatch[]>("search_filename", { query, limit });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Semantic (vector) search over the HNSW index (#202).
+ * Returns up to `k` nearest chunks to `query` by cosine similarity.
+ * `k` is clamped to [1, 100] on the Rust side. Returns an empty list
+ * when embeddings are disabled or the model is not bundled.
+ */
+export async function semanticSearch(
+  query: string,
+  k: number = 10,
+): Promise<SemanticHit[]> {
+  try {
+    return await invoke<SemanticHit[]>("semantic_search", { query, k });
   } catch (e) {
     throw normalizeError(e);
   }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -15,6 +15,15 @@ export interface SearchResult {
   matchCount: number;
 }
 
+/** Semantic-search hit from the HNSW vector index (#202).
+ *  Path + chunkIndex identify the span; `score` is cosine similarity in
+ *  `[-1, 1]` (typically `[0, 1]` for English prose) — higher = more similar. */
+export interface SemanticHit {
+  path: string;
+  chunkIndex: number;
+  score: number;
+}
+
 /** A fuzzy filename match result with character positions for highlight. */
 export interface FileMatch {
   /** Vault-relative path with forward-slash separators. */


### PR DESCRIPTION
## Summary
- Text-input top-k query helper `semantic_search_query(handles, text, k)` composing `EmbeddingService` + `VectorIndex`, returning `SemanticHit { path, chunkIndex, score }` where `score = 1 - cosine_distance`.
- Tauri command `semantic_search(query, k)` wrapping the helper in `spawn_blocking`; clamps `k` to `[1, 100]`; returns empty on empty query / disabled embeddings.
- `VaultState.query_handles` plumbs an `Arc<HnswSink>` alongside the coordinator so queries see the same live index the embed worker writes to.
- Frontend: `SemanticHit` type + `semanticSearch(query, k)` IPC wrapper.

Stacked on #223 (`feat/201d-bench-tuning`).

## Acceptance criteria (ticket #202)
- [x] `VectorIndex::query(text, k) -> Vec<(note_id, score)>` → realised as the `semantic_search_query` free helper (VectorIndex itself has no embedder handle; the helper composes both layers).
- [x] IPC-Command `semantic_search(query, k)`.
- [x] Result includes path (stable note id), chunk offset, similarity score. Raw HNSW `u32` ids are intentionally not exposed — they are reassigned on compaction (#200).
- [ ] p50 < 5 ms @ 100k — covered by `#[ignore] bench_semantic_query_p50_under_5ms`, manual UAT on target hardware. The CI sandbox's noisy single-digit-ms HNSW traversal + cold ORT embed does not represent target hardware.

## Design notes
- **Score direction**: `1 - distance` (range `[-1, 1]`), not `(2 - d) / 2`. Keeps the `0 = orthogonal` reading so RRF fusion in #203 can compare ranks cleanly.
- **Why no `u32 note_id`**: `VectorIndex::compact_into_fresh` (#200) reassigns dense ids. Exposing them over IPC would let a client issue `semantic_search → click hit #42` only to get a different note after a concurrent compaction. Path + chunk_index is stable.
- **`spawn_blocking`**: a typical MiniLM embed is ~15 ms; running that on the tokio runtime thread would stall other async IPC traffic (save, file-read, fulltext-search). Mirrors the rationale in `EmbedCoordinator` (#196).
- **Mutex contention with the embed worker**: `EmbeddingService` serialises inference through a single `Mutex`. Under heavy reindex the query path can block for a full embed batch. Call-out to #205 (ORT session tuning) — no mitigation in this PR to keep scope tight.

## Test plan
- [x] `cargo test --features embeddings --lib embeddings::query::` — 8 passed (empty query / empty index / k=0 / k cap / cosine ordering on live model / Send+Sync / serde shape / helper composition)
- [x] `cargo test --features embeddings --lib embeddings::` — 73 passed, 0 failed, 6 ignored
- [x] `cargo test --features embeddings --lib` — 291 passed, 0 failed, 9 ignored
- [x] `cargo check` (no-default-features) — clean
- [x] `cargo check --features embeddings` — clean
- [x] `tsc --noEmit` — clean
- [ ] Manual UAT on target hardware: open a vault with ≥10k notes, trigger reindex, call `semanticSearch` from devtools console against a handful of known-related queries, confirm ranking is sensible and p50 < 5 ms.

## Plan-subagent review
Ran a Plan-subagent pressure test on the approach before implementation (per CLAUDE.md TDD workflow). Incorporated:
- merged sink + service into one `QueryHandles` struct behind one lock (avoids adding two parallel `Mutex<Option<_>>` fields),
- raw `1 - dist` score (no clamp),
- `k` cap at 100 at the IPC boundary,
- `spawn_blocking` in the command,
- test for empty index,
- `SemanticHit` drops u32 id.