### PR TITLE
feat(graph): cluster similar notes into super-nodes via second slider (#237)

### DIFF
--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -11,6 +11,7 @@
   import { listenFileChange } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import type { LocalGraph, GraphNode } from "../../types/links";
+  import { clusterGraph } from "./clusterGraph";
 
   // ── Persistence ─────────────────────────────────────────────────────────────
   const CAMERA_KEY_PREFIX = "vaultcore-graph-camera-";
@@ -20,6 +21,8 @@
   // #235 — embedding-mode persistence keys.
   const MODE_KEY_PREFIX = "vaultcore-graph-mode-";
   const THRESHOLD_KEY_PREFIX = "vaultcore-graph-threshold-";
+  // #237 — second embedding-mode slider: cluster-collapse threshold.
+  const CLUSTER_KEY_PREFIX = "vaultcore-graph-cluster-";
 
   // #235 — embedding-mode constants. `top_k` is fixed in v1; widen the
   // slider to 0.30 so users can deliberately surface looser relations
@@ -31,6 +34,16 @@
   const EMBEDDING_THRESHOLD_MAX = 0.95;
   const EMBEDDING_THRESHOLD_DEFAULT = 0.7;
   const EMBEDDING_THRESHOLD_STEP = 0.05;
+
+  // #237 — cluster slider. Right edge (= 1.0) disables clustering. Min
+  // value sits at 0.55 so the user never sees an effectively useless
+  // sub-edge-threshold range; the actual lower bound is clamped to the
+  // current edge threshold at runtime (clusterThresholdMin below).
+  const CLUSTER_THRESHOLD_ABS_MIN = 0.55;
+  const CLUSTER_THRESHOLD_MAX = 1.0;
+  const CLUSTER_THRESHOLD_DEFAULT = 1.0;
+  const CLUSTER_THRESHOLD_STEP = 0.05;
+  const CLUSTER_DEBOUNCE_MS = 200;
 
   /**
    * Small synchronous string hash — used to key per-vault localStorage slots.
@@ -180,6 +193,26 @@
     }
   }
 
+  function loadClusterThreshold(vaultPath: string): number {
+    try {
+      const raw = localStorage.getItem(CLUSTER_KEY_PREFIX + hashVaultPath(vaultPath));
+      if (!raw) return CLUSTER_THRESHOLD_DEFAULT;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) return CLUSTER_THRESHOLD_DEFAULT;
+      return Math.min(CLUSTER_THRESHOLD_MAX, Math.max(CLUSTER_THRESHOLD_ABS_MIN, n));
+    } catch {
+      return CLUSTER_THRESHOLD_DEFAULT;
+    }
+  }
+
+  function saveClusterThreshold(vaultPath: string, t: number): void {
+    try {
+      localStorage.setItem(CLUSTER_KEY_PREFIX + hashVaultPath(vaultPath), String(t));
+    } catch {
+      /* ignore */
+    }
+  }
+
   // ── State ───────────────────────────────────────────────────────────────────
   let vaultPath = $state<string | null>(null);
   let tabs = $state<Tab[]>([]);
@@ -206,6 +239,14 @@
   // a distinct empty state so users know to wait for indexing rather
   // than lower the threshold.
   let embeddingsUnavailable = $state<boolean>(false);
+  // #237 — 1.0 = clustering off; any lower value collapses notes whose
+  // pairwise cosine similarity clears this threshold. Two values: the
+  // instant slider reading (shown on the UI) and the debounced applied
+  // value (fed into the render pipeline). Separating them keeps the
+  // thumb responsive while avoiding per-mousemove sim rebuilds.
+  let embeddingClusterThreshold = $state<number>(CLUSTER_THRESHOLD_DEFAULT);
+  let embeddingClusterThresholdApplied = $state<number>(CLUSTER_THRESHOLD_DEFAULT);
+  let clusterTimer: ReturnType<typeof setTimeout> | null = null;
 
   let unlistenFileChange: UnlistenFn | null = null;
   let refetchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -230,6 +271,9 @@
         frozen = loadFrozen(vaultPath);
         mode = loadMode(vaultPath);
         embeddingThreshold = loadThreshold(vaultPath);
+        const loadedCluster = loadClusterThreshold(vaultPath);
+        embeddingClusterThreshold = loadedCluster;
+        embeddingClusterThresholdApplied = loadedCluster;
       }
       // Vault identity changed → refetch with full relayout.
       datasetVersion += 1;
@@ -253,6 +297,33 @@
       return t.filePath.slice(vaultPath.length + 1);
     }
     return null;
+  });
+
+  // Cluster slider's effective lower bound — clamped to the edge threshold
+  // so the user never gets a slider range that can't cluster anything
+  // (edges below `embeddingThreshold` are filtered out backend-side and
+  // therefore never union a cluster; with cluster_threshold < edge_threshold
+  // every surviving edge would collapse into a single mega-cluster).
+  const clusterThresholdMin = $derived.by<number>(() => {
+    return Math.max(CLUSTER_THRESHOLD_ABS_MIN, embeddingThreshold);
+  });
+
+  // Effective cluster threshold feeding the render pipeline. Uses the
+  // debounced `Applied` value and clamps it to the current edge threshold
+  // so a below-edge cluster_threshold doesn't accidentally collapse every
+  // surviving edge into a mega-cluster.
+  const effectiveClusterThreshold = $derived.by<number>(() => {
+    return Math.max(clusterThresholdMin, embeddingClusterThresholdApplied);
+  });
+
+  // #237 — clustered view handed to GraphCanvas. In link mode or when the
+  // slider is at the off position this is a reference passthrough so the
+  // canvas-side memo/equality checks don't see a new object per tick.
+  const renderedData = $derived.by<LocalGraph | null>(() => {
+    if (!data) return null;
+    if (mode !== "embedding") return data;
+    if (effectiveClusterThreshold >= CLUSTER_THRESHOLD_MAX) return data;
+    return clusterGraph(data, effectiveClusterThreshold).graph;
   });
 
   // Available tag/folder filter options derived from the current dataset.
@@ -426,6 +497,24 @@
     }, THRESHOLD_DEBOUNCE_MS);
   }
 
+  function onClusterChange(next: number): void {
+    const clamped = Math.min(
+      CLUSTER_THRESHOLD_MAX,
+      Math.max(CLUSTER_THRESHOLD_ABS_MIN, next),
+    );
+    embeddingClusterThreshold = clamped;
+    if (vaultPath) saveClusterThreshold(vaultPath, clamped);
+    // Debounce the render-feeding `Applied` value so rapid slider drags
+    // don't rebuild the force simulation on every mousemove. Clustering
+    // itself is a pure O(N+E) pass — the expensive downstream work is
+    // sigma + d3-force reacting to a new node/edge set.
+    if (clusterTimer) clearTimeout(clusterTimer);
+    clusterTimer = setTimeout(() => {
+      clusterTimer = null;
+      embeddingClusterThresholdApplied = clamped;
+    }, CLUSTER_DEBOUNCE_MS);
+  }
+
   function onCameraChange(cam: SavedCamera): void {
     if (vaultPath) saveCamera(vaultPath, cam);
   }
@@ -509,6 +598,7 @@
     unlistenFileChange?.();
     if (refetchTimer) clearTimeout(refetchTimer);
     if (thresholdTimer) clearTimeout(thresholdTimer);
+    if (clusterTimer) clearTimeout(clusterTimer);
   });
 </script>
 
@@ -549,6 +639,24 @@
         />
         <span class="vc-graph-threshold-value">{embeddingThreshold.toFixed(2)}</span>
       </label>
+      <label class="vc-graph-threshold" title="Fasst ähnliche Notizen zu einem Oberbegriff zusammen. Rechts (1.00) = aus.">
+        <span class="vc-graph-threshold-label">Cluster</span>
+        <input
+          type="range"
+          min={clusterThresholdMin}
+          max={CLUSTER_THRESHOLD_MAX}
+          step={CLUSTER_THRESHOLD_STEP}
+          value={Math.max(clusterThresholdMin, embeddingClusterThreshold)}
+          oninput={(e) =>
+            onClusterChange(Number((e.target as HTMLInputElement).value))}
+          aria-label="Cluster-Schwellwert"
+        />
+        <span class="vc-graph-threshold-value">
+          {embeddingClusterThreshold >= CLUSTER_THRESHOLD_MAX
+            ? "aus"
+            : Math.max(clusterThresholdMin, embeddingClusterThreshold).toFixed(2)}
+        </span>
+      </label>
     {/if}
   </div>
   {#if errorMessage}
@@ -565,7 +673,7 @@
     </div>
   {:else}
     <GraphCanvas
-      {data}
+      data={renderedData}
       activeId={activeRelPath}
       {savedCamera}
       dimForNode={(id) => dimForNode(id)}

--- a/src/components/Graph/__tests__/clusterGraph.test.ts
+++ b/src/components/Graph/__tests__/clusterGraph.test.ts
@@ -1,0 +1,194 @@
+// Pure-function tests for the embedding-mode clustering helper (#237).
+//
+// `clusterGraph` takes a LocalGraph produced by `get_embedding_graph` plus
+// a cluster-threshold slider value, and collapses any connected component
+// whose internal edges all clear the threshold into a single super-node.
+// No sigma / graphology imports — the helper is pure so we test it flat.
+
+import { describe, expect, it } from "vitest";
+import type { LocalGraph } from "../../../types/links";
+import { clusterGraph, CLUSTER_NODE_ID_PREFIX } from "../clusterGraph";
+
+function node(id: string, label: string, backlinkCount = 0) {
+  return { id, label, path: id, backlinkCount, resolved: true };
+}
+
+function edge(from: string, to: string, weight?: number) {
+  return weight === undefined ? { from, to } : { from, to, weight };
+}
+
+describe("clusterGraph", () => {
+  it("passes through unchanged when threshold >= 1.0", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md", 0.95)],
+    };
+    const out = clusterGraph(raw, 1.0);
+    expect(out.graph.nodes).toEqual(raw.nodes);
+    expect(out.graph.edges).toEqual(raw.edges);
+    expect(out.clusters.size).toBe(0);
+  });
+
+  it("passes through link-mode graphs (edges without weight) regardless of threshold", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md")],
+    };
+    const out = clusterGraph(raw, 0.5);
+    expect(out.graph.nodes).toEqual(raw.nodes);
+    expect(out.graph.edges).toEqual(raw.edges);
+    expect(out.clusters.size).toBe(0);
+  });
+
+  it("collapses a single high-weight pair into one super-node and drops its intra-edge", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md", 0.8)],
+    };
+    const out = clusterGraph(raw, 0.7);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.edges).toHaveLength(0);
+    expect(out.graph.nodes[0]!.id.startsWith(CLUSTER_NODE_ID_PREFIX)).toBe(true);
+    expect(out.clusters.size).toBe(1);
+  });
+
+  it("uses the min member id to derive the cluster id (stable across slider ticks)", () => {
+    const raw: LocalGraph = {
+      nodes: [node("z.md", "Z"), node("a.md", "A"), node("m.md", "M")],
+      edges: [
+        edge("z.md", "a.md", 0.9),
+        edge("a.md", "m.md", 0.85),
+        edge("z.md", "m.md", 0.82),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.id).toBe(`${CLUSTER_NODE_ID_PREFIX}a.md`);
+    const info = out.clusters.get(`${CLUSTER_NODE_ID_PREFIX}a.md`);
+    expect(info?.members).toEqual(["a.md", "m.md", "z.md"]);
+  });
+
+  it("picks the representative as the member with the highest sum of intra-cluster weights", () => {
+    // Weights: (a,b)=0.9, (a,c)=0.9, (b,c)=0.75
+    // Sums: a = 1.8, b = 1.65, c = 1.65 → a wins.
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B"), node("c.md", "C")],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("a.md", "c.md", 0.9),
+        edge("b.md", "c.md", 0.75),
+      ],
+    };
+    const out = clusterGraph(raw, 0.7);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.label.startsWith("A")).toBe(true);
+    expect(out.graph.nodes[0]!.label).toContain("+2");
+  });
+
+  it("breaks representative ties by backlinkCount then alphabetical id", () => {
+    // Weights tie all pairs at 0.8 so weight sums tie; b has highest backlinks.
+    const raw: LocalGraph = {
+      nodes: [
+        node("a.md", "Alpha", 1),
+        node("b.md", "Beta", 5),
+        node("c.md", "Gamma", 1),
+      ],
+      edges: [
+        edge("a.md", "b.md", 0.8),
+        edge("a.md", "c.md", 0.8),
+        edge("b.md", "c.md", 0.8),
+      ],
+    };
+    const out = clusterGraph(raw, 0.7);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.label.startsWith("Beta")).toBe(true);
+  });
+
+  it("labels the super-node as '<representative> · +N'", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "Alpha"), node("b.md", "Beta"), node("c.md", "Gamma")],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("a.md", "c.md", 0.85),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.label).toBe("Alpha · +2");
+  });
+
+  it("passes through singleton nodes unchanged (no incident high-weight edges)", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B"), node("lone.md", "Lone")],
+      edges: [edge("a.md", "b.md", 0.9)],
+    };
+    const out = clusterGraph(raw, 0.8);
+    // One cluster node + one lone singleton.
+    expect(out.graph.nodes).toHaveLength(2);
+    const lone = out.graph.nodes.find((n) => n.id === "lone.md");
+    expect(lone).toEqual(node("lone.md", "Lone"));
+  });
+
+  it("aggregates inter-cluster edges with the maximum member-pair weight", () => {
+    // Two clusters: {a,b} (via 0.9) and {c,d} (via 0.9).
+    // Cross edges a-c = 0.6, b-d = 0.65 → super-edge weight = 0.65.
+    const raw: LocalGraph = {
+      nodes: [
+        node("a.md", "A"),
+        node("b.md", "B"),
+        node("c.md", "C"),
+        node("d.md", "D"),
+      ],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("c.md", "d.md", 0.9),
+        edge("a.md", "c.md", 0.6),
+        edge("b.md", "d.md", 0.65),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(2);
+    expect(out.graph.edges).toHaveLength(1);
+    expect(out.graph.edges[0]!.weight).toBeCloseTo(0.65, 6);
+  });
+
+  it("filters self-loops after cluster collapse", () => {
+    // All edges above threshold → everything collapses into one cluster;
+    // every would-be edge becomes a self-loop and must be dropped.
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B"), node("c.md", "C")],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("b.md", "c.md", 0.9),
+        edge("a.md", "c.md", 0.9),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.edges).toHaveLength(0);
+  });
+
+  it("preserves a below-threshold edge between two singletons", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md", 0.6)],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(2);
+    expect(out.graph.edges).toHaveLength(1);
+    expect(out.graph.edges[0]).toEqual(raw.edges[0]);
+  });
+
+  it("sums member backlinkCounts onto the super-node so sizing reflects cluster mass", () => {
+    const raw: LocalGraph = {
+      nodes: [
+        node("a.md", "A", 3),
+        node("b.md", "B", 4),
+      ],
+      edges: [edge("a.md", "b.md", 0.9)],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.backlinkCount).toBe(7);
+  });
+});

--- a/src/components/Graph/clusterGraph.ts
+++ b/src/components/Graph/clusterGraph.ts
@@ -1,0 +1,219 @@
+// #237 — second graph-mode slider that collapses groups of highly-similar
+// notes into a single representative super-node ("Oberbegriff").
+//
+// Runs purely in the frontend between the backend IPC response and the
+// sigma/graphology render pass so the slider stays live (no roundtrip per
+// tick). Algorithm is a union-find over the weighted embedding graph:
+//
+//   1. Every edge whose cosine similarity clears `threshold` unions its
+//      endpoints. Lower threshold → more aggressive merging.
+//   2. Each component of size ≥ 2 becomes a super-node whose label
+//      surfaces the most "central" member (highest Σ intra-cluster
+//      weight), and whose backlinkCount is the sum of its members' so
+//      sigma renders it at a size that reflects cluster mass.
+//   3. Edges are rewritten onto super-node ids, self-loops are dropped,
+//      and multi-edges between the same cluster pair collapse to the
+//      max member-pair weight — consistent with the backend's
+//      chunk-pair-max aggregation.
+//
+// At `threshold >= 1.0` the helper is a strict passthrough, so the slider
+// at its right edge reproduces the raw per-note graph byte-for-byte.
+// Link-mode edges have no `weight`, so they never union anything and the
+// helper no-ops regardless of the threshold.
+
+import type { LocalGraph, GraphNode, GraphEdge } from "../../types/links";
+
+/** Super-node ids are prefixed so the surrounding UI can cheaply tell a
+ *  cluster apart from a real note (the Tauri side only ever mints real
+ *  note paths as ids). */
+export const CLUSTER_NODE_ID_PREFIX = "cluster:";
+
+export interface ClusterMembership {
+  /** Member id chosen as visual representative (max Σ intra-cluster weight,
+   *  tiebreak by backlinkCount then alphabetical id). */
+  representative: string;
+  /** All member ids in the cluster, including the representative. */
+  members: string[];
+}
+
+export interface ClusterResult {
+  graph: LocalGraph;
+  /** Keyed by the super-node id. Empty when no clustering was applied. */
+  clusters: Map<string, ClusterMembership>;
+}
+
+/**
+ * Collapse tight embedding components into super-nodes.
+ *
+ * Backwards-compatible shape: callers that only care about the resulting
+ * graph can destructure `.graph`; the `clusters` map is there for UI that
+ * wants to surface membership (e.g. tooltip listing, future expand-on-click).
+ */
+export function clusterGraph(raw: LocalGraph, threshold: number): ClusterResult {
+  // Fast path — slider at rest (= off). Also covers `threshold > 1.0`
+  // for paranoid callers.
+  if (threshold >= 1.0) {
+    return { graph: raw, clusters: new Map() };
+  }
+
+  // Build a parent array keyed by node id.
+  const parent = new Map<string, string>();
+  for (const n of raw.nodes) parent.set(n.id, n.id);
+
+  const find = (x: string): string => {
+    let cur = x;
+    while (parent.get(cur) !== cur) {
+      const p = parent.get(cur)!;
+      const gp = parent.get(p)!;
+      parent.set(cur, gp);
+      cur = gp;
+    }
+    return cur;
+  };
+  const union = (a: string, b: string): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra === rb) return;
+    // Deterministic union: prefer the lexicographically smaller root so
+    // cluster identity is stable across slider ticks.
+    if (ra < rb) parent.set(rb, ra);
+    else parent.set(ra, rb);
+  };
+
+  // Phase 1 — union high-weight edges. Edges without weight never union,
+  // which is how link-mode passthrough falls out naturally.
+  for (const e of raw.edges) {
+    if (typeof e.weight !== "number" || !Number.isFinite(e.weight)) continue;
+    if (e.weight < threshold) continue;
+    if (!parent.has(e.from) || !parent.has(e.to)) continue;
+    union(e.from, e.to);
+  }
+
+  // Phase 2 — group members by root.
+  const byRoot = new Map<string, string[]>();
+  for (const n of raw.nodes) {
+    const r = find(n.id);
+    const arr = byRoot.get(r);
+    if (arr) arr.push(n.id);
+    else byRoot.set(r, [n.id]);
+  }
+
+  // Detect whether anything actually clustered. If every root maps to a
+  // single-member component we can fast-path to passthrough — saves a
+  // surprising amount of churn on big vaults where the slider sits above
+  // the natural similarity ceiling.
+  let hasMultiMember = false;
+  for (const members of byRoot.values()) {
+    if (members.length >= 2) {
+      hasMultiMember = true;
+      break;
+    }
+  }
+  if (!hasMultiMember) {
+    return { graph: raw, clusters: new Map() };
+  }
+
+  // Phase 3 — for each multi-member component pick a representative and
+  // mint the super-node. Singletons pass through as-is.
+  const nodesById = new Map<string, GraphNode>();
+  for (const n of raw.nodes) nodesById.set(n.id, n);
+
+  // Per-member Σ intra-cluster weight — used by the representative picker.
+  const weightSum = new Map<string, number>();
+  for (const e of raw.edges) {
+    if (typeof e.weight !== "number" || !Number.isFinite(e.weight)) continue;
+    if (e.weight < threshold) continue;
+    if (find(e.from) !== find(e.to)) continue;
+    weightSum.set(e.from, (weightSum.get(e.from) ?? 0) + e.weight);
+    weightSum.set(e.to, (weightSum.get(e.to) ?? 0) + e.weight);
+  }
+
+  // Map original id → super-node id (or itself for singletons).
+  const remap = new Map<string, string>();
+  const clusters = new Map<string, ClusterMembership>();
+  const outNodes: GraphNode[] = [];
+
+  // Stable iteration: sort roots so the output node order is deterministic
+  // (nice for tests + snapshot-diff debugging).
+  const rootKeys = Array.from(byRoot.keys()).sort();
+
+  for (const root of rootKeys) {
+    const members = byRoot.get(root)!;
+    if (members.length === 1) {
+      const only = members[0]!;
+      remap.set(only, only);
+      outNodes.push(nodesById.get(only)!);
+      continue;
+    }
+
+    // Representative pick: max Σ weight, tiebreak by backlinkCount desc,
+    // then alphabetical id asc. Using a stable sort on a copy.
+    const ranked = members.slice().sort((a, b) => {
+      const wa = weightSum.get(a) ?? 0;
+      const wb = weightSum.get(b) ?? 0;
+      if (wa !== wb) return wb - wa;
+      const ba = nodesById.get(a)?.backlinkCount ?? 0;
+      const bb = nodesById.get(b)?.backlinkCount ?? 0;
+      if (ba !== bb) return bb - ba;
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+    const rep = ranked[0]!;
+
+    const sortedMembers = members.slice().sort();
+    const clusterId = CLUSTER_NODE_ID_PREFIX + sortedMembers[0]!;
+    const repNode = nodesById.get(rep)!;
+    const sumBacklinks = members.reduce(
+      (acc, m) => acc + (nodesById.get(m)?.backlinkCount ?? 0),
+      0,
+    );
+
+    outNodes.push({
+      id: clusterId,
+      label: `${repNode.label} · +${members.length - 1}`,
+      path: "",
+      backlinkCount: sumBacklinks,
+      resolved: true,
+    });
+
+    clusters.set(clusterId, { representative: rep, members: sortedMembers });
+    for (const m of members) remap.set(m, clusterId);
+  }
+
+  // Phase 4 — rewrite edges. Self-loops drop; duplicates between the same
+  // cluster pair collapse to the max observed member-pair weight (matches
+  // the backend's chunk-pair-max semantics).
+  const edgeByKey = new Map<string, GraphEdge>();
+  const passthrough: GraphEdge[] = [];
+  for (const e of raw.edges) {
+    const from = remap.get(e.from) ?? e.from;
+    const to = remap.get(e.to) ?? e.to;
+    if (from === to) continue;
+
+    // Only edges that touch a cluster need aggregation — passthrough the
+    // rest so link-mode graphs (no weight) keep their original edge list
+    // shape and the existing GraphCanvas equality checks don't thrash.
+    const isCluster = from.startsWith(CLUSTER_NODE_ID_PREFIX) || to.startsWith(CLUSTER_NODE_ID_PREFIX);
+    if (!isCluster) {
+      passthrough.push(e);
+      continue;
+    }
+
+    const lo = from < to ? from : to;
+    const hi = from < to ? to : from;
+    const key = `${lo}|${hi}`;
+    const w = typeof e.weight === "number" && Number.isFinite(e.weight) ? e.weight : 0;
+    const existing = edgeByKey.get(key);
+    if (!existing || (existing.weight ?? 0) < w) {
+      const next: GraphEdge = { from: lo, to: hi };
+      if (w > 0) next.weight = w;
+      edgeByKey.set(key, next);
+    }
+  }
+
+  const outEdges = passthrough.concat(Array.from(edgeByKey.values()));
+
+  return {
+    graph: { nodes: outNodes, edges: outEdges },
+    clusters,
+  };
+}


### PR DESCRIPTION
Closes #237. Stacked on #236 — base will rebase to `epic/semantic-embeddings` once that merges.

## Summary

Embedding-mode graph view gets a second toolbar slider **„Cluster"** that collapses tightly-related notes into a single representative super-node ("Oberbegriff"). Default position `1.0` (right edge) = clustering off. Sliding left progressively merges components.

## How it works

Pure helper `clusterGraph(raw, threshold)` runs in the Svelte component between the IPC response and the existing `mountGraph`/`updateGraph` calls — no backend roundtrip per slider tick.

1. **Union-find** over edges with `weight >= cluster_threshold`. Edges without weight (link mode) never union → helper is a no-op there.
2. Components of size ≥ 2 mint a super-node:
   - `id = "cluster:<min_member_id>"` — stable identity across slider ticks.
   - `label = "<representative.label> · +N"`.
   - Representative = max Σ intra-cluster weight, tiebreak by `backlinkCount` desc then alphabetical id asc.
   - `backlinkCount` = sum of members' (drives sigma node sizing so cluster mass is visible).
3. Singletons pass through unchanged.
4. Inter-cluster edges aggregate by **max** member-pair weight — consistent with the backend's chunk-pair-max semantics from #235.
5. Self-loops dropped after collapse.

## UI

- Second slider next to the existing edge-threshold slider, only visible in embedding mode.
- Range: `max(0.55, edge_threshold) … 1.0`, step `0.05`.
- Min clamps **dynamically** to the edge-threshold slider — a `cluster_threshold` below `edge_threshold` would collapse every surviving edge into one mega-cluster, so the UI prevents it.
- Display reads `"aus"` at 1.0, otherwise the rounded value.
- 200ms debounce on the applied value: slider thumb stays responsive, the d3-force simulation rebuilds at most once per drag-pause.
- Per-vault localStorage under new prefix `vaultcore-graph-cluster-`.
- Cluster nodes have empty `path` → existing click handler already no-ops on them.

## Tests

`src/components/Graph/__tests__/clusterGraph.test.ts` (12 specs):

- Passthrough at `threshold >= 1.0`.
- Passthrough on link-mode (weightless) edges regardless of threshold.
- Two-node collapse + cluster-id prefix.
- Stable cluster id (= `cluster:<min_member_id>`) across triangle.
- Representative selection by max Σ weight.
- Tiebreaks: weight tie → backlinkCount → alphabetical.
- Label format `"<rep> · +N"`.
- Singleton passthrough.
- Inter-cluster edge = max member-pair weight.
- Self-loop filtering after total collapse.
- Below-threshold edge between singletons preserved.
- `backlinkCount` sum on super-node.

23/23 graph specs pass (11 existing + 12 new). `svelte-check` clean.

## Out of scope (documented follow-ups)

- TF-IDF / embedding-centroid topic name instead of picking an existing note title for the cluster label.
- Click-to-expand a cluster.
- Position-hint plumbing so super-nodes inherit the representative's previous coordinate (currently they get `populateGraph`'s random disc seed and the force layout resettles them within a tick or two).
- Server-side clustering — only worth it at >100k edge graph scale.

## Test plan

- [ ] Open vault with embeddings indexed, switch graph to **„Semantisch"**.
- [ ] Cluster slider sits at right (`aus`), graph identical to before.
- [ ] Drag cluster slider left in steps — verify components collapse into super-nodes labelled `"<title> · +N"`.
- [ ] Verify cluster slider min jumps when edge-threshold is raised.
- [ ] Reload — cluster slider value persists per vault.
- [ ] Switch to **„Links"** mode — cluster slider hidden, graph unchanged.
- [ ] Switch back to **„Semantisch"** — cluster slider returns at saved value.