### PR TITLE
feat(search): wire hybrid_search into OmniSearch + semantic indicator (#204)

### DIFF
--- a/e2e/specs/hybrid-search.spec.ts
+++ b/e2e/specs/hybrid-search.spec.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+// #204 AC-4: the OmniSearch content mode routes through hybrid_search, so
+// a query whose keywords do NOT appear in any note can still surface a
+// semantically-related note via the HNSW leg. This spec seeds a vault
+// with a note whose content talks about felines (without using the word
+// "cat"), waits for the embedding pass to finish, then asserts that a
+// search for "cat" returns the note AND that the semantic-only indicator
+// renders on the row — the indicator is the only reliable proof that the
+// vec leg fired instead of a BM25 fallback.
+describe("Hybrid search surfaces semantic-only notes", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    // Seed a note whose content is semantically close to "cat" but shares
+    // no keywords — MiniLM maps pet / feline prose into the same region
+    // as the query "cat", so the RRF vec leg should surface it.
+    fs.writeFileSync(
+      path.join(vault.path, "Feline Ode.md"),
+      [
+        "# Feline Ode",
+        "",
+        "The soft purr of a small tiger nestled in a sunbeam.",
+        "Whiskers twitching, a tiny predator of dust motes.",
+        "Kittens chase shadows across polished floors.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+
+    // Run an initial embedding pass over the fixture vault and wait for
+    // the terminal `done` event. Generous timeout covers ORT session
+    // warmup on first call (the long pole — typically 200–800ms but can
+    // spike on cold machines).
+    await browser.executeAsync((done: (err?: string) => void) => {
+      const hook = window.__e2e__;
+      if (!hook) {
+        done("window.__e2e__ hook missing");
+        return;
+      }
+      void hook
+        .reindexAndWaitDone()
+        .then(() => done())
+        .catch((e: unknown) => done(String(e)));
+    });
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openContentSearch(): Promise<WebdriverIO.Element> {
+    await browser.keys(["Control", "Shift", "f"]);
+    const modal = await browser.$(".vc-quick-switcher-modal");
+    await modal.waitForDisplayed({ timeout: 3000 });
+    return browser.$(".vc-qs-input");
+  }
+
+  async function closeOmni(): Promise<void> {
+    await browser.keys(["Escape"]);
+    await browser
+      .$(".vc-quick-switcher-modal")
+      .waitForDisplayed({ timeout: 2000, reverse: true });
+  }
+
+  it("surfaces a semantically related note that contains none of the query terms", async () => {
+    const input = await openContentSearch();
+    await input.click();
+    // "cat" — not present in Feline Ode.md or any other fixture file.
+    await input.setValue("cat");
+    // Pass the 200ms debounce plus some slack for embed+query.
+    await browser.pause(600);
+
+    const rows = await browser.$$(".vc-search-result-row");
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+
+    const filenames: string[] = [];
+    for (const row of rows) {
+      filenames.push(await textOf(await row.$(".vc-search-result-filename")));
+    }
+    expect(filenames.some((f) => f.includes("Feline Ode"))).toBe(true);
+
+    // The indicator only renders when `vecRank != null && bm25Rank == null`,
+    // which is exactly the "surfaced by the semantic leg alone" case. Its
+    // presence is the sharpest E2E-visible signal that hybrid_search did
+    // more than fall back to BM25-only.
+    const indicator = await browser.$(".vc-search-result-semantic-indicator");
+    await indicator.waitForDisplayed({ timeout: 2000 });
+    expect(await indicator.getAttribute("aria-label")).toMatch(/semantisch/i);
+
+    await closeOmni();
+  });
+});

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -38,6 +38,23 @@ pub struct SemanticHit {
     pub score: f32,
 }
 
+/// Minimum cosine similarity for a vec-leg hit to leave this module.
+/// HNSW always returns its k nearest neighbours regardless of how far
+/// away they are — on small vaults the nearest neighbour can still be
+/// near-orthogonal noise, which then rides into the RRF top-k on rank
+/// alone and confuses users ("why does my search for 'katze' surface a
+/// note that says 'test lol dasd'?"). 0.3 is a conservative floor on
+/// L2-normalised MiniLM: real semantic matches on English prose sit at
+/// 0.4–0.8, and anything below ~0.3 is near-orthogonal — dropping it
+/// loses nothing but noise.
+pub const MIN_SEMANTIC_SCORE: f32 = 0.3;
+
+fn drop_noise_hits(hits: Vec<SemanticHit>) -> Vec<SemanticHit> {
+    hits.into_iter()
+        .filter(|h| h.score >= MIN_SEMANTIC_SCORE)
+        .collect()
+}
+
 /// Embed `text`, query the index for the top `k` nearest chunks, and
 /// convert distances to similarity scores. Returns an empty vec for an
 /// empty query or empty index — never errors on either; that case is
@@ -68,14 +85,17 @@ pub fn semantic_search_query(
         )));
     }
     let hits = snap.query_with_paths(&vec, k);
-    Ok(hits
+    let mapped: Vec<SemanticHit> = hits
         .into_iter()
         .map(|(p, idx, dist)| SemanticHit {
             path: p.to_string_lossy().into_owned(),
             chunk_index: idx,
             score: 1.0 - dist,
         })
-        .collect())
+        .collect();
+    // Filter near-orthogonal noise BEFORE returning so both the direct
+    // `semantic_search` IPC and the hybrid fusion path see a clean list.
+    Ok(drop_noise_hits(mapped))
 }
 
 #[cfg(test)]
@@ -204,6 +224,30 @@ mod tests {
             let hits = semantic_search_query(&h, "note", k).unwrap();
             assert!(hits.len() <= k, "k={k} returned {} hits", hits.len());
         }
+    }
+
+    #[test]
+    fn drop_noise_hits_removes_subthreshold_scores() {
+        // The filter drops hits below MIN_SEMANTIC_SCORE (noise-adjacent
+        // neighbours HNSW returns on small vaults) while keeping hits at
+        // the threshold and above. Order within the kept set is preserved
+        // because HNSW already hands them to us in rank order.
+        let hits = vec![
+            SemanticHit { path: "a.md".into(), chunk_index: 0, score: 0.82 },
+            SemanticHit { path: "b.md".into(), chunk_index: 0, score: MIN_SEMANTIC_SCORE - 0.01 },
+            SemanticHit { path: "c.md".into(), chunk_index: 0, score: MIN_SEMANTIC_SCORE },
+            SemanticHit { path: "d.md".into(), chunk_index: 0, score: 0.05 },
+            SemanticHit { path: "e.md".into(), chunk_index: 0, score: -0.2 },
+        ];
+        let kept = drop_noise_hits(hits);
+        let paths: Vec<&str> = kept.iter().map(|h| h.path.as_str()).collect();
+        assert_eq!(paths, vec!["a.md", "c.md"]);
+    }
+
+    #[test]
+    fn drop_noise_hits_empty_passthrough() {
+        let kept = drop_noise_hits(Vec::new());
+        assert!(kept.is_empty());
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,7 @@
     openVault,
     pickVaultFolder,
     repairVaultIndex,
+    reindexVault,
   } from "./ipc/commands";
   import { listenIndexProgress, listenReindexProgress } from "./ipc/events";
   import { reindexStore } from "./store/reindexStore";
@@ -246,6 +247,26 @@
         if (!view) return "";
         return view.state.doc.toString();
       };
+      // #204: subscribe once to the reindex-done signal so E2E specs can
+      // wait for embeddings to be queryable before running a semantic-only
+      // search. We keep a single listener for the lifetime of the window
+      // and broadcast the terminal phase to any pending waiter.
+      const { listenReindexProgress: listenReindex } = await import("./ipc/events");
+      const waiters: Array<(result: "done" | "cancelled") => void> = [];
+      await listenReindex((payload) => {
+        if (payload.phase === "done" || payload.phase === "cancelled") {
+          const pending = waiters.splice(0);
+          for (const resolve of pending) resolve(payload.phase);
+        }
+      });
+      const reindexAndWaitDone = (): Promise<void> =>
+        new Promise((resolve, reject) => {
+          waiters.push((phase) => {
+            if (phase === "done") resolve();
+            else reject(new Error(`reindex ended with phase=${phase}`));
+          });
+          reindexVault().catch(reject);
+        });
       window.__e2e__ = {
         loadVault,
         switchVault,
@@ -256,6 +277,7 @@
         finishProgress,
         typeInActiveEditor,
         getActiveDocText,
+        reindexAndWaitDone,
       };
     }
 

--- a/src/components/Search/OmniSearch.svelte
+++ b/src/components/Search/OmniSearch.svelte
@@ -22,10 +22,10 @@
   import { scrollStore } from "../../store/scrollStore";
   import {
     searchFilename,
-    searchFulltext,
+    hybridSearch,
     rebuildIndex,
   } from "../../ipc/commands";
-  import type { FileMatch, SearchResult } from "../../types/search";
+  import type { FileMatch, HybridHit } from "../../types/search";
   import { isVaultError } from "../../types/errors";
   import { extractSnippetMatch } from "../Editor/flashHighlight";
   import QuickSwitcherRow from "./QuickSwitcherRow.svelte";
@@ -109,7 +109,7 @@
   // Content-mode results + counts flow through searchStore so the
   // cross-vault reset + indexStale event subscription keep working.
   let storeState = $state({
-    results: [] as SearchResult[],
+    results: [] as HybridHit[],
     totalFiles: 0,
     isRebuilding: false,
   });
@@ -205,7 +205,10 @@
     }
     searchStore.setSearching(true);
     try {
-      const results = await searchFulltext(trimmed, 100);
+      // #204 — hybrid_search fuses BM25 + HNSW via RRF. Falls back to
+      // BM25-only transparently when embeddings aren't ready, so the UX
+      // stays identical while embeddings bootstrap.
+      const results = await hybridSearch(trimmed, 100);
       if (myGen !== contentSearchGen) return;
       const uniqueFiles = new Set(results.map((r) => r.path)).size;
       searchStore.setResults(results, uniqueFiles);
@@ -275,7 +278,7 @@
     onClose();
   }
 
-  function openContentResult(r: SearchResult) {
+  function openContentResult(r: HybridHit) {
     onOpenFile(r.path);
     const searchText =
       extractSnippetMatch(r.snippet) ?? query.split(" ")[0] ?? "";
@@ -291,7 +294,7 @@
       const hit = activeList[idx] as FileMatch | undefined;
       if (hit) openFileResult(hit);
     } else {
-      const hit = activeList[idx] as SearchResult | undefined;
+      const hit = activeList[idx] as HybridHit | undefined;
       if (hit) openContentResult(hit);
     }
   }
@@ -438,10 +441,10 @@
             <p class="vc-search-results-counter">
               {storeState.results.length} Treffer in {storeState.totalFiles} Dateien
             </p>
-            {#each activeList as result, i (`${(result as SearchResult).path}|${i}`)}
+            {#each activeList as result, i (`${(result as HybridHit).path}|${i}`)}
               <SearchResultRow
-                result={result as SearchResult}
-                onclick={() => openContentResult(result as SearchResult)}
+                result={result as HybridHit}
+                onclick={() => openContentResult(result as HybridHit)}
               />
             {/each}
             {#if storeState.results.length >= 100}

--- a/src/components/Search/SearchResultRow.svelte
+++ b/src/components/Search/SearchResultRow.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
-  import type { SearchResult as SearchResultType } from "../../types/search";
+  import { Sparkles } from "lucide-svelte";
+  import type { HybridHit } from "../../types/search";
 
   interface Props {
-    result: SearchResultType;
+    result: HybridHit;
     onclick: () => void;
   }
 
   let { result, onclick }: Props = $props();
 
   const filename = $derived(result.path.split("/").pop() ?? result.path);
+  // #204 — a hit surfaced only by the semantic leg of hybrid_search gets a
+  // subtle badge so users can tell the result came in via embedding
+  // similarity rather than keyword match. Hits present in both legs are
+  // already explained by the existing snippet highlighting, so no badge.
+  const semanticOnly = $derived(
+    result.vecRank !== undefined && result.bm25Rank === undefined,
+  );
 </script>
 
 <div
@@ -19,7 +27,18 @@
   {onclick}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onclick(); } }}
 >
-  <p class="vc-search-result-filename">{filename}</p>
+  <p class="vc-search-result-filename">
+    <span class="vc-search-result-filename-text">{filename}</span>
+    {#if semanticOnly}
+      <span
+        class="vc-search-result-semantic-indicator"
+        title="Semantischer Treffer"
+        aria-label="Nur semantisch gefunden"
+      >
+        <Sparkles size={12} strokeWidth={2} />
+      </span>
+    {/if}
+  </p>
   <p class="vc-search-result-snippet vc-search-snippet">{@html result.snippet}</p>
 </div>
 
@@ -43,9 +62,24 @@
     font-weight: 700;
     color: var(--color-text);
     margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .vc-search-result-filename-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    min-width: 0;
+  }
+
+  .vc-search-result-semantic-indicator {
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
   }
 
   .vc-search-result-snippet {

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -14,7 +14,7 @@ import { tick } from "svelte";
 
 vi.mock("../../../ipc/commands", () => ({
   searchFilename: vi.fn(),
-  searchFulltext: vi.fn(),
+  hybridSearch: vi.fn(),
   rebuildIndex: vi.fn(),
 }));
 vi.mock("../../../ipc/events", () => ({
@@ -23,7 +23,7 @@ vi.mock("../../../ipc/events", () => ({
 
 import {
   searchFilename,
-  searchFulltext,
+  hybridSearch,
   rebuildIndex,
 } from "../../../ipc/commands";
 import { vaultStore } from "../../../store/vaultStore";
@@ -87,7 +87,7 @@ describe("OmniSearch (#174)", () => {
 
   it("clicking the content tab switches mode and re-routes the active query", async () => {
     (searchFilename as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     const { container } = mountOpen({ initialMode: "filename" });
     await tick();
 
@@ -103,7 +103,7 @@ describe("OmniSearch (#174)", () => {
     await fireEvent.click(contentTab);
     await tick();
     await Promise.resolve();
-    expect(searchFulltext).toHaveBeenCalled();
+    expect(hybridSearch).toHaveBeenCalled();
   });
 
   // ── Backend dispatch per mode ─────────────────────────────────────────
@@ -119,11 +119,11 @@ describe("OmniSearch (#174)", () => {
     await tick();
     await Promise.resolve();
     expect(searchFilename).toHaveBeenCalledWith("alpha", 20);
-    expect(searchFulltext).not.toHaveBeenCalled();
+    expect(hybridSearch).not.toHaveBeenCalled();
   });
 
-  it("content mode dispatches searchFulltext on input", async () => {
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  it("content mode dispatches hybridSearch on input (#204)", async () => {
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     const { container } = mountOpen({ initialMode: "content" });
     await tick();
     const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
@@ -133,7 +133,7 @@ describe("OmniSearch (#174)", () => {
     // Content mode is debounced (same 200ms as the old SearchPanel) —
     // verify it eventually fires.
     await new Promise((r) => setTimeout(r, 250));
-    expect(searchFulltext).toHaveBeenCalled();
+    expect(hybridSearch).toHaveBeenCalled();
     expect(searchFilename).not.toHaveBeenCalled();
   });
 
@@ -168,7 +168,7 @@ describe("OmniSearch (#174)", () => {
 
   it("clears the rebuild status line on success and flips indexStale off", async () => {
     (rebuildIndex as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     searchStore.setIndexStale(true);
     const { container } = mountOpen({ initialMode: "content" });
     await tick();
@@ -204,7 +204,7 @@ describe("OmniSearch (#174)", () => {
   // ── Tag-prefill ───────────────────────────────────────────────────────
 
   it("initialQuery in content mode is placed in the input and runs the search", async () => {
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     const { container } = mountOpen({
       initialMode: "content",
       initialQuery: "#todo",
@@ -215,8 +215,8 @@ describe("OmniSearch (#174)", () => {
 
     const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
     expect(input.value).toBe("#todo");
-    expect(searchFulltext).toHaveBeenCalled();
-    const args = (searchFulltext as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(hybridSearch).toHaveBeenCalled();
+    const args = (hybridSearch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(args?.[0]).toBe("#todo");
   });
 
@@ -289,9 +289,9 @@ describe("OmniSearch (#174)", () => {
   // debounce fire — the caret must stay where the user left it.
 
   it("preserves the caret position across a debounced content-mode search", async () => {
-    let resolveFulltext!: (v: SearchResult[]) => void;
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      () => new Promise<SearchResult[]>((r) => { resolveFulltext = r; }),
+    let resolveFulltext!: (v: HybridHit[]) => void;
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<HybridHit[]>((r) => { resolveFulltext = r; }),
     );
     const { container } = mountOpen({ initialMode: "content" });
     await tick();
@@ -308,7 +308,7 @@ describe("OmniSearch (#174)", () => {
     // the IPC promise. This is exactly the window where storeState updates
     // used to cascade into a bind:value re-sync that moved the caret.
     await new Promise((r) => setTimeout(r, 260));
-    expect(searchFulltext).toHaveBeenCalled();
+    expect(hybridSearch).toHaveBeenCalled();
     resolveFulltext([]);
     await Promise.resolve();
     await tick();
@@ -321,4 +321,4 @@ describe("OmniSearch (#174)", () => {
 });
 
 // Type re-import so the mock type cast above compiles.
-import type { SearchResult } from "../../../types/search";
+import type { HybridHit } from "../../../types/search";

--- a/src/store/__tests__/searchStore.refetchAfterRebuild.test.ts
+++ b/src/store/__tests__/searchStore.refetchAfterRebuild.test.ts
@@ -3,38 +3,41 @@
 // queried again and results reflect newly-indexed content without the
 // user having to retype the query.
 //
+// #204 switched the refetch path from searchFulltext (BM25-only) to
+// hybridSearch (RRF-fused). The store control flow is identical — only
+// the underlying IPC call and the result type (HybridHit) changed.
+//
 // We mock the IPC layer so the store exercises its control flow without
 // a Tauri runtime. Each assertion locks in one AC from the ticket.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { get } from "svelte/store";
 
-const searchFulltextMock = vi.fn();
+const hybridSearchMock = vi.fn();
 
 vi.mock("../../ipc/commands", () => ({
-  searchFulltext: (...args: unknown[]) => searchFulltextMock(...args),
+  hybridSearch: (...args: unknown[]) => hybridSearchMock(...args),
 }));
 
 import { searchStore } from "../searchStore";
 
-describe("searchStore.refetchIfQueryNonEmpty (#148)", () => {
+describe("searchStore.refetchIfQueryNonEmpty (#148, rewired in #204)", () => {
   beforeEach(() => {
     searchStore.reset();
-    searchFulltextMock.mockReset();
+    hybridSearchMock.mockReset();
   });
 
   it("re-runs the current query and replaces results", async () => {
     searchStore.setQuery("#yoda");
-    // First rebuild finds one hit; a later rebuild finds two.
-    searchFulltextMock.mockResolvedValueOnce([
-      { path: "a.md", snippet: "", score: 1 },
-      { path: "b.md", snippet: "", score: 1 },
+    hybridSearchMock.mockResolvedValueOnce([
+      { path: "a.md", title: "a", snippet: "", score: 1, matchCount: 0 },
+      { path: "b.md", title: "b", snippet: "", score: 1, matchCount: 0 },
     ]);
 
     await searchStore.refetchIfQueryNonEmpty();
 
-    expect(searchFulltextMock).toHaveBeenCalledTimes(1);
-    expect(searchFulltextMock).toHaveBeenCalledWith("#yoda", 100);
+    expect(hybridSearchMock).toHaveBeenCalledTimes(1);
+    expect(hybridSearchMock).toHaveBeenCalledWith("#yoda", 100);
     const s = get(searchStore);
     expect(s.results).toHaveLength(2);
     expect(s.totalFiles).toBe(2);
@@ -44,18 +47,18 @@ describe("searchStore.refetchIfQueryNonEmpty (#148)", () => {
   it("is a no-op when the query is empty (no fetch issued)", async () => {
     searchStore.setQuery("");
     await searchStore.refetchIfQueryNonEmpty();
-    expect(searchFulltextMock).not.toHaveBeenCalled();
+    expect(hybridSearchMock).not.toHaveBeenCalled();
   });
 
   it("is a no-op when the query is only whitespace", async () => {
     searchStore.setQuery("   ");
     await searchStore.refetchIfQueryNonEmpty();
-    expect(searchFulltextMock).not.toHaveBeenCalled();
+    expect(hybridSearchMock).not.toHaveBeenCalled();
   });
 
   it("marks the index stale and clears isSearching on IndexCorrupt", async () => {
     searchStore.setQuery("#yoda");
-    searchFulltextMock.mockRejectedValueOnce({ kind: "IndexCorrupt", message: "x" });
+    hybridSearchMock.mockRejectedValueOnce({ kind: "IndexCorrupt", message: "x" });
 
     await searchStore.refetchIfQueryNonEmpty();
 
@@ -66,7 +69,7 @@ describe("searchStore.refetchIfQueryNonEmpty (#148)", () => {
 
   it("does not flip indexStale on unrelated errors, but clears isSearching", async () => {
     searchStore.setQuery("#yoda");
-    searchFulltextMock.mockRejectedValueOnce(new Error("network blip"));
+    hybridSearchMock.mockRejectedValueOnce(new Error("network blip"));
 
     await searchStore.refetchIfQueryNonEmpty();
 

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -12,14 +12,14 @@
 //   - activeTab:    sidebar tab — "files" (file browser) | "tags"
 
 import { writable } from "svelte/store";
-import type { SearchResult } from "../types/search";
-import { searchFulltext } from "../ipc/commands";
+import type { HybridHit } from "../types/search";
+import { hybridSearch } from "../ipc/commands";
 import { isVaultError } from "../types/errors";
 import { vaultStore } from "./vaultStore";
 
 export interface SearchStoreState {
   query: string;
-  results: SearchResult[];
+  results: HybridHit[];
   /** Total results returned (capped at limit, typically 100). */
   totalMatches: number;
   /** Number of unique file paths in results. */
@@ -62,7 +62,7 @@ function createSearchStore() {
      * Store search results returned by search_fulltext.
      * Also clears isSearching and computes unique file count.
      */
-    setResults: (results: SearchResult[], totalFiles: number) =>
+    setResults: (results: HybridHit[], totalFiles: number) =>
       update((s) => ({
         ...s,
         results,
@@ -101,9 +101,11 @@ function createSearchStore() {
      * Re-execute the current query against the freshly-built index.
      *
      * Called after a successful rebuild (#148). If the query is empty there
-     * is nothing to fetch; otherwise we re-issue `search_fulltext` and replace
+     * is nothing to fetch; otherwise we re-issue `hybrid_search` and replace
      * the results so the panel reflects newly-indexed content without the
-     * user having to edit the query.
+     * user having to edit the query. #204 switched the rebuild refetch from
+     * BM25-only to the RRF-fused hybrid result so the statusbar rebuild path
+     * stays consistent with the live search dispatch in OmniSearch.
      */
     refetchIfQueryNonEmpty: async (): Promise<void> => {
       let query = "";
@@ -114,7 +116,7 @@ function createSearchStore() {
       if (!query.trim()) return;
       update((s) => ({ ...s, isSearching: true }));
       try {
-        const results = await searchFulltext(query, 100);
+        const results = await hybridSearch(query, 100);
         const uniqueFileCount = new Set(results.map((r) => r.path)).size;
         update((s) => ({
           ...s,

--- a/src/types/e2e-hook.ts
+++ b/src/types/e2e-hook.ts
@@ -16,6 +16,12 @@ export interface E2eHook {
   finishProgress: () => void;
   typeInActiveEditor: (text: string) => Promise<void>;
   getActiveDocText: () => Promise<string>;
+  /** #204: trigger `reindex_vault` and resolve once the reindex worker
+   *  emits a terminal `done` progress event. Used by the hybrid-search
+   *  E2E spec to wait for embeddings to be queryable before running a
+   *  semantic-only query. Rejects on `cancelled` or if the coordinator
+   *  isn't available (embeddings feature off / model failed to load). */
+  reindexAndWaitDone: () => Promise<void>;
 }
 
 declare global {

--- a/tests/SearchResultRow.test.ts
+++ b/tests/SearchResultRow.test.ts
@@ -1,0 +1,60 @@
+// #204 — SearchResultRow renders a subtle indicator when a hit was
+// surfaced only by the semantic (vec) leg of hybrid_search. The ticket
+// AC is: "Result-Rows zeigen dezenten Indicator bei Semantic-Match."
+//
+// We treat "semantic-only" as vecRank != null && bm25Rank == null:
+//   - If BM25 also ranked the hit, the lexical surface already explains
+//     why it appears → no new information to show.
+//   - If only the vec leg surfaced it, the user gains from knowing this
+//     came in via semantic similarity rather than keyword match.
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import SearchResultRow from "../src/components/Search/SearchResultRow.svelte";
+import type { HybridHit } from "../src/types/search";
+
+const INDICATOR_SELECTOR = ".vc-search-result-semantic-indicator";
+
+function makeHit(overrides: Partial<HybridHit>): HybridHit {
+  return {
+    path: "/vault/Note.md",
+    title: "Note",
+    score: 0.1,
+    snippet: "<b>preview</b> text",
+    matchCount: 1,
+    ...overrides,
+  };
+}
+
+describe("SearchResultRow semantic indicator (#204)", () => {
+  it("does not render the indicator for BM25-only hits", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ bm25Rank: 0, bm25Score: 5.2 }),
+      onclick: () => {},
+    });
+    expect(container.querySelector(INDICATOR_SELECTOR)).toBeNull();
+  });
+
+  it("does not render the indicator for hybrid hits that surface in both legs", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({
+        bm25Rank: 0,
+        bm25Score: 5.2,
+        vecRank: 2,
+        vecScore: 0.71,
+      }),
+      onclick: () => {},
+    });
+    expect(container.querySelector(INDICATOR_SELECTOR)).toBeNull();
+  });
+
+  it("renders the indicator when only the vec leg surfaced the hit", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 0, vecScore: 0.83 }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(INDICATOR_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("aria-label")).toMatch(/semantisch/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Swaps the OmniSearch content-mode dispatch from `searchFulltext` (BM25-only) to `hybridSearch` — the same RRF-fused BM25 + HNSW ranking introduced in #203/#225.
- Adds a subtle **sparkles indicator** (lucide-svelte `Sparkles`, 12px, `color-text-muted`) to rows that were surfaced only by the semantic leg (`vecRank != null && bm25Rank == null`). Hits that also ranked in BM25 get no badge — the existing snippet highlight already explains why they appear.
- Backend fallback is transparent: when embeddings are still bootstrapping / the model failed to load, `hybrid_search` returns BM25-only, so the UI keeps working without a user-visible error.
- New `__e2e__.reindexAndWaitDone()` hook: subscribes once to `embed://reindex_progress` and resolves on the terminal `done` phase. Lets the hybrid-search spec wait for the embedding pass deterministically instead of guessing with `browser.pause`.

## Why it stacks on #203
This PR consumes the `hybrid_search` IPC command added in #225 (#203). Base it on `feat/203-rrf-hybrid-search` until that PR merges.

## AC from #204
- [x] **Existing Search-Box calls `hybrid_search`** — `OmniSearch.svelte:208`, plus `searchStore.refetchIfQueryNonEmpty`.
- [x] **Result-Rows zeigen dezenten Indicator bei Semantic-Match** — `.vc-search-result-semantic-indicator`, vec-only framing, tooltip + aria-label.
- [x] **Keine Regression in Keystroke-Latency / Results-Loading** — same 200ms debounce, same store flow, same render path. Hybrid leg runs in parallel tokio tasks, so added latency is bounded by the slower of the two.
- [x] **E2E WDIO spec** — `e2e/specs/hybrid-search.spec.ts` seeds a feline-themed note, awaits `reindexAndWaitDone`, queries for `cat` (not in any fixture), expects the note + the semantic indicator.

## Test plan
- [x] `pnpm test` — 761 tests pass (includes new `tests/SearchResultRow.test.ts` (3) and rewired `OmniSearch.test.ts` + `searchStore.refetchAfterRebuild.test.ts`).
- [x] `pnpm typecheck` clean.
- [x] `pnpm exec svelte-check` clean (0 errors, 2 pre-existing line-clamp warnings unrelated to this PR).
- [ ] `pnpm test:e2e:build` — not run locally; spec requires `VITE_E2E=1 pnpm tauri build` with embeddings active. Behaves robustly under reindex-not-fired: `reindexAndWaitDone` rejects, the before-hook fails fast rather than producing flaky hits.