### PR TITLE
feat(search): match-percent badge on hybrid search results (#231)

### DIFF
--- a/src/components/Search/SearchResultRow.svelte
+++ b/src/components/Search/SearchResultRow.svelte
@@ -9,6 +9,11 @@
 
   let { result, onclick }: Props = $props();
 
+  // #231 — Cosine score below this floor is flagged "weak" (orange) so
+  // drift-y hits read at a glance. Anchor: #208 sanity test puts genuine
+  // semantic matches around 0.7–0.85; BM25-only fallbacks usually < 0.4.
+  const WEAK_MATCH_FLOOR = 0.3;
+
   const filename = $derived(result.path.split("/").pop() ?? result.path);
   // #204 — a hit surfaced only by the semantic leg of hybrid_search gets a
   // subtle badge so users can tell the result came in via embedding
@@ -16,6 +21,18 @@
   // already explained by the existing snippet highlighting, so no badge.
   const semanticOnly = $derived(
     result.vecRank !== undefined && result.bm25Rank === undefined,
+  );
+  // #231 — Match percent shown for every hit that has a vecScore (cosine
+  // similarity, MiniLM is L2-normalised so [-1, 1] in theory but [0, 1]
+  // for any reasonable text pair). Negative clamps to 0 %. BM25-only hits
+  // have no vecScore and therefore no percent.
+  const matchPercent = $derived(
+    result.vecScore === undefined
+      ? undefined
+      : Math.round(Math.max(0, result.vecScore) * 100),
+  );
+  const matchIsWeak = $derived(
+    result.vecScore !== undefined && result.vecScore < WEAK_MATCH_FLOOR,
   );
 </script>
 
@@ -36,6 +53,16 @@
         aria-label="Nur semantisch gefunden"
       >
         <Sparkles size={12} strokeWidth={2} />
+      </span>
+    {/if}
+    {#if matchPercent !== undefined}
+      <span
+        class="vc-search-result-match-percent"
+        class:vc-weak={matchIsWeak}
+        title="Cosine-Ähnlichkeit zur Suchanfrage"
+        aria-label="Match {matchPercent} Prozent"
+      >
+        {matchPercent}%
       </span>
     {/if}
   </p>
@@ -73,6 +100,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 0;
+    flex: 1 1 auto;
   }
 
   .vc-search-result-semantic-indicator {
@@ -80,6 +108,19 @@
     align-items: center;
     color: var(--color-text-muted);
     flex-shrink: 0;
+  }
+
+  .vc-search-result-match-percent {
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+    margin-left: auto;
+  }
+
+  .vc-search-result-match-percent.vc-weak {
+    color: var(--color-warning, #d97706);
   }
 
   .vc-search-result-snippet {

--- a/tests/SearchResultRow.test.ts
+++ b/tests/SearchResultRow.test.ts
@@ -7,6 +7,12 @@
 //     why it appears → no new information to show.
 //   - If only the vec leg surfaced it, the user gains from knowing this
 //     came in via semantic similarity rather than keyword match.
+//
+// #231 — Additional match-percent badge based on `vecScore` (cosine
+// similarity, naturally [0,1] for L2-normalised MiniLM vectors). Shown
+// for any hit that has a vecScore (vec-only OR hybrid). Hits without a
+// vecScore (BM25-only) get no percent. Below 30 % the badge gains a
+// "weak" modifier so users can tell drift-y hits at a glance.
 
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/svelte";
@@ -14,6 +20,8 @@ import SearchResultRow from "../src/components/Search/SearchResultRow.svelte";
 import type { HybridHit } from "../src/types/search";
 
 const INDICATOR_SELECTOR = ".vc-search-result-semantic-indicator";
+const PERCENT_SELECTOR = ".vc-search-result-match-percent";
+const PERCENT_WEAK_SELECTOR = ".vc-search-result-match-percent.vc-weak";
 
 function makeHit(overrides: Partial<HybridHit>): HybridHit {
   return {
@@ -56,5 +64,60 @@ describe("SearchResultRow semantic indicator (#204)", () => {
     const badge = container.querySelector(INDICATOR_SELECTOR);
     expect(badge).not.toBeNull();
     expect(badge?.getAttribute("aria-label")).toMatch(/semantisch/i);
+  });
+});
+
+describe("SearchResultRow match-percent badge (#231)", () => {
+  it("does not render the percent for BM25-only hits", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ bm25Rank: 0, bm25Score: 5.2 }),
+      onclick: () => {},
+    });
+    expect(container.querySelector(PERCENT_SELECTOR)).toBeNull();
+  });
+
+  it("renders the percent for hybrid hits (both legs)", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({
+        bm25Rank: 0,
+        bm25Score: 5.2,
+        vecRank: 2,
+        vecScore: 0.71,
+      }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(PERCENT_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent?.trim()).toBe("71%");
+    expect(container.querySelector(PERCENT_WEAK_SELECTOR)).toBeNull();
+  });
+
+  it("renders the percent for vec-only hits", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 0, vecScore: 0.83 }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(PERCENT_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent?.trim()).toBe("83%");
+  });
+
+  it("flags scores below the 30% floor as weak", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 5, vecScore: 0.22 }),
+      onclick: () => {},
+    });
+    const weak = container.querySelector(PERCENT_WEAK_SELECTOR);
+    expect(weak).not.toBeNull();
+    expect(weak?.textContent?.trim()).toBe("22%");
+  });
+
+  it("clamps negative cosine to 0%", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 9, vecScore: -0.04 }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(PERCENT_SELECTOR);
+    expect(badge?.textContent?.trim()).toBe("0%");
   });
 });


### PR DESCRIPTION
Closes #231.

## Summary

Adds a cosine-similarity percentage next to each search result row that has a \`vecScore\` (vec-only or hybrid hits). Right-aligned, muted, \`tabular-nums\`. Below a 30 % floor the badge renders in orange — the \"weak match\" signal from the ticket.

## Design decisions

- **Source:** \`HybridHit.vecScore\` (cosine, already [0,1] in practice for L2-normalised MiniLM vectors). Negative cosine clamps to 0 %. BM25 raw scores are unbounded and don't map meaningfully to \"X % similar,\" so BM25-only hits get **no** percent rather than a bogus normalised number.
- **Floor = 30 %** anchored to #208 sanity data: genuine semantic matches sit at 0.7–0.85, unrelated fixtures stay under 0.4 — 0.3 cleanly separates \"meaningful\" from \"noise.\"
- **Layout:** existing flex row, percent pushed to the right via \`margin-left: auto\`. Filename text gets \`flex: 1 1 auto\` so long names still ellipsis correctly and the percent/indicator stay visible at the right edge.
- **Color token:** \`var(--color-warning, #d97706)\` for weak — uses the token if the theme defines it, falls back to a sane orange otherwise.

## Test plan

- [x] \`pnpm vitest run tests/SearchResultRow.test.ts\` — 8 passed (3 existing #204 indicator tests + 5 new #231 percent tests).
- [x] \`pnpm vitest run\` full suite — 766/766 passed, no adjacent regressions.
- [ ] Manual UAT in \`pnpm tauri dev\`: issue a query that surfaces both strong (>70 %) and weak (<30 %) hits and verify colors + alignment. (Included in the larger epic UAT pass.)