### PR TITLE
perf(embeddings): bench harness with regression gate (#207)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ coverage
 src-tauri/target
 src-tauri/gen/schemas
 
+# Bench harness (#207) — transient run output; baseline.json stays tracked.
+src-tauri/benches/latest.json
+
 # Reference material (not part of the codebase)
 VaultCore_MVP_Spezifikation_v3.md
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,107 @@
+# Benchmarks
+
+Reproducible, regression-gated benchmarks for the perf-critical paths in
+VaultCore's semantic search stack. Covers issue [#207](https://github.com/herox215/vaultcore/issues/207).
+
+## What's measured
+
+The `#[ignore]`-gated benches live next to the code they exercise and each
+emits a single `BENCH_JSON {...}` line so the harness can collect them
+without a coupled Criterion or custom bench crate.
+
+| Name                   | Source                                      | What it measures                                                                   |
+| ---------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `single_embed`         | `src/embeddings/service.rs`                 | End-to-end text → 384-d vector latency through `EmbeddingService::embed`.         |
+| `semantic_search_100k` | `src/embeddings/query.rs`                   | Embed + HNSW query against a 100 000-vector index, k=10 ef_search=64.             |
+| `reindex_throughput`   | `src/embeddings/reindex.rs`                 | Files-per-second through the full reindex pipeline (reader → chunker → embed → sink). |
+| `rrf_fuse`             | `src/embeddings/hybrid.rs`                  | Pure-math RRF fusion cost at hybrid-search's top_n=200 per leg.                   |
+
+The spec targets they defend are in `CLAUDE.md` — keep this table in sync if
+that file moves.
+
+## How to run
+
+```bash
+# Full suite. ~2 min on reference hardware (single_embed is ~5 s; 100k index
+# build is the slow part at ~90 s; reindex is 12 s; rrf_fuse is negligible).
+scripts/run-benchmarks.sh
+
+# Write to a custom path (default: src-tauri/benches/latest.json):
+scripts/run-benchmarks.sh /tmp/my-run.json
+
+# Subset via regex filter:
+BENCH_FILTER="single_embed|rrf_fuse" scripts/run-benchmarks.sh
+
+# Bigger reindex (2000 files, ~2 min) — linear-extrapolates to 100k:
+LARGE_REINDEX_BENCH=1 scripts/run-benchmarks.sh
+```
+
+The script shells out to `cargo test --release --features embeddings --
+--ignored --nocapture --test-threads=1` with a `bench_` test-name filter. The
+`--test-threads=1` is load-bearing: the embed bench and the 100k-query bench
+both load the MiniLM model and compete for the ORT global thread pool
+(capped at intra=2/inter=1 per #197).
+
+## Regression gate (>10 %)
+
+```bash
+# After run-benchmarks.sh has produced latest.json:
+scripts/bench-regression.py
+
+# Custom threshold (0.15 = 15 %):
+BENCH_THRESHOLD=0.15 scripts/bench-regression.py
+
+# Explicit paths:
+scripts/bench-regression.py my-run.json my-baseline.json
+```
+
+Exits `1` with a per-metric FAIL line when any tracked field regresses more
+than `BENCH_THRESHOLD` against `src-tauri/benches/baseline.json`. Direction
+is inferred per field: latencies (`*_ms`) are "lower is better", throughput
+(`files_per_sec`) is "higher is better".
+
+A missing metric in the new run is a hard fail (bench disappeared). A new
+metric without a baseline entry is a warn-only (adding a bench is not a
+regression).
+
+## Baseline
+
+`src-tauri/benches/baseline.json` holds reference numbers captured on:
+
+- CPU: 13th Gen Intel Core i7-13700H (20 cores)
+- RAM: 32 GiB
+- OS: Linux 6.19.9-1-cachyos (x86_64)
+- Git SHA: c6ae94a (post-#205)
+
+Values are rounded with a small noise margin — p99 in particular varies run
+to run by up to 2× on shared hardware, so the committed baseline sits above
+the median observed run.
+
+### Updating the baseline
+
+Pick the lowest-noise run you can (no compiles in parallel, no browser open,
+AC plugged in on laptops), then:
+
+```bash
+scripts/run-benchmarks.sh src-tauri/benches/baseline.json
+# edit the JSON: add the hardware block, round p99 upward ~20 % to absorb noise,
+# round throughput downward ~10 %.
+```
+
+Commit baseline changes in a dedicated PR with the reference-hardware specs
+in the commit message. Never update the baseline in the same PR as a perf
+change — reviewers need to see the delta against the prior line in the diff.
+
+## CI integration
+
+Currently not wired into CI (no `.github/workflows/*` in this repo yet).
+Recommended shape when added:
+
+- `workflow_dispatch` + scheduled nightly, **not** blocking per-PR CI — the
+  full run costs ~2 min on cold-cache hosted runners and variance makes
+  per-PR gating brittle.
+- Upload `latest.json` as an artifact, diff against `baseline.json` via
+  `bench-regression.py`, fail the job on non-zero exit.
+- For per-PR perf signal, run only the fast benches (`single_embed`,
+  `rrf_fuse`) with a relaxed 25 % threshold and record the numbers in the
+  PR body.

--- a/scripts/bench-regression.py
+++ b/scripts/bench-regression.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""bench-regression.py — #207 guard that fails CI on >10% slowdown.
+
+Compares a fresh benchmark run (as produced by `scripts/run-benchmarks.sh`)
+against a committed baseline and exits non-zero when any tracked metric
+regresses beyond the configured threshold.
+
+Metric handling:
+  - Latency fields (*_ms): regression = new > baseline * (1 + threshold).
+  - Throughput fields (files_per_sec): regression = new < baseline * (1 - threshold).
+  - Metrics missing from the new run → hard fail (a bench disappeared).
+  - Metrics in the new run but not in the baseline → warn but don't fail
+    (so adding a bench is not itself a regression).
+
+Usage:
+  scripts/bench-regression.py              # compares latest.json vs baseline.json
+  scripts/bench-regression.py new.json baseline.json
+  BENCH_THRESHOLD=0.15 scripts/bench-regression.py  # 15% instead of 10%
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_NEW = REPO_ROOT / "src-tauri" / "benches" / "latest.json"
+DEFAULT_BASELINE = REPO_ROOT / "src-tauri" / "benches" / "baseline.json"
+
+# Per AC #3: >10% slowdown must fail the job.
+THRESHOLD = float(os.environ.get("BENCH_THRESHOLD", "0.10"))
+
+# (metric_name, direction) — "lower" means smaller is better (latency),
+# "higher" means larger is better (throughput). Driven by the `name` field
+# the benches emit, not by file layout.
+TRACKED: dict[str, dict[str, str]] = {
+    "single_embed":         {"p50_ms": "lower", "p99_ms": "lower"},
+    "semantic_search_100k": {"p50_ms": "lower", "p99_ms": "lower"},
+    "reindex_throughput":   {"files_per_sec": "higher"},
+    "rrf_fuse":             {"p50_ms": "lower", "p99_ms": "lower"},
+}
+
+
+def load(path: Path) -> dict[str, dict]:
+    with path.open() as fh:
+        doc = json.load(fh)
+    return {entry["name"]: entry for entry in doc.get("results", [])}
+
+
+def compare(new: dict[str, dict], baseline: dict[str, dict]) -> list[str]:
+    failures: list[str] = []
+    for name, fields in TRACKED.items():
+        if name not in new:
+            failures.append(f"[MISSING] bench `{name}` did not appear in new run")
+            continue
+        if name not in baseline:
+            print(f"[warn] bench `{name}` has no baseline entry — skipping")
+            continue
+        for field, direction in fields.items():
+            if field not in new[name] or field not in baseline[name]:
+                failures.append(
+                    f"[MISSING FIELD] `{name}.{field}` absent "
+                    f"(new={field in new[name]}, baseline={field in baseline[name]})"
+                )
+                continue
+            n = float(new[name][field])
+            b = float(baseline[name][field])
+            if direction == "lower":
+                budget = b * (1 + THRESHOLD)
+                regressed = n > budget
+                delta_pct = (n - b) / b * 100.0 if b else 0.0
+            else:
+                budget = b * (1 - THRESHOLD)
+                regressed = n < budget
+                delta_pct = (n - b) / b * 100.0 if b else 0.0
+            status = "FAIL" if regressed else "ok"
+            print(
+                f"[{status}] {name}.{field}: baseline={b:.4f} "
+                f"new={n:.4f} ({delta_pct:+.1f}%, budget={budget:.4f}, {direction})"
+            )
+            if regressed:
+                failures.append(
+                    f"{name}.{field} regressed {delta_pct:+.1f}% "
+                    f"(baseline={b:.4f}, new={n:.4f}, threshold={THRESHOLD * 100:.0f}%)"
+                )
+    return failures
+
+
+def main() -> int:
+    new_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_NEW
+    base_path = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_BASELINE
+
+    if not new_path.exists():
+        print(f"error: new results file not found: {new_path}", file=sys.stderr)
+        return 2
+    if not base_path.exists():
+        print(f"error: baseline file not found: {base_path}", file=sys.stderr)
+        return 2
+
+    new = load(new_path)
+    baseline = load(base_path)
+
+    print(f"[bench-regression] threshold={THRESHOLD * 100:.0f}%")
+    print(f"[bench-regression] new={new_path}")
+    print(f"[bench-regression] baseline={base_path}")
+    print()
+
+    failures = compare(new, baseline)
+
+    print()
+    if failures:
+        print(f"[bench-regression] {len(failures)} regression(s):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("[bench-regression] no regressions above threshold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# run-benchmarks.sh — #207 benchmark harness runner.
+#
+# Runs the `#[ignore]`-gated benches in release mode with the `embeddings`
+# feature enabled, parses the `BENCH_JSON {...}` lines they emit on stderr,
+# and writes a combined JSON document to the target path (default:
+# `src-tauri/benches/latest.json`).
+#
+# The benches themselves live next to the code they measure:
+#   - service.rs            bench_single_embed_p50_p99       → "single_embed"
+#   - query.rs              bench_semantic_query_p50_under_5ms → "semantic_search_100k"
+#   - reindex.rs            bench_reindex_throughput         → "reindex_throughput"
+#   - hybrid.rs             bench_rrf_fuse_p50_p99           → "rrf_fuse"
+#
+# Usage:
+#   scripts/run-benchmarks.sh                         # writes src-tauri/benches/latest.json
+#   scripts/run-benchmarks.sh path/to/out.json        # custom output path
+#   BENCH_FILTER="single_embed|rrf_fuse" scripts/run-benchmarks.sh  # subset
+#
+# Env overrides:
+#   CARGO           cargo binary (default: cargo)
+#   BENCH_FEATURES  feature list (default: embeddings)
+#   BENCH_FILTER    test-name regex passed to cargo test (default: bench_)
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out_path="${1:-$repo_root/src-tauri/benches/latest.json}"
+
+cargo_bin="${CARGO:-cargo}"
+features="${BENCH_FEATURES:-embeddings}"
+filter="${BENCH_FILTER:-bench_}"
+
+tmp_out="$(mktemp)"
+trap 'rm -f "$tmp_out"' EXIT
+
+echo "[bench] cargo test --release --features $features -- --ignored --nocapture $filter" >&2
+(
+  cd "$repo_root/src-tauri"
+  # stderr carries the BENCH_JSON lines (eprintln!); merge to stdout for capture.
+  "$cargo_bin" test --release --features "$features" --tests -- \
+    --ignored --nocapture --test-threads=1 "$filter" 2>&1
+) | tee "$tmp_out"
+
+# Collect every BENCH_JSON {...} record. cargo test sometimes prepends
+# `test ... ok BENCH_JSON {...}` onto the same line when eprintln! is the last
+# line a test emits, so we match `BENCH_JSON {...}` anywhere, not just at BOL.
+# The grep -o emits one record per line (non-greedy via perl regex).
+entries="$(grep -oE 'BENCH_JSON \{[^}]*\}' "$tmp_out" | sed -E 's/^BENCH_JSON //' || true)"
+
+if [ -z "$entries" ]; then
+  echo "[bench] no BENCH_JSON lines emitted — did any #[ignore] benches run?" >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$out_path")"
+
+# Build the combined document with jq: wrap the per-bench objects in an array
+# under `results`, plus a timestamp + git SHA for provenance.
+git_sha="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '%s\n' "$entries" \
+  | jq -s --arg sha "$git_sha" --arg ts "$timestamp" \
+      '{timestamp: $ts, git_sha: $sha, results: .}' \
+  > "$out_path"
+
+echo "[bench] wrote $out_path" >&2
+cat "$out_path"

--- a/src-tauri/benches/baseline.json
+++ b/src-tauri/benches/baseline.json
@@ -1,0 +1,46 @@
+{
+  "timestamp": "2026-04-19T14:54:30Z",
+  "git_sha": "c6ae94a",
+  "hardware": {
+    "cpu": "13th Gen Intel Core i7-13700H",
+    "cores": 20,
+    "ram_gb": 32,
+    "arch": "x86_64",
+    "os": "Linux 6.19.9-1-cachyos"
+  },
+  "notes": [
+    "Captured on the reference dev machine above under no-load conditions.",
+    "p99 figures are noisier than p50 — allow extra headroom when comparing.",
+    "reindex_throughput uses the 200-file variant; set LARGE_REINDEX_BENCH=1 for 2000.",
+    "Regenerate via scripts/run-benchmarks.sh src-tauri/benches/baseline.json",
+    "and commit in a separate hardware-update PR."
+  ],
+  "results": [
+    {
+      "name": "rrf_fuse",
+      "p50_ms": 0.06,
+      "p99_ms": 0.2,
+      "n": 1000,
+      "per_leg": 200
+    },
+    {
+      "name": "semantic_search_100k",
+      "p50_ms": 2.2,
+      "p99_ms": 8.0,
+      "n": 100,
+      "vectors": 100000
+    },
+    {
+      "name": "reindex_throughput",
+      "files_per_sec": 16.0,
+      "files": 200,
+      "elapsed_ms": 12500.0
+    },
+    {
+      "name": "single_embed",
+      "p50_ms": 2.0,
+      "p99_ms": 3.2,
+      "n": 200
+    }
+  ]
+}

--- a/src-tauri/src/embeddings/hybrid.rs
+++ b/src-tauri/src/embeddings/hybrid.rs
@@ -305,4 +305,45 @@ mod tests {
             "expected mostly two-source hits in top 50, got {overlap_top}",
         );
     }
+
+    /// #207 AC #1 — RRF fusion p50/p99 at hybrid-search's realistic
+    /// working size (each leg returns top_n = 200 per search.rs). This is
+    /// the only hybrid-specific time on top of the component legs; the
+    /// end-to-end embed + HNSW + BM25 times are captured by their own
+    /// benches and summed by the harness.
+    #[test]
+    #[ignore]
+    fn bench_rrf_fuse_p50_p99() {
+        use std::time::Instant;
+        const WARMUP: usize = 50;
+        const N: usize = 1000;
+        const PER_LEG: usize = 200;
+
+        // Deterministic synthetic legs: 50% overlap between BM25 and vec,
+        // mimicking search.rs's top_n after a realistic dual-retrieval.
+        let bm25: Vec<(String, f32)> = (0..PER_LEG)
+            .map(|i| (format!("doc-{i}.md"), (PER_LEG - i) as f32))
+            .collect();
+        let vec_hits: Vec<(String, f32)> = (0..PER_LEG)
+            .map(|i| (format!("doc-{}.md", i + PER_LEG / 2), 1.0 - (i as f32 / PER_LEG as f32)))
+            .collect();
+
+        for _ in 0..WARMUP {
+            let _ = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        }
+        let mut samples = Vec::with_capacity(N);
+        for _ in 0..N {
+            let t0 = Instant::now();
+            let _ = rrf_fuse(&bm25, &vec_hits, RRF_K);
+            samples.push(t0.elapsed());
+        }
+        samples.sort();
+        let p50 = samples[N / 2];
+        let p99 = samples[(N * 99) / 100];
+        eprintln!(
+            "BENCH_JSON {{\"name\":\"rrf_fuse\",\"p50_ms\":{:.4},\"p99_ms\":{:.4},\"n\":{N},\"per_leg\":{PER_LEG}}}",
+            p50.as_secs_f64() * 1000.0,
+            p99.as_secs_f64() * 1000.0,
+        );
+    }
 }

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -351,7 +351,12 @@ mod tests {
         }
         samples.sort();
         let p50 = samples[Q / 2];
-        eprintln!("semantic_search p50 over {Q} queries @ {N} vectors: {p50:?}");
+        let p99 = samples[(Q * 99) / 100];
+        eprintln!(
+            "BENCH_JSON {{\"name\":\"semantic_search_100k\",\"p50_ms\":{:.3},\"p99_ms\":{:.3},\"n\":{Q},\"vectors\":{N}}}",
+            p50.as_secs_f64() * 1000.0,
+            p99.as_secs_f64() * 1000.0,
+        );
         assert!(
             p50 < Duration::from_millis(5),
             "p50 latency too slow: {p50:?}",

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -946,6 +946,13 @@ mod tests {
                 elapsed,
                 (100_000.0 / per_sec) / 60.0,
             );
+            // #207: the reindex bench is a total-wall-clock measurement;
+            // we publish files/sec instead of p50 so the harness can
+            // compare against a baseline throughput floor.
+            eprintln!(
+                "BENCH_JSON {{\"name\":\"reindex_throughput\",\"files_per_sec\":{per_sec:.3},\"files\":{done},\"elapsed_ms\":{:.1}}}",
+                elapsed.as_secs_f64() * 1000.0,
+            );
 
             assert_eq!(done, n_files, "every file must reach the sink");
             // Floor: 3.0 files/sec. On the 100k target this would be

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -286,4 +286,58 @@ mod tests {
         assert_send_sync::<EmbeddingService>();
         assert_send_sync::<Arc<EmbeddingService>>();
     }
+
+    /// #207 AC #1 — single-note embed latency p50/p99. Warm, steady-state
+    /// (ORT session already loaded, arena stable). Emits a JSON line to
+    /// stderr for `scripts/run-benchmarks.sh` to collect.
+    ///
+    /// `#[ignore]` because it needs the bundled model and should only
+    /// run through the benchmark harness. Run with:
+    /// `cargo test --release --features embeddings -- --ignored bench_single_embed --nocapture`.
+    #[test]
+    #[ignore]
+    fn bench_single_embed_p50_p99() {
+        use std::time::{Duration, Instant};
+        const WARMUP: usize = 20;
+        const N: usize = 200;
+
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+
+        // Representative prose — varied length so we exercise the tokenizer's
+        // padding + truncation paths, not just the shortest possible input.
+        let probes: Vec<String> = (0..N)
+            .map(|i| {
+                format!(
+                    "note {i} about markdown workflows, cross-linking between \
+                     files, and incremental indexing of a personal knowledge vault"
+                )
+            })
+            .collect();
+        for p in probes.iter().take(WARMUP) {
+            let _ = svc.embed(p).unwrap();
+        }
+
+        let mut samples = Vec::with_capacity(N);
+        for p in &probes {
+            let t0 = Instant::now();
+            let _ = svc.embed(p).unwrap();
+            samples.push(t0.elapsed());
+        }
+        samples.sort();
+        let p50 = samples[N / 2];
+        let p99 = samples[(N * 99) / 100];
+        eprintln!("BENCH_JSON {{\"name\":\"single_embed\",\"p50_ms\":{:.3},\"p99_ms\":{:.3},\"n\":{N}}}",
+            p50.as_secs_f64() * 1000.0,
+            p99.as_secs_f64() * 1000.0);
+        // Loose ceiling: 20 ms p50 is well above warm ORT inference for
+        // MiniLM-L6-v2 on any modern CPU. The harness's regression check
+        // catches real drift against the committed baseline.
+        assert!(
+            p50 < Duration::from_millis(20),
+            "single_embed p50 too slow: {p50:?}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #207. Stacked on #227 (#205 branch).

## Summary

- Adds a lightweight bench harness covering the four perf-critical paths of the semantic stack: single-note embed, 100k semantic query, reindex throughput, hybrid RRF fusion.
- Each bench lives next to the code it measures and emits a single `BENCH_JSON {...}` line — `scripts/run-benchmarks.sh` collects them into `src-tauri/benches/latest.json` with timestamp + git SHA.
- `scripts/bench-regression.py` diffs a fresh run against `src-tauri/benches/baseline.json` and exits non-zero when any tracked metric regresses beyond `BENCH_THRESHOLD` (default 10 %, per AC).
- Reference-hardware numbers committed as the baseline. `BENCHMARKS.md` documents hardware, how to run, how to update the baseline, and the recommended CI shape.

## Why this shape

- **No Criterion crate / no bench-only crate.** Two of the four measured paths already had `#[ignore]`-gated latency tests; wrapping them in Criterion would mean rewriting already-working tests and adding a compile-time dependency that we'd end up using only in these four places. The `BENCH_JSON` eprintln! convention keeps the "compile once, run many" ergonomics of `cargo test --release -- --ignored` and stays machine-parseable.
- **Baseline as JSON, not as thresholds inline in tests.** Hardware moves, so hardcoding `assert!(p50 < 5ms)` inside each bench ties the threshold to whatever machine runs it. The external baseline + regression script makes the hardware assumption explicit and reviewable as a one-line numeric diff when it needs to move.
- **No GitHub Actions workflow in this PR.** `.github/workflows/` does not yet exist in this repo. Wiring bench regression into per-PR CI against a 2-minute suite on shared runners with high variance would be more noise than signal; `BENCHMARKS.md` sketches the recommended `workflow_dispatch` + nightly shape as a follow-up.

## New / retrofitted benches

| Bench                                        | File                      | p50 / p99 / throughput (reference machine) |
| -------------------------------------------- | ------------------------- | ------------------------------------------ |
| `bench_single_embed_p50_p99` *(new)*         | `service.rs`              | 1.96 ms / 2.48 ms                          |
| `bench_semantic_query_p50_under_5ms`         | `query.rs` *(retrofit)*   | 2.10 ms / 7.62 ms                          |
| `bench_reindex_throughput`                   | `reindex.rs` *(retrofit)* | 16.97 files/s                              |
| `bench_rrf_fuse_p50_p99` *(new)*             | `hybrid.rs`               | 0.055 ms / 0.167 ms                        |

## Test plan

- [x] `scripts/run-benchmarks.sh` produces `latest.json` with all four records.
- [x] `scripts/bench-regression.py` against the committed baseline: all ok.
- [x] Retrofitted existing `bench_semantic_query_p50_under_5ms` assertion still holds (`p50 < 5 ms`).
- [x] New `bench_single_embed_p50_p99` floor (`p50 < 20 ms`) holds on the reference machine.
- [ ] CI workflow integration — deliberately deferred; tracked in `BENCHMARKS.md` as the recommended follow-up.