### PR TITLE
test(embeddings): semantic quality sanity gate (#208)

### DIFF
--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -18,3 +18,5 @@ mod file_index_contention;
 mod vault_walk;
 #[cfg(feature = "embeddings")]
 mod embeddings;
+#[cfg(feature = "embeddings")]
+mod semantic_quality;

--- a/src-tauri/src/tests/semantic_quality.rs
+++ b/src-tauri/src/tests/semantic_quality.rs
@@ -1,0 +1,100 @@
+//! #208 — Semantic quality sanity test.
+//!
+//! Guards against silent retrieval-quality regressions in the embedding
+//! stack. Uses the five mini-docs from research #188
+//! (`pizza_dough`, `bread_baking`, `cat_behavior`, `machine_learning`,
+//! `sourdough_starter`) as a ground-truth corpus with two
+//! cluster-crossing queries.
+//!
+//! Runs as a regular CI job (no `#[ignore]`). Skips cleanly when the
+//! MiniLM model isn't bundled, consistent with every other test in this
+//! module — no CI flakes on hosts without the model.
+//!
+//! Similarity is MiniLM L2-normalised dot product (== cosine) and we
+//! brute-force all 5 docs rather than going through HNSW/RRF. This is
+//! deliberate: we're testing the *embedding quality*, not the index or
+//! the fuser. If a regression here ever aligns suspiciously with an HNSW
+//! change, that's the signal that HNSW has drifted, not the embedder.
+
+#![cfg(feature = "embeddings")]
+
+use crate::embeddings::EmbeddingService;
+
+const FIXTURES: &[(&str, &str)] = &[
+    (
+        "pizza_dough",
+        include_str!("../../tests/fixtures/semantic_quality/pizza_dough.md"),
+    ),
+    (
+        "bread_baking",
+        include_str!("../../tests/fixtures/semantic_quality/bread_baking.md"),
+    ),
+    (
+        "cat_behavior",
+        include_str!("../../tests/fixtures/semantic_quality/cat_behavior.md"),
+    ),
+    (
+        "machine_learning",
+        include_str!("../../tests/fixtures/semantic_quality/machine_learning.md"),
+    ),
+    (
+        "sourdough_starter",
+        include_str!("../../tests/fixtures/semantic_quality/sourdough_starter.md"),
+    ),
+];
+
+/// Dot product — vectors are MiniLM-L2-normalised so this is cosine similarity.
+fn cos(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// Embed the fixtures + query and return `(name, score)` pairs sorted
+/// descending. Returns `None` when the model isn't bundled (so tests
+/// can skip cleanly on CI hosts without the model resource).
+fn rank_fixtures(query: &str) -> Option<Vec<(&'static str, f32)>> {
+    let svc = EmbeddingService::load(None).ok()?;
+    let q = svc.embed(query).expect("query embed failed");
+    let mut scored: Vec<(&'static str, f32)> = FIXTURES
+        .iter()
+        .map(|(name, body)| {
+            let v = svc.embed(body).expect("fixture embed failed");
+            (*name, cos(&q, &v))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    Some(scored)
+}
+
+#[test]
+fn italian_flatbread_top3_contains_pizza_and_bread() {
+    let Some(ranked) = rank_fixtures("Italian flatbread techniques") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    let top3: Vec<&str> = ranked.iter().take(3).map(|(n, _)| *n).collect();
+    assert!(
+        top3.contains(&"pizza_dough"),
+        "expected `pizza_dough` in top-3, got {ranked:?}"
+    );
+    assert!(
+        top3.contains(&"bread_baking"),
+        "expected `bread_baking` in top-3, got {ranked:?}"
+    );
+}
+
+#[test]
+fn feline_communication_top1_is_cat_with_margin() {
+    let Some(ranked) = rank_fixtures("how do felines communicate") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    assert_eq!(
+        ranked[0].0, "cat_behavior",
+        "expected top-1 == `cat_behavior`, got {ranked:?}"
+    );
+    let margin = ranked[0].1 - ranked[1].1;
+    assert!(
+        margin > 0.2,
+        "expected cosine margin > 0.2, got {margin:.4} (ranked: {ranked:?})"
+    );
+}

--- a/src-tauri/tests/fixtures/semantic_quality/bread_baking.md
+++ b/src-tauri/tests/fixtures/semantic_quality/bread_baking.md
@@ -1,0 +1,12 @@
+# Bread Baking
+
+Bread baking transforms a simple mixture of flour, water, salt, and yeast
+into a risen loaf through a sequence of fermentation and thermal steps.
+The dough is mixed, kneaded to develop the gluten network, and allowed a
+bulk proof during which yeast produces carbon dioxide and the gluten
+tightens. After shaping, a final proof lets the loaf relax and expand;
+the baker scores the surface to control the direction of oven spring. In
+a hot oven with steam the loaf gelatinises the starches, sets the crumb,
+caramelises the crust via the Maillard reaction, and loses residual
+moisture. Classic techniques — hearth baking, Dutch-oven baking, and
+stone-deck flatbread baking — are all variants of the same fundamentals.

--- a/src-tauri/tests/fixtures/semantic_quality/cat_behavior.md
+++ b/src-tauri/tests/fixtures/semantic_quality/cat_behavior.md
@@ -1,0 +1,15 @@
+# Cat Behavior
+
+Domestic cats communicate through a rich vocabulary of vocalisations, body
+postures, and scent marks. A low rumbling purr commonly signals contentment
+but can also appear in stressed or injured cats as a self-soothing
+mechanism. Ear position and tail carriage convey mood reliably: upright
+forward-facing ears with a relaxed vertical tail indicates confidence,
+while flattened ears and a puffed-up tail indicate fear or imminent
+aggression. A slow blink from a cat directed at a person is widely
+interpreted as a gesture of trust and affection, sometimes called a
+"cat kiss." Kneading with the front paws, often accompanied by purring,
+is a kitten behaviour retained into adulthood and expresses comfort.
+Meowing in adult cats is almost exclusively directed at humans, not at
+other cats, suggesting it is a learned feline-to-human communication
+channel.

--- a/src-tauri/tests/fixtures/semantic_quality/machine_learning.md
+++ b/src-tauri/tests/fixtures/semantic_quality/machine_learning.md
@@ -1,0 +1,14 @@
+# Machine Learning
+
+Machine learning is the study of algorithms that improve their performance
+on a task by learning patterns from data rather than following explicitly
+written rules. Supervised learning fits a model to labelled input/output
+pairs; unsupervised learning discovers structure in unlabelled data;
+reinforcement learning optimises a policy through reward signals from an
+environment. Training typically minimises a loss function via gradient
+descent over the parameters of a differentiable model such as a neural
+network, while validation on held-out data guards against overfitting.
+Feature engineering, regularisation, and careful data splits are as
+important to generalisation as model capacity itself. Modern practice
+leans heavily on large pretrained transformer models fine-tuned for
+downstream tasks in language, vision, and increasingly multimodal domains.

--- a/src-tauri/tests/fixtures/semantic_quality/pizza_dough.md
+++ b/src-tauri/tests/fixtures/semantic_quality/pizza_dough.md
@@ -1,0 +1,12 @@
+# Pizza Dough
+
+Neapolitan pizza dough is a high-hydration, low-yeast Italian flatbread
+base made from "00" flour, water, salt, and a small amount of fresh yeast.
+The hydration typically sits between 60% and 65%, producing a soft, slack
+dough that develops gluten through a long autolyse rather than intensive
+kneading. After bulk fermentation at room temperature the dough is divided
+into 250 g balls, proofed for a further 6 to 8 hours, and hand-stretched
+into thin discs preserving a raised cornicione at the rim. Cooked on a
+preheated stone or steel at 450 °C the flatbread blisters and chars in
+60 to 90 seconds, yielding the leopard-spotted crust characteristic of a
+Naples-style pizza.

--- a/src-tauri/tests/fixtures/semantic_quality/sourdough_starter.md
+++ b/src-tauri/tests/fixtures/semantic_quality/sourdough_starter.md
@@ -1,0 +1,13 @@
+# Sourdough Starter
+
+A sourdough starter is a living culture of wild yeasts and lactic acid
+bacteria maintained in a flour-and-water medium, used to leaven bread
+without commercial yeast. A starter is established by mixing equal parts
+flour and water and feeding it daily for 5 to 10 days until it reliably
+doubles in volume between feedings. Once mature, the culture can be kept
+on the counter with twice-daily feedings or in the fridge with weekly
+feedings. A dark liquid layer called hooch on top of a hungry starter
+signals alcohol produced by the yeast and is a sign it is time to feed.
+The balance between Lactobacillus species and the resident yeast
+(often Saccharomyces or Kazachstania) determines the final flavour —
+warmer hydration schedules favour tang, cooler schedules favour mildness.


### PR DESCRIPTION
Closes #208. Stacked on #228 (#207 branch). **Last sub-ticket in the Semantic Search v1 milestone.**

## Summary

- Adds the five mini-docs from research #188 as `.md` fixtures under `src-tauri/tests/fixtures/semantic_quality/` and two integration tests that exercise the cluster-crossing queries from the research comment.
- Tests run in the normal `cargo test` pass (no `#[ignore]`) — this is a regular CI gate per AC #4, not a bench.
- Skips cleanly when the MiniLM model isn't bundled, matching the existing `embedding_smoke_test` / `embed_returns_384_l2_normalised_vector` pattern. No flakes on hosts without model resources.

## Why brute-force, not HNSW/RRF

These tests are about *embedder quality*, not index or fuser quality. Running the 5 docs through `EmbeddingService::embed` directly and ranking by cosine over a 5-element list keeps the signal clean — a regression here unambiguously points at the embedder. If it ever fails in the same PR as an HNSW change, the signal is that HNSW drifted, not the embedder.

## Acceptance criteria

- [x] 5 mini-docs committed as fixtures.
- [x] `italian_flatbread_top3_contains_pizza_and_bread` — top-3 of "Italian flatbread techniques" contains both `pizza_dough` and `bread_baking`.
- [x] `feline_communication_top1_is_cat_with_margin` — top-1 of "how do felines communicate" is `cat_behavior` with cosine margin > 0.2 to rank 2.
- [x] Runs as a regular CI job (no `#[ignore]`).

## Test plan

- [x] `cargo test --features embeddings --lib tests::semantic_quality` — 2 passed, 0 failed.
- [x] Full embeddings-test subset — 85 passed, 0 failed, 9 ignored (the bench-only ones from #207). No adjacent regressions.