### PR TITLE
feat(embeddings): swap to multilingual-e5-small for DE retrieval (#233)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -148,9 +148,11 @@ fn ensure_model(
         }
     }
 
-    // Bundle Apache-2.0 LICENSE + NOTICE next to the model files. Both are
-    // required to satisfy the upstream Apache-2.0 attribution clause.
-    write_if_missing(&dest_dir.join("LICENSE"), APACHE_2_0_LICENSE)?;
+    // Bundle model LICENSE + NOTICE. e5-small is MIT (different from the
+    // Apache-2.0 MiniLM predecessor); ship the MIT text verbatim next to the
+    // binary so the copyright + permission notice travel with the model as
+    // the license requires.
+    write_if_missing(&dest_dir.join("LICENSE"), MIT_LICENSE)?;
     write_if_missing(&dest_dir.join("NOTICE"), MODEL_NOTICE)?;
     Ok(())
 }
@@ -183,17 +185,19 @@ fn write_if_missing(path: &Path, contents: &str) -> Result<(), AssetError> {
     write_atomic(path, |f| f.write_all(contents.as_bytes()))
 }
 
-const MODEL_NOTICE: &str = "all-MiniLM-L6-v2 (sentence-transformers)\n\
-Copyright sentence-transformers contributors\n\
-Licensed under the Apache License, Version 2.0.\n\
+const MODEL_NOTICE: &str = "multilingual-e5-small\n\
+Copyright (c) 2023 Liang Wang, Nan Yang, Xiaolong Huang, Linjun Yang,\n\
+Rangan Majumder, Furu Wei (Microsoft / intfloat).\n\
+Licensed under the MIT License.\n\
 \n\
-Source: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2\n\
+Source (upstream):   https://huggingface.co/intfloat/multilingual-e5-small\n\
+Source (ONNX INT8):  https://huggingface.co/Xenova/multilingual-e5-small\n\
 \n\
-This product bundles the architecture-specific INT8 / UINT8 ONNX export\n\
-of the model (`model_quint8_avx2.onnx` for x86_64,\n`model_qint8_arm64.onnx`\n\
-for aarch64). The original model card and license live upstream.\n";
+This product bundles the portable INT8 ONNX export (`model_quantized.onnx`)\n\
+from Xenova's repackaging, which runs on every VaultCore target CPU\n\
+(x86_64 + aarch64). The original model card and license live upstream.\n";
 
-const APACHE_2_0_LICENSE: &str = include_str!("resources/LICENSE-APACHE-2.0");
+const MIT_LICENSE: &str = include_str!("resources/LICENSE-MIT");
 
 fn http_get(url: &str) -> Result<Vec<u8>, AssetError> {
     let resp = ureq::get(url)

--- a/src-tauri/resources/.gitignore
+++ b/src-tauri/resources/.gitignore
@@ -1,8 +1,11 @@
 # Binary assets fetched by build.rs are pinned via checksums.toml and
-# kept out of git. Only this file, checksums.toml, and the upstream
-# Apache-2.0 LICENSE template (used by build.rs to populate model
-# resource directories) are tracked.
+# kept out of git. Only this file, checksums.toml, and the LICENSE
+# templates (used by build.rs to populate model resource directories)
+# are tracked. LICENSE-APACHE-2.0 is kept for historical bundles and any
+# future Apache-2.0 model; LICENSE-MIT is the active one for the bundled
+# multilingual-e5-small model (#233).
 *
 !.gitignore
 !checksums.toml
 !LICENSE-APACHE-2.0
+!LICENSE-MIT

--- a/src-tauri/resources/LICENSE-MIT
+++ b/src-tauri/resources/LICENSE-MIT
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2023 intfloat (Liang Wang, Nan Yang, Xiaolong Huang,
+Linjun Yang, Rangan Majumder, Furu Wei — Microsoft)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src-tauri/resources/checksums.toml
+++ b/src-tauri/resources/checksums.toml
@@ -35,51 +35,56 @@ sha256 = "0b38df9af21834e41e73d602d90db5cb06dbd1ca618948b8f1d66d607ac9f3cd"
 archive_path = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
 dylib_name = "onnxruntime.dll"
 
-# MiniLM-L6-v2 INT8 ONNX, Apache-2.0 (sentence-transformers).
-# Sources: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+# multilingual-e5-small INT8 ONNX, MIT (#233).
+# Sources:
+#   https://huggingface.co/Xenova/multilingual-e5-small  (portable INT8)
+#   https://huggingface.co/intfloat/multilingual-e5-small (upstream, MIT)
 #
-# The ONNX file is per CPU-architecture because the upstream Optimum exports
-# bake architecture-specific quantization kernels into the model graph
-# (avx2 / avx512 / arm64). Tokenizer + config files are architecture-agnostic.
+# Why Xenova's mirror: upstream intfloat only ships `model_qint8_avx512_vnni.onnx`
+# which breaks on ARM64 (Apple Silicon). Xenova's `model_quantized.onnx` is a
+# portable INT8 export that runs on every VaultCore target CPU — same 118 MB,
+# same quality, no arch split. All four arches therefore point to the same
+# file + SHA256; we keep the per-arch table shape so build.rs doesn't need
+# restructuring.
 [model]
-id = "all-MiniLM-L6-v2-int8"
+id = "multilingual-e5-small-int8"
 
 [model.shared.tokenizer_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
-sha256 = "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/tokenizer.json"
+sha256 = "0b44a9d7b51c3c62626640cda0e2c2f70fdacdc25bbbd68038369d14ebdf4c39"
 dest_name = "tokenizer.json"
 
 [model.shared.config_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json"
-sha256 = "953f9c0d463486b10a6871cc2fd59f223b2c70184f49815e7efbcab5d8908b41"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/config.json"
+sha256 = "cb99455288675345e1a4f411438d5d0adbba5fbd3a67ea4fb03c015433b996c1"
 dest_name = "config.json"
 
 [model.shared.tokenizer_config_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer_config.json"
-sha256 = "acb92769e8195aabd29b7b2137a9e6d6e25c476a4f15aa4355c233426c61576b"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/tokenizer_config.json"
+sha256 = "a1d6bc8734a6f635dc158508bef000f8e2e5a759c7d92f984b2c86e5ff53425b"
 dest_name = "tokenizer_config.json"
 
 [model.shared.special_tokens_map_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/special_tokens_map.json"
-sha256 = "303df45a03609e4ead04bc3dc1536d0ab19b5358db685b6f3da123d05ec200e3"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/special_tokens_map.json"
+sha256 = "d05497f1da52c5e09554c0cd874037a083e1dc1b9cfd48034d1c717f1afc07a7"
 dest_name = "special_tokens_map.json"
 
 [model.linux-x86_64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
-sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"
 
 [model.macos-x86_64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
-sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"
 
 [model.macos-aarch64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx"
-sha256 = "4278337fd0ff3c68bfb6291042cad8ab363e1d9fbc43dcb499fe91c871902474"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"
 
 [model.windows-x86_64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
-sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"

--- a/src-tauri/src/embeddings/chunking.rs
+++ b/src-tauri/src/embeddings/chunking.rs
@@ -31,10 +31,10 @@ use tokenizers::Tokenizer;
 
 use super::{model_dir, EmbeddingError};
 
-/// Maximum *content* tokens per chunk. Picked so that after fastembed
-/// re-tokenises and prepends [CLS] / appends [SEP] (2 special tokens),
-/// the on-wire sequence is exactly 256 — matching MiniLM-L6-v2's training
-/// `max_seq_length` and the cap configured in `EmbeddingService::load`.
+/// Maximum *content* tokens per chunk. Picked so that after the embedder
+/// re-tokenises and adds 2 special tokens (`[CLS]`/`[SEP]` on BERT-style
+/// MiniLM, `<s>`/`</s>` on XLM-RoBERTa-style e5), the on-wire sequence is
+/// exactly 256 — matching the cap configured in `EmbeddingService::load`.
 pub const MAX_CONTENT_TOKENS: usize = 254;
 
 /// Default sliding-window overlap. 32/254 ≈ 12 % is the standard RAG
@@ -59,7 +59,7 @@ pub struct Chunker {
 }
 
 impl Chunker {
-    /// Load the bundled MiniLM tokenizer with default caps
+    /// Load the bundled embedder's tokenizer with default caps
     /// (`MAX_CONTENT_TOKENS` / `DEFAULT_OVERLAP_TOKENS`). Reuses
     /// `model_dir()` for path resolution so it shares the resource-dir /
     /// env-override / dev-fallback story with `EmbeddingService`.
@@ -112,8 +112,9 @@ impl Chunker {
         }
 
         // Encode WITHOUT special tokens — we want only content tokens with
-        // byte offsets pointing into `input`. fastembed will re-add
-        // [CLS]/[SEP] when it embeds.
+        // byte offsets pointing into `input`. The embedder re-adds the
+        // model-specific bookends (`[CLS]/[SEP]` for BERT, `<s>/</s>` for
+        // XLM-RoBERTa) at inference time.
         let enc = self
             .tokenizer
             .encode(input, false)
@@ -182,15 +183,18 @@ mod tests {
     }
 
     /// Build an input that encodes to *exactly* `target` content tokens.
-    /// "hello" tokenises to a single WordPiece on MiniLM; we repeat it,
-    /// then trim.
+    /// `"the"` is a single token in both BERT WordPiece and XLM-RoBERTa
+    /// SentencePiece (id 70 in e5), so repeating it space-separated gives
+    /// us a 1-word == 1-token relationship that the synthesis loop can
+    /// rely on. (We previously used `"hello"`, which is 2 tokens in
+    /// XLM-R — broke the tests when #233 swapped MiniLM for e5.)
     fn synth_input(chunker: &Chunker, target: usize) -> String {
         let mut s = String::new();
         for _ in 0..target {
             if !s.is_empty() {
                 s.push(' ');
             }
-            s.push_str("hello");
+            s.push_str("the");
         }
         // Defensive: in case spacing affects pretokenisation, trim down or
         // pad up until token count matches.
@@ -199,7 +203,7 @@ mod tests {
             s.truncate(cut);
         }
         while chunker.token_count(&s) < target {
-            s.push_str(" hello");
+            s.push_str(" the");
         }
         s
     }

--- a/src-tauri/src/embeddings/embed_coordinator.rs
+++ b/src-tauri/src/embeddings/embed_coordinator.rs
@@ -284,7 +284,10 @@ fn run_embed_batch(
     // reindex checkpoint / next save covers the re-queue).
     for (sub_start, sub_texts) in flat_texts.chunks(EMBED_BATCH_SIZE).enumerate() {
         let global_offset = sub_start * EMBED_BATCH_SIZE;
-        let vectors = match service.embed_batch(sub_texts) {
+        // Indexing path — every chunk gets the e5 "passage: " prefix so
+        // the index lives in the same subspace that `embed_query` targets.
+        // Dropping to bare `embed_batch` here silently halves recall.
+        let vectors = match service.embed_passage_batch(sub_texts) {
             Ok(v) => v,
             Err(e) => {
                 log::warn!(

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -1,9 +1,11 @@
 //! Local embeddings stack — gated behind the `embeddings` Cargo feature.
 //!
 //! This module owns the dlopen'd ONNX Runtime lifecycle and the discovery of
-//! the bundled MiniLM model. Higher-level services (#194 EmbeddingService,
-//! #198 VectorIndex, #203 hybrid search) build on top of `init_runtime` +
-//! `model_dir`.
+//! the bundled embedding model (multilingual-e5-small INT8 since #233; was
+//! all-MiniLM-L6-v2 INT8 before — swapped because MiniLM is English-only and
+//! collapsed non-English queries onto a noise-floor band). Higher-level
+//! services (#194 EmbeddingService, #198 VectorIndex, #203 hybrid search)
+//! build on top of `init_runtime` + `model_dir`.
 //!
 //! Path resolution order for both the runtime dylib and the model directory:
 //!
@@ -147,7 +149,7 @@ pub fn model_dir(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingError>
     if let Some(p) = std::env::var_os(ENV_MODEL_DIR) {
         return Ok(PathBuf::from(p));
     }
-    let leaf = Path::new("models").join("all-MiniLM-L6-v2-int8");
+    let leaf = Path::new("models").join("multilingual-e5-small-int8");
     if let Some(dir) = resource_dir {
         let p = dir.join(&leaf);
         if p.exists() {
@@ -218,13 +220,14 @@ pub fn ensure_runtime_initialized(
 }
 
 /// Smoke-test entry point used by tests/embeddings.rs. Loads the bundled
-/// MiniLM model, embeds a fixed string, and returns the raw 384-dim vector.
-///
-/// The caller (the test) asserts vector length and L2 norm. Returns
-/// `Err(ModelMissing)` cleanly if the model isn't bundled yet (#192 not
-/// done) so the test can skip rather than fail.
+/// embedding model, embeds a fixed string, and returns the raw 384-dim
+/// vector. Uses `embed_passage` so the e5 prefix protocol is exercised
+/// end-to-end — the smoke test then doubles as a "tokenizer accepts the
+/// `passage: ` prefix without choking" check. The caller (the test) asserts
+/// vector length and L2 norm. Returns `Err(ModelMissing)` cleanly if the
+/// model isn't bundled yet (#192 not done) so the test can skip.
 #[cfg(feature = "embeddings")]
 pub fn smoke_test(resource_dir: Option<&Path>) -> Result<Vec<f32>, EmbeddingError> {
     let svc = EmbeddingService::load(resource_dir)?;
-    svc.embed("VaultCore semantic search smoke test")
+    svc.embed_passage("VaultCore semantic search smoke test")
 }

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -76,7 +76,7 @@ pub fn semantic_search_query(
     if snap.is_empty() {
         return Ok(Vec::new());
     }
-    let vec = handles.service.embed(text)?;
+    let vec = handles.service.embed_query(text)?;
     if vec.len() != super::DIM {
         return Err(EmbeddingError::InvalidArgument(format!(
             "embedding dim mismatch: got {}, expected {}",
@@ -176,7 +176,11 @@ mod tests {
             ("math.md", "Eigenvalues of a symmetric matrix are always real numbers."),
         ];
         for (path, text) in docs {
-            let v = svc.embed(text).unwrap();
+            // Seed via the indexing path — same prefix semantics as
+            // `embed_coordinator::run_embed_batch` uses in production, so
+            // the subspace matches what `semantic_search_query` below
+            // produces from `embed_query`.
+            let v = svc.embed_passage(text).unwrap();
             snap.insert(PathBuf::from(path), 0, &v);
         }
         drop(snap);
@@ -214,7 +218,9 @@ mod tests {
         let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
         let snap = sink.snapshot();
         for i in 0..5u64 {
-            let v = svc.embed(&format!("note number {i} with unique content")).unwrap();
+            let v = svc
+                .embed_passage(&format!("note number {i} with unique content"))
+                .unwrap();
             snap.insert(PathBuf::from(format!("n-{i}.md")), 0, &v);
         }
         drop(snap);

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -56,8 +56,14 @@ use crate::hash::hash_bytes;
 /// Filename of the checkpoint JSON under `<vault>/.vaultcore/embeddings/`.
 pub const CHECKPOINT_FILE: &str = "reindex.checkpoint.json";
 /// Current on-disk layout version. Bumped when the schema changes in a
-/// breaking way; older versions load as empty (force full re-walk).
-pub const CHECKPOINT_VERSION: u32 = 1;
+/// breaking way or when the embedding model changes — older versions load
+/// as empty (force full re-walk).
+///
+/// - v1: initial format.
+/// - v2: (#233) model swap from MiniLM to multilingual-e5-small. Hashes
+///   in the checkpoint refer to files whose embeddings are now in the
+///   wrong subspace; the only safe recovery is a full reindex.
+pub const CHECKPOINT_VERSION: u32 = 2;
 /// Flush cadence: every N successful enqueues we atomically write the
 /// checkpoint. Trades worst-case re-work (≤ N files) against disk churn.
 const FLUSH_EVERY: usize = 100;

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -19,12 +19,23 @@ use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams, Tr
 use super::session::{build_minilm_session, register_cpu_arena_if_needed};
 use super::{ensure_runtime_initialized, model_dir, EmbeddingError};
 
-/// MiniLM-L6-v2 output dimensionality. Matches `embeddings::vector_index::DIM`.
+/// Embedding output dimensionality — 384 for both MiniLM-L6 and
+/// multilingual-e5-small. Matches `embeddings::vector_index::DIM`.
 const EMBED_DIM: usize = 384;
 
-/// Matches the tokenizer cap fastembed used via `with_max_length(256)` and
-/// MiniLM's training `max_seq_length`.
+/// Tokenizer cap. Both bundled models train at 512, but VaultCore notes
+/// rarely exceed 256 tokens per chunk and we keep the lower cap to bound
+/// peak memory + latency under bulk reindex (#205 budget). Chunking
+/// (`chunking.rs`) is sized accordingly.
 const MAX_SEQ_LEN: usize = 256;
+
+/// e5 prefix protocol (#233). The intfloat/multilingual-e5 family was
+/// trained with these literal prefixes — applying them lets the model put
+/// queries and passages in the same retrieval-friendly subspace. Stripping
+/// them, or using the same one for both, measurably degrades retrieval.
+/// See: https://huggingface.co/intfloat/multilingual-e5-small#faq
+const E5_QUERY_PREFIX: &str = "query: ";
+const E5_PASSAGE_PREFIX: &str = "passage: ";
 
 pub struct EmbeddingService {
     inner: Mutex<Inner>,
@@ -33,14 +44,15 @@ pub struct EmbeddingService {
 struct Inner {
     tokenizer: Tokenizer,
     session: Session,
-    /// Some MiniLM exports omit `token_type_ids` (all-MiniLM is BERT-style
-    /// and always has it, but we probe to stay portable to alternative
-    /// models bundled via `VAULTCORE_MODEL_DIR`).
+    /// Some exports omit `token_type_ids` (BERT-style models declare it,
+    /// XLM-RoBERTa-style — including e5 — does not). We probe the session
+    /// inputs to stay portable across both families and any future model
+    /// bundled via `VAULTCORE_MODEL_DIR`.
     need_token_type_ids: bool,
 }
 
 impl EmbeddingService {
-    /// Load the bundled MiniLM model. Triggers `ensure_runtime_initialized`
+    /// Load the bundled embedding model. Triggers `ensure_runtime_initialized`
     /// and registers the env-level CPU arena allocator before building the
     /// session — both are idempotent.
     pub fn load(resource_dir: Option<&Path>) -> Result<Arc<Self>, EmbeddingError> {
@@ -70,13 +82,26 @@ impl EmbeddingService {
                 direction: tokenizers::TruncationDirection::Right,
             }))
             .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+        // Resolve pad token from the tokenizer's own vocab — XLM-RoBERTa
+        // (e5) uses `<pad>` (id 1), BERT-style (MiniLM) uses `[PAD]` (id 0).
+        // Hardcoding either silently corrupts attention on the other family
+        // by padding with a real content token. Probe both candidates and
+        // pick the first one the vocab knows.
+        let (pad_token, pad_id) = ["<pad>", "[PAD]"]
+            .iter()
+            .find_map(|t| tokenizer.token_to_id(t).map(|id| ((*t).to_string(), id)))
+            .ok_or_else(|| {
+                EmbeddingError::Tokenizer(
+                    "tokenizer vocab declares neither <pad> nor [PAD]".into(),
+                )
+            })?;
         tokenizer.with_padding(Some(PaddingParams {
             strategy: PaddingStrategy::BatchLongest,
             direction: tokenizers::PaddingDirection::Right,
             pad_to_multiple_of: None,
-            pad_id: 0,
+            pad_id,
             pad_type_id: 0,
-            pad_token: "[PAD]".to_string(),
+            pad_token,
         }));
 
         Ok(Arc::new(Self {
@@ -88,12 +113,51 @@ impl EmbeddingService {
         }))
     }
 
-    /// Embed a single string. Returns a 384-d L2-normalised vector.
+    /// Embed a single string verbatim — no e5 prefix is applied. Prefer
+    /// `embed_query` / `embed_passage` over this primitive: bare embeds
+    /// against e5 land in a different subspace than the indexed passages
+    /// and silently degrade retrieval quality. Kept public for benchmarks
+    /// and the smoke test, where the prefix is irrelevant.
     pub fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
         let mut batch = self.embed_batch(&[text])?;
         batch
             .pop()
             .ok_or_else(|| EmbeddingError::Inference("empty embedding batch".into()))
+    }
+
+    /// Embed a user query with the e5 `"query: "` prefix. Use this on the
+    /// query path (semantic search input). See module-level e5 prefix note.
+    pub fn embed_query(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        self.embed(&format!("{E5_QUERY_PREFIX}{text}"))
+    }
+
+    /// Embed an indexed passage with the e5 `"passage: "` prefix. Use this
+    /// on the indexing path (every chunk that lands in the vector index).
+    pub fn embed_passage(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        self.embed(&format!("{E5_PASSAGE_PREFIX}{text}"))
+    }
+
+    /// Batched query embed — same prefix semantics as `embed_query`.
+    pub fn embed_query_batch(
+        &self,
+        texts: &[&str],
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let prefixed: Vec<String> =
+            texts.iter().map(|t| format!("{E5_QUERY_PREFIX}{t}")).collect();
+        let refs: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
+        self.embed_batch(&refs)
+    }
+
+    /// Batched passage embed — same prefix semantics as `embed_passage`.
+    /// The indexing pipeline (`reindex.rs`) calls this for every batch.
+    pub fn embed_passage_batch(
+        &self,
+        texts: &[&str],
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let prefixed: Vec<String> =
+            texts.iter().map(|t| format!("{E5_PASSAGE_PREFIX}{t}")).collect();
+        let refs: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
+        self.embed_batch(&refs)
     }
 
     /// Embed a batch of strings in one inference pass. Returns one 384-d
@@ -161,10 +225,11 @@ impl EmbeddingService {
             .run(inputs)
             .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
 
-        // MiniLM exports expose the token-level hidden states either as
+        // ONNX exports expose the token-level hidden states either as
         // `last_hidden_state` (standard HF export) or as `output_0` / the
         // first output (some quantised exports strip names). Pick the first
-        // 3-D float output to stay robust.
+        // 3-D float output to stay robust across both BERT-style (MiniLM)
+        // and XLM-RoBERTa-style (e5) graphs.
         let (_name, first) = outputs
             .iter()
             .find(|(_, v)| {
@@ -266,17 +331,23 @@ mod tests {
             eprintln!("SKIP: embeddings not bundled");
             return;
         };
-        let a = svc.embed("how do cats communicate").unwrap();
-        let b = svc.embed("feline body language").unwrap();
-        let c = svc.embed("rust async runtime internals").unwrap();
+        // Ask + passage prefixes — mirrors the production query path so we
+        // benchmark the actual subspace the index uses.
+        let a = svc.embed_query("how do cats communicate").unwrap();
+        let b = svc.embed_passage("feline body language").unwrap();
+        let c = svc.embed_passage("rust async runtime internals").unwrap();
         let cos = |x: &[f32], y: &[f32]| -> f32 {
             x.iter().zip(y).map(|(a, b)| a * b).sum()
         };
         let close = cos(&a, &b);
         let far = cos(&a, &c);
+        // Margin calibrated for multilingual-e5-small (#233): the model
+        // uses a tighter cosine range than MiniLM did — same *ordering*,
+        // smaller absolute gap. 0.05 keeps the semantic signal clear
+        // while not being miscalibrated for the current model.
         assert!(
-            close > far + 0.1,
-            "expected close > far + 0.1, got close={close}, far={far}"
+            close > far + 0.05,
+            "expected close > far + 0.05, got close={close}, far={far}"
         );
     }
 
@@ -332,11 +403,12 @@ mod tests {
         eprintln!("BENCH_JSON {{\"name\":\"single_embed\",\"p50_ms\":{:.3},\"p99_ms\":{:.3},\"n\":{N}}}",
             p50.as_secs_f64() * 1000.0,
             p99.as_secs_f64() * 1000.0);
-        // Loose ceiling: 20 ms p50 is well above warm ORT inference for
-        // MiniLM-L6-v2 on any modern CPU. The harness's regression check
-        // catches real drift against the committed baseline.
+        // Loose ceiling: 20 ms p50 was the MiniLM-era headroom; e5-small
+        // is ~5x larger so warm p50 climbs accordingly. We raise the cap
+        // to 100 ms as an absolute sanity ceiling — the real regression
+        // detector is `scripts/bench-regression.py` against `baseline.json`.
         assert!(
-            p50 < Duration::from_millis(20),
+            p50 < Duration::from_millis(100),
             "single_embed p50 too slow: {p50:?}"
         );
     }

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -74,10 +74,20 @@ struct MappingFile {
     tombstones: Vec<u32>,
 }
 
-/// Bumped to 2 in #200 to add the `tombstones` field. v1 dumps still load
-/// (the field defaults to empty) and silently upgrade on next save.
-const MAPPING_VERSION: u32 = 2;
-const MAPPING_VERSION_MIN: u32 = 1;
+/// Mapping-dump wire version.
+///
+/// - v1: initial format.
+/// - v2: (#200) added `tombstones` field.
+/// - v3: (#233) model swap from MiniLM to multilingual-e5-small. The 384-d
+///   vector geometry is unchanged but the *embedding subspace* is
+///   incompatible — old vectors would retrieve nonsense against new
+///   queries. Bumping both `MAPPING_VERSION` and `MAPPING_VERSION_MIN` to
+///   3 forces `load()` to reject pre-e5 dumps, which `load_or_empty()`
+///   absorbs as a fresh rebuild from embeddings (AC #3). The orphaned
+///   `vectors.hnsw.{graph,data}` from the old run stay on disk briefly;
+///   the first save after the rebuild overwrites them by basename.
+const MAPPING_VERSION: u32 = 3;
+const MAPPING_VERSION_MIN: u32 = 3;
 
 /// Closure-backed `FilterT` with no allocation. Only kept as a doc anchor
 /// — actual call sites use a closure passed by reference, which the
@@ -905,34 +915,54 @@ mod tests {
     }
 
     #[test]
-    fn load_v1_mapping_silently_upgrades() {
-        // Hand-craft a v1 dump: save a v2 file then rewrite the mapping
-        // file to a v1-shaped JSON without the `tombstones` field.
+    fn load_pre_v3_mapping_is_rejected_so_caller_rebuilds() {
+        // #233 — when the embedding model swapped from MiniLM to e5, the
+        // existing 384-d vectors in v1/v2 dumps lived in an incompatible
+        // subspace. We bumped both `MAPPING_VERSION` and
+        // `MAPPING_VERSION_MIN` to 3 specifically so that pre-existing
+        // dumps are *rejected* on load — the caller (`load_or_empty`)
+        // then absorbs the error and rebuilds from the embedder. This
+        // test pins that rejection so a future "be lenient" patch doesn't
+        // silently start loading mismatched vectors.
         let tmp = tempfile::tempdir().expect("tempdir");
         let idx = VectorIndex::new(4);
         for i in 0..4u64 {
-            idx.insert(PathBuf::from(format!("v1-{i}.md")), 0, &unit_vec(i));
+            idx.insert(PathBuf::from(format!("legacy-{i}.md")), 0, &unit_vec(i));
         }
         idx.save(tmp.path()).expect("save");
 
-        let v1_json = serde_json::json!({
-            "version": 1,
-            "entries": [
-                ["v1-0.md", 0],
-                ["v1-1.md", 0],
-                ["v1-2.md", 0],
-                ["v1-3.md", 0],
-            ],
-        });
-        std::fs::write(
-            tmp.path().join("vectors.mapping.json"),
-            serde_json::to_vec(&v1_json).unwrap(),
-        )
-        .expect("write v1 mapping");
+        for legacy_version in [1u32, 2u32] {
+            let mapping = serde_json::json!({
+                "version": legacy_version,
+                "entries": [
+                    ["legacy-0.md", 0],
+                    ["legacy-1.md", 0],
+                    ["legacy-2.md", 0],
+                    ["legacy-3.md", 0],
+                ],
+            });
+            std::fs::write(
+                tmp.path().join("vectors.mapping.json"),
+                serde_json::to_vec(&mapping).unwrap(),
+            )
+            .expect("write legacy mapping");
 
-        let loaded = VectorIndex::load(tmp.path()).expect("v1 load");
-        assert_eq!(loaded.len(), 4);
-        assert_eq!(loaded.tombstone_count(), 0);
+            let err = match VectorIndex::load(tmp.path()) {
+                Err(e) => e,
+                Ok(_) => panic!(
+                    "pre-v3 mapping must be rejected so load_or_empty rebuilds"
+                ),
+            };
+            let msg = err.to_string();
+            assert!(
+                msg.contains("mapping version unsupported"),
+                "unexpected error for v{legacy_version}: {msg}"
+            );
+
+            // load_or_empty absorbs the rejection and yields a fresh empty index.
+            let recovered = VectorIndex::load_or_empty(tmp.path(), 4);
+            assert_eq!(recovered.len(), 0);
+        }
     }
 
     #[test]

--- a/src-tauri/src/tests/semantic_quality.rs
+++ b/src-tauri/src/tests/semantic_quality.rs
@@ -1,20 +1,28 @@
 //! #208 — Semantic quality sanity test.
+//! #233 — Extended with DE fixtures + queries to guard the multilingual
+//! retrieval path. MiniLM-L6 is English-only and collapses DE inputs onto
+//! the noise floor — these tests are the regression guard that forced the
+//! swap to `multilingual-e5-small`.
 //!
 //! Guards against silent retrieval-quality regressions in the embedding
-//! stack. Uses the five mini-docs from research #188
+//! stack. EN corpus: five mini-docs from research #188
 //! (`pizza_dough`, `bread_baking`, `cat_behavior`, `machine_learning`,
-//! `sourdough_starter`) as a ground-truth corpus with two
-//! cluster-crossing queries.
+//! `sourdough_starter`). DE corpus: three mini-docs covering disjoint
+//! topics (`hund_verhalten`, `pizza_teig_de`, `maschinelles_lernen_de`).
 //!
 //! Runs as a regular CI job (no `#[ignore]`). Skips cleanly when the
-//! MiniLM model isn't bundled, consistent with every other test in this
+//! model isn't bundled, consistent with every other test in this
 //! module — no CI flakes on hosts without the model.
 //!
-//! Similarity is MiniLM L2-normalised dot product (== cosine) and we
-//! brute-force all 5 docs rather than going through HNSW/RRF. This is
-//! deliberate: we're testing the *embedding quality*, not the index or
+//! Similarity is L2-normalised dot product (== cosine) and we
+//! brute-force the full fixture set rather than going through HNSW/RRF.
+//! Deliberate: we're testing the *embedding quality*, not the index or
 //! the fuser. If a regression here ever aligns suspiciously with an HNSW
 //! change, that's the signal that HNSW has drifted, not the embedder.
+//!
+//! Uses `embed_query` / `embed_passage` (added in #233) because e5 needs
+//! `"query: "` / `"passage: "` prefixes — applying them symmetrically
+//! reduces quality significantly per the e5 model card.
 
 #![cfg(feature = "embeddings")]
 
@@ -43,6 +51,21 @@ const FIXTURES: &[(&str, &str)] = &[
     ),
 ];
 
+const DE_FIXTURES: &[(&str, &str)] = &[
+    (
+        "hund_verhalten",
+        include_str!("../../tests/fixtures/semantic_quality/hund_verhalten.md"),
+    ),
+    (
+        "pizza_teig_de",
+        include_str!("../../tests/fixtures/semantic_quality/pizza_teig_de.md"),
+    ),
+    (
+        "maschinelles_lernen_de",
+        include_str!("../../tests/fixtures/semantic_quality/maschinelles_lernen_de.md"),
+    ),
+];
+
 /// Dot product — vectors are MiniLM-L2-normalised so this is cosine similarity.
 fn cos(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| x * y).sum()
@@ -52,12 +75,23 @@ fn cos(a: &[f32], b: &[f32]) -> f32 {
 /// descending. Returns `None` when the model isn't bundled (so tests
 /// can skip cleanly on CI hosts without the model resource).
 fn rank_fixtures(query: &str) -> Option<Vec<(&'static str, f32)>> {
+    rank_set(query, FIXTURES)
+}
+
+fn rank_de(query: &str) -> Option<Vec<(&'static str, f32)>> {
+    rank_set(query, DE_FIXTURES)
+}
+
+fn rank_set(
+    query: &str,
+    fixtures: &'static [(&'static str, &'static str)],
+) -> Option<Vec<(&'static str, f32)>> {
     let svc = EmbeddingService::load(None).ok()?;
-    let q = svc.embed(query).expect("query embed failed");
-    let mut scored: Vec<(&'static str, f32)> = FIXTURES
+    let q = svc.embed_query(query).expect("query embed failed");
+    let mut scored: Vec<(&'static str, f32)> = fixtures
         .iter()
         .map(|(name, body)| {
-            let v = svc.embed(body).expect("fixture embed failed");
+            let v = svc.embed_passage(body).expect("fixture embed failed");
             (*name, cos(&q, &v))
         })
         .collect();
@@ -93,8 +127,53 @@ fn feline_communication_top1_is_cat_with_margin() {
         "expected top-1 == `cat_behavior`, got {ranked:?}"
     );
     let margin = ranked[0].1 - ranked[1].1;
+    // 0.10 margin threshold — multilingual-e5-small (#233) runs a tighter
+    // cosine spread than the MiniLM-era 0.2 assumed. Top-1 still dominates
+    // clearly (measured ~0.12 margin on the committed fixtures); 0.10
+    // leaves slack for inference-order noise while catching a real
+    // regression to the sub-0.05 "noise floor" band.
     assert!(
-        margin > 0.2,
-        "expected cosine margin > 0.2, got {margin:.4} (ranked: {ranked:?})"
+        margin > 0.10,
+        "expected cosine margin > 0.10, got {margin:.4} (ranked: {ranked:?})"
+    );
+}
+
+// #233 — DE quality gate. MiniLM fails these because DE queries cluster
+// at the noise floor (~0.30–0.34 cosine across all topics, margins ~0);
+// e5-small-multilingual separates topics cleanly. Margin threshold 0.10
+// is conservative vs. EN 0.20 — multilingual models spread DE somewhat
+// tighter than native-EN MiniLM does EN, but still well above noise.
+
+#[test]
+fn de_query_hundeerziehung_top1_is_hund_with_margin() {
+    let Some(ranked) = rank_de("Wie erziehe ich einen Hund richtig?") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    assert_eq!(
+        ranked[0].0, "hund_verhalten",
+        "expected top-1 == `hund_verhalten`, got {ranked:?}"
+    );
+    let margin = ranked[0].1 - ranked[1].1;
+    assert!(
+        margin > 0.10,
+        "expected DE cosine margin > 0.10, got {margin:.4} (ranked: {ranked:?})"
+    );
+}
+
+#[test]
+fn de_query_neuronale_netze_top1_is_ml_with_margin() {
+    let Some(ranked) = rank_de("Was sind neuronale Netze im maschinellen Lernen?") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    assert_eq!(
+        ranked[0].0, "maschinelles_lernen_de",
+        "expected top-1 == `maschinelles_lernen_de`, got {ranked:?}"
+    );
+    let margin = ranked[0].1 - ranked[1].1;
+    assert!(
+        margin > 0.10,
+        "expected DE cosine margin > 0.10, got {margin:.4} (ranked: {ranked:?})"
     );
 }

--- a/src-tauri/tests/fixtures/semantic_quality/hund_verhalten.md
+++ b/src-tauri/tests/fixtures/semantic_quality/hund_verhalten.md
@@ -1,0 +1,12 @@
+# Hundeverhalten
+
+Hunde sind Rudeltiere und zeigen ein breites Spektrum an sozialen
+Verhaltensweisen. Sie kommunizieren über Körpersprache, Gesichtsausdruck,
+Lautäußerungen wie Bellen und Winseln sowie über Geruchsmarkierungen.
+Welpen lernen die Kommunikationsregeln ihres Rudels durch Nachahmung
+ihrer Mutter und der Wurfgeschwister. Erwachsene Hunde zeigen Unterwerfung
+durch eingeklappte Ruten und geduckte Haltung, während aufgerichtetes
+Fell und starrer Blick als Drohgebärden gelten. Artgerechte Auslastung
+durch Bewegung, Kopftraining und Sozialkontakt ist entscheidend für das
+Wohlbefinden und verhindert problematisches Verhalten wie übermäßiges
+Bellen oder destruktives Kauen.

--- a/src-tauri/tests/fixtures/semantic_quality/maschinelles_lernen_de.md
+++ b/src-tauri/tests/fixtures/semantic_quality/maschinelles_lernen_de.md
@@ -1,0 +1,13 @@
+# Maschinelles Lernen
+
+Maschinelles Lernen bezeichnet Verfahren, bei denen Algorithmen Muster
+aus Daten extrahieren, statt fest programmiert zu werden. Beim
+überwachten Lernen trainiert man ein Modell anhand von Eingabe-Ausgabe-
+Paaren, beim unüberwachten Lernen werden Strukturen in unbeschrifteten
+Daten entdeckt. Das Training minimiert typischerweise eine Verlustfunktion
+mittels Gradientenabstieg über die Parameter eines differenzierbaren
+Modells, häufig eines neuronalen Netzes. Regularisierung und sorgfältige
+Trennung von Trainings- und Validierungsdaten schützen vor
+Überanpassung. In der modernen Praxis dominieren große, vortrainierte
+Transformer-Modelle, die für nachgelagerte Aufgaben wie Textklassifikation,
+maschinelle Übersetzung oder Bilderkennung feinjustiert werden.

--- a/src-tauri/tests/fixtures/semantic_quality/pizza_teig_de.md
+++ b/src-tauri/tests/fixtures/semantic_quality/pizza_teig_de.md
@@ -1,0 +1,12 @@
+# Pizzateig
+
+Ein klassischer neapolitanischer Pizzateig besteht aus wenigen Zutaten:
+Mehl, Wasser, Salz und Hefe. Die Hydration liegt typischerweise zwischen
+60 und 70 Prozent, je nach Mehlqualität und gewünschter Krume. Nach dem
+Kneten folgt eine lange, kalte Stockgare im Kühlschrank über 24 bis 72
+Stunden – dabei entwickelt der Teig sein charakteristisches Aroma durch
+langsame Gärung. Kurz vor dem Backen wird der Teig zu Bällchen geformt
+und bei Raumtemperatur nochmals aufgehen gelassen. Ausgezogen werden die
+Teiglinge von Hand, ohne Nudelholz, um die Randbildung (Cornicione) zu
+erhalten. Gebacken wird idealerweise im Holzofen bei rund 450 Grad
+Celsius für 60 bis 90 Sekunden.


### PR DESCRIPTION
## Summary

Swap the embedding model from `all-MiniLM-L6-v2-int8` to `Xenova/multilingual-e5-small` (INT8, 118 MB, MIT) to fix the German-query regression surfaced during UAT of the Semantic Search v1 epic. MiniLM-L6 is English-only; DE queries collapsed onto the noise floor (~0.30 cosine across all topics, margins ~0). e5-small-multilingual separates DE topics cleanly.

Closes #233.

## Why Xenova's mirror

Upstream `intfloat/multilingual-e5-small` only ships AVX512-VNNI-specific INT8 weights, which break on Apple Silicon ARM64. Xenova's quantized ONNX is portable across all four shipped arches (linux-x86_64, macos-x86_64, macos-aarch64, windows-x86_64) — same URL + SHA in `checksums.toml`.

## Key changes

- **Model/tokenizer resources** (`checksums.toml`, `build.rs`, `LICENSE-MIT`): pinned Xenova SHAs, MIT license + intfloat copyright shipped in the generated `MODEL_NOTICE`.
- **XLM-R tokenizer support** (`service.rs`): dynamic pad-token resolution (`<pad>`/id 1 for XLM-R vs `[PAD]`/id 0 for BERT) — hardcoding MiniLM's pad would silently corrupt attention masks on e5.
- **e5 prefix API** (`service.rs` + callers): new `embed_query` / `embed_passage` (+ batch variants) apply the asymmetric `"query: "` / `"passage: "` prefixes e5 requires. Symmetric prefix application tanks retrieval quality per the model card.
- **Version bumps to force reindex**:
  - `vector_index.rs`: `MAPPING_VERSION` 2 → 3, `MAPPING_VERSION_MIN` bumped to 3 (old MiniLM vectors are 384-dim too but live in a different embedding space — must not be reused).
  - `reindex.rs`: `CHECKPOINT_VERSION` 1 → 2.
- **Chunking test fix** (`chunking.rs`): `synth_input` switched from `"hello"` (2 tokens in XLM-R SentencePiece) to `"the"` (1 token in both WordPiece and XLM-R). Boundary test was off-by-one under the new tokenizer.
- **DE quality gate** (`semantic_quality.rs` + 3 new DE fixtures): 2 new tests cover `Hundeerziehung` and `neuronale Netze` queries against disjoint DE topics. These tests fail hard against MiniLM — they're the regression guard that forced the swap.
- **EN threshold recalibration**: e5 runs tighter cosine spreads than MiniLM. `feline_communication` margin 0.20 → 0.10, `semantically_close_strings` delta 0.10 → 0.05. Ordering still preserved; thresholds sit comfortably above the noise floor.

## Test plan

- [x] `cargo test --lib` — 307/307 pass on local (including 5 EN + 2 DE semantic-quality tests, chunking boundary tests, vector_index version-rejection test).
- [x] Verified `load_pre_v3_mapping_is_rejected_so_caller_rebuilds` forces rebuild from stale v1/v2 dumps.
- [x] DE queries produce margin > 0.10 against noise (measured ~0.12–0.15 on committed fixtures).
- [ ] Manual UAT of epic branch after this PR lands — confirm DE vault retrieval no longer collapses onto noise floor.

## Follow-ups (not in this PR)

- Re-capture `src-tauri/benches/baseline.json` against e5. Model is ~5× larger than MiniLM; encode latency + per-token cost will shift, baseline is stale.
- Revisit #188's 100k-vault initial-indexing AC (< 60s). e5's encode cost is higher; if reindex breaches the ceiling, either relax the AC or batch more aggressively.