### PR TITLE
feat(graph): embedding-based relation mode as second graph view (#235)

### DIFF
--- a/src-tauri/src/commands/embedding_graph.rs
+++ b/src-tauri/src/commands/embedding_graph.rs
@@ -1,0 +1,296 @@
+//! #235 — Embedding-based relation graph.
+//!
+//! Second mode for the whole-vault graph view: instead of walking link
+//! edges, derive edges from cosine similarity between note embeddings.
+//! Reuses the HNSW index built for semantic search (#198) — no new
+//! datastore, no new index type.
+//!
+//! Aggregation strategy (per ticket alignment): **chunk-pair max**. For
+//! each source chunk we run a k-NN on the shared HNSW, dedupe the hits
+//! to note-level by taking the maximum cosine per target path, then
+//! apply `threshold` + `top_k` per source.
+//!
+//! Edges are undirected: symmetric keys (lo, hi) collapse into one
+//! entry; when both directions score a pair we keep the larger cosine
+//! (which is the max over chunk pairs regardless of direction).
+//!
+//! All paths emitted in the graph payload are vault-relative
+//! (forward-slash separators). The `VectorIndex` mapping holds whatever
+//! the embed coordinator stored — currently absolute paths — so the
+//! builder strips `vault_root` before using the path as a node id or
+//! `TagIndex` lookup key. Vectors whose paths fall outside the vault
+//! are dropped (defensive against a stale-index leak).
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::commands::links::{file_stem_label, GraphEdge, GraphNode, LocalGraph};
+use crate::embeddings::VectorIndex;
+use crate::indexer::memory::FileIndex;
+use crate::indexer::tag_index::TagIndex;
+
+/// Multiplier applied to `top_k` when sampling raw HNSW hits, so the
+/// chunk→note dedup step still produces enough unique target notes
+/// after collapsing same-note chunk hits.
+///
+/// Failure mode being defended against: a single long target note with
+/// `N` chunks can occupy all of an under-sampled hit list, leaving the
+/// dedup step with one unique target instead of `top_k`. With
+/// `OVERSHOOT = 8` and `top_k = 10`, we sample 80 raw hits; dedup
+/// undershoot only happens when one note dominates 80+ slots, which
+/// requires a single note with ~80 chunks tightly clustered around the
+/// source — rare in practice. Bump if real vaults show <top_k unique
+/// neighbours despite many candidates above threshold.
+const OVERSHOOT: usize = 8;
+
+/// Pure builder that constructs the embedding-similarity graph. Split
+/// out from the Tauri command so unit tests can drive it with synthetic
+/// `VectorIndex` fixtures without standing up the full coordinator.
+///
+/// Nodes come from the VectorIndex's live path set — notes without
+/// embeddings are excluded (they have no semantic position).
+/// Edges are emitted when the max-chunk-pair cosine between two notes
+/// is `>= threshold`, capped to `top_k` per source note. Edge weight is
+/// the cosine similarity (not HNSW distance) in `[0, 1]`.
+///
+/// `vault_root` is stripped from each chunk path before use; pass an
+/// empty `Path` for tests that already use vault-relative fixtures.
+pub fn compute_embedding_graph(
+    vi: &VectorIndex,
+    _fi: &FileIndex,
+    ti: &TagIndex,
+    vault_root: &Path,
+    top_k: usize,
+    threshold: f32,
+) -> LocalGraph {
+    if top_k == 0 {
+        return LocalGraph {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        };
+    }
+
+    // Phase 1 — snapshot all live chunks grouped by (vault-rel) path.
+    // We collect vectors here so subsequent `vi.query` calls don't race
+    // the layer iterator against later compactions.
+    let mut chunks_by_path: HashMap<String, Vec<Vec<f32>>> = HashMap::new();
+    let mut id_to_path: HashMap<u32, String> = HashMap::new();
+    vi.for_each_live(|id, path, _chunk_idx, vec| {
+        let Some(rel) = relativize(path, vault_root) else {
+            return;
+        };
+        chunks_by_path
+            .entry(rel.clone())
+            .or_default()
+            .push(vec.to_vec());
+        id_to_path.insert(id, rel);
+    });
+
+    // Phase 2 — snapshot tags once. Holding the TagIndex lock for the
+    // entire build (as `compute_link_graph` does) would block tag-panel
+    // refreshes for seconds on a 100k vault. One pass, drop the lock,
+    // then build.
+    let tags_by_path: HashMap<String, Vec<String>> = chunks_by_path
+        .keys()
+        .map(|rel| (rel.clone(), ti.tags_for_file(rel)))
+        .collect();
+
+    // Phase 3 — for each source path × chunk, k-NN + chunk-pair-max
+    // aggregation. Edges are keyed (lo, hi) so the symmetric pair
+    // collapses naturally to one entry.
+    let mut edge_weight: HashMap<(String, String), f32> = HashMap::new();
+    let raw_k = top_k.saturating_mul(OVERSHOOT);
+    for (src_rel, chunks) in &chunks_by_path {
+        // Per source: target_rel → best cosine across all (src_chunk, hit) pairs.
+        let mut best_per_target: HashMap<String, f32> = HashMap::new();
+        for chunk_vec in chunks {
+            for (hit_id, distance) in vi.query(chunk_vec, raw_k) {
+                let Some(tgt_rel) = id_to_path.get(&hit_id) else {
+                    continue; // tombstoned mid-build, or foreign-vault leak
+                };
+                if tgt_rel == src_rel {
+                    continue;
+                }
+                let cos = (1.0_f32 - distance).clamp(0.0, 1.0);
+                if !cos.is_finite() {
+                    continue;
+                }
+                if cos < threshold {
+                    continue;
+                }
+                let entry = best_per_target.entry(tgt_rel.clone()).or_insert(cos);
+                if cos > *entry {
+                    *entry = cos;
+                }
+            }
+        }
+
+        // Top-K cap per source. `total_cmp` is NaN-safe; we already
+        // filtered non-finite cosines but use the safer comparator
+        // anyway — partial_cmp would panic on a future regression.
+        let mut neighbours: Vec<(String, f32)> = best_per_target.into_iter().collect();
+        neighbours.sort_by(|a, b| b.1.total_cmp(&a.1));
+        neighbours.truncate(top_k);
+
+        for (tgt_rel, cos) in neighbours {
+            let key = if src_rel < &tgt_rel {
+                (src_rel.clone(), tgt_rel)
+            } else {
+                (tgt_rel, src_rel.clone())
+            };
+            edge_weight
+                .entry(key)
+                .and_modify(|w| {
+                    if cos > *w {
+                        *w = cos;
+                    }
+                })
+                .or_insert(cos);
+        }
+    }
+
+    // Phase 4 — build sorted node + edge lists. Every chunked path
+    // becomes a node, even if it ends up edgeless — orphans are
+    // informative ("this note is semantically unique") and let users
+    // loosen the threshold to find connections.
+    let mut node_list: Vec<GraphNode> = chunks_by_path
+        .keys()
+        .map(|rel| GraphNode {
+            id: rel.clone(),
+            label: file_stem_label(rel),
+            path: rel.clone(),
+            backlink_count: 0, // backlinks are a link-graph concept; N/A here.
+            resolved: true,
+            tags: tags_by_path.get(rel).cloned().unwrap_or_default(),
+        })
+        .collect();
+    node_list.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut edge_list: Vec<GraphEdge> = edge_weight
+        .into_iter()
+        .map(|((from, to), w)| GraphEdge {
+            from,
+            to,
+            weight: Some(w),
+        })
+        .collect();
+    edge_list.sort_by(|a, b| match a.from.cmp(&b.from) {
+        Ordering::Equal => a.to.cmp(&b.to),
+        other => other,
+    });
+
+    LocalGraph {
+        nodes: node_list,
+        edges: edge_list,
+    }
+}
+
+/// Strip `vault_root` from `path` and normalise separators to `/` so the
+/// id matches the rest of the graph payload. Returns `None` when `path`
+/// doesn't live under `vault_root` (defensive: stale-index leakage).
+fn relativize(path: &Path, vault_root: &Path) -> Option<String> {
+    let stripped = path.strip_prefix(vault_root).ok()?;
+    Some(stripped.to_string_lossy().replace('\\', "/"))
+}
+
+// ── IPC ────────────────────────────────────────────────────────────────────
+
+use crate::error::VaultError;
+use crate::VaultState;
+
+/// `top_k` ceiling — bounds the per-source neighbour budget so
+/// pathological client inputs can't trigger an `O(N²)` build. The UI
+/// fixes this at 10 in v1; the cap leaves headroom for power-user
+/// experimentation.
+const MAX_TOP_K: usize = 50;
+
+/// Build the embedding-similarity graph for the currently-open vault.
+///
+/// Snapshots the live `VectorIndex` once at entry so concurrent
+/// compactions don't reassign ids mid-build (#200). Runs the build
+/// inside `spawn_blocking` because at 100k chunks the algorithm is
+/// O(chunks × k) HNSW probes, easily seconds — running it on a tokio
+/// runtime thread would stall every other async IPC for the duration.
+///
+/// Returns an empty graph when:
+/// - no vault is open,
+/// - the embeddings subsystem is not initialised (model missing, ORT
+///   init failed, etc.), or
+/// - the index is genuinely empty.
+///
+/// The frontend distinguishes "embeddings not ready" from "no edges
+/// over threshold" by checking whether `nodes` is also empty.
+#[tauri::command]
+pub async fn get_embedding_graph(
+    top_k: usize,
+    threshold: f32,
+    state: tauri::State<'_, VaultState>,
+) -> Result<LocalGraph, VaultError> {
+    let top_k = top_k.clamp(1, MAX_TOP_K);
+    let threshold = threshold.clamp(0.0, 1.0);
+
+    let vault_root = match state
+        .current_vault
+        .lock()
+        .map_err(|_| VaultError::IndexCorrupt)?
+        .clone()
+    {
+        Some(p) => p,
+        None => {
+            return Ok(LocalGraph {
+                nodes: Vec::new(),
+                edges: Vec::new(),
+            })
+        }
+    };
+
+    let handles = {
+        let guard = state
+            .query_handles
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(h) => std::sync::Arc::clone(h),
+            None => {
+                return Ok(LocalGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                })
+            }
+        }
+    };
+
+    let (fi_arc, ti_arc) = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(c) => (c.file_index(), c.tag_index()),
+            None => {
+                return Ok(LocalGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                })
+            }
+        }
+    };
+
+    let snap = handles.sink.snapshot();
+
+    tokio::task::spawn_blocking(move || {
+        let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
+        let ti = ti_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        Ok(compute_embedding_graph(
+            &snap,
+            &fi,
+            &ti,
+            &vault_root,
+            top_k,
+            threshold,
+        ))
+    })
+    .await
+    .map_err(|_| VaultError::IndexCorrupt)?
+}

--- a/src-tauri/src/commands/embedding_graph_stub.rs
+++ b/src-tauri/src/commands/embedding_graph_stub.rs
@@ -1,0 +1,20 @@
+//! #235 — feature-off stub for `get_embedding_graph`.
+//!
+//! Mirrors the `semantic_search` pattern: when the `embeddings` feature
+//! is disabled the IPC call still resolves with an empty graph, so the
+//! frontend doesn't have to branch on feature availability.
+
+use crate::commands::links::LocalGraph;
+use crate::error::VaultError;
+
+#[tauri::command]
+pub async fn get_embedding_graph(
+    _top_k: usize,
+    _threshold: f32,
+    _state: tauri::State<'_, crate::VaultState>,
+) -> Result<LocalGraph, VaultError> {
+    Ok(LocalGraph {
+        nodes: Vec::new(),
+        edges: Vec::new(),
+    })
+}

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -607,6 +607,13 @@ pub struct GraphNode {
 pub struct GraphEdge {
     pub from: String,
     pub to: String,
+    /// Optional similarity weight in `[0, 1]`. Link-graph edges leave
+    /// this `None`; embedding-graph edges (#235) set it to the max
+    /// chunk-pair cosine similarity between the two notes. Skipped in
+    /// the serialized payload when absent so the link-graph JSON shape
+    /// is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f32>,
 }
 
 /// Result payload returned by `get_local_graph`.
@@ -618,7 +625,7 @@ pub struct LocalGraph {
 }
 
 /// Derive a filename stem from a vault-relative path (strip folder + `.md`).
-fn file_stem_label(rel_path: &str) -> String {
+pub(crate) fn file_stem_label(rel_path: &str) -> String {
     let base = rel_path.rsplit('/').next().unwrap_or(rel_path);
     base.strip_suffix(".md").unwrap_or(base).to_string()
 }
@@ -766,7 +773,7 @@ pub fn compute_local_graph(
 
     let mut edge_list: Vec<GraphEdge> = edges
         .into_iter()
-        .map(|(from, to)| GraphEdge { from, to })
+        .map(|(from, to)| GraphEdge { from, to, weight: None })
         .collect();
     edge_list.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
 
@@ -885,7 +892,7 @@ pub fn compute_link_graph(
 
     let mut edge_list: Vec<GraphEdge> = edges
         .into_iter()
-        .map(|(from, to)| GraphEdge { from, to })
+        .map(|(from, to)| GraphEdge { from, to, weight: None })
         .collect();
     edge_list.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,3 +8,7 @@ pub mod bookmarks;
 pub mod snippets;
 pub mod templates;
 pub mod export;
+#[cfg(feature = "embeddings")]
+pub mod embedding_graph;
+#[cfg(not(feature = "embeddings"))]
+pub mod embedding_graph_stub;

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -388,6 +388,50 @@ impl VectorIndex {
         Ok(fresh)
     }
 
+    /// #235 — yield every live (non-tombstoned) chunk via callback. Used
+    /// by the embedding-graph builder to enumerate source vectors
+    /// without copying the whole index.
+    ///
+    /// Walks HNSW layers one at a time and drops each layer's iterator
+    /// before stepping to the next — same pattern as `compact_into_fresh`,
+    /// for the same reason: holding a single iterator across all layers
+    /// would pin the `points_by_layer` read lock for the full walk and
+    /// stall concurrent inserts from the embed worker.
+    ///
+    /// Tombstones are snapshotted once at entry; ids tombstoned during
+    /// the walk continue to be yielded (consistent snapshot semantics).
+    /// Mapping is read once per yield to resolve `(path, chunk_index)`.
+    pub fn for_each_live<F>(&self, mut f: F)
+    where
+        F: FnMut(u32, &Path, usize, &[f32]),
+    {
+        let tomb_snapshot: HashSet<u32> = self
+            .tombstones
+            .read()
+            .expect("tombstones lock")
+            .clone();
+        let mapping_snapshot = self.mapping.read().expect("mapping lock").clone();
+
+        let indexation = self.hnsw.get_point_indexation();
+        let nb_layers = indexation.get_max_level_observed() as usize + 1;
+        for l in 0..nb_layers {
+            let iter = indexation.get_layer_iterator(l);
+            for point in iter {
+                let origin_id = point.get_origin_id() as u32;
+                if tomb_snapshot.contains(&origin_id) {
+                    continue;
+                }
+                let Some((path, chunk_idx)) =
+                    mapping_snapshot.get(origin_id as usize)
+                else {
+                    continue;
+                };
+                f(origin_id, path.as_path(), *chunk_idx, point.get_v());
+            }
+            // iterator drops here — read lock released before next layer.
+        }
+    }
+
     /// Persist the index to `dir` (created if missing). Writes three files:
     /// `vectors.hnsw.graph`, `vectors.hnsw.data`, `vectors.mapping.json`.
     /// Mapping is written atomically (tmp + rename); the hnsw_rs dump is not

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,6 +153,10 @@ pub fn run() {
             commands::links::get_resolved_attachments,
             commands::links::get_local_graph,
             commands::links::get_link_graph,
+            #[cfg(feature = "embeddings")]
+            commands::embedding_graph::get_embedding_graph,
+            #[cfg(not(feature = "embeddings"))]
+            commands::embedding_graph_stub::get_embedding_graph,
             commands::tags::list_tags,
             commands::tags::get_tag_occurrences,
             commands::bookmarks::load_bookmarks,

--- a/src-tauri/src/tests/embedding_graph.rs
+++ b/src-tauri/src/tests/embedding_graph.rs
@@ -1,0 +1,329 @@
+//! #235 — unit tests for `compute_embedding_graph`.
+//!
+//! Drives the pure builder with synthetic `VectorIndex` fixtures so the
+//! tests don't depend on the actual embedding model being bundled. All
+//! similarities are constructed analytically: unit vectors along
+//! disjoint axes (cosine 0) or mixed along two axes with known weights
+//! (cosine = dot product since inputs are L2-normalised).
+//!
+//! Behaviours guarded:
+//! - Threshold filters low-similarity pairs.
+//! - `top_k` caps neighbours per source.
+//! - Edges are undirected and deduplicated.
+//! - Edge weight = **max** chunk-pair cosine (not mean, not last-write).
+//! - Self-loops (source-chunk hitting itself or a sibling chunk of the
+//!   same note) never emit an edge.
+//! - Empty index yields an empty graph.
+//! - Nodes come from the VectorIndex path set; a note that exists in
+//!   `FileIndex` but has no embedding does NOT appear as a node.
+
+#![cfg(feature = "embeddings")]
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::embedding_graph::compute_embedding_graph;
+use crate::commands::links::{GraphEdge, LocalGraph};
+use crate::embeddings::{VectorIndex, DIM};
+use crate::indexer::memory::{FileIndex, FileMeta};
+use crate::indexer::tag_index::TagIndex;
+
+/// Empty `Path` is the no-op vault root that lets tests use
+/// already-relative `PathBuf::from("a.md")` fixtures —
+/// `strip_prefix("")` succeeds and returns the original path unchanged.
+const NO_VAULT_ROOT: &str = "";
+
+/// Build a 384-dim unit vector with non-zero components only at the
+/// given `(axis, weight)` positions. Weights must be pre-arranged so
+/// that `sum(w_i^2) == 1` — caller's responsibility.
+fn mixed_unit(components: &[(usize, f32)]) -> Vec<f32> {
+    let mut v = vec![0f32; DIM];
+    for (axis, w) in components {
+        assert!(*axis < DIM, "axis {axis} out of range");
+        v[*axis] = *w;
+    }
+    // Cheap sanity check — catches miscalibrated weights in fixtures.
+    let norm_sq: f32 = v.iter().map(|x| x * x).sum();
+    assert!(
+        (norm_sq - 1.0).abs() < 1e-5,
+        "fixture vector not unit-norm: {norm_sq:.6}"
+    );
+    v
+}
+
+/// Unit vector along a single axis.
+fn axis_unit(axis: usize) -> Vec<f32> {
+    mixed_unit(&[(axis, 1.0)])
+}
+
+fn empty_file_index() -> FileIndex {
+    FileIndex::new()
+}
+
+fn file_index_with(paths: &[&str]) -> FileIndex {
+    let mut fi = FileIndex::new();
+    for rel in paths {
+        fi.insert(
+            PathBuf::from(format!("/vault/{rel}")),
+            FileMeta {
+                relative_path: (*rel).to_string(),
+                hash: "h".into(),
+                title: (*rel).into(),
+                aliases: Vec::new(),
+            },
+        );
+    }
+    fi
+}
+
+fn edge_pairs(g: &LocalGraph) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = g
+        .edges
+        .iter()
+        .map(|e| (e.from.clone(), e.to.clone()))
+        .collect();
+    out.sort();
+    out
+}
+
+fn edge_weight(g: &LocalGraph, a: &str, b: &str) -> Option<f32> {
+    g.edges.iter().find_map(|e| {
+        let same = (e.from == a && e.to == b) || (e.from == b && e.to == a);
+        if same {
+            e.weight
+        } else {
+            None
+        }
+    })
+}
+
+// ── tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_vector_index_yields_empty_graph() {
+    let vi = VectorIndex::new(4);
+    let fi = empty_file_index();
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.0);
+
+    assert!(g.nodes.is_empty(), "expected no nodes, got {:?}", g.nodes);
+    assert!(g.edges.is_empty(), "expected no edges, got {:?}", g.edges);
+}
+
+#[test]
+fn threshold_filters_low_similarity_edges() {
+    // a.md + b.md live near axis 0 (cos ≈ 0.9987).
+    // c.md lives on axis 7 (cos with a/b = 0).
+    let vi = VectorIndex::new(8);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("b.md"),
+        0,
+        &mixed_unit(&[(0, 0.95), (1, 0.3122499)]), // 0.95^2 + 0.3122499^2 ≈ 1.0
+    );
+    vi.insert(PathBuf::from("c.md"), 0, &axis_unit(7));
+
+    let fi = file_index_with(&["a.md", "b.md", "c.md"]);
+    let ti = TagIndex::new();
+
+    // threshold 0.7 → only a↔b edge survives.
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.7);
+
+    let pairs = edge_pairs(&g);
+    assert_eq!(
+        pairs,
+        vec![("a.md".to_string(), "b.md".to_string())],
+        "expected single a↔b edge above threshold, got {pairs:?}"
+    );
+}
+
+#[test]
+fn top_k_caps_neighbors_per_source() {
+    // a.md is near three other notes b/c/d with distinct similarities.
+    // With top_k=1 we keep only the single best neighbor of `a`.
+    let vi = VectorIndex::new(8);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("b.md"),
+        0,
+        &mixed_unit(&[(0, 0.99), (1, 0.0199_f32.sqrt())]), // cos ≈ 0.99
+    );
+    vi.insert(
+        PathBuf::from("c.md"),
+        0,
+        &mixed_unit(&[(0, 0.95), (1, 0.3122499)]), // cos ≈ 0.95
+    );
+    vi.insert(
+        PathBuf::from("d.md"),
+        0,
+        &mixed_unit(&[(0, 0.90), (1, 0.4358899)]), // cos ≈ 0.90
+    );
+
+    let fi = file_index_with(&["a.md", "b.md", "c.md", "d.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 1, 0.80);
+
+    // Because edges are undirected and every pair (b,c,d) is also >0.80
+    // with each other, the top-1-per-source budget yields exactly three
+    // edges after deduplication: one per source picks one best neighbour;
+    // symmetric duplicates collapse to the same (lo, hi) entry.
+    // Specifically: a→b, b→a (dupe), c→?, d→? — the resulting unique
+    // edge set has cardinality at most 4 and must contain a↔b (the
+    // tightest pair). Precise count depends on the tie-break but must
+    // never exceed sources.
+    assert!(
+        g.edges.len() <= 4,
+        "top_k=1 per source should cap edges (≤4 unique), got {}",
+        g.edges.len()
+    );
+    assert!(
+        edge_weight(&g, "a.md", "b.md").is_some(),
+        "a↔b (tightest) must survive the top-1 cap; got {:?}",
+        edge_pairs(&g)
+    );
+}
+
+#[test]
+fn edges_are_undirected_and_deduplicated() {
+    // Two notes on nearly-identical vectors — every direction of the
+    // k-NN finds the pair. Result must still be exactly one edge.
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("b.md"),
+        0,
+        &mixed_unit(&[(0, 0.98), (1, 0.19899749)]),
+    );
+
+    let fi = file_index_with(&["a.md", "b.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.5);
+
+    assert_eq!(g.edges.len(), 1, "expected 1 unique edge, got {:?}", g.edges);
+    let e = &g.edges[0];
+    assert!(e.from < e.to, "edge should be normalized lo<hi: {e:?}");
+}
+
+#[test]
+fn edge_weight_is_max_chunk_pair_similarity() {
+    // `a.md` has two chunks:
+    //   chunk 0 — axis 0 (matches `b.md`'s single axis-0 chunk at cos 1.0)
+    //   chunk 1 — axis 5 (matches `c.md` at cos 1.0)
+    //
+    // `b.md` has only chunk 0 on axis 0 (cos with a-chunk0 = 1.0).
+    // `b.md` also has chunk 1 on axis 5 rotated slightly — a weaker
+    //   match against a-chunk1 at cos 0.5.
+    //
+    // The edge a↔b must carry the MAX chunk-pair cosine (1.0), not the
+    // mean (0.75) or the last-written value.
+    let vi = VectorIndex::new(8);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(PathBuf::from("a.md"), 1, &axis_unit(5));
+    vi.insert(PathBuf::from("b.md"), 0, &axis_unit(0)); // cos(a0,b0)=1.0
+    vi.insert(
+        PathBuf::from("b.md"),
+        1,
+        &mixed_unit(&[(5, 0.5), (6, 0.75_f32.sqrt())]), // cos(a1,b1)=0.5
+    );
+
+    let fi = file_index_with(&["a.md", "b.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.4);
+
+    let w = edge_weight(&g, "a.md", "b.md").expect("a↔b edge must exist");
+    assert!(
+        (w - 1.0).abs() < 0.01,
+        "expected edge weight == max chunk-pair cosine ≈ 1.0, got {w:.4}"
+    );
+}
+
+#[test]
+fn self_edges_excluded() {
+    // Single note, multiple chunks. No edge should be emitted to itself.
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(PathBuf::from("a.md"), 1, &axis_unit(1));
+    vi.insert(PathBuf::from("a.md"), 2, &axis_unit(2));
+
+    let fi = file_index_with(&["a.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.0);
+
+    assert!(
+        g.edges.is_empty(),
+        "a.md must not edge to itself; got {:?}",
+        g.edges
+    );
+    // The node itself should still appear so the graph isn't empty.
+    let ids: Vec<&str> = g.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(ids, vec!["a.md"]);
+}
+
+#[test]
+fn nodes_come_from_vector_index_only() {
+    // `orphan.md` exists in FileIndex but has no chunks in VectorIndex
+    // → it must NOT appear in the embedding graph (no semantic position).
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("indexed.md"), 0, &axis_unit(0));
+
+    let fi = file_index_with(&["indexed.md", "orphan.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.0);
+
+    let ids: Vec<&str> = g.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["indexed.md"],
+        "only notes with embeddings belong in the embedding graph"
+    );
+}
+
+#[test]
+fn paths_are_stripped_to_vault_relative_ids() {
+    // VectorIndex stores absolute paths (the embed coordinator passes
+    // abs paths from `dispatch_embed_update`). The graph payload uses
+    // vault-relative paths — `\\` normalised to `/` — so the frontend
+    // can key into FileIndex / TagIndex consistently with link-mode.
+    //
+    // Plan-agent flagged this as the highest-impact correctness bug:
+    // without the strip, every node id would be the absolute path and
+    // tag/path lookups in the UI silently miss.
+    let vault_root = PathBuf::from("/vault");
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("/vault/notes/a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("/vault/notes/b.md"),
+        0,
+        &mixed_unit(&[(0, 0.98), (1, 0.19899749)]),
+    );
+
+    let fi = file_index_with(&["notes/a.md", "notes/b.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, &vault_root, 10, 0.5);
+
+    let ids: Vec<&str> = g.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(ids, vec!["notes/a.md", "notes/b.md"]);
+    assert_eq!(g.edges.len(), 1);
+    let e = &g.edges[0];
+    assert_eq!(e.from, "notes/a.md");
+    assert_eq!(e.to, "notes/b.md");
+}
+
+/// Guard: a GraphEdge without a weight (link-graph case) is still a
+/// valid construction — we haven't accidentally made the field
+/// mandatory. This keeps link-graph code paths compiling.
+#[test]
+fn graph_edge_without_weight_still_constructs() {
+    let e = GraphEdge {
+        from: "a".into(),
+        to: "b".into(),
+        weight: None,
+    };
+    assert!(e.weight.is_none());
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -20,3 +20,5 @@ mod vault_walk;
 mod embeddings;
 #[cfg(feature = "embeddings")]
 mod semantic_quality;
+#[cfg(feature = "embeddings")]
+mod embedding_graph;

--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -7,7 +7,7 @@
   import { DEFAULT_FORCE_SETTINGS, type ForceSettings } from "./graphRender";
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore, type Tab, GRAPH_TAB_PATH } from "../../store/tabStore";
-  import { getLinkGraph } from "../../ipc/commands";
+  import { getEmbeddingGraph, getLinkGraph } from "../../ipc/commands";
   import { listenFileChange } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import type { LocalGraph, GraphNode } from "../../types/links";
@@ -17,6 +17,20 @@
   const FILTER_KEY_PREFIX = "vaultcore-graph-filters-";
   const FORCES_KEY_PREFIX = "vaultcore-graph-forces-";
   const FROZEN_KEY_PREFIX = "vaultcore-graph-frozen-";
+  // #235 — embedding-mode persistence keys.
+  const MODE_KEY_PREFIX = "vaultcore-graph-mode-";
+  const THRESHOLD_KEY_PREFIX = "vaultcore-graph-threshold-";
+
+  // #235 — embedding-mode constants. `top_k` is fixed in v1; widen the
+  // slider to 0.30 so users can deliberately surface looser relations
+  // (multilingual-e5-small real semantic matches sit at 0.4–0.8 per the
+  // semantic-search noise floor in `query.rs`).
+  type GraphMode = "link" | "embedding";
+  const EMBEDDING_TOP_K = 10;
+  const EMBEDDING_THRESHOLD_MIN = 0.3;
+  const EMBEDDING_THRESHOLD_MAX = 0.95;
+  const EMBEDDING_THRESHOLD_DEFAULT = 0.7;
+  const EMBEDDING_THRESHOLD_STEP = 0.05;
 
   /**
    * Small synchronous string hash — used to key per-vault localStorage slots.
@@ -129,6 +143,43 @@
     }
   }
 
+  function loadMode(vaultPath: string): GraphMode {
+    try {
+      const raw = localStorage.getItem(MODE_KEY_PREFIX + hashVaultPath(vaultPath));
+      return raw === "embedding" ? "embedding" : "link";
+    } catch {
+      return "link";
+    }
+  }
+
+  function saveMode(vaultPath: string, m: GraphMode): void {
+    try {
+      localStorage.setItem(MODE_KEY_PREFIX + hashVaultPath(vaultPath), m);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function loadThreshold(vaultPath: string): number {
+    try {
+      const raw = localStorage.getItem(THRESHOLD_KEY_PREFIX + hashVaultPath(vaultPath));
+      if (!raw) return EMBEDDING_THRESHOLD_DEFAULT;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) return EMBEDDING_THRESHOLD_DEFAULT;
+      return Math.min(EMBEDDING_THRESHOLD_MAX, Math.max(EMBEDDING_THRESHOLD_MIN, n));
+    } catch {
+      return EMBEDDING_THRESHOLD_DEFAULT;
+    }
+  }
+
+  function saveThreshold(vaultPath: string, t: number): void {
+    try {
+      localStorage.setItem(THRESHOLD_KEY_PREFIX + hashVaultPath(vaultPath), String(t));
+    } catch {
+      /* ignore */
+    }
+  }
+
   // ── State ───────────────────────────────────────────────────────────────────
   let vaultPath = $state<string | null>(null);
   let tabs = $state<Tab[]>([]);
@@ -145,9 +196,30 @@
   let frozen = $state<boolean>(false);
   let forcesPanelOpen = $state<boolean>(false);
 
+  // #235 — embedding-mode state.
+  let mode = $state<GraphMode>("link");
+  let embeddingThreshold = $state<number>(EMBEDDING_THRESHOLD_DEFAULT);
+  // Discriminator for "embeddings not initialised" vs "no edges over
+  // threshold": the backend returns an empty payload for the former
+  // (vault not open, embeddings subsystem missing, sink empty). When in
+  // embedding mode and the response has zero nodes, we surface that as
+  // a distinct empty state so users know to wait for indexing rather
+  // than lower the threshold.
+  let embeddingsUnavailable = $state<boolean>(false);
+
   let unlistenFileChange: UnlistenFn | null = null;
   let refetchTimer: ReturnType<typeof setTimeout> | null = null;
   const REFETCH_DEBOUNCE_MS = 300;
+  // Threshold-slider drag → debounce IPC re-queries so dragging doesn't
+  // spam the backend. 200ms is the smallest debounce that feels
+  // responsive while still coalescing typical drag traffic.
+  const THRESHOLD_DEBOUNCE_MS = 200;
+  let thresholdTimer: ReturnType<typeof setTimeout> | null = null;
+  // Monotonic request id — only the latest in-flight refetch is allowed
+  // to commit its response to `data`. Without this, a slow link-graph
+  // load racing a fast embedding-graph swap would overwrite the newer
+  // result with the stale one.
+  let inflightRequestId = 0;
 
   const unsubVault = vaultStore.subscribe((s) => {
     if (s.currentPath !== vaultPath) {
@@ -156,6 +228,8 @@
         filters = loadFilters(vaultPath);
         forces = loadForces(vaultPath);
         frozen = loadFrozen(vaultPath);
+        mode = loadMode(vaultPath);
+        embeddingThreshold = loadThreshold(vaultPath);
       }
       // Vault identity changed → refetch with full relayout.
       datasetVersion += 1;
@@ -292,21 +366,64 @@
   async function refetch(): Promise<void> {
     if (!vaultPath) {
       data = { nodes: [], edges: [] };
+      embeddingsUnavailable = false;
       return;
     }
+    inflightRequestId += 1;
+    const requestId = inflightRequestId;
     loading = true;
     errorMessage = null;
+    const currentMode = mode;
+    const currentThreshold = embeddingThreshold;
     try {
-      data = await getLinkGraph();
+      const result =
+        currentMode === "embedding"
+          ? await getEmbeddingGraph(EMBEDDING_TOP_K, currentThreshold)
+          : await getLinkGraph();
+      // Stale-response guard: a newer refetch superseded this one.
+      if (requestId !== inflightRequestId) return;
+      data = result;
+      // In embedding mode, an empty-node payload is the backend's
+      // signal that embeddings aren't ready (sink missing, vault not
+      // open for embeddings yet, etc.). Link mode hits the same empty
+      // state only for truly empty vaults, which has its own message.
+      embeddingsUnavailable =
+        currentMode === "embedding" && result.nodes.length === 0;
     } catch (err) {
+      if (requestId !== inflightRequestId) return;
       errorMessage =
         err && typeof err === "object" && "message" in err
           ? String((err as { message: unknown }).message)
           : "Graph konnte nicht geladen werden.";
       data = { nodes: [], edges: [] };
+      embeddingsUnavailable = false;
     } finally {
-      loading = false;
+      if (requestId === inflightRequestId) loading = false;
     }
+  }
+
+  function onModeChange(next: GraphMode): void {
+    if (next === mode) return;
+    mode = next;
+    if (vaultPath) saveMode(vaultPath, next);
+    // Full dataset swap — force a layout re-seed so nodes don't animate
+    // from link-graph positions into embedding-graph positions.
+    datasetVersion += 1;
+    scheduleRefetch();
+  }
+
+  function onThresholdChange(next: number): void {
+    const clamped = Math.min(
+      EMBEDDING_THRESHOLD_MAX,
+      Math.max(EMBEDDING_THRESHOLD_MIN, next),
+    );
+    embeddingThreshold = clamped;
+    if (vaultPath) saveThreshold(vaultPath, clamped);
+    if (thresholdTimer) clearTimeout(thresholdTimer);
+    thresholdTimer = setTimeout(() => {
+      thresholdTimer = null;
+      void refetch();
+    }, THRESHOLD_DEBOUNCE_MS);
   }
 
   function onCameraChange(cam: SavedCamera): void {
@@ -391,17 +508,60 @@
     unsubTabsContent();
     unlistenFileChange?.();
     if (refetchTimer) clearTimeout(refetchTimer);
+    if (thresholdTimer) clearTimeout(thresholdTimer);
   });
 </script>
 
 <svelte:document onkeydown={handleKeydown} />
 
 <div class="vc-graph-view" role="region" aria-label="Graph-Ansicht">
+  <div class="vc-graph-mode-toolbar" role="group" aria-label="Graph-Modus">
+    <div class="vc-graph-mode-pills">
+      <button
+        type="button"
+        class="vc-graph-mode-pill"
+        class:vc-graph-mode-pill--active={mode === "link"}
+        onclick={() => onModeChange("link")}
+        aria-pressed={mode === "link"}
+        title="Link-basierter Graph (Wiki-Links)"
+      >Links</button>
+      <button
+        type="button"
+        class="vc-graph-mode-pill"
+        class:vc-graph-mode-pill--active={mode === "embedding"}
+        onclick={() => onModeChange("embedding")}
+        aria-pressed={mode === "embedding"}
+        title="Semantischer Graph (Embedding-Ähnlichkeit)"
+      >Semantisch</button>
+    </div>
+    {#if mode === "embedding"}
+      <label class="vc-graph-threshold">
+        <span class="vc-graph-threshold-label">Schwellwert</span>
+        <input
+          type="range"
+          min={EMBEDDING_THRESHOLD_MIN}
+          max={EMBEDDING_THRESHOLD_MAX}
+          step={EMBEDDING_THRESHOLD_STEP}
+          value={embeddingThreshold}
+          oninput={(e) =>
+            onThresholdChange(Number((e.target as HTMLInputElement).value))}
+          aria-label="Cosine-Schwellwert"
+        />
+        <span class="vc-graph-threshold-value">{embeddingThreshold.toFixed(2)}</span>
+      </label>
+    {/if}
+  </div>
   {#if errorMessage}
     <div class="vc-graph-empty">{errorMessage}</div>
   {:else if !data || data.nodes.length === 0}
     <div class="vc-graph-empty">
-      {loading ? "Graph wird geladen..." : "Keine Notizen im Vault."}
+      {#if loading}
+        Graph wird geladen...
+      {:else if mode === "embedding" && embeddingsUnavailable}
+        Semantischer Graph nicht verfügbar — Embeddings sind noch nicht erstellt.
+      {:else}
+        Keine Notizen im Vault.
+      {/if}
     </div>
   {:else}
     <GraphCanvas
@@ -503,5 +663,63 @@
     color: var(--color-accent);
     border-color: var(--color-accent);
     background: var(--color-accent-bg);
+  }
+  .vc-graph-mode-toolbar {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 11;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 4px 8px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+  }
+  .vc-graph-mode-pills {
+    display: inline-flex;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .vc-graph-mode-pill {
+    padding: 4px 10px;
+    background: transparent;
+    border: none;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .vc-graph-mode-pill + .vc-graph-mode-pill {
+    border-left: 1px solid var(--color-border);
+  }
+  .vc-graph-mode-pill:hover {
+    color: var(--color-accent);
+  }
+  .vc-graph-mode-pill--active {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+  .vc-graph-threshold {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: var(--color-text-muted);
+  }
+  .vc-graph-threshold-label {
+    user-select: none;
+  }
+  .vc-graph-threshold input[type="range"] {
+    width: 110px;
+    accent-color: var(--color-accent);
+  }
+  .vc-graph-threshold-value {
+    width: 28px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text);
   }
 </style>

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -64,7 +64,12 @@ interface SimNode extends SimulationNodeDatum {
   radius: number;
 }
 
-type SimLink = SimulationLinkDatum<SimNode>;
+/** Link datum handed to d3-force. `weight` carries the edge similarity
+ *  (cosine in the 0..1 range) for the embedding-mode graph. Link-mode
+ *  edges leave it undefined — callers fall back to the scalar strength. */
+interface SimLink extends SimulationLinkDatum<SimNode> {
+  weight?: number;
+}
 
 /** Options accepted by `mountGraph` — future-proofed for the #32 global view.
  *  The `| undefined` on every optional member is deliberate: svelte-check runs
@@ -200,8 +205,42 @@ function populateGraph(graph: Graph, data: LocalGraph): void {
   for (const edge of data.edges) {
     if (!graph.hasNode(edge.from) || !graph.hasNode(edge.to)) continue;
     if (graph.hasEdge(edge.from, edge.to)) continue;
-    graph.addEdge(edge.from, edge.to);
+    const attrs: Record<string, unknown> = {};
+    if (typeof edge.weight === "number" && Number.isFinite(edge.weight)) {
+      attrs.weight = edge.weight;
+    }
+    graph.addEdge(edge.from, edge.to, attrs);
   }
+}
+
+// ── Weight-driven visual mapping ───────────────────────────────────────────────
+//
+// Edge weight (cosine similarity) flows through three visuals in embedding
+// mode: d3-force link strength/distance for spatial clustering, and edge
+// thickness/alpha for the rendered line. Link-mode edges carry no weight,
+// so the helpers fall back to a neutral 1.0 multiplier and the original
+// scalar strength/distance stay in effect.
+
+/** Normalize a weight into 0..1. Inputs outside the range clamp. */
+function normalizeWeight(weight: number | undefined): number | null {
+  if (typeof weight !== "number" || !Number.isFinite(weight)) return null;
+  if (weight <= 0) return 0;
+  if (weight >= 1) return 1;
+  return weight;
+}
+
+/** Edge rest length scales inversely with weight — stronger similarity pulls
+ *  nodes closer. Link-mode (weight=null) keeps the historical 80-unit default. */
+function edgeDistanceForWeight(weight: number | null): number {
+  if (weight === null) return 80;
+  return 120 - 80 * weight;
+}
+
+/** Edge pull strength multiplier. Link-mode passes through unchanged (1);
+ *  embedding-mode scales with weight so weak edges barely tug. */
+function edgeStrengthScaleForWeight(weight: number | null): number {
+  if (weight === null) return 1;
+  return 0.25 + 0.75 * weight;
 }
 
 /** Build the d3-force node/link datum arrays from the current graphology
@@ -229,9 +268,12 @@ function buildSimState(
     index.set(id, sim);
   });
   const links: SimLink[] = [];
-  graph.forEachEdge((_edge, _attrs, source, target) => {
+  graph.forEachEdge((_edge, attrs, source, target) => {
     if (index.has(source) && index.has(target)) {
-      links.push({ source, target });
+      const link: SimLink = { source, target };
+      const w = normalizeWeight(attrs.weight as number | undefined);
+      if (w !== null) link.weight = w;
+      links.push(link);
     }
   });
   return { nodes, links, index };
@@ -265,12 +307,21 @@ function applyForceSettings(
     | ReturnType<typeof forceLink<SimNode, SimLink>>
     | undefined;
   if (link) {
-    const strength = Math.min(1, Math.max(0, settings.edgeWeightInfluence));
-    link.strength(strength);
-    // Shorter rest length pulls linked nodes closer — combined with the
-    // capped repulsion range above this produces visible clusters instead
-    // of an evenly-spread globe.
-    link.distance(80);
+    const base = Math.min(1, Math.max(0, settings.edgeWeightInfluence));
+    // Per-edge strength: link-mode edges (no weight) keep the scalar `base`;
+    // embedding-mode edges fold in their cosine similarity so strong pairs
+    // pull hard and weak pairs barely register.
+    link.strength((l) => {
+      const w = normalizeWeight((l as SimLink).weight);
+      return base * edgeStrengthScaleForWeight(w);
+    });
+    // Shorter rest length pulls linked nodes closer. Embedding-mode edges
+    // shrink the rest length with weight so clusters of highly-similar
+    // notes visibly collapse toward each other.
+    link.distance((l) => {
+      const w = normalizeWeight((l as SimLink).weight);
+      return edgeDistanceForWeight(w);
+    });
   }
 
   const center = simulation.force("center") as
@@ -310,7 +361,7 @@ function buildSimulation(
       "link",
       forceLink<SimNode, SimLink>(links)
         .id((n) => n.id)
-        .distance(80),
+        .distance((l) => edgeDistanceForWeight(normalizeWeight((l as SimLink).weight))),
     )
     .force("charge", forceManyBody<SimNode>())
     .force("center", forceCenter<SimNode>(0, 0))
@@ -483,17 +534,30 @@ export function mountGraph(
     return result;
   });
 
-  // Edge reducer — hover dim for non-adjacent edges.
+  // Edge reducer — hover dim + weight-driven thickness/alpha.
+  //
+  // In embedding mode each edge carries a `weight` attr (cosine similarity
+  // in 0..1). Map it to:
+  //   size  : 1  → 3.5  (thicker line for stronger relations)
+  //   alpha : 0.45 → 1.0 (fade weak edges into the background)
+  //
+  // Link-mode edges have no weight — they render with the historical
+  // size=1 / full-opacity color, so the link graph is visually unchanged.
   renderer.setSetting("edgeReducer", (e, attrs) => {
+    const weight = normalizeWeight(attrs.weight as number | undefined);
+    const baseSize = weight === null ? 1 : 1 + weight * 2.5;
+    const baseAlpha = weight === null ? 1 : 0.45 + weight * 0.55;
+    const weightedEdgeColor = baseAlpha < 1 ? applyAlpha(edge, baseAlpha) : edge;
+
     if (!handle.hoveredNode) {
-      return { ...attrs, color: edge, size: 1 };
+      return { ...attrs, color: weightedEdgeColor, size: baseSize };
     }
     const [source, target] = graph.extremities(e);
     const adjacent = source === handle.hoveredNode || target === handle.hoveredNode;
     return {
       ...attrs,
-      color: adjacent ? edge : applyAlpha(edge, 0.2),
-      size: 1,
+      color: adjacent ? weightedEdgeColor : applyAlpha(edge, 0.2),
+      size: baseSize,
     };
   });
 

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -381,6 +381,35 @@ export async function getLinkGraph(): Promise<LocalGraph> {
   }
 }
 
+/**
+ * #235 — embedding-similarity graph for the whole vault. Same payload
+ * shape as `getLinkGraph()` so the renderer can swap data sources
+ * without restructuring; only `edge.weight` is populated (cosine
+ * similarity in [0, 1]).
+ *
+ * `topK` caps neighbours per source note; `threshold` drops edges whose
+ * max chunk-pair cosine falls below it. The backend snapshots the
+ * VectorIndex once and runs the build inside `spawn_blocking`, so the
+ * call is safe to issue from the UI without blocking other IPC traffic.
+ *
+ * Returns an empty payload when the embeddings subsystem is not
+ * initialised; the caller distinguishes "embeddings not ready" from
+ * "no edges over threshold" by checking whether `nodes.length === 0`.
+ */
+export async function getEmbeddingGraph(
+  topK: number,
+  threshold: number,
+): Promise<LocalGraph> {
+  try {
+    return await invoke<LocalGraph>("get_embedding_graph", {
+      topK,
+      threshold,
+    });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function getResolvedAttachments(): Promise<Map<string, string>> {
   try {
     const record = await invoke<Record<string, string>>("get_resolved_attachments");

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -63,6 +63,9 @@ export interface GraphNode {
 export interface GraphEdge {
   from: string;
   to: string;
+  /** Similarity weight in `[0, 1]`. Populated by the embedding-graph
+   * mode (#235); absent on link-graph edges. */
+  weight?: number;
 }
 
 /** Result returned by `get_local_graph`. */


### PR DESCRIPTION
## Summary

Add a **semantic** mode to the whole-vault graph view that derives edges from cosine similarity between note embeddings instead of wiki-link traversal. Reuses the HNSW index from the Semantic Search v1 epic — no new datastore, no new index type.

Closes #235.

## Aggregation

**Chunk-pair max** (per ticket alignment with the user). For each source chunk the builder runs a k-NN on the shared HNSW (oversampled 8× to survive note-level dedup), keeps the maximum cosine per target path, then applies threshold + top-K per source. Edges are undirected; symmetric pairs collapse to a single `(lo, hi)` entry with the max weight.

## Backend

- **`VectorIndex.for_each_live`**: per-layer HNSW walk that releases the iterator's read lock between layers, so the embed worker can keep inserting during graph builds.
- **`compute_embedding_graph`**: pure builder. Snapshots all live chunks once, snapshots tags once (avoids holding the `TagIndex` Mutex across a multi-second build at 100k notes), then runs the chunk-pair-max aggregation. NaN-safe sort via `total_cmp`.
- **`get_embedding_graph` IPC**: snapshots `Arc<VectorIndex>` at entry to avoid id-space mixing across compactions, runs the build inside `spawn_blocking` so it doesn't stall the tokio runtime.
- **Path normalisation**: `VectorIndex` stores absolute paths; the builder strips `vault_root` and normalises `\\` → `/` so node ids match the rest of the graph payload (`FileIndex` / `TagIndex` use vault-relative keys).
- **`GraphEdge`** gains optional `weight: Option<f32>` with `skip_serializing_if = None` so the link-graph wire shape is unchanged.
- **Feature-off stub** mirrors the `semantic_search` pattern — IPC always resolves with an empty payload.

## Frontend

- Mode pill toggle (Links / Semantisch) + threshold slider (0.30 – 0.95, step 0.05) in a centred toolbar above the canvas. Slider only visible in semantic mode.
- Per-vault `localStorage` persistence (mode + threshold) using the existing `hashVaultPath` pattern.
- Refetch dispatcher uses a monotonic request id so a slow link-graph load can't overwrite a newer embedding-graph result, and threshold drag debounces 200ms before re-querying.
- Empty state distinguishes "Embeddings sind noch nicht erstellt" (semantic mode + zero nodes = sink not initialised) from "Keine Notizen im Vault" (link mode).

## Test plan

- [x] `cargo test --lib --features embeddings` — 316 passed (was 307 before; +9 new embedding-graph tests).
- [x] `cargo build` clean with and without the `embeddings` feature.
- [x] `svelte-check` — 0 errors.
- [x] Vitest graph specs (11/11) still pass.
- [ ] Manual UAT after merge: toggle modes, drag threshold, verify per-vault persistence, confirm empty-state messaging.

## Plan-agent review

Plan-agent flagged and these are addressed in the implementation:
- abs/rel path mismatch (highest-impact bug) — fixed via `vault_root` strip + new `paths_are_stripped_to_vault_relative_ids` test
- `Arc<VectorIndex>` snapshot stability across compactions — single `handles.sink.snapshot()` at entry
- NaN sort hazard — `total_cmp`
- `TagIndex` lock contention — snapshot once, drop lock, build
- `spawn_blocking` missing on the IPC handler — wrapped
- frontend cancellation — monotonic request id
- threshold range too narrow — widened to 0.30 – 0.95
- feature-off stub — added

## Follow-ups (not in this PR)

- Graph-build caching keyed by `(snapshot generation, top_k)` so threshold drags can re-filter client-side instead of triggering a full HNSW re-walk per slider step. Acceptable cost in v1 at current vault sizes; revisit when 100k UAT lands.
- Edge-weight visual scaling (opacity / thickness). The weight is in the payload; renderer treatment is a separate aesthetic pass.
- Surface "X of Y notes have embeddings" in the response so the UI can warn when chunk coverage is incomplete.