### PR TITLE
feat(embeddings): RRF hybrid BM25 + HNSW search (#203)

### DIFF
--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -340,6 +340,277 @@ pub async fn semantic_search(
     Ok(Vec::new())
 }
 
+// ── hybrid_search ─────────────────────────────────────────────────────────────
+
+/// Per-source visibility for one fused hit. `None` on either side means
+/// the path was not in that source's top-N result list — the row was
+/// surfaced by the other source alone. Skipped from JSON when None so
+/// the wire shape stays clean for single-source hits.
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HybridHit {
+    pub path: String,
+    pub title: String,
+    /// Fused RRF score (sum of `1 / (k + rank_i)` per source).
+    pub score: f32,
+    /// HTML snippet with `<b>highlighted</b>` BM25 terms; empty when
+    /// the path was vec-only and the title-only fallback fired.
+    pub snippet: String,
+    pub match_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bm25_rank: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bm25_score: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vec_rank: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vec_score: Option<f32>,
+}
+
+/// Hybrid search (#203): fuses BM25 (Tantivy) + HNSW (vector) ranks via
+/// Reciprocal Rank Fusion (k=60). Both sides run on the blocking pool
+/// in parallel via `tokio::join!`, so the embed (~15 ms) overlaps with
+/// the BM25 traversal.
+///
+/// `k` is clamped to `[1, 100]`. Each source is over-fetched to
+/// `max(k * 5, 50)` capped at 200, per Cormack 2009 + downstream
+/// production tuning — recall plateaus around 50.
+///
+/// Snippets: BM25-side hits keep their native highlighted snippet.
+/// Vec-only hits get a snippet by re-running `SnippetGenerator` against
+/// a `TermQuery(path:<path>)` lookup in the same searcher. Falls back
+/// to filename-only title with empty snippet when the doc is missing
+/// (race during initial indexing).
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn hybrid_search(
+    query: String,
+    k: usize,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<HybridHit>, VaultError> {
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let k = k.clamp(1, 100);
+    let top_n = k.saturating_mul(5).clamp(50, 200);
+
+    // Extract Tantivy + embedding handles up front so the spawn_blocking
+    // closures own `Send + 'static` data — matches the existing pattern
+    // in search_fulltext (lock, clone Arcs, drop guard before work).
+    let bm25_handles = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().map(|c| (c.index.clone(), c.reader.clone()))
+    };
+    let query_handles = {
+        let guard = state
+            .query_handles
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().map(std::sync::Arc::clone)
+    };
+
+    // BM25 side returns top_n (path, score). Cheap to spawn even when
+    // the coordinator hasn't booted — empty result, no work.
+    let bm25_query = query.clone();
+    let bm25_task = tokio::task::spawn_blocking(move || -> Result<Vec<(String, f32)>, VaultError> {
+        let Some((index, reader)) = bm25_handles.as_ref() else {
+            return Ok(Vec::new());
+        };
+        run_bm25_top_n(index, reader, &bm25_query, top_n)
+    });
+
+    let vec_query = query.clone();
+    let vec_task = tokio::task::spawn_blocking(move || -> Result<Vec<(String, f32)>, VaultError> {
+        let Some(h) = query_handles.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let hits = crate::embeddings::semantic_search_query(h, &vec_query, top_n)
+            .map_err(|e| {
+                log::warn!("hybrid_search vec leg failed: {e}");
+                VaultError::IndexCorrupt
+            })?;
+        Ok(hits
+            .into_iter()
+            .map(|h| (h.path, h.score))
+            .collect())
+    });
+
+    let (bm25_res, vec_res) = tokio::join!(bm25_task, vec_task);
+    let bm25 = bm25_res.map_err(|_| VaultError::IndexCorrupt)??;
+    let vec_hits = vec_res.map_err(|_| VaultError::IndexCorrupt)??;
+
+    let fused = crate::embeddings::rrf_fuse(&bm25, &vec_hits, crate::embeddings::RRF_K);
+    let fused = fused.into_iter().take(k).collect::<Vec<_>>();
+
+    if fused.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Hydrate snippets + titles. We need a Tantivy searcher again — if
+    // the BM25 leg saw `None` (no coordinator) the fused result can only
+    // contain vec-only hits, so skip hydration and fall back to
+    // filename-only titles.
+    let bm25_handles2 = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().map(|c| (c.index.clone(), c.reader.clone()))
+    };
+    let hydrated = tokio::task::spawn_blocking(move || -> Result<Vec<HybridHit>, VaultError> {
+        hydrate_hits(bm25_handles2.as_ref(), &query, fused)
+    })
+    .await
+    .map_err(|_| VaultError::IndexCorrupt)??;
+
+    Ok(hydrated)
+}
+
+#[cfg(feature = "embeddings")]
+fn run_bm25_top_n(
+    index: &std::sync::Arc<tantivy::Index>,
+    reader: &std::sync::Arc<tantivy::IndexReader>,
+    query: &str,
+    top_n: usize,
+) -> Result<Vec<(String, f32)>, VaultError> {
+    let schema = index.schema();
+    let path_field = schema.get_field("path").map_err(|_| VaultError::IndexCorrupt)?;
+    let title_field = schema.get_field("title").map_err(|_| VaultError::IndexCorrupt)?;
+    let body_field = schema.get_field("body").map_err(|_| VaultError::IndexCorrupt)?;
+
+    let mut qp = QueryParser::for_index(index, vec![title_field, body_field]);
+    qp.set_conjunction_by_default();
+    let (parsed, _errors) = qp.parse_query_lenient(query);
+
+    let searcher = reader.searcher();
+    let docs = searcher
+        .search(&parsed, &TopDocs::with_limit(top_n).order_by_score())
+        .map_err(|_| VaultError::IndexCorrupt)?;
+
+    let mut out = Vec::with_capacity(docs.len());
+    for (score, addr) in docs {
+        let doc = searcher
+            .doc::<TantivyDocument>(addr)
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        let path = doc
+            .get_first(path_field)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if !path.is_empty() {
+            out.push((path, score));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(feature = "embeddings")]
+fn hydrate_hits(
+    bm25_handles: Option<&(std::sync::Arc<tantivy::Index>, std::sync::Arc<tantivy::IndexReader>)>,
+    query: &str,
+    fused: Vec<crate::embeddings::FusedHit>,
+) -> Result<Vec<HybridHit>, VaultError> {
+    use tantivy::query::TermQuery;
+    use tantivy::schema::IndexRecordOption;
+    use tantivy::Term;
+
+    let Some((index, reader)) = bm25_handles else {
+        // No Tantivy index → vec-only hits with filename-derived titles.
+        return Ok(fused
+            .into_iter()
+            .map(|h| HybridHit {
+                title: filename_title(&h.path),
+                path: h.path,
+                score: h.score,
+                snippet: String::new(),
+                match_count: 0,
+                bm25_rank: h.bm25_rank,
+                bm25_score: h.bm25_score,
+                vec_rank: h.vec_rank,
+                vec_score: h.vec_score,
+            })
+            .collect());
+    };
+
+    let schema = index.schema();
+    let path_field = schema.get_field("path").map_err(|_| VaultError::IndexCorrupt)?;
+    let title_field = schema.get_field("title").map_err(|_| VaultError::IndexCorrupt)?;
+    let body_field = schema.get_field("body").map_err(|_| VaultError::IndexCorrupt)?;
+
+    let mut qp = QueryParser::for_index(index, vec![title_field, body_field]);
+    qp.set_conjunction_by_default();
+    let (parsed, _errors) = qp.parse_query_lenient(query);
+
+    let searcher = reader.searcher();
+    let mut snippet_gen = SnippetGenerator::create(&searcher, &*parsed, body_field)
+        .map_err(|_| VaultError::IndexCorrupt)?;
+    snippet_gen.set_max_num_chars(200);
+
+    let mut out = Vec::with_capacity(fused.len());
+    for hit in fused {
+        // Look up the doc by exact path. Path field is stored as STRING
+        // (untokenised) so a TermQuery exact-matches.
+        let term = Term::from_field_text(path_field, &hit.path);
+        let term_q = TermQuery::new(term, IndexRecordOption::Basic);
+        let lookup: Vec<(f32, tantivy::DocAddress)> = searcher
+            .search(&term_q, &TopDocs::with_limit(1).order_by_score())
+            .map_err(|_| VaultError::IndexCorrupt)?;
+
+        let (title, snippet, match_count) = if let Some((_score, addr)) = lookup.first() {
+            let doc = searcher
+                .doc::<TantivyDocument>(*addr)
+                .map_err(|_| VaultError::IndexCorrupt)?;
+            let title = doc
+                .get_first(title_field)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let snip = snippet_gen.snippet_from_doc(&doc);
+            let mc = snip.highlighted().len();
+            (title, snip.to_html(), mc)
+        } else {
+            (filename_title(&hit.path), String::new(), 0)
+        };
+
+        out.push(HybridHit {
+            path: hit.path,
+            title,
+            score: hit.score,
+            snippet,
+            match_count,
+            bm25_rank: hit.bm25_rank,
+            bm25_score: hit.bm25_score,
+            vec_rank: hit.vec_rank,
+            vec_score: hit.vec_score,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(feature = "embeddings")]
+fn filename_title(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+/// Stub for builds without `embeddings` — returns an empty list so the
+/// frontend IPC call always resolves to a valid array.
+#[cfg(not(feature = "embeddings"))]
+#[tauri::command]
+pub async fn hybrid_search(
+    _query: String,
+    _k: usize,
+    _state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<serde_json::Value>, VaultError> {
+    Ok(Vec::new())
+}
+
 // ── rebuild_index ─────────────────────────────────────────────────────────────
 
 /// Trigger a full index rebuild.

--- a/src-tauri/src/embeddings/hybrid.rs
+++ b/src-tauri/src/embeddings/hybrid.rs
@@ -1,0 +1,308 @@
+//! `hybrid` (#203) — Reciprocal Rank Fusion of BM25 (Tantivy) and
+//! HNSW (vector) ranks into a single top-k list.
+//!
+//! RRF per Cormack et al. 2009 § 3: `score(d) = Σ 1 / (k_rrf + rank_i(d))`
+//! where `rank_i` is 1-indexed within each source. `k_rrf = 60` is the
+//! literature-standard anchor (see research #188).
+//!
+//! This module is the pure math layer — no Tantivy / no HNSW imports.
+//! The Tauri command (`commands::search::hybrid_search`) owns the
+//! parallel fan-out, snippet re-generation, and serde shape.
+//!
+//! Chunked input handling: the vector side returns one hit per
+//! *chunk*, so a chunky note can occupy ranks 1, 3, and 8. Per the
+//! standard recipe (and every production RRF implementation I've
+//! seen — Weaviate, Vespa, Elastic) we **collapse to best-rank-per-path
+//! before fusing**. Keeping chunk ranks inflates chunky notes with a
+//! harmonic-series mass that is not a property of the underlying
+//! document's relevance.
+
+use std::collections::HashMap;
+
+/// Literature-standard RRF anchor (#188). Exposed as a `const` so the
+/// #207 benchmark harness can sweep without touching the math.
+pub const RRF_K: f32 = 60.0;
+
+/// One post-fusion ranked entry. `path` is the stable note id; the
+/// per-source rank/score fields let callers show "matched by: BM25
+/// rank 3 / vector rank 12" in debug UIs. All `Option<_>` fields
+/// default-skip in serde so the wire shape stays clean when a hit
+/// comes from only one source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedHit {
+    pub path: String,
+    pub score: f32,
+    pub bm25_rank: Option<u32>,
+    pub vec_rank: Option<u32>,
+    pub bm25_score: Option<f32>,
+    pub vec_score: Option<f32>,
+}
+
+/// Compute RRF fusion over one BM25 rank list and one vector rank list.
+///
+/// Inputs are already sorted by each source's native relevance (BM25
+/// desc by score; vector desc by cosine similarity). The function:
+/// 1. Collapses vector chunks to best-rank-per-path.
+/// 2. Walks each list assigning 1-indexed rank and accumulating
+///    `1 / (RRF_K + rank)` per path.
+/// 3. Sorts by fused score desc; breaks ties by BM25 rank, then
+///    alphabetical path, so the output is fully deterministic.
+///
+/// Scales O(B + V) in lookup + O(P log P) in the final sort, where P
+/// ≤ B + V. No allocations beyond the output.
+pub fn rrf_fuse(
+    bm25: &[(String, f32)],
+    vec_hits: &[(String, f32)],
+    k_rrf: f32,
+) -> Vec<FusedHit> {
+    // Step 1: collapse vec chunks to best-rank-per-path. Input is
+    // sorted, so the first occurrence of a path is already its best
+    // rank. Use an order-preserving dedup walk.
+    let mut vec_by_path: HashMap<&str, (u32, f32)> = HashMap::new();
+    let mut vec_collapsed: Vec<(&str, u32, f32)> = Vec::new();
+    for (path, score) in vec_hits {
+        if vec_by_path.contains_key(path.as_str()) {
+            continue;
+        }
+        let rank = (vec_collapsed.len() + 1) as u32;
+        vec_by_path.insert(path.as_str(), (rank, *score));
+        vec_collapsed.push((path.as_str(), rank, *score));
+    }
+
+    // Step 2: accumulate. `BTreeMap` would give deterministic iter but
+    // we sort at the end anyway — HashMap is fine and cheaper.
+    struct Acc {
+        score: f32,
+        bm25_rank: Option<u32>,
+        bm25_score: Option<f32>,
+        vec_rank: Option<u32>,
+        vec_score: Option<f32>,
+    }
+    let mut acc: HashMap<String, Acc> = HashMap::new();
+
+    for (i, (path, score)) in bm25.iter().enumerate() {
+        let rank = (i + 1) as u32;
+        let entry = acc.entry(path.clone()).or_insert(Acc {
+            score: 0.0,
+            bm25_rank: None,
+            bm25_score: None,
+            vec_rank: None,
+            vec_score: None,
+        });
+        entry.score += 1.0 / (k_rrf + rank as f32);
+        entry.bm25_rank = Some(rank);
+        entry.bm25_score = Some(*score);
+    }
+
+    for (path, rank, score) in &vec_collapsed {
+        let entry = acc.entry((*path).to_string()).or_insert(Acc {
+            score: 0.0,
+            bm25_rank: None,
+            bm25_score: None,
+            vec_rank: None,
+            vec_score: None,
+        });
+        entry.score += 1.0 / (k_rrf + *rank as f32);
+        entry.vec_rank = Some(*rank);
+        entry.vec_score = Some(*score);
+    }
+
+    // Step 3: sort by fused score desc; stable tie-break so callers
+    // observing two hits with identical scores (e.g. both rank-1 on
+    // their side) get a predictable order.
+    let mut out: Vec<FusedHit> = acc
+        .into_iter()
+        .map(|(path, a)| FusedHit {
+            path,
+            score: a.score,
+            bm25_rank: a.bm25_rank,
+            vec_rank: a.vec_rank,
+            bm25_score: a.bm25_score,
+            vec_score: a.vec_score,
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| match (a.bm25_rank, b.bm25_rank) {
+                (Some(ar), Some(br)) => ar.cmp(&br),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(hits: &[FusedHit]) -> Vec<&str> {
+        hits.iter().map(|h| h.path.as_str()).collect()
+    }
+
+    #[test]
+    fn empty_inputs_produce_empty_output() {
+        assert!(rrf_fuse(&[], &[], RRF_K).is_empty());
+    }
+
+    #[test]
+    fn bm25_only_preserves_order() {
+        let bm25 = vec![
+            ("a.md".into(), 9.0),
+            ("b.md".into(), 5.0),
+            ("c.md".into(), 1.0),
+        ];
+        let hits = rrf_fuse(&bm25, &[], RRF_K);
+        assert_eq!(paths(&hits), vec!["a.md", "b.md", "c.md"]);
+        // Scores must be strictly decreasing.
+        for w in hits.windows(2) {
+            assert!(w[0].score > w[1].score);
+        }
+        // bm25_* fields populated; vec_* empty.
+        for h in &hits {
+            assert!(h.bm25_rank.is_some());
+            assert!(h.bm25_score.is_some());
+            assert!(h.vec_rank.is_none());
+            assert!(h.vec_score.is_none());
+        }
+    }
+
+    #[test]
+    fn vec_only_preserves_order() {
+        let vec_hits = vec![
+            ("x.md".into(), 0.9),
+            ("y.md".into(), 0.5),
+        ];
+        let hits = rrf_fuse(&[], &vec_hits, RRF_K);
+        assert_eq!(paths(&hits), vec!["x.md", "y.md"]);
+        for h in &hits {
+            assert!(h.vec_rank.is_some());
+            assert!(h.bm25_rank.is_none());
+        }
+    }
+
+    #[test]
+    fn both_sources_combine_scores() {
+        // Same doc ranks 1 on BM25 and 1 on vec — score should be 2×(1/61).
+        let bm25 = vec![("overlap.md".into(), 10.0)];
+        let vec_hits = vec![("overlap.md".into(), 0.9)];
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        assert_eq!(hits.len(), 1);
+        let expected = 2.0 / (RRF_K + 1.0);
+        assert!(
+            (hits[0].score - expected).abs() < 1e-6,
+            "score={} expected≈{}",
+            hits[0].score,
+            expected
+        );
+        assert_eq!(hits[0].bm25_rank, Some(1));
+        assert_eq!(hits[0].vec_rank, Some(1));
+    }
+
+    #[test]
+    fn overlapping_doc_outranks_singleton_at_same_rank() {
+        // A ranks 1 in BM25 only; B ranks 2 in BM25 and 1 in vec.
+        // B's fused score: 1/(60+2) + 1/(60+1) = 1/62 + 1/61
+        // A's fused score: 1/(60+1) = 1/61
+        // B > A.
+        let bm25 = vec![("a.md".into(), 10.0), ("b.md".into(), 5.0)];
+        let vec_hits = vec![("b.md".into(), 0.9)];
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        assert_eq!(paths(&hits), vec!["b.md", "a.md"]);
+    }
+
+    #[test]
+    fn vector_chunks_collapse_to_best_rank_per_path() {
+        // Path "multi.md" has three chunks at ranks 1, 2, 4; "other.md"
+        // at rank 3. After collapse, ranks should be multi=1, other=2.
+        let vec_hits = vec![
+            ("multi.md".into(), 0.95),
+            ("multi.md".into(), 0.90),
+            ("other.md".into(), 0.80),
+            ("multi.md".into(), 0.70),
+        ];
+        let hits = rrf_fuse(&[], &vec_hits, RRF_K);
+        assert_eq!(paths(&hits), vec!["multi.md", "other.md"]);
+        assert_eq!(hits[0].vec_rank, Some(1));
+        assert_eq!(hits[1].vec_rank, Some(2));
+        // Chunky notes must NOT get a harmonic-series boost.
+        let expected_multi = 1.0 / (RRF_K + 1.0);
+        assert!((hits[0].score - expected_multi).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rrf_formula_matches_literature_exactly() {
+        // Cormack 2009 § 3: score(d) = Σ 1 / (k + rank_i(d))
+        // Three sources simulated as: BM25 ranks a=1, b=2; Vec ranks a=2, b=1.
+        let bm25 = vec![("a.md".into(), 1.0), ("b.md".into(), 0.5)];
+        let vec_hits = vec![("b.md".into(), 0.9), ("a.md".into(), 0.8)];
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        assert_eq!(hits.len(), 2);
+        // Both end up with the same score: 1/61 + 1/62, tied.
+        let expected = 1.0 / (RRF_K + 1.0) + 1.0 / (RRF_K + 2.0);
+        for h in &hits {
+            assert!((h.score - expected).abs() < 1e-6);
+        }
+        // Tie-break: bm25_rank asc, so a.md (bm25=1) first, b.md (bm25=2) second.
+        assert_eq!(paths(&hits), vec!["a.md", "b.md"]);
+    }
+
+    #[test]
+    fn deterministic_tiebreak_by_path_when_no_bm25_rank() {
+        // Two vec-only hits at different ranks — scores differ, so no tie.
+        // But two at the same rank via duplicate collapse would tie; the
+        // input is by construction already ordered so this tests the
+        // path tie-break when bm25 ranks are both None.
+        let vec_a = vec![("z.md".into(), 0.9), ("a.md".into(), 0.9)];
+        let hits1 = rrf_fuse(&[], &vec_a, RRF_K);
+        // z ranks 1, a ranks 2 → z first (higher score), not path order.
+        assert_eq!(paths(&hits1), vec!["z.md", "a.md"]);
+    }
+
+    #[test]
+    fn k_rrf_smaller_amplifies_top_ranks() {
+        // With k_rrf=0, rank-1 score is 1.0 and rank-2 is 0.5 — a 2×
+        // gap. With k_rrf=60, rank-1 is ~0.0164 and rank-2 is ~0.0161
+        // — gap shrinks to ~2%. Sanity check that the knob works.
+        let bm25 = vec![("a.md".into(), 1.0), ("b.md".into(), 0.5)];
+        let sharp = rrf_fuse(&bm25, &[], 0.0);
+        let flat = rrf_fuse(&bm25, &[], 60.0);
+        let sharp_gap = sharp[0].score / sharp[1].score;
+        let flat_gap = flat[0].score / flat[1].score;
+        assert!(sharp_gap > flat_gap, "{sharp_gap} should exceed {flat_gap}");
+    }
+
+    #[test]
+    fn handles_large_inputs_without_collisions() {
+        // Smoke test: 10k paths on each side with 5k overlap. Asserts the
+        // collapse + accumulate + sort path produces the expected output
+        // size without dropping or duplicating entries. No timing
+        // assertion — perf is covered by the #[ignore] bench in the IPC
+        // command path; running this test under heavy parallel load
+        // (full lib suite at 16 threads) makes wall-clock thresholds
+        // here flaky without telling us anything about real hybrid-
+        // search latency.
+        let bm25: Vec<(String, f32)> = (0..10_000)
+            .map(|i| (format!("bm-{i}.md"), 10_000.0 - i as f32))
+            .collect();
+        let vec_hits: Vec<(String, f32)> = (0..10_000)
+            .map(|i| (format!("bm-{}.md", i + 5_000), 1.0 - (i as f32 / 10_000.0)))
+            .collect();
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        // 10k BM25 + 10k vec − 5k overlap = 15k unique paths.
+        assert_eq!(hits.len(), 15_000);
+        // Spot-check: the 5k-overlap region must rank ahead of singletons
+        // because two-source hits accumulate two RRF terms.
+        let overlap_top = hits.iter().take(50).filter(|h| {
+            h.bm25_rank.is_some() && h.vec_rank.is_some()
+        }).count();
+        assert!(
+            overlap_top > 25,
+            "expected mostly two-source hits in top 50, got {overlap_top}",
+        );
+    }
+}

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -61,6 +61,11 @@ mod query;
 #[cfg(feature = "embeddings")]
 pub use query::{semantic_search_query, QueryHandles, SemanticHit};
 
+#[cfg(feature = "embeddings")]
+mod hybrid;
+#[cfg(feature = "embeddings")]
+pub use hybrid::{rrf_fuse, FusedHit, RRF_K};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,6 +142,7 @@ pub fn run() {
             commands::search::search_fulltext,
             commands::search::search_filename,
             commands::search::semantic_search,
+            commands::search::hybrid_search,
             commands::search::rebuild_index,
             commands::links::get_backlinks,
             commands::links::get_outgoing_links,

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -10,7 +10,7 @@ import type { VaultError } from "../types/errors";
 import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
 import type { DirEntry } from "../types/tree";
-import type { SearchResult, FileMatch, SemanticHit } from "../types/search";
+import type { SearchResult, FileMatch, SemanticHit, HybridHit } from "../types/search";
 import type { BacklinkEntry, ParsedLink, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
 
@@ -227,6 +227,24 @@ export async function semanticSearch(
 ): Promise<SemanticHit[]> {
   try {
     return await invoke<SemanticHit[]>("semantic_search", { query, k });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Hybrid search (#203): fuses BM25 (Tantivy) and HNSW (vector) ranks via
+ * Reciprocal Rank Fusion (k=60). Both legs run in parallel on the Rust
+ * blocking pool. `k` is clamped to [1, 100]. Falls back to BM25-only when
+ * embeddings are disabled / not bundled, and to vec-only when the BM25
+ * index is unavailable.
+ */
+export async function hybridSearch(
+  query: string,
+  k: number = 10,
+): Promise<HybridHit[]> {
+  try {
+    return await invoke<HybridHit[]>("hybrid_search", { query, k });
   } catch (e) {
     throw normalizeError(e);
   }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -24,6 +24,24 @@ export interface SemanticHit {
   score: number;
 }
 
+/** Hybrid (BM25 + HNSW) search hit fused via Reciprocal Rank Fusion (#203).
+ *  `score` is the fused RRF score (sum of `1 / (60 + rank_i)` per source).
+ *  Per-source `*Rank` and `*Score` fields are present only for the source(s)
+ *  that surfaced the hit — both populated means it ranked in both indices. */
+export interface HybridHit {
+  path: string;
+  title: string;
+  score: number;
+  /** HTML with `<b>highlighted</b>` BM25 terms; empty for vec-only hits with
+   *  no BM25 doc found. */
+  snippet: string;
+  matchCount: number;
+  bm25Rank?: number;
+  bm25Score?: number;
+  vecRank?: number;
+  vecScore?: number;
+}
+
 /** A fuzzy filename match result with character positions for highlight. */
 export interface FileMatch {
   /** Vault-relative path with forward-slash separators. */


### PR DESCRIPTION
## Summary
- Adds `rrf_fuse` (Reciprocal Rank Fusion, k=60 per Cormack et al. 2009) merging BM25 and HNSW result lists into a single ranking by `Σ 1/(k + rank_i)`.
- Adds `hybrid_search` Tauri command that fans BM25 + semantic legs out via `spawn_blocking + tokio::join!`, fuses, and hydrates snippets/titles for the top-K. Vec-only hits get snippet hydration via `TermQuery(path:...)` against the same Tantivy searcher; falls back to filename stem if the doc isn't in the BM25 index yet (race during indexing).
- Vec hits collapse to best-rank-per-path before fusion (standard RRF recipe — prevents chunky notes getting a harmonic-series boost).
- Per-source debug fields (`bm25Rank`, `bm25Score`, `vecRank`, `vecScore`) on `HybridHit` are `skip_serializing_if = Option::is_none` so the JSON shape signals which leg surfaced each hit.
- TS types + `hybridSearch` IPC wrapper added; not yet wired into UI (that's #204).

## Why it stacks on #202
This PR builds on the `QueryHandles` plumbing introduced in #224 (#202). Base it after that one merges or rebase if conflicts arise.

## Test plan
- [x] `cargo test -p vaultcore_lib --features embeddings hybrid::tests` — 10 unit tests (empty inputs, bm25-only, vec-only, both-combine, chunk collapse, formula vs literature, k_rrf knob, deterministic tiebreak, large-input correctness)
- [x] Full lib suite (301 tests) passes with `--features embeddings`
- [x] `cargo check` clean for both `--features embeddings` and default (stub returns `Ok(vec![])`)
- [x] `cargo clippy -p vaultcore_lib --features embeddings -- -D warnings` clean for new code
- [x] `npm run check` (TypeScript) clean
- [ ] Manual: covered by #204 once UI is wired