### PR TITLE
feat: Semantic Search v1 (epic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ coverage
 src-tauri/target
 src-tauri/gen/schemas
 
+# Bench harness (#207) — transient run output; baseline.json stays tracked.
+src-tauri/benches/latest.json
+
 # Reference material (not part of the codebase)
 VaultCore_MVP_Spezifikation_v3.md
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,107 @@
+# Benchmarks
+
+Reproducible, regression-gated benchmarks for the perf-critical paths in
+VaultCore's semantic search stack. Covers issue [#207](https://github.com/herox215/vaultcore/issues/207).
+
+## What's measured
+
+The `#[ignore]`-gated benches live next to the code they exercise and each
+emits a single `BENCH_JSON {...}` line so the harness can collect them
+without a coupled Criterion or custom bench crate.
+
+| Name                   | Source                                      | What it measures                                                                   |
+| ---------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `single_embed`         | `src/embeddings/service.rs`                 | End-to-end text → 384-d vector latency through `EmbeddingService::embed`.         |
+| `semantic_search_100k` | `src/embeddings/query.rs`                   | Embed + HNSW query against a 100 000-vector index, k=10 ef_search=64.             |
+| `reindex_throughput`   | `src/embeddings/reindex.rs`                 | Files-per-second through the full reindex pipeline (reader → chunker → embed → sink). |
+| `rrf_fuse`             | `src/embeddings/hybrid.rs`                  | Pure-math RRF fusion cost at hybrid-search's top_n=200 per leg.                   |
+
+The spec targets they defend are in `CLAUDE.md` — keep this table in sync if
+that file moves.
+
+## How to run
+
+```bash
+# Full suite. ~2 min on reference hardware (single_embed is ~5 s; 100k index
+# build is the slow part at ~90 s; reindex is 12 s; rrf_fuse is negligible).
+scripts/run-benchmarks.sh
+
+# Write to a custom path (default: src-tauri/benches/latest.json):
+scripts/run-benchmarks.sh /tmp/my-run.json
+
+# Subset via regex filter:
+BENCH_FILTER="single_embed|rrf_fuse" scripts/run-benchmarks.sh
+
+# Bigger reindex (2000 files, ~2 min) — linear-extrapolates to 100k:
+LARGE_REINDEX_BENCH=1 scripts/run-benchmarks.sh
+```
+
+The script shells out to `cargo test --release --features embeddings --
+--ignored --nocapture --test-threads=1` with a `bench_` test-name filter. The
+`--test-threads=1` is load-bearing: the embed bench and the 100k-query bench
+both load the MiniLM model and compete for the ORT global thread pool
+(capped at intra=2/inter=1 per #197).
+
+## Regression gate (>10 %)
+
+```bash
+# After run-benchmarks.sh has produced latest.json:
+scripts/bench-regression.py
+
+# Custom threshold (0.15 = 15 %):
+BENCH_THRESHOLD=0.15 scripts/bench-regression.py
+
+# Explicit paths:
+scripts/bench-regression.py my-run.json my-baseline.json
+```
+
+Exits `1` with a per-metric FAIL line when any tracked field regresses more
+than `BENCH_THRESHOLD` against `src-tauri/benches/baseline.json`. Direction
+is inferred per field: latencies (`*_ms`) are "lower is better", throughput
+(`files_per_sec`) is "higher is better".
+
+A missing metric in the new run is a hard fail (bench disappeared). A new
+metric without a baseline entry is a warn-only (adding a bench is not a
+regression).
+
+## Baseline
+
+`src-tauri/benches/baseline.json` holds reference numbers captured on:
+
+- CPU: 13th Gen Intel Core i7-13700H (20 cores)
+- RAM: 32 GiB
+- OS: Linux 6.19.9-1-cachyos (x86_64)
+- Git SHA: c6ae94a (post-#205)
+
+Values are rounded with a small noise margin — p99 in particular varies run
+to run by up to 2× on shared hardware, so the committed baseline sits above
+the median observed run.
+
+### Updating the baseline
+
+Pick the lowest-noise run you can (no compiles in parallel, no browser open,
+AC plugged in on laptops), then:
+
+```bash
+scripts/run-benchmarks.sh src-tauri/benches/baseline.json
+# edit the JSON: add the hardware block, round p99 upward ~20 % to absorb noise,
+# round throughput downward ~10 %.
+```
+
+Commit baseline changes in a dedicated PR with the reference-hardware specs
+in the commit message. Never update the baseline in the same PR as a perf
+change — reviewers need to see the delta against the prior line in the diff.
+
+## CI integration
+
+Currently not wired into CI (no `.github/workflows/*` in this repo yet).
+Recommended shape when added:
+
+- `workflow_dispatch` + scheduled nightly, **not** blocking per-PR CI — the
+  full run costs ~2 min on cold-cache hosted runners and variance makes
+  per-PR gating brittle.
+- Upload `latest.json` as an artifact, diff against `baseline.json` via
+  `bench-regression.py`, fail the job on non-zero exit.
+- For per-PR perf signal, run only the fast benches (`single_embed`,
+  `rrf_fuse`) with a relaxed 25 % threshold and record the numbers in the
+  PR body.

--- a/e2e/specs/hybrid-search.spec.ts
+++ b/e2e/specs/hybrid-search.spec.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+// #204 AC-4: the OmniSearch content mode routes through hybrid_search, so
+// a query whose keywords do NOT appear in any note can still surface a
+// semantically-related note via the HNSW leg. This spec seeds a vault
+// with a note whose content talks about felines (without using the word
+// "cat"), waits for the embedding pass to finish, then asserts that a
+// search for "cat" returns the note AND that the semantic-only indicator
+// renders on the row — the indicator is the only reliable proof that the
+// vec leg fired instead of a BM25 fallback.
+describe("Hybrid search surfaces semantic-only notes", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    // Seed a note whose content is semantically close to "cat" but shares
+    // no keywords — MiniLM maps pet / feline prose into the same region
+    // as the query "cat", so the RRF vec leg should surface it.
+    fs.writeFileSync(
+      path.join(vault.path, "Feline Ode.md"),
+      [
+        "# Feline Ode",
+        "",
+        "The soft purr of a small tiger nestled in a sunbeam.",
+        "Whiskers twitching, a tiny predator of dust motes.",
+        "Kittens chase shadows across polished floors.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await openVaultInApp(vault.path);
+
+    // Run an initial embedding pass over the fixture vault and wait for
+    // the terminal `done` event. Generous timeout covers ORT session
+    // warmup on first call (the long pole — typically 200–800ms but can
+    // spike on cold machines).
+    await browser.executeAsync((done: (err?: string) => void) => {
+      const hook = window.__e2e__;
+      if (!hook) {
+        done("window.__e2e__ hook missing");
+        return;
+      }
+      void hook
+        .reindexAndWaitDone()
+        .then(() => done())
+        .catch((e: unknown) => done(String(e)));
+    });
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openContentSearch(): Promise<WebdriverIO.Element> {
+    await browser.keys(["Control", "Shift", "f"]);
+    const modal = await browser.$(".vc-quick-switcher-modal");
+    await modal.waitForDisplayed({ timeout: 3000 });
+    return browser.$(".vc-qs-input");
+  }
+
+  async function closeOmni(): Promise<void> {
+    await browser.keys(["Escape"]);
+    await browser
+      .$(".vc-quick-switcher-modal")
+      .waitForDisplayed({ timeout: 2000, reverse: true });
+  }
+
+  it("surfaces a semantically related note that contains none of the query terms", async () => {
+    const input = await openContentSearch();
+    await input.click();
+    // "cat" — not present in Feline Ode.md or any other fixture file.
+    await input.setValue("cat");
+    // Pass the 200ms debounce plus some slack for embed+query.
+    await browser.pause(600);
+
+    const rows = await browser.$$(".vc-search-result-row");
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+
+    const filenames: string[] = [];
+    for (const row of rows) {
+      filenames.push(await textOf(await row.$(".vc-search-result-filename")));
+    }
+    expect(filenames.some((f) => f.includes("Feline Ode"))).toBe(true);
+
+    // The indicator only renders when `vecRank != null && bm25Rank == null`,
+    // which is exactly the "surfaced by the semantic leg alone" case. Its
+    // presence is the sharpest E2E-visible signal that hybrid_search did
+    // more than fall back to BM25-only.
+    const indicator = await browser.$(".vc-search-result-semantic-indicator");
+    await indicator.waitForDisplayed({ timeout: 2000 });
+    expect(await indicator.getAttribute("aria-label")).toMatch(/semantisch/i);
+
+    await closeOmni();
+  });
+});

--- a/scripts/bench-regression.py
+++ b/scripts/bench-regression.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""bench-regression.py — #207 guard that fails CI on >10% slowdown.
+
+Compares a fresh benchmark run (as produced by `scripts/run-benchmarks.sh`)
+against a committed baseline and exits non-zero when any tracked metric
+regresses beyond the configured threshold.
+
+Metric handling:
+  - Latency fields (*_ms): regression = new > baseline * (1 + threshold).
+  - Throughput fields (files_per_sec): regression = new < baseline * (1 - threshold).
+  - Metrics missing from the new run → hard fail (a bench disappeared).
+  - Metrics in the new run but not in the baseline → warn but don't fail
+    (so adding a bench is not itself a regression).
+
+Usage:
+  scripts/bench-regression.py              # compares latest.json vs baseline.json
+  scripts/bench-regression.py new.json baseline.json
+  BENCH_THRESHOLD=0.15 scripts/bench-regression.py  # 15% instead of 10%
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_NEW = REPO_ROOT / "src-tauri" / "benches" / "latest.json"
+DEFAULT_BASELINE = REPO_ROOT / "src-tauri" / "benches" / "baseline.json"
+
+# Per AC #3: >10% slowdown must fail the job.
+THRESHOLD = float(os.environ.get("BENCH_THRESHOLD", "0.10"))
+
+# (metric_name, direction) — "lower" means smaller is better (latency),
+# "higher" means larger is better (throughput). Driven by the `name` field
+# the benches emit, not by file layout.
+TRACKED: dict[str, dict[str, str]] = {
+    "single_embed":         {"p50_ms": "lower", "p99_ms": "lower"},
+    "semantic_search_100k": {"p50_ms": "lower", "p99_ms": "lower"},
+    "reindex_throughput":   {"files_per_sec": "higher"},
+    "rrf_fuse":             {"p50_ms": "lower", "p99_ms": "lower"},
+}
+
+
+def load(path: Path) -> dict[str, dict]:
+    with path.open() as fh:
+        doc = json.load(fh)
+    return {entry["name"]: entry for entry in doc.get("results", [])}
+
+
+def compare(new: dict[str, dict], baseline: dict[str, dict]) -> list[str]:
+    failures: list[str] = []
+    for name, fields in TRACKED.items():
+        if name not in new:
+            failures.append(f"[MISSING] bench `{name}` did not appear in new run")
+            continue
+        if name not in baseline:
+            print(f"[warn] bench `{name}` has no baseline entry — skipping")
+            continue
+        for field, direction in fields.items():
+            if field not in new[name] or field not in baseline[name]:
+                failures.append(
+                    f"[MISSING FIELD] `{name}.{field}` absent "
+                    f"(new={field in new[name]}, baseline={field in baseline[name]})"
+                )
+                continue
+            n = float(new[name][field])
+            b = float(baseline[name][field])
+            if direction == "lower":
+                budget = b * (1 + THRESHOLD)
+                regressed = n > budget
+                delta_pct = (n - b) / b * 100.0 if b else 0.0
+            else:
+                budget = b * (1 - THRESHOLD)
+                regressed = n < budget
+                delta_pct = (n - b) / b * 100.0 if b else 0.0
+            status = "FAIL" if regressed else "ok"
+            print(
+                f"[{status}] {name}.{field}: baseline={b:.4f} "
+                f"new={n:.4f} ({delta_pct:+.1f}%, budget={budget:.4f}, {direction})"
+            )
+            if regressed:
+                failures.append(
+                    f"{name}.{field} regressed {delta_pct:+.1f}% "
+                    f"(baseline={b:.4f}, new={n:.4f}, threshold={THRESHOLD * 100:.0f}%)"
+                )
+    return failures
+
+
+def main() -> int:
+    new_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_NEW
+    base_path = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_BASELINE
+
+    if not new_path.exists():
+        print(f"error: new results file not found: {new_path}", file=sys.stderr)
+        return 2
+    if not base_path.exists():
+        print(f"error: baseline file not found: {base_path}", file=sys.stderr)
+        return 2
+
+    new = load(new_path)
+    baseline = load(base_path)
+
+    print(f"[bench-regression] threshold={THRESHOLD * 100:.0f}%")
+    print(f"[bench-regression] new={new_path}")
+    print(f"[bench-regression] baseline={base_path}")
+    print()
+
+    failures = compare(new, baseline)
+
+    print()
+    if failures:
+        print(f"[bench-regression] {len(failures)} regression(s):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("[bench-regression] no regressions above threshold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# run-benchmarks.sh — #207 benchmark harness runner.
+#
+# Runs the `#[ignore]`-gated benches in release mode with the `embeddings`
+# feature enabled, parses the `BENCH_JSON {...}` lines they emit on stderr,
+# and writes a combined JSON document to the target path (default:
+# `src-tauri/benches/latest.json`).
+#
+# The benches themselves live next to the code they measure:
+#   - service.rs            bench_single_embed_p50_p99       → "single_embed"
+#   - query.rs              bench_semantic_query_p50_under_5ms → "semantic_search_100k"
+#   - reindex.rs            bench_reindex_throughput         → "reindex_throughput"
+#   - hybrid.rs             bench_rrf_fuse_p50_p99           → "rrf_fuse"
+#
+# Usage:
+#   scripts/run-benchmarks.sh                         # writes src-tauri/benches/latest.json
+#   scripts/run-benchmarks.sh path/to/out.json        # custom output path
+#   BENCH_FILTER="single_embed|rrf_fuse" scripts/run-benchmarks.sh  # subset
+#
+# Env overrides:
+#   CARGO           cargo binary (default: cargo)
+#   BENCH_FEATURES  feature list (default: embeddings)
+#   BENCH_FILTER    test-name regex passed to cargo test (default: bench_)
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out_path="${1:-$repo_root/src-tauri/benches/latest.json}"
+
+cargo_bin="${CARGO:-cargo}"
+features="${BENCH_FEATURES:-embeddings}"
+filter="${BENCH_FILTER:-bench_}"
+
+tmp_out="$(mktemp)"
+trap 'rm -f "$tmp_out"' EXIT
+
+echo "[bench] cargo test --release --features $features -- --ignored --nocapture $filter" >&2
+(
+  cd "$repo_root/src-tauri"
+  # stderr carries the BENCH_JSON lines (eprintln!); merge to stdout for capture.
+  "$cargo_bin" test --release --features "$features" --tests -- \
+    --ignored --nocapture --test-threads=1 "$filter" 2>&1
+) | tee "$tmp_out"
+
+# Collect every BENCH_JSON {...} record. cargo test sometimes prepends
+# `test ... ok BENCH_JSON {...}` onto the same line when eprintln! is the last
+# line a test emits, so we match `BENCH_JSON {...}` anywhere, not just at BOL.
+# The grep -o emits one record per line (non-greedy via perl regex).
+entries="$(grep -oE 'BENCH_JSON \{[^}]*\}' "$tmp_out" | sed -E 's/^BENCH_JSON //' || true)"
+
+if [ -z "$entries" ]; then
+  echo "[bench] no BENCH_JSON lines emitted — did any #[ignore] benches run?" >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$out_path")"
+
+# Build the combined document with jq: wrap the per-bench objects in an array
+# under `results`, plus a timestamp + git SHA for provenance.
+git_sha="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '%s\n' "$entries" \
+  | jq -s --arg sha "$git_sha" --arg ts "$timestamp" \
+      '{timestamp: $ts, git_sha: $sha, results: .}' \
+  > "$out_path"
+
+echo "[bench] wrote $out_path" >&2
+cat "$out_path"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1131,21 +1131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
-name = "fastembed"
-version = "5.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f54fc1188b7f7eac8f47be2ab7b3a79ffd842cc8ff2e38316dd59ba4858890e"
-dependencies = [
- "anyhow",
- "ndarray",
- "ort",
- "safetensors",
- "serde",
- "serde_json",
- "tokenizers",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,8 +1703,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -3919,17 +3902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "safetensors"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
-dependencies = [
- "hashbrown 0.16.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5605,14 +5577,15 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "env_logger",
- "fastembed",
  "flate2",
  "fs2",
  "hnsw_rs",
  "log",
+ "ndarray",
  "notify-debouncer-full",
  "nucleo-matcher",
  "ort",
+ "ort-sys",
  "pulldown-cmark",
  "rayon",
  "regex",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -62,6 +62,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "anndists"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8396b473aa0bceed68fb32462505387ea39fa47c7029417e0a49f10592b036"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "simdeez",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +216,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -467,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +596,16 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
  "libc",
+]
+
+[[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1012,6 +1055,18 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "env_filter"
@@ -1649,6 +1704,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1684,10 +1741,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hnsw_rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5258f079b97bf2e8311ff9579e903c899dcbac0d9a138d62e9a066778bd07"
+dependencies = [
+ "anndists",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "lazy_static",
+ "log",
+ "mmap-rs",
+ "num-traits",
+ "num_cpus",
+ "parking_lot",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+]
 
 [[package]]
 name = "html5ever"
@@ -2231,6 +2319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2455,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2498,6 +2601,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mmap-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecce9d566cb9234ae3db9e249c8b55665feaaf32b0859ff1e27e310d2beb3d8"
+dependencies = [
+ "bitflags 2.11.0",
+ "combine",
+ "libc",
+ "mach2",
+ "nix",
+ "sysctl",
+ "thiserror 2.0.18",
+ "widestring",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "monostate"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,6 +2718,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,6 +2826,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4106,6 +4248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdeez"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bc92272e09cdb506befe0c48f5f865fdda52e77bbe1738f74bed79f29c4733"
+dependencies = [
+ "cfg-if",
+ "paste",
+]
+
+[[package]]
 name = "similar"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,6 +4496,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,7 +4702,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4619,7 +4785,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4766,7 +4932,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4791,7 +4957,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5442,6 +5608,7 @@ dependencies = [
  "fastembed",
  "flate2",
  "fs2",
+ "hnsw_rs",
  "log",
  "notify-debouncer-full",
  "nucleo-matcher",
@@ -5745,7 +5912,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5769,9 +5936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -5817,6 +5990,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6020,6 +6202,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6077,6 +6274,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6095,6 +6298,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6110,6 +6319,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6143,6 +6358,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6158,6 +6379,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6179,6 +6406,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6194,6 +6427,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6373,7 +6612,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +174,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -243,7 +263,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -378,6 +398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +483,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -632,12 +676,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -655,13 +723,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -678,6 +766,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -925,10 +1044,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
+name = "fastembed"
+version = "5.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f54fc1188b7f7eac8f47be2ab7b3a79ffd842cc8ff2e38316dd59ba4858890e"
+dependencies = [
+ "anyhow",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+]
 
 [[package]]
 name = "fastrand"
@@ -1480,6 +1620,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2079,7 +2221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2097,6 +2239,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2167,6 +2319,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2375,16 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "measure_time"
@@ -2276,6 +2454,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2501,21 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "ndk"
@@ -2405,10 +2620,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2584,6 +2817,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2852,25 @@ checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+dependencies = [
+ "libloading 0.9.0",
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 
 [[package]]
 name = "ownedbytes"
@@ -2654,6 +2928,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -3084,6 +3364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3119,6 +3419,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3146,6 +3455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3468,17 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
 ]
 
 [[package]]
@@ -3341,6 +3667,17 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -3575,7 +3912,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3761,10 +4098,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -4480,6 +4835,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4805,6 +5193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4821,6 +5218,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"
@@ -4889,9 +5292,11 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "env_logger",
+ "fastembed",
  "log",
  "notify-debouncer-full",
  "nucleo-matcher",
+ "ort",
  "pulldown-cmark",
  "rayon",
  "regex",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -118,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +778,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1125,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1203,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2257,7 +2298,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2924,7 +2968,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3139,6 +3183,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3501,6 +3551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3678,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3727,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4064,7 +4172,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4175,6 +4283,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4437,6 +4551,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5226,6 +5351,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5293,6 +5440,8 @@ dependencies = [
  "base64 0.22.1",
  "env_logger",
  "fastembed",
+ "flate2",
+ "fs2",
  "log",
  "notify-debouncer-full",
  "nucleo-matcher",
@@ -5306,6 +5455,7 @@ dependencies = [
  "sha2",
  "similar",
  "tantivy",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -5313,7 +5463,10 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml 0.8.2",
+ "ureq",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -5566,6 +5719,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5793,6 +5964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6220,6 +6400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6284,6 +6474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6317,10 +6513,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5462,6 +5462,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tempfile",
  "thiserror 2.0.18",
+ "tokenizers",
  "tokio",
  "toml 0.8.2",
  "ureq",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,10 +62,11 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["load-dy
 # Used by the embedding chunker (#195) to split notes into overlapping
 # ≤256-token windows before they reach the embedder.
 tokenizers = { version = "0.22", default-features = false, features = ["onig"], optional = true }
+hnsw_rs = { version = "0.3.4", optional = true, features = ["simdeez_f"] }
 
 [features]
 default = ["embeddings"]
-embeddings = ["dep:fastembed", "dep:ort", "dep:tokenizers"]
+embeddings = ["dep:fastembed", "dep:ort", "dep:tokenizers", "dep:hnsw_rs"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,16 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.5.6", features = [] }
+# Used by build.rs to fetch + verify the bundled libonnxruntime (#191) and
+# MiniLM model (#192). Kept lean: blocking ureq, manual TOML parse, sha2,
+# flate2/tar for .tgz, zip for Windows .zip.
+ureq = { version = "2", features = ["tls"] }
+sha2 = "0.10"
+flate2 = "1"
+tar = "0.4"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+fs2 = "0.4"
+toml = { version = "0.8", default-features = false, features = ["parse"] }
 
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,23 +50,27 @@ serde_yml = "0.0.12"
 base64 = "0.22"
 
 # Embeddings stack — gated behind `embeddings` feature.
-# fastembed re-exports `ort` with the `load-dynamic` feature, so libonnxruntime
-# is dlopen'd at runtime from a Tauri-bundled resource (#191) instead of being
-# linked statically. Default features are disabled to suppress the binary
-# downloader (`ort-download-binaries-native-tls`) and unused candle backends.
-fastembed = { version = "5", default-features = false, features = ["ort-load-dynamic"], optional = true }
-# Pin must match fastembed's exact `ort` requirement — fastembed 5.13.2 needs rc.11.
+# `ort` with the `load-dynamic` feature dlopen's libonnxruntime at runtime
+# from a Tauri-bundled resource (#191) instead of linking statically.
+# Default features are disabled to suppress the binary downloader
+# (`ort-download-binaries-native-tls`) and unused candle backends.
+# #205: SessionBuilder is used directly — no fastembed wrapper — so we can
+# set `memory_pattern=false` and opt into an env-level CPU arena allocator
+# with `arena_extend_strategy=kSameAsRequested`.
 ort = { version = "=2.0.0-rc.11", default-features = false, features = ["load-dynamic", "ndarray"], optional = true }
-# Direct dep on the same `tokenizers` crate fastembed pulls in transitively
-# (Cargo.lock pins 0.22.2). Same feature set so cargo unifies to one copy.
+ort-sys = { version = "=2.0.0-rc.11", optional = true }
+# ndarray is used to build `[batch, seq]` i64 tensors for MiniLM inputs.
+# Version pinned to ort's requirement so cargo unifies on one copy.
+ndarray = { version = "0.17", optional = true }
 # Used by the embedding chunker (#195) to split notes into overlapping
-# ≤256-token windows before they reach the embedder.
+# ≤256-token windows, and by `EmbeddingService` (#205) to tokenize queries
+# directly without the fastembed wrapper.
 tokenizers = { version = "0.22", default-features = false, features = ["onig"], optional = true }
 hnsw_rs = { version = "0.3.4", optional = true, features = ["simdeez_f"] }
 
 [features]
 default = ["embeddings"]
-embeddings = ["dep:fastembed", "dep:ort", "dep:tokenizers", "dep:hnsw_rs"]
+embeddings = ["dep:ort", "dep:ort-sys", "dep:ndarray", "dep:tokenizers", "dep:hnsw_rs"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,10 +57,15 @@ base64 = "0.22"
 fastembed = { version = "5", default-features = false, features = ["ort-load-dynamic"], optional = true }
 # Pin must match fastembed's exact `ort` requirement — fastembed 5.13.2 needs rc.11.
 ort = { version = "=2.0.0-rc.11", default-features = false, features = ["load-dynamic", "ndarray"], optional = true }
+# Direct dep on the same `tokenizers` crate fastembed pulls in transitively
+# (Cargo.lock pins 0.22.2). Same feature set so cargo unifies to one copy.
+# Used by the embedding chunker (#195) to split notes into overlapping
+# ≤256-token windows before they reach the embedder.
+tokenizers = { version = "0.22", default-features = false, features = ["onig"], optional = true }
 
 [features]
 default = ["embeddings"]
-embeddings = ["dep:fastembed", "dep:ort"]
+embeddings = ["dep:fastembed", "dep:ort", "dep:tokenizers"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,5 +39,18 @@ pulldown-cmark = "0.13"
 serde_yml = "0.0.12"
 base64 = "0.22"
 
+# Embeddings stack — gated behind `embeddings` feature.
+# fastembed re-exports `ort` with the `load-dynamic` feature, so libonnxruntime
+# is dlopen'd at runtime from a Tauri-bundled resource (#191) instead of being
+# linked statically. Default features are disabled to suppress the binary
+# downloader (`ort-download-binaries-native-tls`) and unused candle backends.
+fastembed = { version = "5", default-features = false, features = ["ort-load-dynamic"], optional = true }
+# Pin must match fastembed's exact `ort` requirement — fastembed 5.13.2 needs rc.11.
+ort = { version = "=2.0.0-rc.11", default-features = false, features = ["load-dynamic", "ndarray"], optional = true }
+
+[features]
+default = ["embeddings"]
+embeddings = ["dep:fastembed", "dep:ort"]
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/benches/baseline.json
+++ b/src-tauri/benches/baseline.json
@@ -1,0 +1,46 @@
+{
+  "timestamp": "2026-04-19T14:54:30Z",
+  "git_sha": "c6ae94a",
+  "hardware": {
+    "cpu": "13th Gen Intel Core i7-13700H",
+    "cores": 20,
+    "ram_gb": 32,
+    "arch": "x86_64",
+    "os": "Linux 6.19.9-1-cachyos"
+  },
+  "notes": [
+    "Captured on the reference dev machine above under no-load conditions.",
+    "p99 figures are noisier than p50 — allow extra headroom when comparing.",
+    "reindex_throughput uses the 200-file variant; set LARGE_REINDEX_BENCH=1 for 2000.",
+    "Regenerate via scripts/run-benchmarks.sh src-tauri/benches/baseline.json",
+    "and commit in a separate hardware-update PR."
+  ],
+  "results": [
+    {
+      "name": "rrf_fuse",
+      "p50_ms": 0.06,
+      "p99_ms": 0.2,
+      "n": 1000,
+      "per_leg": 200
+    },
+    {
+      "name": "semantic_search_100k",
+      "p50_ms": 2.2,
+      "p99_ms": 8.0,
+      "n": 100,
+      "vectors": 100000
+    },
+    {
+      "name": "reindex_throughput",
+      "files_per_sec": 16.0,
+      "files": 200,
+      "elapsed_ms": 12500.0
+    },
+    {
+      "name": "single_embed",
+      "p50_ms": 2.0,
+      "p99_ms": 3.2,
+      "n": 200
+    }
+  ]
+}

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,215 @@
+//! Build-script: ensures the bundled libonnxruntime (#191) and MiniLM model
+//! (#192) are present in `src-tauri/resources/...` before tauri-build runs.
+//!
+//! Strategy: skip-on-cached-with-sha. The first build downloads the pinned
+//! upstream archive into a tempfile, verifies SHA-256 against
+//! `resources/checksums.toml`, extracts only the dylib (or model files),
+//! and writes them into `resources/onnxruntime/<platform>/`. Subsequent
+//! builds compare the on-disk SHA against the manifest and short-circuit.
+//!
+//! Concurrent cargo workers are serialised through an exclusive file lock
+//! on `resources/.fetch.lock` so two parallel `cargo test` runs don't race
+//! on the same destination file.
+//!
+//! Network failures only emit a `cargo:warning=...` and continue — the
+//! embedding smoke test (#190) is gated and will skip cleanly when the
+//! runtime / model isn't present.
+
+use std::env;
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
+
 fn main() {
-  tauri_build::build()
+    println!("cargo:rerun-if-changed=resources/checksums.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let resources_dir = manifest_dir.join("resources");
+
+    if let Err(e) = ensure_assets(&resources_dir) {
+        // Non-fatal — gated tests (#190) skip when runtime is missing.
+        println!("cargo:warning=onnx asset fetch skipped: {e}");
+    }
+
+    tauri_build::build()
+}
+
+#[derive(Debug)]
+struct AssetError(String);
+impl std::fmt::Display for AssetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for AssetError {}
+impl From<io::Error> for AssetError {
+    fn from(e: io::Error) -> Self {
+        AssetError(e.to_string())
+    }
+}
+impl From<toml::de::Error> for AssetError {
+    fn from(e: toml::de::Error) -> Self {
+        AssetError(e.to_string())
+    }
+}
+
+fn ensure_assets(resources_dir: &Path) -> Result<(), AssetError> {
+    fs::create_dir_all(resources_dir)?;
+    let lock_path = resources_dir.join(".fetch.lock");
+    let lock_file = File::create(&lock_path)?;
+    lock_file.lock_exclusive()?;
+
+    let manifest_text = fs::read_to_string(resources_dir.join("checksums.toml"))
+        .map_err(|e| AssetError(format!("read checksums.toml: {e}")))?;
+    let manifest: toml::Value = toml::from_str(&manifest_text)?;
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let platform = match (target_os.as_str(), target_arch.as_str()) {
+        ("linux", "x86_64") => "linux-x86_64",
+        ("macos", "aarch64") => "macos-aarch64",
+        ("macos", "x86_64") => "macos-x86_64",
+        ("windows", "x86_64") => "windows-x86_64",
+        _ => {
+            return Err(AssetError(format!(
+                "no onnxruntime asset pinned for {target_os}/{target_arch}"
+            )));
+        }
+    };
+
+    let entry = manifest
+        .get("onnxruntime")
+        .and_then(|v| v.get(platform))
+        .ok_or_else(|| AssetError(format!("missing onnxruntime.{platform}")))?;
+
+    let url = entry
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing url".into()))?;
+    let sha256 = entry
+        .get("sha256")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing sha256".into()))?;
+    let archive_path = entry
+        .get("archive_path")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing archive_path".into()))?;
+    let dylib_name = entry
+        .get("dylib_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError("missing dylib_name".into()))?;
+
+    let dest_dir = resources_dir.join("onnxruntime");
+    fs::create_dir_all(&dest_dir)?;
+    let dest = dest_dir.join(dylib_name);
+
+    if dest.exists() {
+        // Already extracted — accept as-is. We don't re-hash the dylib here
+        // because the archive SHA does not equal the dylib SHA, and dylib
+        // SHA varies across upstream rebuilds. The trust anchor is the
+        // archive SHA at download time.
+        return Ok(());
+    }
+
+    println!("cargo:warning=fetching {url}");
+    let archive_bytes = http_get(url)?;
+    verify_sha256(&archive_bytes, sha256)?;
+
+    if url.ends_with(".tgz") || url.ends_with(".tar.gz") {
+        extract_from_tgz(&archive_bytes, archive_path, &dest)?;
+    } else if url.ends_with(".zip") {
+        extract_from_zip(&archive_bytes, archive_path, &dest)?;
+    } else {
+        return Err(AssetError(format!("unsupported archive extension: {url}")));
+    }
+    Ok(())
+}
+
+fn http_get(url: &str) -> Result<Vec<u8>, AssetError> {
+    let resp = ureq::get(url)
+        .call()
+        .map_err(|e| AssetError(format!("http get {url}: {e}")))?;
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .read_to_end(&mut buf)
+        .map_err(|e| AssetError(format!("read body: {e}")))?;
+    Ok(buf)
+}
+
+fn verify_sha256(bytes: &[u8], expected: &str) -> Result<(), AssetError> {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected.to_lowercase() {
+        return Err(AssetError(format!(
+            "sha256 mismatch: expected {expected}, got {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn extract_from_tgz(
+    archive_bytes: &[u8],
+    inner_path: &str,
+    dest: &Path,
+) -> Result<(), AssetError> {
+    let dec = flate2::read::GzDecoder::new(archive_bytes);
+    let mut tar = tar::Archive::new(dec);
+    for entry in tar
+        .entries()
+        .map_err(|e| AssetError(format!("tar iter: {e}")))?
+    {
+        let mut entry = entry.map_err(|e| AssetError(format!("tar entry: {e}")))?;
+        let path = entry
+            .path()
+            .map_err(|e| AssetError(format!("tar path: {e}")))?
+            .into_owned();
+        // tar entries may begin with "./" — strip for comparison.
+        let trimmed = path.strip_prefix("./").unwrap_or(&path);
+        if trimmed == Path::new(inner_path) {
+            write_atomic(dest, |f| {
+                io::copy(&mut entry, f)?;
+                Ok(())
+            })?;
+            return Ok(());
+        }
+    }
+    Err(AssetError(format!(
+        "{inner_path} not found in tgz archive"
+    )))
+}
+
+fn extract_from_zip(
+    archive_bytes: &[u8],
+    inner_path: &str,
+    dest: &Path,
+) -> Result<(), AssetError> {
+    let cursor = io::Cursor::new(archive_bytes);
+    let mut zip = zip::ZipArchive::new(cursor)
+        .map_err(|e| AssetError(format!("zip open: {e}")))?;
+    let mut entry = zip
+        .by_name(inner_path)
+        .map_err(|e| AssetError(format!("{inner_path} not in zip: {e}")))?;
+    write_atomic(dest, |f| {
+        io::copy(&mut entry, f)?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+fn write_atomic<F: FnOnce(&mut File) -> Result<(), io::Error>>(
+    dest: &Path,
+    write: F,
+) -> Result<(), AssetError> {
+    let tmp = dest.with_extension("tmp");
+    let mut f = File::create(&tmp)?;
+    write(&mut f).map_err(|e| AssetError(format!("write tmp: {e}")))?;
+    f.flush()?;
+    drop(f);
+    fs::rename(&tmp, dest)?;
+    Ok(())
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -76,49 +76,41 @@ fn ensure_assets(resources_dir: &Path) -> Result<(), AssetError> {
         ("windows", "x86_64") => "windows-x86_64",
         _ => {
             return Err(AssetError(format!(
-                "no onnxruntime asset pinned for {target_os}/{target_arch}"
+                "no asset pinned for {target_os}/{target_arch}"
             )));
         }
     };
 
+    ensure_onnxruntime(&manifest, resources_dir, platform)?;
+    ensure_model(&manifest, resources_dir, platform)?;
+    Ok(())
+}
+
+fn ensure_onnxruntime(
+    manifest: &toml::Value,
+    resources_dir: &Path,
+    platform: &str,
+) -> Result<(), AssetError> {
     let entry = manifest
         .get("onnxruntime")
         .and_then(|v| v.get(platform))
         .ok_or_else(|| AssetError(format!("missing onnxruntime.{platform}")))?;
 
-    let url = entry
-        .get("url")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing url".into()))?;
-    let sha256 = entry
-        .get("sha256")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing sha256".into()))?;
-    let archive_path = entry
-        .get("archive_path")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing archive_path".into()))?;
-    let dylib_name = entry
-        .get("dylib_name")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| AssetError("missing dylib_name".into()))?;
+    let url = required_str(entry, "url")?;
+    let sha256 = required_str(entry, "sha256")?;
+    let archive_path = required_str(entry, "archive_path")?;
+    let dylib_name = required_str(entry, "dylib_name")?;
 
     let dest_dir = resources_dir.join("onnxruntime");
     fs::create_dir_all(&dest_dir)?;
     let dest = dest_dir.join(dylib_name);
-
     if dest.exists() {
-        // Already extracted — accept as-is. We don't re-hash the dylib here
-        // because the archive SHA does not equal the dylib SHA, and dylib
-        // SHA varies across upstream rebuilds. The trust anchor is the
-        // archive SHA at download time.
         return Ok(());
     }
 
     println!("cargo:warning=fetching {url}");
     let archive_bytes = http_get(url)?;
     verify_sha256(&archive_bytes, sha256)?;
-
     if url.ends_with(".tgz") || url.ends_with(".tar.gz") {
         extract_from_tgz(&archive_bytes, archive_path, &dest)?;
     } else if url.ends_with(".zip") {
@@ -128,6 +120,80 @@ fn ensure_assets(resources_dir: &Path) -> Result<(), AssetError> {
     }
     Ok(())
 }
+
+fn ensure_model(
+    manifest: &toml::Value,
+    resources_dir: &Path,
+    platform: &str,
+) -> Result<(), AssetError> {
+    let model_block = match manifest.get("model") {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let id = required_str(model_block, "id")?;
+    let dest_dir = resources_dir.join("models").join(id);
+    fs::create_dir_all(&dest_dir)?;
+
+    // Per-arch ONNX file (renamed to model.onnx so embeddings code stays
+    // architecture-agnostic).
+    let arch_entry = model_block
+        .get(platform)
+        .ok_or_else(|| AssetError(format!("missing model.{platform}")))?;
+    fetch_one_file(arch_entry, &dest_dir)?;
+
+    // Architecture-shared tokenizer + config files.
+    if let Some(shared) = model_block.get("shared").and_then(|v| v.as_table()) {
+        for entry in shared.values() {
+            fetch_one_file(entry, &dest_dir)?;
+        }
+    }
+
+    // Bundle Apache-2.0 LICENSE + NOTICE next to the model files. Both are
+    // required to satisfy the upstream Apache-2.0 attribution clause.
+    write_if_missing(&dest_dir.join("LICENSE"), APACHE_2_0_LICENSE)?;
+    write_if_missing(&dest_dir.join("NOTICE"), MODEL_NOTICE)?;
+    Ok(())
+}
+
+fn fetch_one_file(entry: &toml::Value, dest_dir: &Path) -> Result<(), AssetError> {
+    let url = required_str(entry, "url")?;
+    let sha256 = required_str(entry, "sha256")?;
+    let dest_name = required_str(entry, "dest_name")?;
+    let dest = dest_dir.join(dest_name);
+    if dest.exists() {
+        return Ok(());
+    }
+    println!("cargo:warning=fetching {url}");
+    let bytes = http_get(url)?;
+    verify_sha256(&bytes, sha256)?;
+    write_atomic(&dest, |f| f.write_all(&bytes))?;
+    Ok(())
+}
+
+fn required_str<'a>(v: &'a toml::Value, key: &str) -> Result<&'a str, AssetError> {
+    v.get(key)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AssetError(format!("missing field: {key}")))
+}
+
+fn write_if_missing(path: &Path, contents: &str) -> Result<(), AssetError> {
+    if path.exists() {
+        return Ok(());
+    }
+    write_atomic(path, |f| f.write_all(contents.as_bytes()))
+}
+
+const MODEL_NOTICE: &str = "all-MiniLM-L6-v2 (sentence-transformers)\n\
+Copyright sentence-transformers contributors\n\
+Licensed under the Apache License, Version 2.0.\n\
+\n\
+Source: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2\n\
+\n\
+This product bundles the architecture-specific INT8 / UINT8 ONNX export\n\
+of the model (`model_quint8_avx2.onnx` for x86_64,\n`model_qint8_arm64.onnx`\n\
+for aarch64). The original model card and license live upstream.\n";
+
+const APACHE_2_0_LICENSE: &str = include_str!("resources/LICENSE-APACHE-2.0");
 
 fn http_get(url: &str) -> Result<Vec<u8>, AssetError> {
     let resp = ureq::get(url)

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -148,9 +148,11 @@ fn ensure_model(
         }
     }
 
-    // Bundle Apache-2.0 LICENSE + NOTICE next to the model files. Both are
-    // required to satisfy the upstream Apache-2.0 attribution clause.
-    write_if_missing(&dest_dir.join("LICENSE"), APACHE_2_0_LICENSE)?;
+    // Bundle model LICENSE + NOTICE. e5-small is MIT (different from the
+    // Apache-2.0 MiniLM predecessor); ship the MIT text verbatim next to the
+    // binary so the copyright + permission notice travel with the model as
+    // the license requires.
+    write_if_missing(&dest_dir.join("LICENSE"), MIT_LICENSE)?;
     write_if_missing(&dest_dir.join("NOTICE"), MODEL_NOTICE)?;
     Ok(())
 }
@@ -183,17 +185,19 @@ fn write_if_missing(path: &Path, contents: &str) -> Result<(), AssetError> {
     write_atomic(path, |f| f.write_all(contents.as_bytes()))
 }
 
-const MODEL_NOTICE: &str = "all-MiniLM-L6-v2 (sentence-transformers)\n\
-Copyright sentence-transformers contributors\n\
-Licensed under the Apache License, Version 2.0.\n\
+const MODEL_NOTICE: &str = "multilingual-e5-small\n\
+Copyright (c) 2023 Liang Wang, Nan Yang, Xiaolong Huang, Linjun Yang,\n\
+Rangan Majumder, Furu Wei (Microsoft / intfloat).\n\
+Licensed under the MIT License.\n\
 \n\
-Source: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2\n\
+Source (upstream):   https://huggingface.co/intfloat/multilingual-e5-small\n\
+Source (ONNX INT8):  https://huggingface.co/Xenova/multilingual-e5-small\n\
 \n\
-This product bundles the architecture-specific INT8 / UINT8 ONNX export\n\
-of the model (`model_quint8_avx2.onnx` for x86_64,\n`model_qint8_arm64.onnx`\n\
-for aarch64). The original model card and license live upstream.\n";
+This product bundles the portable INT8 ONNX export (`model_quantized.onnx`)\n\
+from Xenova's repackaging, which runs on every VaultCore target CPU\n\
+(x86_64 + aarch64). The original model card and license live upstream.\n";
 
-const APACHE_2_0_LICENSE: &str = include_str!("resources/LICENSE-APACHE-2.0");
+const MIT_LICENSE: &str = include_str!("resources/LICENSE-MIT");
 
 fn http_get(url: &str) -> Result<Vec<u8>, AssetError> {
     let resp = ureq::get(url)

--- a/src-tauri/resources/.gitignore
+++ b/src-tauri/resources/.gitignore
@@ -1,5 +1,8 @@
 # Binary assets fetched by build.rs are pinned via checksums.toml and
-# kept out of git. Only this file and checksums.toml are tracked.
+# kept out of git. Only this file, checksums.toml, and the upstream
+# Apache-2.0 LICENSE template (used by build.rs to populate model
+# resource directories) are tracked.
 *
 !.gitignore
 !checksums.toml
+!LICENSE-APACHE-2.0

--- a/src-tauri/resources/.gitignore
+++ b/src-tauri/resources/.gitignore
@@ -1,8 +1,11 @@
 # Binary assets fetched by build.rs are pinned via checksums.toml and
-# kept out of git. Only this file, checksums.toml, and the upstream
-# Apache-2.0 LICENSE template (used by build.rs to populate model
-# resource directories) are tracked.
+# kept out of git. Only this file, checksums.toml, and the LICENSE
+# templates (used by build.rs to populate model resource directories)
+# are tracked. LICENSE-APACHE-2.0 is kept for historical bundles and any
+# future Apache-2.0 model; LICENSE-MIT is the active one for the bundled
+# multilingual-e5-small model (#233).
 *
 !.gitignore
 !checksums.toml
 !LICENSE-APACHE-2.0
+!LICENSE-MIT

--- a/src-tauri/resources/.gitignore
+++ b/src-tauri/resources/.gitignore
@@ -1,0 +1,5 @@
+# Binary assets fetched by build.rs are pinned via checksums.toml and
+# kept out of git. Only this file and checksums.toml are tracked.
+*
+!.gitignore
+!checksums.toml

--- a/src-tauri/resources/LICENSE-APACHE-2.0
+++ b/src-tauri/resources/LICENSE-APACHE-2.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src-tauri/resources/LICENSE-MIT
+++ b/src-tauri/resources/LICENSE-MIT
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2023 intfloat (Liang Wang, Nan Yang, Xiaolong Huang,
+Linjun Yang, Rangan Majumder, Furu Wei — Microsoft)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src-tauri/resources/checksums.toml
+++ b/src-tauri/resources/checksums.toml
@@ -1,0 +1,36 @@
+# Pinned third-party assets fetched by build.rs (#191, #192).
+#
+# Each entry pins the upstream archive and the file path inside it that
+# build.rs extracts into `src-tauri/resources/onnxruntime/<platform>/`
+# or `src-tauri/resources/models/<id>/`. SHA-256 is verified before
+# extraction; mismatch aborts the build.
+
+[onnxruntime]
+version = "1.23.2"
+
+# Required ORT runtime version for `ort = =2.0.0-rc.11`.
+# Sources: https://github.com/microsoft/onnxruntime/releases/tag/v1.23.2
+
+[onnxruntime.linux-x86_64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz"
+sha256 = "1fa4dcaef22f6f7d5cd81b28c2800414350c10116f5fdd46a2160082551c5f9b"
+archive_path = "onnxruntime-linux-x64-1.23.2/lib/libonnxruntime.so.1.23.2"
+dylib_name = "libonnxruntime.so.1.23.2"
+
+[onnxruntime.macos-aarch64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-arm64-1.23.2.tgz"
+sha256 = "b4d513ab2b26f088c66891dbbc1408166708773d7cc4163de7bdca0e9bbb7856"
+archive_path = "onnxruntime-osx-arm64-1.23.2/lib/libonnxruntime.1.23.2.dylib"
+dylib_name = "libonnxruntime.1.23.2.dylib"
+
+[onnxruntime.macos-x86_64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-x86_64-1.23.2.tgz"
+sha256 = "d10359e16347b57d9959f7e80a225a5b4a66ed7d7e007274a15cae86836485a6"
+archive_path = "onnxruntime-osx-x86_64-1.23.2/lib/libonnxruntime.1.23.2.dylib"
+dylib_name = "libonnxruntime.1.23.2.dylib"
+
+[onnxruntime.windows-x86_64]
+url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-win-x64-1.23.2.zip"
+sha256 = "0b38df9af21834e41e73d602d90db5cb06dbd1ca618948b8f1d66d607ac9f3cd"
+archive_path = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
+dylib_name = "onnxruntime.dll"

--- a/src-tauri/resources/checksums.toml
+++ b/src-tauri/resources/checksums.toml
@@ -34,3 +34,52 @@ url = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxru
 sha256 = "0b38df9af21834e41e73d602d90db5cb06dbd1ca618948b8f1d66d607ac9f3cd"
 archive_path = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
 dylib_name = "onnxruntime.dll"
+
+# MiniLM-L6-v2 INT8 ONNX, Apache-2.0 (sentence-transformers).
+# Sources: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+#
+# The ONNX file is per CPU-architecture because the upstream Optimum exports
+# bake architecture-specific quantization kernels into the model graph
+# (avx2 / avx512 / arm64). Tokenizer + config files are architecture-agnostic.
+[model]
+id = "all-MiniLM-L6-v2-int8"
+
+[model.shared.tokenizer_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
+sha256 = "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037"
+dest_name = "tokenizer.json"
+
+[model.shared.config_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json"
+sha256 = "953f9c0d463486b10a6871cc2fd59f223b2c70184f49815e7efbcab5d8908b41"
+dest_name = "config.json"
+
+[model.shared.tokenizer_config_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer_config.json"
+sha256 = "acb92769e8195aabd29b7b2137a9e6d6e25c476a4f15aa4355c233426c61576b"
+dest_name = "tokenizer_config.json"
+
+[model.shared.special_tokens_map_json]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/special_tokens_map.json"
+sha256 = "303df45a03609e4ead04bc3dc1536d0ab19b5358db685b6f3da123d05ec200e3"
+dest_name = "special_tokens_map.json"
+
+[model.linux-x86_64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
+sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+dest_name = "model.onnx"
+
+[model.macos-x86_64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
+sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+dest_name = "model.onnx"
+
+[model.macos-aarch64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx"
+sha256 = "4278337fd0ff3c68bfb6291042cad8ab363e1d9fbc43dcb499fe91c871902474"
+dest_name = "model.onnx"
+
+[model.windows-x86_64]
+url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
+sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+dest_name = "model.onnx"

--- a/src-tauri/resources/checksums.toml
+++ b/src-tauri/resources/checksums.toml
@@ -35,51 +35,56 @@ sha256 = "0b38df9af21834e41e73d602d90db5cb06dbd1ca618948b8f1d66d607ac9f3cd"
 archive_path = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
 dylib_name = "onnxruntime.dll"
 
-# MiniLM-L6-v2 INT8 ONNX, Apache-2.0 (sentence-transformers).
-# Sources: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+# multilingual-e5-small INT8 ONNX, MIT (#233).
+# Sources:
+#   https://huggingface.co/Xenova/multilingual-e5-small  (portable INT8)
+#   https://huggingface.co/intfloat/multilingual-e5-small (upstream, MIT)
 #
-# The ONNX file is per CPU-architecture because the upstream Optimum exports
-# bake architecture-specific quantization kernels into the model graph
-# (avx2 / avx512 / arm64). Tokenizer + config files are architecture-agnostic.
+# Why Xenova's mirror: upstream intfloat only ships `model_qint8_avx512_vnni.onnx`
+# which breaks on ARM64 (Apple Silicon). Xenova's `model_quantized.onnx` is a
+# portable INT8 export that runs on every VaultCore target CPU — same 118 MB,
+# same quality, no arch split. All four arches therefore point to the same
+# file + SHA256; we keep the per-arch table shape so build.rs doesn't need
+# restructuring.
 [model]
-id = "all-MiniLM-L6-v2-int8"
+id = "multilingual-e5-small-int8"
 
 [model.shared.tokenizer_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json"
-sha256 = "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/tokenizer.json"
+sha256 = "0b44a9d7b51c3c62626640cda0e2c2f70fdacdc25bbbd68038369d14ebdf4c39"
 dest_name = "tokenizer.json"
 
 [model.shared.config_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/config.json"
-sha256 = "953f9c0d463486b10a6871cc2fd59f223b2c70184f49815e7efbcab5d8908b41"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/config.json"
+sha256 = "cb99455288675345e1a4f411438d5d0adbba5fbd3a67ea4fb03c015433b996c1"
 dest_name = "config.json"
 
 [model.shared.tokenizer_config_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer_config.json"
-sha256 = "acb92769e8195aabd29b7b2137a9e6d6e25c476a4f15aa4355c233426c61576b"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/tokenizer_config.json"
+sha256 = "a1d6bc8734a6f635dc158508bef000f8e2e5a759c7d92f984b2c86e5ff53425b"
 dest_name = "tokenizer_config.json"
 
 [model.shared.special_tokens_map_json]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/special_tokens_map.json"
-sha256 = "303df45a03609e4ead04bc3dc1536d0ab19b5358db685b6f3da123d05ec200e3"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/special_tokens_map.json"
+sha256 = "d05497f1da52c5e09554c0cd874037a083e1dc1b9cfd48034d1c717f1afc07a7"
 dest_name = "special_tokens_map.json"
 
 [model.linux-x86_64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
-sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"
 
 [model.macos-x86_64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
-sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"
 
 [model.macos-aarch64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx"
-sha256 = "4278337fd0ff3c68bfb6291042cad8ab363e1d9fbc43dcb499fe91c871902474"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"
 
 [model.windows-x86_64]
-url = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_quint8_avx2.onnx"
-sha256 = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
+url = "https://huggingface.co/Xenova/multilingual-e5-small/resolve/main/onnx/model_quantized.onnx"
+sha256 = "f80102d3f2a1229f387d3c81909990d8945513e347b0eab049f7de3c6f98c193"
 dest_name = "model.onnx"

--- a/src-tauri/src/commands/embedding_graph.rs
+++ b/src-tauri/src/commands/embedding_graph.rs
@@ -1,0 +1,296 @@
+//! #235 — Embedding-based relation graph.
+//!
+//! Second mode for the whole-vault graph view: instead of walking link
+//! edges, derive edges from cosine similarity between note embeddings.
+//! Reuses the HNSW index built for semantic search (#198) — no new
+//! datastore, no new index type.
+//!
+//! Aggregation strategy (per ticket alignment): **chunk-pair max**. For
+//! each source chunk we run a k-NN on the shared HNSW, dedupe the hits
+//! to note-level by taking the maximum cosine per target path, then
+//! apply `threshold` + `top_k` per source.
+//!
+//! Edges are undirected: symmetric keys (lo, hi) collapse into one
+//! entry; when both directions score a pair we keep the larger cosine
+//! (which is the max over chunk pairs regardless of direction).
+//!
+//! All paths emitted in the graph payload are vault-relative
+//! (forward-slash separators). The `VectorIndex` mapping holds whatever
+//! the embed coordinator stored — currently absolute paths — so the
+//! builder strips `vault_root` before using the path as a node id or
+//! `TagIndex` lookup key. Vectors whose paths fall outside the vault
+//! are dropped (defensive against a stale-index leak).
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::commands::links::{file_stem_label, GraphEdge, GraphNode, LocalGraph};
+use crate::embeddings::VectorIndex;
+use crate::indexer::memory::FileIndex;
+use crate::indexer::tag_index::TagIndex;
+
+/// Multiplier applied to `top_k` when sampling raw HNSW hits, so the
+/// chunk→note dedup step still produces enough unique target notes
+/// after collapsing same-note chunk hits.
+///
+/// Failure mode being defended against: a single long target note with
+/// `N` chunks can occupy all of an under-sampled hit list, leaving the
+/// dedup step with one unique target instead of `top_k`. With
+/// `OVERSHOOT = 8` and `top_k = 10`, we sample 80 raw hits; dedup
+/// undershoot only happens when one note dominates 80+ slots, which
+/// requires a single note with ~80 chunks tightly clustered around the
+/// source — rare in practice. Bump if real vaults show <top_k unique
+/// neighbours despite many candidates above threshold.
+const OVERSHOOT: usize = 8;
+
+/// Pure builder that constructs the embedding-similarity graph. Split
+/// out from the Tauri command so unit tests can drive it with synthetic
+/// `VectorIndex` fixtures without standing up the full coordinator.
+///
+/// Nodes come from the VectorIndex's live path set — notes without
+/// embeddings are excluded (they have no semantic position).
+/// Edges are emitted when the max-chunk-pair cosine between two notes
+/// is `>= threshold`, capped to `top_k` per source note. Edge weight is
+/// the cosine similarity (not HNSW distance) in `[0, 1]`.
+///
+/// `vault_root` is stripped from each chunk path before use; pass an
+/// empty `Path` for tests that already use vault-relative fixtures.
+pub fn compute_embedding_graph(
+    vi: &VectorIndex,
+    _fi: &FileIndex,
+    ti: &TagIndex,
+    vault_root: &Path,
+    top_k: usize,
+    threshold: f32,
+) -> LocalGraph {
+    if top_k == 0 {
+        return LocalGraph {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        };
+    }
+
+    // Phase 1 — snapshot all live chunks grouped by (vault-rel) path.
+    // We collect vectors here so subsequent `vi.query` calls don't race
+    // the layer iterator against later compactions.
+    let mut chunks_by_path: HashMap<String, Vec<Vec<f32>>> = HashMap::new();
+    let mut id_to_path: HashMap<u32, String> = HashMap::new();
+    vi.for_each_live(|id, path, _chunk_idx, vec| {
+        let Some(rel) = relativize(path, vault_root) else {
+            return;
+        };
+        chunks_by_path
+            .entry(rel.clone())
+            .or_default()
+            .push(vec.to_vec());
+        id_to_path.insert(id, rel);
+    });
+
+    // Phase 2 — snapshot tags once. Holding the TagIndex lock for the
+    // entire build (as `compute_link_graph` does) would block tag-panel
+    // refreshes for seconds on a 100k vault. One pass, drop the lock,
+    // then build.
+    let tags_by_path: HashMap<String, Vec<String>> = chunks_by_path
+        .keys()
+        .map(|rel| (rel.clone(), ti.tags_for_file(rel)))
+        .collect();
+
+    // Phase 3 — for each source path × chunk, k-NN + chunk-pair-max
+    // aggregation. Edges are keyed (lo, hi) so the symmetric pair
+    // collapses naturally to one entry.
+    let mut edge_weight: HashMap<(String, String), f32> = HashMap::new();
+    let raw_k = top_k.saturating_mul(OVERSHOOT);
+    for (src_rel, chunks) in &chunks_by_path {
+        // Per source: target_rel → best cosine across all (src_chunk, hit) pairs.
+        let mut best_per_target: HashMap<String, f32> = HashMap::new();
+        for chunk_vec in chunks {
+            for (hit_id, distance) in vi.query(chunk_vec, raw_k) {
+                let Some(tgt_rel) = id_to_path.get(&hit_id) else {
+                    continue; // tombstoned mid-build, or foreign-vault leak
+                };
+                if tgt_rel == src_rel {
+                    continue;
+                }
+                let cos = (1.0_f32 - distance).clamp(0.0, 1.0);
+                if !cos.is_finite() {
+                    continue;
+                }
+                if cos < threshold {
+                    continue;
+                }
+                let entry = best_per_target.entry(tgt_rel.clone()).or_insert(cos);
+                if cos > *entry {
+                    *entry = cos;
+                }
+            }
+        }
+
+        // Top-K cap per source. `total_cmp` is NaN-safe; we already
+        // filtered non-finite cosines but use the safer comparator
+        // anyway — partial_cmp would panic on a future regression.
+        let mut neighbours: Vec<(String, f32)> = best_per_target.into_iter().collect();
+        neighbours.sort_by(|a, b| b.1.total_cmp(&a.1));
+        neighbours.truncate(top_k);
+
+        for (tgt_rel, cos) in neighbours {
+            let key = if src_rel < &tgt_rel {
+                (src_rel.clone(), tgt_rel)
+            } else {
+                (tgt_rel, src_rel.clone())
+            };
+            edge_weight
+                .entry(key)
+                .and_modify(|w| {
+                    if cos > *w {
+                        *w = cos;
+                    }
+                })
+                .or_insert(cos);
+        }
+    }
+
+    // Phase 4 — build sorted node + edge lists. Every chunked path
+    // becomes a node, even if it ends up edgeless — orphans are
+    // informative ("this note is semantically unique") and let users
+    // loosen the threshold to find connections.
+    let mut node_list: Vec<GraphNode> = chunks_by_path
+        .keys()
+        .map(|rel| GraphNode {
+            id: rel.clone(),
+            label: file_stem_label(rel),
+            path: rel.clone(),
+            backlink_count: 0, // backlinks are a link-graph concept; N/A here.
+            resolved: true,
+            tags: tags_by_path.get(rel).cloned().unwrap_or_default(),
+        })
+        .collect();
+    node_list.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut edge_list: Vec<GraphEdge> = edge_weight
+        .into_iter()
+        .map(|((from, to), w)| GraphEdge {
+            from,
+            to,
+            weight: Some(w),
+        })
+        .collect();
+    edge_list.sort_by(|a, b| match a.from.cmp(&b.from) {
+        Ordering::Equal => a.to.cmp(&b.to),
+        other => other,
+    });
+
+    LocalGraph {
+        nodes: node_list,
+        edges: edge_list,
+    }
+}
+
+/// Strip `vault_root` from `path` and normalise separators to `/` so the
+/// id matches the rest of the graph payload. Returns `None` when `path`
+/// doesn't live under `vault_root` (defensive: stale-index leakage).
+fn relativize(path: &Path, vault_root: &Path) -> Option<String> {
+    let stripped = path.strip_prefix(vault_root).ok()?;
+    Some(stripped.to_string_lossy().replace('\\', "/"))
+}
+
+// ── IPC ────────────────────────────────────────────────────────────────────
+
+use crate::error::VaultError;
+use crate::VaultState;
+
+/// `top_k` ceiling — bounds the per-source neighbour budget so
+/// pathological client inputs can't trigger an `O(N²)` build. The UI
+/// fixes this at 10 in v1; the cap leaves headroom for power-user
+/// experimentation.
+const MAX_TOP_K: usize = 50;
+
+/// Build the embedding-similarity graph for the currently-open vault.
+///
+/// Snapshots the live `VectorIndex` once at entry so concurrent
+/// compactions don't reassign ids mid-build (#200). Runs the build
+/// inside `spawn_blocking` because at 100k chunks the algorithm is
+/// O(chunks × k) HNSW probes, easily seconds — running it on a tokio
+/// runtime thread would stall every other async IPC for the duration.
+///
+/// Returns an empty graph when:
+/// - no vault is open,
+/// - the embeddings subsystem is not initialised (model missing, ORT
+///   init failed, etc.), or
+/// - the index is genuinely empty.
+///
+/// The frontend distinguishes "embeddings not ready" from "no edges
+/// over threshold" by checking whether `nodes` is also empty.
+#[tauri::command]
+pub async fn get_embedding_graph(
+    top_k: usize,
+    threshold: f32,
+    state: tauri::State<'_, VaultState>,
+) -> Result<LocalGraph, VaultError> {
+    let top_k = top_k.clamp(1, MAX_TOP_K);
+    let threshold = threshold.clamp(0.0, 1.0);
+
+    let vault_root = match state
+        .current_vault
+        .lock()
+        .map_err(|_| VaultError::IndexCorrupt)?
+        .clone()
+    {
+        Some(p) => p,
+        None => {
+            return Ok(LocalGraph {
+                nodes: Vec::new(),
+                edges: Vec::new(),
+            })
+        }
+    };
+
+    let handles = {
+        let guard = state
+            .query_handles
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(h) => std::sync::Arc::clone(h),
+            None => {
+                return Ok(LocalGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                })
+            }
+        }
+    };
+
+    let (fi_arc, ti_arc) = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(c) => (c.file_index(), c.tag_index()),
+            None => {
+                return Ok(LocalGraph {
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                })
+            }
+        }
+    };
+
+    let snap = handles.sink.snapshot();
+
+    tokio::task::spawn_blocking(move || {
+        let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
+        let ti = ti_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        Ok(compute_embedding_graph(
+            &snap,
+            &fi,
+            &ti,
+            &vault_root,
+            top_k,
+            threshold,
+        ))
+    })
+    .await
+    .map_err(|_| VaultError::IndexCorrupt)?
+}

--- a/src-tauri/src/commands/embedding_graph_stub.rs
+++ b/src-tauri/src/commands/embedding_graph_stub.rs
@@ -1,0 +1,20 @@
+//! #235 — feature-off stub for `get_embedding_graph`.
+//!
+//! Mirrors the `semantic_search` pattern: when the `embeddings` feature
+//! is disabled the IPC call still resolves with an empty graph, so the
+//! frontend doesn't have to branch on feature availability.
+
+use crate::commands::links::LocalGraph;
+use crate::error::VaultError;
+
+#[tauri::command]
+pub async fn get_embedding_graph(
+    _top_k: usize,
+    _threshold: f32,
+    _state: tauri::State<'_, crate::VaultState>,
+) -> Result<LocalGraph, VaultError> {
+    Ok(LocalGraph {
+        nodes: Vec::new(),
+        edges: Vec::new(),
+    })
+}

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -146,6 +146,23 @@ fn dispatch_embed_update(state: &VaultState, abs_path: PathBuf, content: &str) {
     }
 }
 
+/// #201 PR-A — dispatch a vector-store delete for `abs_path`. Called
+/// from the internal delete_file / rename_file / move_file paths
+/// because write_ignore suppresses the watcher's natural delete event
+/// for self-mutations.
+#[cfg(feature = "embeddings")]
+pub(crate) fn dispatch_embed_delete(state: &VaultState, abs_path: PathBuf) {
+    let coord_handles = {
+        let Ok(guard) = state.embed_coordinator.lock() else { return };
+        guard.as_ref().map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
+    };
+    let Some((tx, pending)) = coord_handles else { return };
+    let probe = crate::embeddings::EmbedCoordinator { tx, pending };
+    if let Err(e) = probe.enqueue_delete(abs_path) {
+        log::warn!("embed delete enqueue: {e}");
+    }
+}
+
 /// Dispatch IndexCmd::UpdateLinks and IndexCmd::UpdateTags for a path we just
 /// wrote from the backend. Called from write_file because write_ignore
 /// suppresses the natural watcher-driven dispatch.
@@ -384,7 +401,21 @@ pub async fn rename_file(
     old_path: String,
     new_name: String,
 ) -> Result<RenameResult, VaultError> {
-    rename_file_impl(&state, old_path, new_name)
+    // Capture the canonical pre-rename path so we can dispatch an embed
+    // delete for the OLD path after the rename succeeds. write_ignore
+    // suppresses the watcher's natural Remove event for self-mutations,
+    // so without this the old path's vectors would linger forever. The
+    // NEW path's vectors get embedded on the next save by the user.
+    #[cfg(feature = "embeddings")]
+    let old_canonical = std::fs::canonicalize(&old_path).ok();
+
+    let result = rename_file_impl(&state, old_path, new_name)?;
+
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = old_canonical {
+        dispatch_embed_delete(&state, p);
+    }
+    Ok(result)
 }
 
 // ─── delete_file ─────────────────────────────────────────────────────────────
@@ -424,9 +455,11 @@ pub async fn delete_file(
     use tauri::Emitter;
     // Canonicalize before delete so the emitted path matches the form the
     // watcher would have used (and matches how tabs/sidebar store paths).
-    let canonical_str = std::fs::canonicalize(&path)
+    let canonical = std::fs::canonicalize(&path).ok();
+    let canonical_str = canonical
+        .as_ref()
         .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| path.clone());
+        .unwrap_or_else(|| path.clone());
     delete_file_impl(&state, path)?;
     // Bug #102: the watcher suppresses this delete via write_ignore (D-12),
     // so emit a synthetic file_changed event so tabs bound to the deleted
@@ -439,6 +472,14 @@ pub async fn delete_file(
             new_path: None,
         },
     );
+    // #201 PR-A: tell the embed coordinator to tombstone this path's
+    // vectors. Same reason as the synthetic file_changed event above —
+    // write_ignore suppresses the watcher's natural Remove event so we
+    // dispatch directly here.
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = canonical {
+        dispatch_embed_delete(&state, p);
+    }
     Ok(())
 }
 
@@ -480,7 +521,19 @@ pub async fn move_file(
     from: String,
     to_folder: String,
 ) -> Result<String, VaultError> {
-    move_file_impl(&state, from, to_folder)
+    // #201 PR-A: same rationale as rename_file — the OLD path's vectors
+    // need an explicit tombstone because write_ignore hides the
+    // watcher's Remove event.
+    #[cfg(feature = "embeddings")]
+    let old_canonical = std::fs::canonicalize(&from).ok();
+
+    let result = move_file_impl(&state, from, to_folder)?;
+
+    #[cfg(feature = "embeddings")]
+    if let Some(p) = old_canonical {
+        dispatch_embed_delete(&state, p);
+    }
+    Ok(result)
 }
 
 // ─── get_file_hash ───────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -122,9 +122,28 @@ pub async fn write_file(
     // Dispatch the updates directly here so the in-memory indexes stay in sync.
     dispatch_index_updates(&state, &final_path, &content).await;
 
+    // Embed-on-save (#196): non-blocking enqueue to the EmbedCoordinator.
+    // Sync, returns immediately; a `QueueFull` outcome is benign because
+    // the latest content already lives in the coordinator's pending map.
+    #[cfg(feature = "embeddings")]
+    dispatch_embed_update(&state, final_path.clone(), &content);
+
     // Return hash so the frontend can track the last-known disk state
     // (EDIT-10 groundwork — Phase 5 will compare against this).
     Ok(hash_bytes(bytes))
+}
+
+#[cfg(feature = "embeddings")]
+fn dispatch_embed_update(state: &VaultState, abs_path: PathBuf, content: &str) {
+    let coord_handles = {
+        let Ok(guard) = state.embed_coordinator.lock() else { return };
+        guard.as_ref().map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
+    };
+    let Some((tx, pending)) = coord_handles else { return };
+    let probe = crate::embeddings::EmbedCoordinator { tx, pending };
+    if let Err(e) = probe.enqueue(abs_path, content.to_string()) {
+        log::warn!("embed enqueue: {e}");
+    }
 }
 
 /// Dispatch IndexCmd::UpdateLinks and IndexCmd::UpdateTags for a path we just

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -607,6 +607,13 @@ pub struct GraphNode {
 pub struct GraphEdge {
     pub from: String,
     pub to: String,
+    /// Optional similarity weight in `[0, 1]`. Link-graph edges leave
+    /// this `None`; embedding-graph edges (#235) set it to the max
+    /// chunk-pair cosine similarity between the two notes. Skipped in
+    /// the serialized payload when absent so the link-graph JSON shape
+    /// is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f32>,
 }
 
 /// Result payload returned by `get_local_graph`.
@@ -618,7 +625,7 @@ pub struct LocalGraph {
 }
 
 /// Derive a filename stem from a vault-relative path (strip folder + `.md`).
-fn file_stem_label(rel_path: &str) -> String {
+pub(crate) fn file_stem_label(rel_path: &str) -> String {
     let base = rel_path.rsplit('/').next().unwrap_or(rel_path);
     base.strip_suffix(".md").unwrap_or(base).to_string()
 }
@@ -766,7 +773,7 @@ pub fn compute_local_graph(
 
     let mut edge_list: Vec<GraphEdge> = edges
         .into_iter()
-        .map(|(from, to)| GraphEdge { from, to })
+        .map(|(from, to)| GraphEdge { from, to, weight: None })
         .collect();
     edge_list.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
 
@@ -885,7 +892,7 @@ pub fn compute_link_graph(
 
     let mut edge_list: Vec<GraphEdge> = edges
         .into_iter()
-        .map(|(from, to)| GraphEdge { from, to })
+        .map(|(from, to)| GraphEdge { from, to, weight: None })
         .collect();
     edge_list.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,3 +8,7 @@ pub mod bookmarks;
 pub mod snippets;
 pub mod templates;
 pub mod export;
+#[cfg(feature = "embeddings")]
+pub mod embedding_graph;
+#[cfg(not(feature = "embeddings"))]
+pub mod embedding_graph_stub;

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -340,6 +340,277 @@ pub async fn semantic_search(
     Ok(Vec::new())
 }
 
+// ── hybrid_search ─────────────────────────────────────────────────────────────
+
+/// Per-source visibility for one fused hit. `None` on either side means
+/// the path was not in that source's top-N result list — the row was
+/// surfaced by the other source alone. Skipped from JSON when None so
+/// the wire shape stays clean for single-source hits.
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HybridHit {
+    pub path: String,
+    pub title: String,
+    /// Fused RRF score (sum of `1 / (k + rank_i)` per source).
+    pub score: f32,
+    /// HTML snippet with `<b>highlighted</b>` BM25 terms; empty when
+    /// the path was vec-only and the title-only fallback fired.
+    pub snippet: String,
+    pub match_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bm25_rank: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bm25_score: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vec_rank: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vec_score: Option<f32>,
+}
+
+/// Hybrid search (#203): fuses BM25 (Tantivy) + HNSW (vector) ranks via
+/// Reciprocal Rank Fusion (k=60). Both sides run on the blocking pool
+/// in parallel via `tokio::join!`, so the embed (~15 ms) overlaps with
+/// the BM25 traversal.
+///
+/// `k` is clamped to `[1, 100]`. Each source is over-fetched to
+/// `max(k * 5, 50)` capped at 200, per Cormack 2009 + downstream
+/// production tuning — recall plateaus around 50.
+///
+/// Snippets: BM25-side hits keep their native highlighted snippet.
+/// Vec-only hits get a snippet by re-running `SnippetGenerator` against
+/// a `TermQuery(path:<path>)` lookup in the same searcher. Falls back
+/// to filename-only title with empty snippet when the doc is missing
+/// (race during initial indexing).
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn hybrid_search(
+    query: String,
+    k: usize,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<HybridHit>, VaultError> {
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let k = k.clamp(1, 100);
+    let top_n = k.saturating_mul(5).clamp(50, 200);
+
+    // Extract Tantivy + embedding handles up front so the spawn_blocking
+    // closures own `Send + 'static` data — matches the existing pattern
+    // in search_fulltext (lock, clone Arcs, drop guard before work).
+    let bm25_handles = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().map(|c| (c.index.clone(), c.reader.clone()))
+    };
+    let query_handles = {
+        let guard = state
+            .query_handles
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().map(std::sync::Arc::clone)
+    };
+
+    // BM25 side returns top_n (path, score). Cheap to spawn even when
+    // the coordinator hasn't booted — empty result, no work.
+    let bm25_query = query.clone();
+    let bm25_task = tokio::task::spawn_blocking(move || -> Result<Vec<(String, f32)>, VaultError> {
+        let Some((index, reader)) = bm25_handles.as_ref() else {
+            return Ok(Vec::new());
+        };
+        run_bm25_top_n(index, reader, &bm25_query, top_n)
+    });
+
+    let vec_query = query.clone();
+    let vec_task = tokio::task::spawn_blocking(move || -> Result<Vec<(String, f32)>, VaultError> {
+        let Some(h) = query_handles.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let hits = crate::embeddings::semantic_search_query(h, &vec_query, top_n)
+            .map_err(|e| {
+                log::warn!("hybrid_search vec leg failed: {e}");
+                VaultError::IndexCorrupt
+            })?;
+        Ok(hits
+            .into_iter()
+            .map(|h| (h.path, h.score))
+            .collect())
+    });
+
+    let (bm25_res, vec_res) = tokio::join!(bm25_task, vec_task);
+    let bm25 = bm25_res.map_err(|_| VaultError::IndexCorrupt)??;
+    let vec_hits = vec_res.map_err(|_| VaultError::IndexCorrupt)??;
+
+    let fused = crate::embeddings::rrf_fuse(&bm25, &vec_hits, crate::embeddings::RRF_K);
+    let fused = fused.into_iter().take(k).collect::<Vec<_>>();
+
+    if fused.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Hydrate snippets + titles. We need a Tantivy searcher again — if
+    // the BM25 leg saw `None` (no coordinator) the fused result can only
+    // contain vec-only hits, so skip hydration and fall back to
+    // filename-only titles.
+    let bm25_handles2 = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().map(|c| (c.index.clone(), c.reader.clone()))
+    };
+    let hydrated = tokio::task::spawn_blocking(move || -> Result<Vec<HybridHit>, VaultError> {
+        hydrate_hits(bm25_handles2.as_ref(), &query, fused)
+    })
+    .await
+    .map_err(|_| VaultError::IndexCorrupt)??;
+
+    Ok(hydrated)
+}
+
+#[cfg(feature = "embeddings")]
+fn run_bm25_top_n(
+    index: &std::sync::Arc<tantivy::Index>,
+    reader: &std::sync::Arc<tantivy::IndexReader>,
+    query: &str,
+    top_n: usize,
+) -> Result<Vec<(String, f32)>, VaultError> {
+    let schema = index.schema();
+    let path_field = schema.get_field("path").map_err(|_| VaultError::IndexCorrupt)?;
+    let title_field = schema.get_field("title").map_err(|_| VaultError::IndexCorrupt)?;
+    let body_field = schema.get_field("body").map_err(|_| VaultError::IndexCorrupt)?;
+
+    let mut qp = QueryParser::for_index(index, vec![title_field, body_field]);
+    qp.set_conjunction_by_default();
+    let (parsed, _errors) = qp.parse_query_lenient(query);
+
+    let searcher = reader.searcher();
+    let docs = searcher
+        .search(&parsed, &TopDocs::with_limit(top_n).order_by_score())
+        .map_err(|_| VaultError::IndexCorrupt)?;
+
+    let mut out = Vec::with_capacity(docs.len());
+    for (score, addr) in docs {
+        let doc = searcher
+            .doc::<TantivyDocument>(addr)
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        let path = doc
+            .get_first(path_field)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if !path.is_empty() {
+            out.push((path, score));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(feature = "embeddings")]
+fn hydrate_hits(
+    bm25_handles: Option<&(std::sync::Arc<tantivy::Index>, std::sync::Arc<tantivy::IndexReader>)>,
+    query: &str,
+    fused: Vec<crate::embeddings::FusedHit>,
+) -> Result<Vec<HybridHit>, VaultError> {
+    use tantivy::query::TermQuery;
+    use tantivy::schema::IndexRecordOption;
+    use tantivy::Term;
+
+    let Some((index, reader)) = bm25_handles else {
+        // No Tantivy index → vec-only hits with filename-derived titles.
+        return Ok(fused
+            .into_iter()
+            .map(|h| HybridHit {
+                title: filename_title(&h.path),
+                path: h.path,
+                score: h.score,
+                snippet: String::new(),
+                match_count: 0,
+                bm25_rank: h.bm25_rank,
+                bm25_score: h.bm25_score,
+                vec_rank: h.vec_rank,
+                vec_score: h.vec_score,
+            })
+            .collect());
+    };
+
+    let schema = index.schema();
+    let path_field = schema.get_field("path").map_err(|_| VaultError::IndexCorrupt)?;
+    let title_field = schema.get_field("title").map_err(|_| VaultError::IndexCorrupt)?;
+    let body_field = schema.get_field("body").map_err(|_| VaultError::IndexCorrupt)?;
+
+    let mut qp = QueryParser::for_index(index, vec![title_field, body_field]);
+    qp.set_conjunction_by_default();
+    let (parsed, _errors) = qp.parse_query_lenient(query);
+
+    let searcher = reader.searcher();
+    let mut snippet_gen = SnippetGenerator::create(&searcher, &*parsed, body_field)
+        .map_err(|_| VaultError::IndexCorrupt)?;
+    snippet_gen.set_max_num_chars(200);
+
+    let mut out = Vec::with_capacity(fused.len());
+    for hit in fused {
+        // Look up the doc by exact path. Path field is stored as STRING
+        // (untokenised) so a TermQuery exact-matches.
+        let term = Term::from_field_text(path_field, &hit.path);
+        let term_q = TermQuery::new(term, IndexRecordOption::Basic);
+        let lookup: Vec<(f32, tantivy::DocAddress)> = searcher
+            .search(&term_q, &TopDocs::with_limit(1).order_by_score())
+            .map_err(|_| VaultError::IndexCorrupt)?;
+
+        let (title, snippet, match_count) = if let Some((_score, addr)) = lookup.first() {
+            let doc = searcher
+                .doc::<TantivyDocument>(*addr)
+                .map_err(|_| VaultError::IndexCorrupt)?;
+            let title = doc
+                .get_first(title_field)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let snip = snippet_gen.snippet_from_doc(&doc);
+            let mc = snip.highlighted().len();
+            (title, snip.to_html(), mc)
+        } else {
+            (filename_title(&hit.path), String::new(), 0)
+        };
+
+        out.push(HybridHit {
+            path: hit.path,
+            title,
+            score: hit.score,
+            snippet,
+            match_count,
+            bm25_rank: hit.bm25_rank,
+            bm25_score: hit.bm25_score,
+            vec_rank: hit.vec_rank,
+            vec_score: hit.vec_score,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(feature = "embeddings")]
+fn filename_title(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+/// Stub for builds without `embeddings` — returns an empty list so the
+/// frontend IPC call always resolves to a valid array.
+#[cfg(not(feature = "embeddings"))]
+#[tauri::command]
+pub async fn hybrid_search(
+    _query: String,
+    _k: usize,
+    _state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<serde_json::Value>, VaultError> {
+    Ok(Vec::new())
+}
+
 // ── rebuild_index ─────────────────────────────────────────────────────────────
 
 /// Trigger a full index rebuild.

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -277,6 +277,69 @@ pub async fn search_filename(
     Ok(matches)
 }
 
+// ── semantic_search ───────────────────────────────────────────────────────────
+
+/// Semantic (vector) search over the HNSW index (#202).
+///
+/// Returns up to `k` nearest chunks to `query` as `SemanticHit`s sorted
+/// by descending similarity. Feature-gated: when the `embeddings` crate
+/// feature is disabled, the bundled model is missing, or the coordinator
+/// failed to initialise, the command returns an empty list rather than
+/// erroring — matches the tolerant contract of the existing full-text
+/// commands.
+///
+/// `k` is clamped to `[1, 100]` at the boundary to bound worst-case query
+/// cost; the HNSW overshoot for tombstone filtering (#200) scales with `k`.
+///
+/// The embed + ANN search is wrapped in `spawn_blocking` so it does not
+/// stall the tokio runtime thread — a typical MiniLM embed is ~15 ms,
+/// which would block other async IPC traffic otherwise.
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn semantic_search(
+    query: String,
+    k: usize,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<crate::embeddings::SemanticHit>, VaultError> {
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let k = k.clamp(1, 100);
+
+    let handles = {
+        let guard = state
+            .query_handles
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(h) => std::sync::Arc::clone(h),
+            None => return Ok(Vec::new()),
+        }
+    };
+
+    tokio::task::spawn_blocking(move || {
+        crate::embeddings::semantic_search_query(&handles, &query, k)
+    })
+    .await
+    .map_err(|_| VaultError::IndexCorrupt)?
+    .map_err(|e| {
+        log::warn!("semantic_search failed: {e}");
+        VaultError::IndexCorrupt
+    })
+}
+
+/// Stub command exposed when the `embeddings` feature is off so the
+/// frontend IPC call always resolves. Returns an empty list.
+#[cfg(not(feature = "embeddings"))]
+#[tauri::command]
+pub async fn semantic_search(
+    _query: String,
+    _k: usize,
+    _state: tauri::State<'_, crate::VaultState>,
+) -> Result<Vec<serde_json::Value>, VaultError> {
+    Ok(Vec::new())
+}
+
 // ── rebuild_index ─────────────────────────────────────────────────────────────
 
 /// Trigger a full index rebuild.

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -202,6 +202,20 @@ pub async fn open_vault(
     // (mirrors the IndexCoordinator drop-then-replace pattern above).
     #[cfg(feature = "embeddings")]
     {
+        // #201 PR-B: cancel any in-flight reindex for the prior vault
+        // BEFORE dropping the old coordinator. The reindex worker holds
+        // clones of the prior coordinator's Sender; cancelling lets it
+        // wind down cleanly so the next vault's worker has a fresh
+        // checkpoint to resume from.
+        {
+            let mut guard = state
+                .reindex_handle
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?;
+            if let Some(h) = guard.take() {
+                h.cancel();
+            }
+        }
         {
             let mut guard = state
                 .embed_coordinator
@@ -481,4 +495,115 @@ pub async fn merge_external_change(
             merged_content: local,
         }),
     }
+}
+
+// ─── #201 PR-B: reindex IPC ──────────────────────────────────────────────────
+
+/// Start a resumable initial-embed pass over the currently-open vault.
+///
+/// Cancels any prior running reindex before spawning. Progress is
+/// streamed to the frontend via `embed://reindex_progress` Tauri events
+/// (payload: `ReindexProgress`). The call returns as soon as the worker
+/// has been parked on its thread; the frontend drives the lifecycle
+/// entirely through events + `cancel_reindex`.
+///
+/// No-op (returns `Ok`) when the embeddings feature is on but the
+/// coordinator didn't spawn (no bundled model / ORT init failed).
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn reindex_vault(
+    app: AppHandle,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<(), VaultError> {
+    use tauri::Emitter;
+
+    let vault_root = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.clone().ok_or_else(|| VaultError::VaultUnavailable {
+            path: String::new(),
+        })?
+    };
+
+    // Cancel any prior reindex so the new one owns the checkpoint.
+    {
+        let mut guard = state
+            .reindex_handle
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        if let Some(h) = guard.take() {
+            h.cancel();
+        }
+    }
+
+    let coord_parts = {
+        let guard = state
+            .embed_coordinator
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard
+            .as_ref()
+            .map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
+    };
+    let Some((tx, pending)) = coord_parts else {
+        log::warn!("reindex_vault: embedding coordinator unavailable; no-op");
+        return Ok(());
+    };
+
+    let checkpoint_dir = vault_root.join(".vaultcore").join("embeddings");
+    let app_for_progress = app.clone();
+
+    let handle = crate::embeddings::start_reindex(
+        vault_root,
+        checkpoint_dir,
+        move |path, content| {
+            let probe = crate::embeddings::EmbedCoordinator {
+                tx: tx.clone(),
+                pending: std::sync::Arc::clone(&pending),
+            };
+            match probe.enqueue(path.to_path_buf(), content) {
+                Ok(()) => true,
+                // QueueFull is benign: the content already lives in the
+                // pending map and the next successful signal drains it.
+                // The file is "on its way" — record the checkpoint.
+                Err(crate::embeddings::EnqueueError::QueueFull) => true,
+                Err(e) => {
+                    log::warn!("reindex enqueue: {e}");
+                    false
+                }
+            }
+        },
+        move |progress| {
+            if let Err(e) = app_for_progress.emit("embed://reindex_progress", progress) {
+                log::debug!("reindex_progress emit dropped: {e}");
+            }
+        },
+    );
+
+    let mut guard = state
+        .reindex_handle
+        .lock()
+        .map_err(|_| VaultError::LockPoisoned)?;
+    *guard = Some(handle);
+    Ok(())
+}
+
+/// Cooperatively cancel any running reindex. Safe to call when no
+/// reindex is in flight (no-op). The worker flushes its checkpoint
+/// before exiting, so the next `reindex_vault` resumes from there.
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn cancel_reindex(
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<(), VaultError> {
+    let mut guard = state
+        .reindex_handle
+        .lock()
+        .map_err(|_| VaultError::LockPoisoned)?;
+    if let Some(h) = guard.take() {
+        h.cancel();
+    }
+    Ok(())
 }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -223,6 +223,13 @@ pub async fn open_vault(
                 .map_err(|_| VaultError::LockPoisoned)?;
             *guard = None;
         }
+        {
+            let mut guard = state
+                .query_handles
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?;
+            *guard = None;
+        }
         let resource_dir = app.path().resource_dir().ok();
         let svc = crate::embeddings::EmbeddingService::load(resource_dir.as_deref());
         let chk = crate::embeddings::Chunker::load(resource_dir.as_deref());
@@ -236,14 +243,31 @@ pub async fn open_vault(
                 // growth past it is supported.
                 let embed_dir = canonical.join(".vaultcore").join("embeddings");
                 let cap = vault_info.file_count.saturating_mul(4).max(64);
+                // #202: keep a concrete `Arc<HnswSink>` alongside the
+                // `Arc<dyn VectorSink>` handed to the coordinator so the
+                // `semantic_search` IPC handler can call `snapshot()`
+                // without widening the trait. Both Arcs share one alloc.
+                let sink_concrete = Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
                 let sink: Arc<dyn crate::embeddings::VectorSink> =
-                    Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
+                    Arc::clone(&sink_concrete) as Arc<dyn crate::embeddings::VectorSink>;
+                let svc_for_query = Arc::clone(&svc);
                 let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
+                {
+                    let mut guard = state
+                        .embed_coordinator
+                        .lock()
+                        .map_err(|_| VaultError::LockPoisoned)?;
+                    *guard = Some(coord);
+                }
+                let handles = Arc::new(crate::embeddings::QueryHandles {
+                    service: svc_for_query,
+                    sink: sink_concrete,
+                });
                 let mut guard = state
-                    .embed_coordinator
+                    .query_handles
                     .lock()
                     .map_err(|_| VaultError::LockPoisoned)?;
-                *guard = Some(coord);
+                *guard = Some(handles);
             }
             (Err(e), _) | (_, Err(e)) => {
                 log::warn!("embed-on-save disabled: {e}");

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -554,23 +554,23 @@ pub async fn reindex_vault(
 
     let checkpoint_dir = vault_root.join(".vaultcore").join("embeddings");
     let app_for_progress = app.clone();
+    let pending_for_bp = std::sync::Arc::clone(&pending);
 
-    let handle = crate::embeddings::start_reindex(
+    let handle = crate::embeddings::start_reindex_with_backpressure(
         vault_root,
         checkpoint_dir,
-        move |path, content| {
+        move |batch| {
             let probe = crate::embeddings::EmbedCoordinator {
                 tx: tx.clone(),
                 pending: std::sync::Arc::clone(&pending),
             };
-            match probe.enqueue(path.to_path_buf(), content) {
-                Ok(()) => true,
-                // QueueFull is benign: the content already lives in the
-                // pending map and the next successful signal drains it.
-                // The file is "on its way" — record the checkpoint.
-                Err(crate::embeddings::EnqueueError::QueueFull) => true,
+            // PR-D: a full batch arrives as a single bulk insert so the
+            // embedder drains many files per wake-up instead of one.
+            // Closed → checkpoint not advanced; next reindex retries.
+            match probe.enqueue_bulk(batch) {
+                Ok(_) => true,
                 Err(e) => {
-                    log::warn!("reindex enqueue: {e}");
+                    log::warn!("reindex enqueue_bulk: {e}");
                     false
                 }
             }
@@ -579,6 +579,12 @@ pub async fn reindex_vault(
             if let Err(e) = app_for_progress.emit("embed://reindex_progress", progress) {
                 log::debug!("reindex_progress emit dropped: {e}");
             }
+        },
+        move || {
+            pending_for_bp
+                .lock()
+                .map(|g| g.len())
+                .unwrap_or(0)
         },
     );
 

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -195,6 +195,41 @@ pub async fn open_vault(
         *guard = Some(coordinator);
     }
 
+    // --- Embed-on-save coordinator (#196) ---
+    // Spawn after the index coordinator so a vault open without bundled
+    // embedding assets still succeeds. Drop the previous coordinator
+    // before spawning the new one so the old worker shuts down cleanly
+    // (mirrors the IndexCoordinator drop-then-replace pattern above).
+    #[cfg(feature = "embeddings")]
+    {
+        {
+            let mut guard = state
+                .embed_coordinator
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?;
+            *guard = None;
+        }
+        let resource_dir = app.path().resource_dir().ok();
+        let svc = crate::embeddings::EmbeddingService::load(resource_dir.as_deref());
+        let chk = crate::embeddings::Chunker::load(resource_dir.as_deref());
+        match (svc, chk) {
+            (Ok(svc), Ok(chk)) => {
+                use std::sync::Arc;
+                let sink: Arc<dyn crate::embeddings::VectorSink> =
+                    Arc::new(crate::embeddings::NoopSink);
+                let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
+                let mut guard = state
+                    .embed_coordinator
+                    .lock()
+                    .map_err(|_| VaultError::LockPoisoned)?;
+                *guard = Some(coord);
+            }
+            (Err(e), _) | (_, Err(e)) => {
+                log::warn!("embed-on-save disabled: {e}");
+            }
+        }
+    }
+
     // --- Spawn file watcher (Plan 04) ---
 
     // Clone the index_tx sender for the watcher so it can dispatch

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -215,8 +215,15 @@ pub async fn open_vault(
         match (svc, chk) {
             (Ok(svc), Ok(chk)) => {
                 use std::sync::Arc;
+                // #201 PR-A: HNSW-backed sink under <vault>/.vaultcore/embeddings/.
+                // capacity_hint of 4×file_count assumes the average note
+                // produces ~4 chunks (#195 splits at 254 content tokens
+                // ≈ 800 words). It only sizes initial allocations — real
+                // growth past it is supported.
+                let embed_dir = canonical.join(".vaultcore").join("embeddings");
+                let cap = vault_info.file_count.saturating_mul(4).max(64);
                 let sink: Arc<dyn crate::embeddings::VectorSink> =
-                    Arc::new(crate::embeddings::NoopSink);
+                    Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
                 let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
                 let mut guard = state
                     .embed_coordinator
@@ -239,12 +246,27 @@ pub async fn open_vault(
         guard.as_ref().map(|c| c.tx.clone())
     };
 
+    // #201 PR-A: snapshot the embed coordinator's Sender so the watcher
+    // can dispatch EmbedOp::Delete for externally-initiated file
+    // removes / renames. None when embeddings are disabled or the
+    // coordinator didn't spawn (no bundled model / ORT init failed).
+    #[cfg(feature = "embeddings")]
+    let embed_tx = {
+        let guard = state
+            .embed_coordinator
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.as_ref().map(|c| c.tx.clone())
+    };
+
     let debouncer = watcher::spawn_watcher(
         app.clone(),
         canonical.clone(),
         state.write_ignore.clone(),
         state.vault_reachable.clone(),
         index_tx,
+        #[cfg(feature = "embeddings")]
+        embed_tx,
     );
     *state.watcher_handle.lock().map_err(|_| VaultError::LockPoisoned)? = Some(debouncer);
 

--- a/src-tauri/src/embeddings/chunking.rs
+++ b/src-tauri/src/embeddings/chunking.rs
@@ -31,10 +31,10 @@ use tokenizers::Tokenizer;
 
 use super::{model_dir, EmbeddingError};
 
-/// Maximum *content* tokens per chunk. Picked so that after fastembed
-/// re-tokenises and prepends [CLS] / appends [SEP] (2 special tokens),
-/// the on-wire sequence is exactly 256 — matching MiniLM-L6-v2's training
-/// `max_seq_length` and the cap configured in `EmbeddingService::load`.
+/// Maximum *content* tokens per chunk. Picked so that after the embedder
+/// re-tokenises and adds 2 special tokens (`[CLS]`/`[SEP]` on BERT-style
+/// MiniLM, `<s>`/`</s>` on XLM-RoBERTa-style e5), the on-wire sequence is
+/// exactly 256 — matching the cap configured in `EmbeddingService::load`.
 pub const MAX_CONTENT_TOKENS: usize = 254;
 
 /// Default sliding-window overlap. 32/254 ≈ 12 % is the standard RAG
@@ -59,7 +59,7 @@ pub struct Chunker {
 }
 
 impl Chunker {
-    /// Load the bundled MiniLM tokenizer with default caps
+    /// Load the bundled embedder's tokenizer with default caps
     /// (`MAX_CONTENT_TOKENS` / `DEFAULT_OVERLAP_TOKENS`). Reuses
     /// `model_dir()` for path resolution so it shares the resource-dir /
     /// env-override / dev-fallback story with `EmbeddingService`.
@@ -112,8 +112,9 @@ impl Chunker {
         }
 
         // Encode WITHOUT special tokens — we want only content tokens with
-        // byte offsets pointing into `input`. fastembed will re-add
-        // [CLS]/[SEP] when it embeds.
+        // byte offsets pointing into `input`. The embedder re-adds the
+        // model-specific bookends (`[CLS]/[SEP]` for BERT, `<s>/</s>` for
+        // XLM-RoBERTa) at inference time.
         let enc = self
             .tokenizer
             .encode(input, false)
@@ -182,15 +183,18 @@ mod tests {
     }
 
     /// Build an input that encodes to *exactly* `target` content tokens.
-    /// "hello" tokenises to a single WordPiece on MiniLM; we repeat it,
-    /// then trim.
+    /// `"the"` is a single token in both BERT WordPiece and XLM-RoBERTa
+    /// SentencePiece (id 70 in e5), so repeating it space-separated gives
+    /// us a 1-word == 1-token relationship that the synthesis loop can
+    /// rely on. (We previously used `"hello"`, which is 2 tokens in
+    /// XLM-R — broke the tests when #233 swapped MiniLM for e5.)
     fn synth_input(chunker: &Chunker, target: usize) -> String {
         let mut s = String::new();
         for _ in 0..target {
             if !s.is_empty() {
                 s.push(' ');
             }
-            s.push_str("hello");
+            s.push_str("the");
         }
         // Defensive: in case spacing affects pretokenisation, trim down or
         // pad up until token count matches.
@@ -199,7 +203,7 @@ mod tests {
             s.truncate(cut);
         }
         while chunker.token_count(&s) < target {
-            s.push_str(" hello");
+            s.push_str(" the");
         }
         s
     }

--- a/src-tauri/src/embeddings/chunking.rs
+++ b/src-tauri/src/embeddings/chunking.rs
@@ -1,0 +1,377 @@
+//! Tokenizer-aware text chunker (#195) — splits long notes into overlapping
+//! ≤256-token windows so MiniLM-L6-v2's 256-token sequence cap doesn't
+//! become a quality cliff for long documents.
+//!
+//! Design contract:
+//! - Each chunk holds at most `MAX_CONTENT_TOKENS = 254` *content* tokens.
+//!   fastembed re-tokenises every input it gets and adds [CLS] + [SEP]
+//!   itself, so the on-wire sequence is always ≤256 (the value
+//!   `EmbeddingService::load` configures via `with_max_length(256)`).
+//! - Consecutive chunks overlap by `DEFAULT_OVERLAP_TOKENS = 32` tokens,
+//!   so context that spans a window boundary is still embedded together at
+//!   least once.
+//! - Per-chunk `byte_offset` is the byte position of `chunk.text[0]` inside
+//!   the parent string. The invariant `parent[byte_offset..byte_offset +
+//!   text.len()] == text` always holds and is asserted in tests.
+//!
+//! The chunker holds its own `Tokenizer` instance (separate from the one
+//! fastembed loads inside `TextEmbedding`) — fastembed exposes no accessor,
+//! and re-loading the bundled `tokenizer.json` (~700 KB) once at startup
+//! is cheaper than refactoring `service.rs` to share state.
+//!
+//! The bundled `tokenizer.json` ships with `truncation.max_length = 128`
+//! and `padding.Fixed = 128` baked in (sentence-transformers exports those
+//! training-time defaults). We disable both in `load()` — without that
+//! step, every chunk would silently cap at 128 tokens.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tokenizers::Tokenizer;
+
+use super::{model_dir, EmbeddingError};
+
+/// Maximum *content* tokens per chunk. Picked so that after fastembed
+/// re-tokenises and prepends [CLS] / appends [SEP] (2 special tokens),
+/// the on-wire sequence is exactly 256 — matching MiniLM-L6-v2's training
+/// `max_seq_length` and the cap configured in `EmbeddingService::load`.
+pub const MAX_CONTENT_TOKENS: usize = 254;
+
+/// Default sliding-window overlap. 32/254 ≈ 12 % is the standard RAG
+/// trade-off between redundant compute and context preservation across
+/// chunk boundaries.
+pub const DEFAULT_OVERLAP_TOKENS: usize = 32;
+
+/// One chunk of source text plus its byte offset into the parent string.
+///
+/// Invariant: `parent[byte_offset..byte_offset + text.len()] == text` for
+/// every `Chunk` produced by `Chunker::chunk`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Chunk {
+    pub text: String,
+    pub byte_offset: usize,
+}
+
+pub struct Chunker {
+    tokenizer: Tokenizer,
+    max_tokens: usize,
+    overlap: usize,
+}
+
+impl Chunker {
+    /// Load the bundled MiniLM tokenizer with default caps
+    /// (`MAX_CONTENT_TOKENS` / `DEFAULT_OVERLAP_TOKENS`). Reuses
+    /// `model_dir()` for path resolution so it shares the resource-dir /
+    /// env-override / dev-fallback story with `EmbeddingService`.
+    pub fn load(resource_dir: Option<&Path>) -> Result<Arc<Self>, EmbeddingError> {
+        Self::with_limits(
+            resource_dir,
+            MAX_CONTENT_TOKENS,
+            DEFAULT_OVERLAP_TOKENS,
+        )
+    }
+
+    /// Load with explicit caps. Useful for tests and for downstream callers
+    /// (e.g. #196) that want different windows.
+    pub fn with_limits(
+        resource_dir: Option<&Path>,
+        max_tokens: usize,
+        overlap: usize,
+    ) -> Result<Arc<Self>, EmbeddingError> {
+        if max_tokens == 0 {
+            return Err(EmbeddingError::InvalidArgument(
+                "max_tokens must be > 0".into(),
+            ));
+        }
+        if overlap >= max_tokens {
+            return Err(EmbeddingError::InvalidArgument(format!(
+                "overlap ({overlap}) must be < max_tokens ({max_tokens})"
+            )));
+        }
+        let dir = model_dir(resource_dir)?;
+        let mut tok = Tokenizer::from_file(dir.join("tokenizer.json"))
+            .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+        // The bundled tokenizer.json has truncation.max_length=128 and
+        // padding.Fixed=128 baked in. Disable both — chunking is the only
+        // place those caps would silently bite us.
+        tok.with_truncation(None)
+            .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+        tok.with_padding(None);
+        Ok(Arc::new(Self {
+            tokenizer: tok,
+            max_tokens,
+            overlap,
+        }))
+    }
+
+    /// Split `input` into ≤`max_tokens` content-token chunks with
+    /// `overlap`-token slide. Whitespace-only input returns an empty Vec.
+    pub fn chunk(&self, input: &str) -> Result<Vec<Chunk>, EmbeddingError> {
+        if input.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Encode WITHOUT special tokens — we want only content tokens with
+        // byte offsets pointing into `input`. fastembed will re-add
+        // [CLS]/[SEP] when it embeds.
+        let enc = self
+            .tokenizer
+            .encode(input, false)
+            .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+        let offsets = enc.get_offsets();
+        let n = offsets.len();
+        if n == 0 {
+            return Ok(Vec::new());
+        }
+
+        if n <= self.max_tokens {
+            return Ok(vec![Chunk {
+                text: input.to_string(),
+                byte_offset: 0,
+            }]);
+        }
+
+        let stride = self.max_tokens - self.overlap;
+        let mut chunks = Vec::new();
+        let mut start_tok = 0usize;
+        loop {
+            let end_tok = (start_tok + self.max_tokens).min(n);
+            let byte_start = offsets[start_tok].0;
+            let byte_end = offsets[end_tok - 1].1;
+            chunks.push(Chunk {
+                text: input[byte_start..byte_end].to_string(),
+                byte_offset: byte_start,
+            });
+            if end_tok == n {
+                break;
+            }
+            start_tok += stride;
+        }
+        Ok(chunks)
+    }
+
+    #[cfg(test)]
+    fn token_count(&self, text: &str) -> usize {
+        self.tokenizer
+            .encode(text, false)
+            .map(|e| e.get_ids().len())
+            .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    fn token_ids(&self, text: &str) -> Vec<u32> {
+        self.tokenizer
+            .encode(text, false)
+            .map(|e| e.get_ids().to_vec())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn try_load() -> Option<Arc<Chunker>> {
+        match Chunker::load(None) {
+            Ok(c) => Some(c),
+            Err(_) => {
+                eprintln!("SKIP: tokenizer not bundled");
+                None
+            }
+        }
+    }
+
+    /// Build an input that encodes to *exactly* `target` content tokens.
+    /// "hello" tokenises to a single WordPiece on MiniLM; we repeat it,
+    /// then trim.
+    fn synth_input(chunker: &Chunker, target: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..target {
+            if !s.is_empty() {
+                s.push(' ');
+            }
+            s.push_str("hello");
+        }
+        // Defensive: in case spacing affects pretokenisation, trim down or
+        // pad up until token count matches.
+        while chunker.token_count(&s) > target {
+            let cut = s.rfind(' ').unwrap_or(0);
+            s.truncate(cut);
+        }
+        while chunker.token_count(&s) < target {
+            s.push_str(" hello");
+        }
+        s
+    }
+
+    #[test]
+    fn chunker_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Chunker>();
+        assert_send_sync::<Arc<Chunker>>();
+    }
+
+    #[test]
+    fn with_limits_rejects_zero_max() {
+        let e = Chunker::with_limits(None, 0, 0).err().expect("should error");
+        assert!(matches!(e, EmbeddingError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn with_limits_rejects_overlap_geq_max() {
+        let e = Chunker::with_limits(None, 10, 10).err().expect("should error");
+        assert!(matches!(e, EmbeddingError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn empty_input_returns_no_chunks() {
+        let Some(c) = try_load() else { return };
+        assert!(c.chunk("").unwrap().is_empty());
+    }
+
+    #[test]
+    fn whitespace_only_input_returns_no_chunks() {
+        let Some(c) = try_load() else { return };
+        assert!(c.chunk("   \n\t  ").unwrap().is_empty());
+    }
+
+    #[test]
+    fn short_note_returns_single_chunk_with_offset_zero() {
+        let Some(c) = try_load() else { return };
+        let chunks = c.chunk("hello world").unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].byte_offset, 0);
+        assert_eq!(chunks[0].text, "hello world");
+    }
+
+    #[test]
+    fn boundary_exactly_max_tokens_returns_single_chunk() {
+        let Some(c) = try_load() else { return };
+        let input = synth_input(&c, MAX_CONTENT_TOKENS);
+        assert_eq!(c.token_count(&input), MAX_CONTENT_TOKENS);
+        let chunks = c.chunk(&input).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].byte_offset, 0);
+        assert_eq!(chunks[0].text, input);
+    }
+
+    #[test]
+    fn boundary_max_plus_one_returns_two_chunks() {
+        let Some(c) = try_load() else { return };
+        let input = synth_input(&c, MAX_CONTENT_TOKENS + 1);
+        assert_eq!(c.token_count(&input), MAX_CONTENT_TOKENS + 1);
+        let chunks = c.chunk(&input).unwrap();
+        assert_eq!(chunks.len(), 2, "expected 2 chunks for max+1 tokens");
+    }
+
+    #[test]
+    fn long_note_chunk_count_matches_window_loop() {
+        let Some(c) = try_load() else { return };
+        let n = 1000usize;
+        let input = synth_input(&c, n);
+        let chunks = c.chunk(&input).unwrap();
+        // Match the loop semantics exactly: starts at 0, MAX-OVERLAP, ...
+        // until end_tok == n.
+        let stride = MAX_CONTENT_TOKENS - DEFAULT_OVERLAP_TOKENS;
+        let mut expected = 0usize;
+        let mut start = 0usize;
+        loop {
+            expected += 1;
+            let end = (start + MAX_CONTENT_TOKENS).min(n);
+            if end == n {
+                break;
+            }
+            start += stride;
+        }
+        assert_eq!(chunks.len(), expected);
+    }
+
+    #[test]
+    fn boundary_max_plus_stride_returns_two_chunks() {
+        let Some(c) = try_load() else { return };
+        let n = MAX_CONTENT_TOKENS + (MAX_CONTENT_TOKENS - DEFAULT_OVERLAP_TOKENS);
+        let input = synth_input(&c, n);
+        let chunks = c.chunk(&input).unwrap();
+        assert_eq!(chunks.len(), 2);
+    }
+
+    #[test]
+    fn offset_invariant_holds_for_every_chunk() {
+        let Some(c) = try_load() else { return };
+        let input = synth_input(&c, 600);
+        let chunks = c.chunk(&input).unwrap();
+        for chunk in &chunks {
+            let end = chunk.byte_offset + chunk.text.len();
+            assert!(input.is_char_boundary(chunk.byte_offset));
+            assert!(input.is_char_boundary(end));
+            assert_eq!(&input[chunk.byte_offset..end], chunk.text);
+        }
+    }
+
+    /// Overlap correctness: re-tokenising consecutive chunks against the
+    /// parent encoding shows the last `overlap` token IDs of chunk i are
+    /// the first `overlap` IDs of chunk i+1.
+    #[test]
+    fn consecutive_chunks_overlap_by_overlap_tokens() {
+        let Some(c) = try_load() else { return };
+        let input = synth_input(&c, 800);
+        let chunks = c.chunk(&input).unwrap();
+        assert!(chunks.len() >= 2);
+        for pair in chunks.windows(2) {
+            let prev_ids = c.token_ids(&pair[0].text);
+            let next_ids = c.token_ids(&pair[1].text);
+            let tail = &prev_ids[prev_ids.len() - DEFAULT_OVERLAP_TOKENS..];
+            let head = &next_ids[..DEFAULT_OVERLAP_TOKENS];
+            assert_eq!(tail, head, "overlap token IDs must match");
+        }
+    }
+
+    #[test]
+    fn multibyte_utf8_offsets_are_codepoint_aligned() {
+        let Some(c) = try_load() else { return };
+        let mut input = String::new();
+        for _ in 0..400 {
+            input.push_str("こんにちは 世界 🌍 ");
+        }
+        let chunks = c.chunk(&input).unwrap();
+        assert!(chunks.len() >= 2, "input should split");
+        for chunk in &chunks {
+            let end = chunk.byte_offset + chunk.text.len();
+            assert!(
+                input.is_char_boundary(chunk.byte_offset),
+                "byte_offset {} not on a char boundary",
+                chunk.byte_offset
+            );
+            assert!(
+                input.is_char_boundary(end),
+                "end {} not on a char boundary",
+                end
+            );
+            assert_eq!(&input[chunk.byte_offset..end], chunk.text);
+        }
+    }
+
+    #[test]
+    fn with_limits_custom_caps_respected() {
+        let Some(_) = try_load() else { return };
+        let c = Chunker::with_limits(None, 16, 4).expect("custom load");
+        let input = synth_input(&c, 50);
+        let chunks = c.chunk(&input).unwrap();
+        assert!(chunks.len() >= 2);
+        for pair in chunks.windows(2) {
+            let prev_ids = c.token_ids(&pair[0].text);
+            let next_ids = c.token_ids(&pair[1].text);
+            assert!(prev_ids.len() <= 16);
+            assert_eq!(&prev_ids[prev_ids.len() - 4..], &next_ids[..4]);
+        }
+    }
+
+    #[test]
+    fn single_token_input_produces_one_chunk() {
+        let Some(c) = try_load() else { return };
+        let chunks = c.chunk("hello").unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].byte_offset, 0);
+        assert_eq!(chunks[0].text, "hello");
+    }
+}

--- a/src-tauri/src/embeddings/embed_coordinator.rs
+++ b/src-tauri/src/embeddings/embed_coordinator.rs
@@ -3,15 +3,23 @@
 //! holding up the save IPC.
 //!
 //! Coalescing strategy: a `pending` map of `path → latest content` plus a
-//! bounded wake-up channel that only carries paths. The map is the source
-//! of truth; the channel is just a "there is work to do" signal. Three
-//! rapid saves to the same path overwrite one another in the map and
-//! produce exactly one embed.
+//! bounded wake-up channel that carries `EmbedOp` ops. The map is the
+//! source of truth for embed content; the channel signals "there is work
+//! to do" plus carries explicit deletes (#201).
 //!
-//! Backpressure: a full wake-up channel is benign because the latest
-//! content already lives in the map — any subsequent successful enqueue
-//! drains it. So the save IPC never blocks: `enqueue` is sync,
-//! non-blocking, and a `QueueFull` outcome only logs.
+//! Three rapid saves to the same path overwrite one another in the map
+//! and produce exactly one embed. Deletes are FIFO with respect to
+//! embeds — so an `Embed → Delete` sequence first inserts vectors then
+//! tombstones them, while a `Delete → Embed` sequence first cancels the
+//! pending embed (by removing the path from the map) then tombstones any
+//! prior vectors. Both end with the path absent from queries, matching
+//! the user's last-action intent.
+//!
+//! Backpressure: a full wake-up channel is benign for `Embed` because
+//! the latest content already lives in the map — any subsequent
+//! successful enqueue drains it. For `Delete` a full channel is rare
+//! enough that we log + drop; the next user save plus #201 PR-B's
+//! periodic reindex will re-converge.
 //!
 //! The worker MUST be spawned on `tokio::task::spawn_blocking` (not
 //! `tokio::spawn`). Two reasons: (1) `Receiver::blocking_recv` panics if
@@ -28,12 +36,21 @@ use tokio::sync::mpsc;
 
 use super::{Chunk, Chunker, EmbeddingService, VectorSink};
 
-/// Wake-up channel capacity. Carries `PathBuf` only — actual content
-/// lives in the `pending` map. 1024 slots is generous: every event is
-/// keyboard-paced (one human, one editor) and a full channel still
-/// preserves correctness via the map. The indexer uses 8192 because it
-/// absorbs bulk filesystem events; this queue does not.
+/// Wake-up channel capacity. Carries `EmbedOp` (path-only signals); embed
+/// content lives in the `pending` map. 1024 slots is generous — every
+/// event is keyboard-paced and even external bulk deletes rarely land
+/// >1k events in a single tick.
 pub const WAKEUP_CAPACITY: usize = 1024;
+
+/// Op carried on the wake-up channel. `Embed` is a content-less signal —
+/// the actual content lives in the `pending` map and the worker drains
+/// it on each Embed wake-up. `Delete(path)` carries the path because
+/// deletes don't go through the pending map.
+#[derive(Debug, Clone)]
+pub enum EmbedOp {
+    Embed,
+    Delete(PathBuf),
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum EnqueueError {
@@ -46,7 +63,7 @@ pub enum EnqueueError {
 }
 
 pub struct EmbedCoordinator {
-    pub tx: mpsc::Sender<PathBuf>,
+    pub tx: mpsc::Sender<EmbedOp>,
     pub pending: Arc<Mutex<HashMap<PathBuf, String>>>,
 }
 
@@ -70,7 +87,7 @@ impl EmbedCoordinator {
         sink: Arc<dyn VectorSink>,
         capacity: usize,
     ) -> Self {
-        let (tx, rx) = mpsc::channel::<PathBuf>(capacity.max(1));
+        let (tx, rx) = mpsc::channel::<EmbedOp>(capacity.max(1));
         let pending: Arc<Mutex<HashMap<PathBuf, String>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let worker_pending = Arc::clone(&pending);
@@ -80,9 +97,9 @@ impl EmbedCoordinator {
         Self { tx, pending }
     }
 
-    /// Non-blocking enqueue. Updates the pending map then signals the
-    /// worker. `QueueFull` is benign — the content is in the map and the
-    /// next successful enqueue (same path or another) will trigger a
+    /// Non-blocking embed enqueue. Updates the pending map then signals
+    /// the worker. `QueueFull` is benign — the content is in the map and
+    /// the next successful enqueue (same path or another) will trigger a
     /// drain. Caller logs and proceeds.
     pub fn enqueue(
         &self,
@@ -94,9 +111,22 @@ impl EmbedCoordinator {
                 .pending
                 .lock()
                 .map_err(|_| EnqueueError::LockPoisoned)?;
-            g.insert(path.clone(), content);
+            g.insert(path, content);
         }
-        match self.tx.try_send(path) {
+        match self.tx.try_send(EmbedOp::Embed) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::QueueFull),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
+        }
+    }
+
+    /// Non-blocking delete enqueue (#201). Worker FIFO-orders Delete
+    /// against any pending Embed wake-ups. A `QueueFull` outcome here is
+    /// rarer than for embeds (deletes don't have the keyboard-burst
+    /// pattern) and the next user save's wake-up will not retroactively
+    /// dispatch the delete — caller logs.
+    pub fn enqueue_delete(&self, path: PathBuf) -> Result<(), EnqueueError> {
+        match self.tx.try_send(EmbedOp::Delete(path)) {
             Ok(()) => Ok(()),
             Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::QueueFull),
             Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
@@ -114,40 +144,52 @@ fn run_worker(
     chunker: Arc<Chunker>,
     sink: Arc<dyn VectorSink>,
     pending: Arc<Mutex<HashMap<PathBuf, String>>>,
-    mut rx: mpsc::Receiver<PathBuf>,
+    mut rx: mpsc::Receiver<EmbedOp>,
 ) {
-    while let Some(_path) = rx.blocking_recv() {
-        // Drain redundant wake-ups — the map already coalesces content.
-        while rx.try_recv().is_ok() {}
-
-        let snapshot: Vec<(PathBuf, String)> = match pending.lock() {
-            Ok(mut g) => g.drain().collect(),
-            Err(_) => {
-                log::warn!("embed pending map poisoned; skipping batch");
-                continue;
+    while let Some(op) = rx.blocking_recv() {
+        match op {
+            EmbedOp::Delete(path) => {
+                // Cancel any in-flight embed for this path so a Delete →
+                // Embed race ends with the path absent. Then mark the
+                // path's vectors tombstoned in the sink.
+                if let Ok(mut g) = pending.lock() {
+                    g.remove(&path);
+                } else {
+                    log::warn!("embed pending map poisoned during delete; tombstone may race");
+                }
+                sink.delete(&path);
             }
-        };
+            EmbedOp::Embed => {
+                let snapshot: Vec<(PathBuf, String)> = match pending.lock() {
+                    Ok(mut g) => g.drain().collect(),
+                    Err(_) => {
+                        log::warn!("embed pending map poisoned; skipping batch");
+                        continue;
+                    }
+                };
 
-        for (path, content) in snapshot {
-            let chunks = match chunker.chunk(&content) {
-                Ok(c) if c.is_empty() => continue,
-                Ok(c) => c,
-                Err(e) => {
-                    log::warn!("chunker failed for {}: {e}", path.display());
-                    continue;
+                for (path, content) in snapshot {
+                    let chunks = match chunker.chunk(&content) {
+                        Ok(c) if c.is_empty() => continue,
+                        Ok(c) => c,
+                        Err(e) => {
+                            log::warn!("chunker failed for {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+                    let vectors = match service.embed_batch(&texts) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            log::warn!("embed failed for {}: {e}", path.display());
+                            continue;
+                        }
+                    };
+                    let pairs: Vec<(Chunk, Vec<f32>)> =
+                        chunks.into_iter().zip(vectors).collect();
+                    sink.store(&path, pairs);
                 }
-            };
-            let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
-            let vectors = match service.embed_batch(&texts) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::warn!("embed failed for {}: {e}", path.display());
-                    continue;
-                }
-            };
-            let pairs: Vec<(Chunk, Vec<f32>)> =
-                chunks.into_iter().zip(vectors).collect();
-            sink.store(&path, pairs);
+            }
         }
     }
     log::info!("EmbedCoordinator worker shut down");
@@ -160,22 +202,31 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
 
-    /// Collects every `store` call so tests can assert coalescing.
+    /// Collects every `store` and `delete` call so tests can assert
+    /// coalescing and FIFO order.
     struct CountingSink {
         calls: AtomicUsize,
+        deletes: AtomicUsize,
         by_path: Mutex<HashMap<PathBuf, Vec<String>>>,
+        deleted_paths: Mutex<Vec<PathBuf>>,
     }
 
     impl CountingSink {
         fn new() -> Arc<Self> {
             Arc::new(Self {
                 calls: AtomicUsize::new(0),
+                deletes: AtomicUsize::new(0),
                 by_path: Mutex::new(HashMap::new()),
+                deleted_paths: Mutex::new(Vec::new()),
             })
         }
 
         fn calls(&self) -> usize {
             self.calls.load(Ordering::SeqCst)
+        }
+
+        fn deletes(&self) -> usize {
+            self.deletes.load(Ordering::SeqCst)
         }
 
         fn paths(&self) -> Vec<PathBuf> {
@@ -196,6 +247,10 @@ mod tests {
                 .entry(path.to_path_buf())
                 .or_default()
                 .extend(snippets);
+        }
+        fn delete(&self, path: &Path) {
+            self.deletes.fetch_add(1, Ordering::SeqCst);
+            self.deleted_paths.lock().unwrap().push(path.to_path_buf());
         }
     }
 
@@ -438,6 +493,63 @@ mod tests {
             let _ = probe.enqueue("/tmp/x".into(), "x".into());
             // Drop the probe (closes the last sender).
             drop(probe);
+        });
+    }
+
+    /// #201 PR-A: enqueue_delete dispatches a Delete op that the sink
+    /// observes. The minimal sanity check; richer FIFO ordering is in
+    /// the next test.
+    #[test]
+    fn enqueue_delete_calls_sink_delete() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            let p = PathBuf::from("/tmp/del.md");
+            coord.enqueue_delete(p.clone()).unwrap();
+            assert!(wait_until(|| sink.deletes() == 1, Duration::from_secs(5)));
+            let deleted = sink.deleted_paths.lock().unwrap();
+            assert_eq!(deleted.as_slice(), &[p]);
+        });
+    }
+
+    /// #201 PR-A: a Delete that arrives before its companion Embed has
+    /// drained must cancel the in-flight embed for the same path so
+    /// the path ends up absent (matching the user's last-action intent).
+    #[test]
+    fn delete_cancels_pending_embed_for_same_path() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            // Capacity 1 so we can almost certainly slot the Delete in
+            // before the worker drains the prior Embed wake-up.
+            let coord = EmbedCoordinator::spawn_with_capacity(
+                svc,
+                chk,
+                sink.clone() as Arc<dyn VectorSink>,
+                4,
+            );
+            let p = PathBuf::from("/tmp/race.md");
+            coord.enqueue(p.clone(), "doomed".to_string()).unwrap();
+            // Immediately follow with a delete. The worker may have
+            // already drained the embed wake-up and started embedding —
+            // both outcomes are acceptable as long as the final state
+            // reports the path tombstoned.
+            coord.enqueue_delete(p.clone()).unwrap();
+            assert!(wait_until(
+                || sink.deletes() == 1,
+                Duration::from_secs(5),
+            ));
+            // Either: embed never ran (cancelled) → calls() == 0
+            // Or:     embed ran then delete tombstoned → calls() == 1
+            // The invariant we care about is that delete was observed.
+            assert_eq!(sink.deletes(), 1);
         });
     }
 }

--- a/src-tauri/src/embeddings/embed_coordinator.rs
+++ b/src-tauri/src/embeddings/embed_coordinator.rs
@@ -120,6 +120,49 @@ impl EmbedCoordinator {
         }
     }
 
+    /// #201 PR-D — bulk enqueue for the reindex worker. Inserts every
+    /// `(path, content)` into the pending map, then sends *one* wake-up
+    /// signal instead of one per file. This gives the embedder a large
+    /// cross-file drain window so `run_embed_batch` can run its sub-batch
+    /// loop over ~N-files × ~3-chunks at once rather than near-singleton
+    /// batches (which made ORT setup overhead dominate).
+    ///
+    /// Per-item behaviour matches `enqueue`: content is written to the
+    /// pending map; a `QueueFull` wake-up is benign because the content
+    /// already sits in the map and the next successful wake-up drains it.
+    /// Returns the number of items inserted; errors on lock poisoning.
+    pub fn enqueue_bulk(
+        &self,
+        items: impl IntoIterator<Item = (PathBuf, String)>,
+    ) -> Result<usize, EnqueueError> {
+        let mut count = 0usize;
+        {
+            let mut g = self
+                .pending
+                .lock()
+                .map_err(|_| EnqueueError::LockPoisoned)?;
+            for (path, content) in items {
+                g.insert(path, content);
+                count += 1;
+            }
+        }
+        if count == 0 {
+            return Ok(0);
+        }
+        match self.tx.try_send(EmbedOp::Embed) {
+            Ok(()) => Ok(count),
+            Err(mpsc::error::TrySendError::Full(_)) => Ok(count),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
+        }
+    }
+
+    /// #201 PR-D — current size of the pending map. Used by the reindex
+    /// worker to bound in-flight memory when reading ahead of the
+    /// embedder (avoids a 100k-vault queuing every file body in RAM).
+    pub fn pending_len(&self) -> usize {
+        self.pending.lock().map(|g| g.len()).unwrap_or(0)
+    }
+
     /// Non-blocking delete enqueue (#201). Worker FIFO-orders Delete
     /// against any pending Embed wake-ups. A `QueueFull` outcome here is
     /// rarer than for embeds (deletes don't have the keyboard-burst
@@ -167,32 +210,106 @@ fn run_worker(
                         continue;
                     }
                 };
-
-                for (path, content) in snapshot {
-                    let chunks = match chunker.chunk(&content) {
-                        Ok(c) if c.is_empty() => continue,
-                        Ok(c) => c,
-                        Err(e) => {
-                            log::warn!("chunker failed for {}: {e}", path.display());
-                            continue;
-                        }
-                    };
-                    let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
-                    let vectors = match service.embed_batch(&texts) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            log::warn!("embed failed for {}: {e}", path.display());
-                            continue;
-                        }
-                    };
-                    let pairs: Vec<(Chunk, Vec<f32>)> =
-                        chunks.into_iter().zip(vectors).collect();
-                    sink.store(&path, pairs);
-                }
+                run_embed_batch(&service, &chunker, &sink, snapshot);
             }
         }
     }
     log::info!("EmbedCoordinator worker shut down");
+}
+
+/// Cross-file batching window (#201 PR-D). When the worker drains the
+/// pending map, it chunks every file, pools all chunks across files into
+/// sub-batches of this size, and runs each sub-batch through a single
+/// `embed_batch` call. This nets 3-5× throughput during reindex (where the
+/// drain may hold hundreds of files) vs the old per-file batch loop that
+/// paid ORT setup overhead once per note.
+///
+/// 64 is picked to keep each inference call small enough to fit comfortably
+/// in RAM (~200 KB of int8 tokens + ~100 KB of fp32 outputs) while large
+/// enough to saturate fastembed's internal parallelism at intra=2.
+const EMBED_BATCH_SIZE: usize = 64;
+
+/// Chunk every file in the drained snapshot, run a single cross-file
+/// `embed_batch` (capped at `EMBED_BATCH_SIZE` per sub-batch), then
+/// partition the resulting vectors back onto their source paths and
+/// hand each (path, (Chunk, Vec<f32>) pairs) slice to the sink.
+///
+/// Failures are localised: a chunker error skips the file; an embed_batch
+/// error fails only the current sub-batch (the files straddling it lose
+/// their store this round and will be retried on the next save/reindex).
+fn run_embed_batch(
+    service: &EmbeddingService,
+    chunker: &Chunker,
+    sink: &Arc<dyn VectorSink>,
+    snapshot: Vec<(PathBuf, String)>,
+) {
+    if snapshot.is_empty() {
+        return;
+    }
+
+    // Chunk every file. `(path, chunks)` pairs are preserved in order so
+    // we can slice vectors back onto them after the cross-file embed.
+    let mut per_file: Vec<(PathBuf, Vec<Chunk>)> = Vec::with_capacity(snapshot.len());
+    for (path, content) in snapshot {
+        match chunker.chunk(&content) {
+            Ok(c) if c.is_empty() => {}
+            Ok(c) => per_file.push((path, c)),
+            Err(e) => log::warn!("chunker failed for {}: {e}", path.display()),
+        }
+    }
+    if per_file.is_empty() {
+        return;
+    }
+
+    // Flatten into a single texts vec; record (file_index, chunk_in_file)
+    // for each flat position so we can re-partition after inference.
+    let mut flat_texts: Vec<&str> = Vec::new();
+    let mut coords: Vec<(usize, usize)> = Vec::new();
+    for (fi, (_p, chunks)) in per_file.iter().enumerate() {
+        for (ci, chunk) in chunks.iter().enumerate() {
+            flat_texts.push(chunk.text.as_str());
+            coords.push((fi, ci));
+        }
+    }
+
+    // Bucket each file's vectors back under its path. Pre-size to the
+    // per-file chunk counts so we can fill by index without resizing.
+    let mut vectors_by_file: Vec<Vec<Option<Vec<f32>>>> = per_file
+        .iter()
+        .map(|(_, chunks)| (0..chunks.len()).map(|_| None).collect())
+        .collect();
+
+    // Run the embed in sub-batches. A sub-batch failure is isolated — we
+    // log and continue (the affected files will miss this round; the
+    // reindex checkpoint / next save covers the re-queue).
+    for (sub_start, sub_texts) in flat_texts.chunks(EMBED_BATCH_SIZE).enumerate() {
+        let global_offset = sub_start * EMBED_BATCH_SIZE;
+        let vectors = match service.embed_batch(sub_texts) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!(
+                    "embed sub-batch failed (size {}): {e}; skipping {} files this round",
+                    sub_texts.len(),
+                    sub_texts.len()
+                );
+                continue;
+            }
+        };
+        for (i, vec) in vectors.into_iter().enumerate() {
+            let (fi, ci) = coords[global_offset + i];
+            vectors_by_file[fi][ci] = Some(vec);
+        }
+    }
+
+    // Hand each fully-populated file to the sink. Partial files (a
+    // sub-batch failed mid-file) are skipped so the sink never sees a
+    // truncated vector set.
+    for ((path, chunks), slots) in per_file.into_iter().zip(vectors_by_file.into_iter()) {
+        let full: Option<Vec<Vec<f32>>> = slots.into_iter().collect();
+        let Some(full_vectors) = full else { continue };
+        let pairs: Vec<(Chunk, Vec<f32>)> = chunks.into_iter().zip(full_vectors).collect();
+        sink.store(&path, pairs);
+    }
 }
 
 #[cfg(test)]
@@ -513,6 +630,59 @@ mod tests {
             assert!(wait_until(|| sink.deletes() == 1, Duration::from_secs(5)));
             let deleted = sink.deleted_paths.lock().unwrap();
             assert_eq!(deleted.as_slice(), &[p]);
+        });
+    }
+
+    /// #201 PR-D: enqueue_bulk inserts every item into the pending map
+    /// and sends exactly one wake-up signal. The worker drains the full
+    /// set on that single wake-up.
+    #[test]
+    fn enqueue_bulk_inserts_all_items_and_wakes_worker_once() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            let batch: Vec<(PathBuf, String)> = (0..8)
+                .map(|i| (PathBuf::from(format!("/tmp/bulk-{i}.md")), format!("body {i}")))
+                .collect();
+            let n = coord.enqueue_bulk(batch).expect("enqueue_bulk ok");
+            assert_eq!(n, 8);
+            assert!(wait_until(
+                || sink.paths().len() >= 8,
+                Duration::from_secs(10),
+            ));
+            assert_eq!(sink.paths().len(), 8);
+        });
+    }
+
+    /// #201 PR-D: pending_len reflects map size before the worker drains.
+    #[test]
+    fn pending_len_reports_queued_items() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn_with_capacity(
+                svc,
+                chk,
+                sink.clone() as Arc<dyn VectorSink>,
+                1,
+            );
+            // Fill the map WITHOUT signalling by not using enqueue — grab
+            // the lock directly. This isolates the counter from the
+            // worker drain.
+            {
+                let mut g = coord.pending.lock().unwrap();
+                for i in 0..5 {
+                    g.insert(PathBuf::from(format!("/tmp/plen-{i}.md")), "x".to_string());
+                }
+            }
+            assert_eq!(coord.pending_len(), 5);
         });
     }
 

--- a/src-tauri/src/embeddings/embed_coordinator.rs
+++ b/src-tauri/src/embeddings/embed_coordinator.rs
@@ -284,7 +284,10 @@ fn run_embed_batch(
     // reindex checkpoint / next save covers the re-queue).
     for (sub_start, sub_texts) in flat_texts.chunks(EMBED_BATCH_SIZE).enumerate() {
         let global_offset = sub_start * EMBED_BATCH_SIZE;
-        let vectors = match service.embed_batch(sub_texts) {
+        // Indexing path — every chunk gets the e5 "passage: " prefix so
+        // the index lives in the same subspace that `embed_query` targets.
+        // Dropping to bare `embed_batch` here silently halves recall.
+        let vectors = match service.embed_passage_batch(sub_texts) {
             Ok(v) => v,
             Err(e) => {
                 log::warn!(

--- a/src-tauri/src/embeddings/embed_coordinator.rs
+++ b/src-tauri/src/embeddings/embed_coordinator.rs
@@ -1,0 +1,443 @@
+//! `EmbedCoordinator` (#196) — async, debounced, non-blocking pipeline
+//! that turns every save into a chunk → embed → sink-store cycle without
+//! holding up the save IPC.
+//!
+//! Coalescing strategy: a `pending` map of `path → latest content` plus a
+//! bounded wake-up channel that only carries paths. The map is the source
+//! of truth; the channel is just a "there is work to do" signal. Three
+//! rapid saves to the same path overwrite one another in the map and
+//! produce exactly one embed.
+//!
+//! Backpressure: a full wake-up channel is benign because the latest
+//! content already lives in the map — any subsequent successful enqueue
+//! drains it. So the save IPC never blocks: `enqueue` is sync,
+//! non-blocking, and a `QueueFull` outcome only logs.
+//!
+//! The worker MUST be spawned on `tokio::task::spawn_blocking` (not
+//! `tokio::spawn`). Two reasons: (1) `Receiver::blocking_recv` panics if
+//! a Tokio runtime is running on the calling thread, and (2) ORT
+//! inference is synchronous + CPU-bound (~10–25 ms), which would stall
+//! every other future on the runtime. Same precedent as the Tantivy
+//! IndexCoordinator at `src-tauri/src/indexer/mod.rs:201-216`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+
+use super::{Chunk, Chunker, EmbeddingService, VectorSink};
+
+/// Wake-up channel capacity. Carries `PathBuf` only — actual content
+/// lives in the `pending` map. 1024 slots is generous: every event is
+/// keyboard-paced (one human, one editor) and a full channel still
+/// preserves correctness via the map. The indexer uses 8192 because it
+/// absorbs bulk filesystem events; this queue does not.
+pub const WAKEUP_CAPACITY: usize = 1024;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EnqueueError {
+    #[error("embed wake-up channel full — embed will run on next save")]
+    QueueFull,
+    #[error("embed coordinator shut down")]
+    Closed,
+    #[error("pending map mutex poisoned")]
+    LockPoisoned,
+}
+
+pub struct EmbedCoordinator {
+    pub tx: mpsc::Sender<PathBuf>,
+    pub pending: Arc<Mutex<HashMap<PathBuf, String>>>,
+}
+
+impl EmbedCoordinator {
+    /// Spawn the worker on the blocking pool. The `service`, `chunker`,
+    /// and `sink` are passed in so tests can inject a counting sink.
+    pub fn spawn(
+        service: Arc<EmbeddingService>,
+        chunker: Arc<Chunker>,
+        sink: Arc<dyn VectorSink>,
+    ) -> Self {
+        Self::spawn_with_capacity(service, chunker, sink, WAKEUP_CAPACITY)
+    }
+
+    /// Spawn with a custom wake-up channel capacity. Test-only entry that
+    /// makes deterministic `QueueFull` reproducible without flooding 1024
+    /// paths.
+    pub fn spawn_with_capacity(
+        service: Arc<EmbeddingService>,
+        chunker: Arc<Chunker>,
+        sink: Arc<dyn VectorSink>,
+        capacity: usize,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel::<PathBuf>(capacity.max(1));
+        let pending: Arc<Mutex<HashMap<PathBuf, String>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let worker_pending = Arc::clone(&pending);
+        tokio::task::spawn_blocking(move || {
+            run_worker(service, chunker, sink, worker_pending, rx);
+        });
+        Self { tx, pending }
+    }
+
+    /// Non-blocking enqueue. Updates the pending map then signals the
+    /// worker. `QueueFull` is benign — the content is in the map and the
+    /// next successful enqueue (same path or another) will trigger a
+    /// drain. Caller logs and proceeds.
+    pub fn enqueue(
+        &self,
+        path: PathBuf,
+        content: String,
+    ) -> Result<(), EnqueueError> {
+        {
+            let mut g = self
+                .pending
+                .lock()
+                .map_err(|_| EnqueueError::LockPoisoned)?;
+            g.insert(path.clone(), content);
+        }
+        match self.tx.try_send(path) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(EnqueueError::QueueFull),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(EnqueueError::Closed),
+        }
+    }
+}
+
+// `tx` is the only Sender clone held outside the coordinator itself —
+// `dispatch_embed_update` in `commands/files.rs` clones it transiently
+// per save and drops it before returning. So dropping the coordinator
+// closes the channel and the worker's `blocking_recv` returns `None`.
+
+fn run_worker(
+    service: Arc<EmbeddingService>,
+    chunker: Arc<Chunker>,
+    sink: Arc<dyn VectorSink>,
+    pending: Arc<Mutex<HashMap<PathBuf, String>>>,
+    mut rx: mpsc::Receiver<PathBuf>,
+) {
+    while let Some(_path) = rx.blocking_recv() {
+        // Drain redundant wake-ups — the map already coalesces content.
+        while rx.try_recv().is_ok() {}
+
+        let snapshot: Vec<(PathBuf, String)> = match pending.lock() {
+            Ok(mut g) => g.drain().collect(),
+            Err(_) => {
+                log::warn!("embed pending map poisoned; skipping batch");
+                continue;
+            }
+        };
+
+        for (path, content) in snapshot {
+            let chunks = match chunker.chunk(&content) {
+                Ok(c) if c.is_empty() => continue,
+                Ok(c) => c,
+                Err(e) => {
+                    log::warn!("chunker failed for {}: {e}", path.display());
+                    continue;
+                }
+            };
+            let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+            let vectors = match service.embed_batch(&texts) {
+                Ok(v) => v,
+                Err(e) => {
+                    log::warn!("embed failed for {}: {e}", path.display());
+                    continue;
+                }
+            };
+            let pairs: Vec<(Chunk, Vec<f32>)> =
+                chunks.into_iter().zip(vectors).collect();
+            sink.store(&path, pairs);
+        }
+    }
+    log::info!("EmbedCoordinator worker shut down");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    /// Collects every `store` call so tests can assert coalescing.
+    struct CountingSink {
+        calls: AtomicUsize,
+        by_path: Mutex<HashMap<PathBuf, Vec<String>>>,
+    }
+
+    impl CountingSink {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                by_path: Mutex::new(HashMap::new()),
+            })
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        fn paths(&self) -> Vec<PathBuf> {
+            self.by_path.lock().unwrap().keys().cloned().collect()
+        }
+    }
+
+    impl VectorSink for CountingSink {
+        fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let snippets: Vec<String> = chunks_with_vectors
+                .into_iter()
+                .map(|(c, _)| c.text)
+                .collect();
+            self.by_path
+                .lock()
+                .unwrap()
+                .entry(path.to_path_buf())
+                .or_default()
+                .extend(snippets);
+        }
+    }
+
+    fn try_load_service_and_chunker() -> Option<(Arc<EmbeddingService>, Arc<Chunker>)> {
+        let svc = EmbeddingService::load(None).ok()?;
+        let chk = Chunker::load(None).ok()?;
+        Some((svc, chk))
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    /// Wait for the worker to drain. Polls the pending map + a sink-side
+    /// signal up to `timeout`. Returns `true` if `cond` becomes true.
+    fn wait_until<F: Fn() -> bool>(cond: F, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        cond()
+    }
+
+    #[test]
+    fn coalesces_three_rapid_saves_to_one_embed() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            let path = PathBuf::from("/tmp/coalesce.md");
+            for v in ["v1", "v2", "v3"] {
+                coord
+                    .enqueue(path.clone(), v.to_string())
+                    .expect("enqueue ok");
+            }
+            assert!(wait_until(|| sink.calls() >= 1, Duration::from_secs(5)));
+            // Give a beat for any spurious extra batches; coalescing should
+            // keep us at exactly one.
+            std::thread::sleep(Duration::from_millis(150));
+            assert_eq!(sink.calls(), 1, "three rapid saves must coalesce");
+            // Latest content wins.
+            let by_path = sink.by_path.lock().unwrap();
+            let snippets = &by_path[&path];
+            assert!(
+                snippets.iter().any(|s| s.contains("v3")),
+                "latest content must reach the sink, got {:?}",
+                snippets
+            );
+        });
+    }
+
+    #[test]
+    fn different_paths_each_get_one_embed() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            for i in 0..5 {
+                let p = PathBuf::from(format!("/tmp/note-{i}.md"));
+                coord.enqueue(p, format!("note number {i}")).unwrap();
+            }
+            assert!(wait_until(
+                || sink.paths().len() >= 5,
+                Duration::from_secs(5)
+            ));
+            assert_eq!(sink.paths().len(), 5);
+        });
+    }
+
+    /// Lost-wake guard: after the last enqueue returns, the worker MUST
+    /// eventually drain the pending map. A regression that swaps the
+    /// `tx.try_send` to before the `pending.insert` would silently drop
+    /// the final save — this test catches that.
+    #[test]
+    fn pending_map_is_eventually_drained() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            for i in 0..20 {
+                let p = PathBuf::from(format!("/tmp/drain-{i}.md"));
+                coord.enqueue(p, format!("content {i}")).unwrap();
+            }
+            let pending = Arc::clone(&coord.pending);
+            let drained = wait_until(
+                || {
+                    pending.lock().map(|g| g.is_empty()).unwrap_or(false)
+                        && sink.calls() >= 1
+                },
+                Duration::from_secs(10),
+            );
+            assert!(drained, "pending map should drain");
+        });
+    }
+
+    #[test]
+    fn queue_full_returns_queue_full_but_content_persists() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            // Capacity 1: as soon as the worker is mid-embed and we issue
+            // 2+ enqueues, the second one MAY return QueueFull (depending
+            // on whether the worker already pulled the first signal).
+            // We assert: regardless of QueueFull occurrences, the latest
+            // content for the path reaches the sink.
+            let coord = EmbedCoordinator::spawn_with_capacity(
+                svc,
+                chk,
+                sink.clone() as Arc<dyn VectorSink>,
+                1,
+            );
+            let path = PathBuf::from("/tmp/qfull.md");
+            // Hammer enough enqueues that at least one observes Full.
+            let mut saw_full = false;
+            for i in 0..50 {
+                match coord.enqueue(path.clone(), format!("v{i}")) {
+                    Ok(()) => {}
+                    Err(EnqueueError::QueueFull) => saw_full = true,
+                    Err(other) => panic!("unexpected err: {other:?}"),
+                }
+            }
+            // Drain.
+            assert!(wait_until(
+                || coord.pending.lock().map(|g| g.is_empty()).unwrap_or(false)
+                    && sink.calls() >= 1,
+                Duration::from_secs(10),
+            ));
+            // The content for path is in the sink even if QueueFull happened.
+            let by_path = sink.by_path.lock().unwrap();
+            assert!(by_path.contains_key(&path), "path must be embedded");
+            // Document the saw_full observation; not asserting because
+            // scheduling can occasionally drain fast enough to never fill.
+            log::info!("queue_full test saw QueueFull = {saw_full}");
+        });
+    }
+
+    /// AC: "Queue bounded; Stress-Test mit 1k Rapid-Saves". 1000 enqueues
+    /// across 30 distinct paths. `#[ignore]` because real MiniLM inference
+    /// saturates the CPU and starves timing-sensitive tests in sibling
+    /// modules (e.g. `orphan_cleanup_tests::wait_for_drain` only allows a
+    /// 400 ms margin around `OnCommitWithDelay`). Run explicitly with
+    /// `cargo test -- --ignored stress_thousand_enqueues_coalesce`.
+    #[test]
+    #[ignore]
+    fn stress_thousand_enqueues_coalesce() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            const N_PATHS: usize = 30;
+            const N_ENQUEUES: usize = 1000;
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            for i in 0..N_ENQUEUES {
+                let p = PathBuf::from(format!("/tmp/stress-{}.md", i % N_PATHS));
+                let _ = coord.enqueue(p, format!("iter {i}"));
+            }
+            assert!(wait_until(
+                || sink.paths().len() >= N_PATHS
+                    && coord.pending.lock().map(|g| g.is_empty()).unwrap_or(false),
+                Duration::from_secs(30),
+            ));
+            assert_eq!(sink.paths().len(), N_PATHS, "every path must embed at least once");
+            let calls = sink.calls();
+            assert!(calls >= N_PATHS, "lower bound: each path embedded once");
+            // Upper bound is loose — coalescing should keep us well under
+            // the input count. 3× the path count = fudge for the
+            // late-arrival re-embed pattern (a save lands after the
+            // worker drained but before the embed completed).
+            assert!(
+                calls <= N_PATHS * 3,
+                "coalescing too weak: {calls} embeds for {N_ENQUEUES} enqueues across {N_PATHS} paths"
+            );
+        });
+    }
+
+    #[test]
+    fn drop_terminates_worker() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink.clone() as Arc<dyn VectorSink>);
+            let tx_weak = coord.tx.clone(); // hold a clone to inspect closure
+            drop(coord);
+            // Closing the only owned Sender (coord.tx) should cause the
+            // worker's blocking_recv to return None and the task to exit
+            // — but we still hold tx_weak. Drop it too.
+            drop(tx_weak);
+            // No direct join handle — exercise the channel: a fresh
+            // Sender clone via the dropped path is impossible. Simply
+            // assert that no panic occurred during drop.
+            std::thread::sleep(Duration::from_millis(50));
+        });
+    }
+
+    #[test]
+    fn enqueue_reports_closed_after_worker_dropped() {
+        let Some((svc, chk)) = try_load_service_and_chunker() else {
+            eprintln!("SKIP");
+            return;
+        };
+        block_on(async move {
+            let sink = CountingSink::new();
+            let coord = EmbedCoordinator::spawn(svc, chk, sink as Arc<dyn VectorSink>);
+            // Clone the sender so we can keep using it after we close the
+            // primary side.
+            let tx = coord.tx.clone();
+            let pending = Arc::clone(&coord.pending);
+            drop(coord);
+            // Wait briefly for the worker to wind down.
+            std::thread::sleep(Duration::from_millis(100));
+            // Now use a hand-built enqueue: the worker is gone, but the
+            // tx clone is still alive. After we drop tx the channel
+            // closes from the receiver side too on next try_send.
+            let probe = EmbedCoordinator { tx, pending };
+            // First try may go through (worker just shut, channel still open).
+            let _ = probe.enqueue("/tmp/x".into(), "x".into());
+            // Drop the probe (closes the last sender).
+            drop(probe);
+        });
+    }
+}

--- a/src-tauri/src/embeddings/hybrid.rs
+++ b/src-tauri/src/embeddings/hybrid.rs
@@ -1,0 +1,308 @@
+//! `hybrid` (#203) — Reciprocal Rank Fusion of BM25 (Tantivy) and
+//! HNSW (vector) ranks into a single top-k list.
+//!
+//! RRF per Cormack et al. 2009 § 3: `score(d) = Σ 1 / (k_rrf + rank_i(d))`
+//! where `rank_i` is 1-indexed within each source. `k_rrf = 60` is the
+//! literature-standard anchor (see research #188).
+//!
+//! This module is the pure math layer — no Tantivy / no HNSW imports.
+//! The Tauri command (`commands::search::hybrid_search`) owns the
+//! parallel fan-out, snippet re-generation, and serde shape.
+//!
+//! Chunked input handling: the vector side returns one hit per
+//! *chunk*, so a chunky note can occupy ranks 1, 3, and 8. Per the
+//! standard recipe (and every production RRF implementation I've
+//! seen — Weaviate, Vespa, Elastic) we **collapse to best-rank-per-path
+//! before fusing**. Keeping chunk ranks inflates chunky notes with a
+//! harmonic-series mass that is not a property of the underlying
+//! document's relevance.
+
+use std::collections::HashMap;
+
+/// Literature-standard RRF anchor (#188). Exposed as a `const` so the
+/// #207 benchmark harness can sweep without touching the math.
+pub const RRF_K: f32 = 60.0;
+
+/// One post-fusion ranked entry. `path` is the stable note id; the
+/// per-source rank/score fields let callers show "matched by: BM25
+/// rank 3 / vector rank 12" in debug UIs. All `Option<_>` fields
+/// default-skip in serde so the wire shape stays clean when a hit
+/// comes from only one source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedHit {
+    pub path: String,
+    pub score: f32,
+    pub bm25_rank: Option<u32>,
+    pub vec_rank: Option<u32>,
+    pub bm25_score: Option<f32>,
+    pub vec_score: Option<f32>,
+}
+
+/// Compute RRF fusion over one BM25 rank list and one vector rank list.
+///
+/// Inputs are already sorted by each source's native relevance (BM25
+/// desc by score; vector desc by cosine similarity). The function:
+/// 1. Collapses vector chunks to best-rank-per-path.
+/// 2. Walks each list assigning 1-indexed rank and accumulating
+///    `1 / (RRF_K + rank)` per path.
+/// 3. Sorts by fused score desc; breaks ties by BM25 rank, then
+///    alphabetical path, so the output is fully deterministic.
+///
+/// Scales O(B + V) in lookup + O(P log P) in the final sort, where P
+/// ≤ B + V. No allocations beyond the output.
+pub fn rrf_fuse(
+    bm25: &[(String, f32)],
+    vec_hits: &[(String, f32)],
+    k_rrf: f32,
+) -> Vec<FusedHit> {
+    // Step 1: collapse vec chunks to best-rank-per-path. Input is
+    // sorted, so the first occurrence of a path is already its best
+    // rank. Use an order-preserving dedup walk.
+    let mut vec_by_path: HashMap<&str, (u32, f32)> = HashMap::new();
+    let mut vec_collapsed: Vec<(&str, u32, f32)> = Vec::new();
+    for (path, score) in vec_hits {
+        if vec_by_path.contains_key(path.as_str()) {
+            continue;
+        }
+        let rank = (vec_collapsed.len() + 1) as u32;
+        vec_by_path.insert(path.as_str(), (rank, *score));
+        vec_collapsed.push((path.as_str(), rank, *score));
+    }
+
+    // Step 2: accumulate. `BTreeMap` would give deterministic iter but
+    // we sort at the end anyway — HashMap is fine and cheaper.
+    struct Acc {
+        score: f32,
+        bm25_rank: Option<u32>,
+        bm25_score: Option<f32>,
+        vec_rank: Option<u32>,
+        vec_score: Option<f32>,
+    }
+    let mut acc: HashMap<String, Acc> = HashMap::new();
+
+    for (i, (path, score)) in bm25.iter().enumerate() {
+        let rank = (i + 1) as u32;
+        let entry = acc.entry(path.clone()).or_insert(Acc {
+            score: 0.0,
+            bm25_rank: None,
+            bm25_score: None,
+            vec_rank: None,
+            vec_score: None,
+        });
+        entry.score += 1.0 / (k_rrf + rank as f32);
+        entry.bm25_rank = Some(rank);
+        entry.bm25_score = Some(*score);
+    }
+
+    for (path, rank, score) in &vec_collapsed {
+        let entry = acc.entry((*path).to_string()).or_insert(Acc {
+            score: 0.0,
+            bm25_rank: None,
+            bm25_score: None,
+            vec_rank: None,
+            vec_score: None,
+        });
+        entry.score += 1.0 / (k_rrf + *rank as f32);
+        entry.vec_rank = Some(*rank);
+        entry.vec_score = Some(*score);
+    }
+
+    // Step 3: sort by fused score desc; stable tie-break so callers
+    // observing two hits with identical scores (e.g. both rank-1 on
+    // their side) get a predictable order.
+    let mut out: Vec<FusedHit> = acc
+        .into_iter()
+        .map(|(path, a)| FusedHit {
+            path,
+            score: a.score,
+            bm25_rank: a.bm25_rank,
+            vec_rank: a.vec_rank,
+            bm25_score: a.bm25_score,
+            vec_score: a.vec_score,
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| match (a.bm25_rank, b.bm25_rank) {
+                (Some(ar), Some(br)) => ar.cmp(&br),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(hits: &[FusedHit]) -> Vec<&str> {
+        hits.iter().map(|h| h.path.as_str()).collect()
+    }
+
+    #[test]
+    fn empty_inputs_produce_empty_output() {
+        assert!(rrf_fuse(&[], &[], RRF_K).is_empty());
+    }
+
+    #[test]
+    fn bm25_only_preserves_order() {
+        let bm25 = vec![
+            ("a.md".into(), 9.0),
+            ("b.md".into(), 5.0),
+            ("c.md".into(), 1.0),
+        ];
+        let hits = rrf_fuse(&bm25, &[], RRF_K);
+        assert_eq!(paths(&hits), vec!["a.md", "b.md", "c.md"]);
+        // Scores must be strictly decreasing.
+        for w in hits.windows(2) {
+            assert!(w[0].score > w[1].score);
+        }
+        // bm25_* fields populated; vec_* empty.
+        for h in &hits {
+            assert!(h.bm25_rank.is_some());
+            assert!(h.bm25_score.is_some());
+            assert!(h.vec_rank.is_none());
+            assert!(h.vec_score.is_none());
+        }
+    }
+
+    #[test]
+    fn vec_only_preserves_order() {
+        let vec_hits = vec![
+            ("x.md".into(), 0.9),
+            ("y.md".into(), 0.5),
+        ];
+        let hits = rrf_fuse(&[], &vec_hits, RRF_K);
+        assert_eq!(paths(&hits), vec!["x.md", "y.md"]);
+        for h in &hits {
+            assert!(h.vec_rank.is_some());
+            assert!(h.bm25_rank.is_none());
+        }
+    }
+
+    #[test]
+    fn both_sources_combine_scores() {
+        // Same doc ranks 1 on BM25 and 1 on vec — score should be 2×(1/61).
+        let bm25 = vec![("overlap.md".into(), 10.0)];
+        let vec_hits = vec![("overlap.md".into(), 0.9)];
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        assert_eq!(hits.len(), 1);
+        let expected = 2.0 / (RRF_K + 1.0);
+        assert!(
+            (hits[0].score - expected).abs() < 1e-6,
+            "score={} expected≈{}",
+            hits[0].score,
+            expected
+        );
+        assert_eq!(hits[0].bm25_rank, Some(1));
+        assert_eq!(hits[0].vec_rank, Some(1));
+    }
+
+    #[test]
+    fn overlapping_doc_outranks_singleton_at_same_rank() {
+        // A ranks 1 in BM25 only; B ranks 2 in BM25 and 1 in vec.
+        // B's fused score: 1/(60+2) + 1/(60+1) = 1/62 + 1/61
+        // A's fused score: 1/(60+1) = 1/61
+        // B > A.
+        let bm25 = vec![("a.md".into(), 10.0), ("b.md".into(), 5.0)];
+        let vec_hits = vec![("b.md".into(), 0.9)];
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        assert_eq!(paths(&hits), vec!["b.md", "a.md"]);
+    }
+
+    #[test]
+    fn vector_chunks_collapse_to_best_rank_per_path() {
+        // Path "multi.md" has three chunks at ranks 1, 2, 4; "other.md"
+        // at rank 3. After collapse, ranks should be multi=1, other=2.
+        let vec_hits = vec![
+            ("multi.md".into(), 0.95),
+            ("multi.md".into(), 0.90),
+            ("other.md".into(), 0.80),
+            ("multi.md".into(), 0.70),
+        ];
+        let hits = rrf_fuse(&[], &vec_hits, RRF_K);
+        assert_eq!(paths(&hits), vec!["multi.md", "other.md"]);
+        assert_eq!(hits[0].vec_rank, Some(1));
+        assert_eq!(hits[1].vec_rank, Some(2));
+        // Chunky notes must NOT get a harmonic-series boost.
+        let expected_multi = 1.0 / (RRF_K + 1.0);
+        assert!((hits[0].score - expected_multi).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rrf_formula_matches_literature_exactly() {
+        // Cormack 2009 § 3: score(d) = Σ 1 / (k + rank_i(d))
+        // Three sources simulated as: BM25 ranks a=1, b=2; Vec ranks a=2, b=1.
+        let bm25 = vec![("a.md".into(), 1.0), ("b.md".into(), 0.5)];
+        let vec_hits = vec![("b.md".into(), 0.9), ("a.md".into(), 0.8)];
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        assert_eq!(hits.len(), 2);
+        // Both end up with the same score: 1/61 + 1/62, tied.
+        let expected = 1.0 / (RRF_K + 1.0) + 1.0 / (RRF_K + 2.0);
+        for h in &hits {
+            assert!((h.score - expected).abs() < 1e-6);
+        }
+        // Tie-break: bm25_rank asc, so a.md (bm25=1) first, b.md (bm25=2) second.
+        assert_eq!(paths(&hits), vec!["a.md", "b.md"]);
+    }
+
+    #[test]
+    fn deterministic_tiebreak_by_path_when_no_bm25_rank() {
+        // Two vec-only hits at different ranks — scores differ, so no tie.
+        // But two at the same rank via duplicate collapse would tie; the
+        // input is by construction already ordered so this tests the
+        // path tie-break when bm25 ranks are both None.
+        let vec_a = vec![("z.md".into(), 0.9), ("a.md".into(), 0.9)];
+        let hits1 = rrf_fuse(&[], &vec_a, RRF_K);
+        // z ranks 1, a ranks 2 → z first (higher score), not path order.
+        assert_eq!(paths(&hits1), vec!["z.md", "a.md"]);
+    }
+
+    #[test]
+    fn k_rrf_smaller_amplifies_top_ranks() {
+        // With k_rrf=0, rank-1 score is 1.0 and rank-2 is 0.5 — a 2×
+        // gap. With k_rrf=60, rank-1 is ~0.0164 and rank-2 is ~0.0161
+        // — gap shrinks to ~2%. Sanity check that the knob works.
+        let bm25 = vec![("a.md".into(), 1.0), ("b.md".into(), 0.5)];
+        let sharp = rrf_fuse(&bm25, &[], 0.0);
+        let flat = rrf_fuse(&bm25, &[], 60.0);
+        let sharp_gap = sharp[0].score / sharp[1].score;
+        let flat_gap = flat[0].score / flat[1].score;
+        assert!(sharp_gap > flat_gap, "{sharp_gap} should exceed {flat_gap}");
+    }
+
+    #[test]
+    fn handles_large_inputs_without_collisions() {
+        // Smoke test: 10k paths on each side with 5k overlap. Asserts the
+        // collapse + accumulate + sort path produces the expected output
+        // size without dropping or duplicating entries. No timing
+        // assertion — perf is covered by the #[ignore] bench in the IPC
+        // command path; running this test under heavy parallel load
+        // (full lib suite at 16 threads) makes wall-clock thresholds
+        // here flaky without telling us anything about real hybrid-
+        // search latency.
+        let bm25: Vec<(String, f32)> = (0..10_000)
+            .map(|i| (format!("bm-{i}.md"), 10_000.0 - i as f32))
+            .collect();
+        let vec_hits: Vec<(String, f32)> = (0..10_000)
+            .map(|i| (format!("bm-{}.md", i + 5_000), 1.0 - (i as f32 / 10_000.0)))
+            .collect();
+        let hits = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        // 10k BM25 + 10k vec − 5k overlap = 15k unique paths.
+        assert_eq!(hits.len(), 15_000);
+        // Spot-check: the 5k-overlap region must rank ahead of singletons
+        // because two-source hits accumulate two RRF terms.
+        let overlap_top = hits.iter().take(50).filter(|h| {
+            h.bm25_rank.is_some() && h.vec_rank.is_some()
+        }).count();
+        assert!(
+            overlap_top > 25,
+            "expected mostly two-source hits in top 50, got {overlap_top}",
+        );
+    }
+}

--- a/src-tauri/src/embeddings/hybrid.rs
+++ b/src-tauri/src/embeddings/hybrid.rs
@@ -305,4 +305,45 @@ mod tests {
             "expected mostly two-source hits in top 50, got {overlap_top}",
         );
     }
+
+    /// #207 AC #1 — RRF fusion p50/p99 at hybrid-search's realistic
+    /// working size (each leg returns top_n = 200 per search.rs). This is
+    /// the only hybrid-specific time on top of the component legs; the
+    /// end-to-end embed + HNSW + BM25 times are captured by their own
+    /// benches and summed by the harness.
+    #[test]
+    #[ignore]
+    fn bench_rrf_fuse_p50_p99() {
+        use std::time::Instant;
+        const WARMUP: usize = 50;
+        const N: usize = 1000;
+        const PER_LEG: usize = 200;
+
+        // Deterministic synthetic legs: 50% overlap between BM25 and vec,
+        // mimicking search.rs's top_n after a realistic dual-retrieval.
+        let bm25: Vec<(String, f32)> = (0..PER_LEG)
+            .map(|i| (format!("doc-{i}.md"), (PER_LEG - i) as f32))
+            .collect();
+        let vec_hits: Vec<(String, f32)> = (0..PER_LEG)
+            .map(|i| (format!("doc-{}.md", i + PER_LEG / 2), 1.0 - (i as f32 / PER_LEG as f32)))
+            .collect();
+
+        for _ in 0..WARMUP {
+            let _ = rrf_fuse(&bm25, &vec_hits, RRF_K);
+        }
+        let mut samples = Vec::with_capacity(N);
+        for _ in 0..N {
+            let t0 = Instant::now();
+            let _ = rrf_fuse(&bm25, &vec_hits, RRF_K);
+            samples.push(t0.elapsed());
+        }
+        samples.sort();
+        let p50 = samples[N / 2];
+        let p99 = samples[(N * 99) / 100];
+        eprintln!(
+            "BENCH_JSON {{\"name\":\"rrf_fuse\",\"p50_ms\":{:.4},\"p99_ms\":{:.4},\"n\":{N},\"per_leg\":{PER_LEG}}}",
+            p50.as_secs_f64() * 1000.0,
+            p99.as_secs_f64() * 1000.0,
+        );
+    }
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -52,8 +52,8 @@ pub use vector_index::{VectorIndex, DEFAULT_EF_SEARCH, DIM};
 mod reindex;
 #[cfg(feature = "embeddings")]
 pub use reindex::{
-    start_reindex, ReindexHandle, ReindexPhase, ReindexProgress, CHECKPOINT_FILE,
-    CHECKPOINT_VERSION,
+    start_reindex, start_reindex_with_backpressure, ReindexHandle, ReindexPhase,
+    ReindexProgress, CHECKPOINT_FILE, CHECKPOINT_VERSION,
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -33,6 +33,16 @@ mod chunking;
 #[cfg(feature = "embeddings")]
 pub use chunking::{Chunk, Chunker, DEFAULT_OVERLAP_TOKENS, MAX_CONTENT_TOKENS};
 
+#[cfg(feature = "embeddings")]
+mod sink;
+#[cfg(feature = "embeddings")]
+pub use sink::{NoopSink, VectorSink};
+
+#[cfg(feature = "embeddings")]
+mod embed_coordinator;
+#[cfg(feature = "embeddings")]
+pub use embed_coordinator::{EmbedCoordinator, EnqueueError, WAKEUP_CAPACITY};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -29,6 +29,9 @@ mod service;
 pub use service::EmbeddingService;
 
 #[cfg(feature = "embeddings")]
+mod session;
+
+#[cfg(feature = "embeddings")]
 mod chunking;
 #[cfg(feature = "embeddings")]
 pub use chunking::{Chunk, Chunker, DEFAULT_OVERLAP_TOKENS, MAX_CONTENT_TOKENS};
@@ -74,8 +77,8 @@ pub enum EmbeddingError {
     ModelMissing,
     #[error("ONNX Runtime init failed: {0}")]
     OrtInit(String),
-    #[error("fastembed error: {0}")]
-    Fastembed(String),
+    #[error("inference error: {0}")]
+    Inference(String),
     #[error("tokenizer error: {0}")]
     Tokenizer(String),
     #[error("invalid argument: {0}")]
@@ -181,11 +184,9 @@ pub fn ensure_runtime_initialized(
                 Err(e) => return Err(format!("ort::init_from failed: {e}")),
             };
             // #197: cap ORT inference at 2 intra-op + 1 inter-op threads
-            // and route through a dedicated ORT-managed pool. Once the
-            // env owns a global thread pool, fastembed's per-session
-            // `with_intra_threads(available_parallelism())` is silently
-            // overridden (`DisablePerSessionThreads` runs in the session
-            // commit path), so we get the cap without patching fastembed.
+            // via a dedicated ORT-managed pool. Installing this on the
+            // env triggers `DisablePerSessionThreads` in every session's
+            // commit path, so no per-session thread config is needed.
             // The cap keeps embed-on-save from contending with Tantivy's
             // rayon pool for cores under bulk-save bursts.
             let pool_opts = match GlobalThreadPoolOptions::default()
@@ -224,31 +225,6 @@ pub fn ensure_runtime_initialized(
 /// done) so the test can skip rather than fail.
 #[cfg(feature = "embeddings")]
 pub fn smoke_test(resource_dir: Option<&Path>) -> Result<Vec<f32>, EmbeddingError> {
-    use fastembed::{
-        InitOptionsUserDefined, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel,
-    };
-
-    ensure_runtime_initialized(resource_dir)?;
-    let dir = model_dir(resource_dir)?;
-    let read = |name: &str| std::fs::read(dir.join(name));
-    let model = UserDefinedEmbeddingModel::new(
-        read("model.onnx")?,
-        TokenizerFiles {
-            tokenizer_file: read("tokenizer.json")?,
-            config_file: read("config.json")?,
-            special_tokens_map_file: read("special_tokens_map.json")?,
-            tokenizer_config_file: read("tokenizer_config.json")?,
-        },
-    );
-    let mut embedder = TextEmbedding::try_new_from_user_defined(
-        model,
-        InitOptionsUserDefined::default(),
-    )
-    .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
-    let mut out = embedder
-        .embed(vec!["VaultCore semantic search smoke test"], None)
-        .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
-    out.pop().ok_or_else(|| {
-        EmbeddingError::Fastembed("empty embedding batch".into())
-    })
+    let svc = EmbeddingService::load(resource_dir)?;
+    svc.embed("VaultCore semantic search smoke test")
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -43,6 +43,11 @@ mod embed_coordinator;
 #[cfg(feature = "embeddings")]
 pub use embed_coordinator::{EmbedCoordinator, EnqueueError, WAKEUP_CAPACITY};
 
+#[cfg(feature = "embeddings")]
+mod vector_index;
+#[cfg(feature = "embeddings")]
+pub use vector_index::{VectorIndex, DEFAULT_EF_SEARCH, DIM};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -28,6 +28,11 @@ mod service;
 #[cfg(feature = "embeddings")]
 pub use service::EmbeddingService;
 
+#[cfg(feature = "embeddings")]
+mod chunking;
+#[cfg(feature = "embeddings")]
+pub use chunking::{Chunk, Chunker, DEFAULT_OVERLAP_TOKENS, MAX_CONTENT_TOKENS};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]
@@ -38,6 +43,10 @@ pub enum EmbeddingError {
     OrtInit(String),
     #[error("fastembed error: {0}")]
     Fastembed(String),
+    #[error("tokenizer error: {0}")]
+    Tokenizer(String),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -40,14 +40,17 @@ pub enum EmbeddingError {
 const ENV_DYLIB: &str = "ORT_DYLIB_PATH";
 const ENV_MODEL_DIR: &str = "VAULTCORE_MODEL_DIR";
 
-/// Platform-specific dylib filename. Bundled under `resources/onnxruntime/`.
+/// Platform-specific dylib filename as bundled by build.rs into
+/// `resources/onnxruntime/`. Versioned suffixes are kept so we can
+/// dlopen via absolute path and bypass SONAME / install-name resolution.
+/// Must stay in sync with `resources/checksums.toml`.
 fn dylib_name() -> &'static str {
     if cfg!(target_os = "windows") {
         "onnxruntime.dll"
     } else if cfg!(target_os = "macos") {
-        "libonnxruntime.dylib"
+        "libonnxruntime.1.23.2.dylib"
     } else {
-        "libonnxruntime.so"
+        "libonnxruntime.so.1.23.2"
     }
 }
 
@@ -74,6 +77,16 @@ pub fn runtime_path(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingErr
         return Ok(dev);
     }
     Err(EmbeddingError::RuntimeMissing)
+}
+
+/// Wire the embeddings runtime into a Tauri AppHandle's setup hook.
+/// Idempotent and non-fatal — failures only emit a `log::warn!`, so the
+/// rest of the app still launches when no dylib is bundled (dev builds,
+/// CI without resources, etc.).
+pub fn bootstrap(app: &tauri::AppHandle) -> Result<(), EmbeddingError> {
+    use tauri::Manager;
+    let resource_dir = app.path().resource_dir().ok();
+    ensure_runtime_initialized(resource_dir.as_deref())
 }
 
 /// Resolve the bundled model directory. Same resolution semantics as

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -48,6 +48,14 @@ mod vector_index;
 #[cfg(feature = "embeddings")]
 pub use vector_index::{VectorIndex, DEFAULT_EF_SEARCH, DIM};
 
+#[cfg(feature = "embeddings")]
+mod reindex;
+#[cfg(feature = "embeddings")]
+pub use reindex::{
+    start_reindex, ReindexHandle, ReindexPhase, ReindexProgress, CHECKPOINT_FILE,
+    CHECKPOINT_VERSION,
+};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -23,6 +23,11 @@
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+#[cfg(feature = "embeddings")]
+mod service;
+#[cfg(feature = "embeddings")]
+pub use service::EmbeddingService;
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -1,9 +1,11 @@
 //! Local embeddings stack — gated behind the `embeddings` Cargo feature.
 //!
 //! This module owns the dlopen'd ONNX Runtime lifecycle and the discovery of
-//! the bundled MiniLM model. Higher-level services (#194 EmbeddingService,
-//! #198 VectorIndex, #203 hybrid search) build on top of `init_runtime` +
-//! `model_dir`.
+//! the bundled embedding model (multilingual-e5-small INT8 since #233; was
+//! all-MiniLM-L6-v2 INT8 before — swapped because MiniLM is English-only and
+//! collapsed non-English queries onto a noise-floor band). Higher-level
+//! services (#194 EmbeddingService, #198 VectorIndex, #203 hybrid search)
+//! build on top of `init_runtime` + `model_dir`.
 //!
 //! Path resolution order for both the runtime dylib and the model directory:
 //!
@@ -147,7 +149,7 @@ pub fn model_dir(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingError>
     if let Some(p) = std::env::var_os(ENV_MODEL_DIR) {
         return Ok(PathBuf::from(p));
     }
-    let leaf = Path::new("models").join("all-MiniLM-L6-v2-int8");
+    let leaf = Path::new("models").join("multilingual-e5-small-int8");
     if let Some(dir) = resource_dir {
         let p = dir.join(&leaf);
         if p.exists() {
@@ -218,13 +220,14 @@ pub fn ensure_runtime_initialized(
 }
 
 /// Smoke-test entry point used by tests/embeddings.rs. Loads the bundled
-/// MiniLM model, embeds a fixed string, and returns the raw 384-dim vector.
-///
-/// The caller (the test) asserts vector length and L2 norm. Returns
-/// `Err(ModelMissing)` cleanly if the model isn't bundled yet (#192 not
-/// done) so the test can skip rather than fail.
+/// embedding model, embeds a fixed string, and returns the raw 384-dim
+/// vector. Uses `embed_passage` so the e5 prefix protocol is exercised
+/// end-to-end — the smoke test then doubles as a "tokenizer accepts the
+/// `passage: ` prefix without choking" check. The caller (the test) asserts
+/// vector length and L2 norm. Returns `Err(ModelMissing)` cleanly if the
+/// model isn't bundled yet (#192 not done) so the test can skip.
 #[cfg(feature = "embeddings")]
 pub fn smoke_test(resource_dir: Option<&Path>) -> Result<Vec<f32>, EmbeddingError> {
     let svc = EmbeddingService::load(resource_dir)?;
-    svc.embed("VaultCore semantic search smoke test")
+    svc.embed_passage("VaultCore semantic search smoke test")
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -36,12 +36,12 @@ pub use chunking::{Chunk, Chunker, DEFAULT_OVERLAP_TOKENS, MAX_CONTENT_TOKENS};
 #[cfg(feature = "embeddings")]
 mod sink;
 #[cfg(feature = "embeddings")]
-pub use sink::{NoopSink, VectorSink};
+pub use sink::{HnswSink, NoopSink, VectorSink};
 
 #[cfg(feature = "embeddings")]
 mod embed_coordinator;
 #[cfg(feature = "embeddings")]
-pub use embed_coordinator::{EmbedCoordinator, EnqueueError, WAKEUP_CAPACITY};
+pub use embed_coordinator::{EmbedCoordinator, EmbedOp, EnqueueError, WAKEUP_CAPACITY};
 
 #[cfg(feature = "embeddings")]
 mod vector_index;

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -1,0 +1,172 @@
+//! Local embeddings stack — gated behind the `embeddings` Cargo feature.
+//!
+//! This module owns the dlopen'd ONNX Runtime lifecycle and the discovery of
+//! the bundled MiniLM model. Higher-level services (#194 EmbeddingService,
+//! #198 VectorIndex, #203 hybrid search) build on top of `init_runtime` +
+//! `model_dir`.
+//!
+//! Path resolution order for both the runtime dylib and the model directory:
+//!
+//! 1. Explicit env override (`ORT_DYLIB_PATH`, `VAULTCORE_MODEL_DIR`) — used
+//!    by the smoke test and by developers running against a non-bundled
+//!    runtime.
+//! 2. The Tauri `resource_dir()` (production install).
+//! 3. `CARGO_MANIFEST_DIR/resources/...` as a dev fallback for `cargo run`
+//!    and `cargo test`, since `resource_dir()` is unreliable in dev builds
+//!    (tauri-apps/tauri#13654) and undefined for unit tests with no AppHandle.
+//!
+//! ORT's `init_from(path).commit()` is global per process and silently
+//! returns `false` on the second call — we wrap it in a `OnceLock` so any
+//! number of test entry points can call `ensure_runtime_initialized()` without
+//! racing or double-initializing.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EmbeddingError {
+    #[error("ONNX Runtime dylib not found at any candidate path")]
+    RuntimeMissing,
+    #[error("Model directory not found at any candidate path")]
+    ModelMissing,
+    #[error("ONNX Runtime init failed: {0}")]
+    OrtInit(String),
+    #[error("fastembed error: {0}")]
+    Fastembed(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+const ENV_DYLIB: &str = "ORT_DYLIB_PATH";
+const ENV_MODEL_DIR: &str = "VAULTCORE_MODEL_DIR";
+
+/// Platform-specific dylib filename. Bundled under `resources/onnxruntime/`.
+fn dylib_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "onnxruntime.dll"
+    } else if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    }
+}
+
+/// Resolve the libonnxruntime path. See module docs for resolution order.
+///
+/// `resource_dir` may be `None` when called outside a Tauri AppHandle context
+/// (e.g. `cargo test`) — the dev fallback then takes over.
+pub fn runtime_path(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingError> {
+    if let Some(p) = std::env::var_os(ENV_DYLIB) {
+        return Ok(PathBuf::from(p));
+    }
+    let name = dylib_name();
+    if let Some(dir) = resource_dir {
+        let p = dir.join("onnxruntime").join(name);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    let dev = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join("onnxruntime")
+        .join(name);
+    if dev.exists() {
+        return Ok(dev);
+    }
+    Err(EmbeddingError::RuntimeMissing)
+}
+
+/// Resolve the bundled model directory. Same resolution semantics as
+/// `runtime_path`. The directory must contain `model.onnx`,
+/// `tokenizer.json`, `config.json`, `tokenizer_config.json`, and
+/// `special_tokens_map.json` (#192).
+pub fn model_dir(resource_dir: Option<&Path>) -> Result<PathBuf, EmbeddingError> {
+    if let Some(p) = std::env::var_os(ENV_MODEL_DIR) {
+        return Ok(PathBuf::from(p));
+    }
+    let leaf = Path::new("models").join("all-MiniLM-L6-v2-int8");
+    if let Some(dir) = resource_dir {
+        let p = dir.join(&leaf);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    let dev = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join(&leaf);
+    if dev.exists() {
+        return Ok(dev);
+    }
+    Err(EmbeddingError::ModelMissing)
+}
+
+static RUNTIME_INIT: OnceLock<Result<(), String>> = OnceLock::new();
+
+/// Idempotent global ORT init. The first caller wins; subsequent callers
+/// see the same outcome. Safe across threads and across multiple test entry
+/// points within a single `cargo test` process.
+pub fn ensure_runtime_initialized(
+    resource_dir: Option<&Path>,
+) -> Result<(), EmbeddingError> {
+    let result = RUNTIME_INIT.get_or_init(|| {
+        let path = match runtime_path(resource_dir) {
+            Ok(p) => p,
+            Err(e) => return Err(e.to_string()),
+        };
+        #[cfg(feature = "embeddings")]
+        {
+            let builder = match ort::init_from(path.to_string_lossy().into_owned()) {
+                Ok(b) => b,
+                Err(e) => return Err(format!("ort::init_from failed: {e}")),
+            };
+            // `commit` returns `false` if a global environment already exists.
+            // That is not a hard error for us (idempotent init across tests
+            // and Tauri setup callbacks), so we don't fail the OnceLock.
+            let _ = builder.commit();
+            Ok(())
+        }
+        #[cfg(not(feature = "embeddings"))]
+        {
+            let _ = path;
+            Err("embeddings feature not enabled".to_string())
+        }
+    });
+    result.clone().map_err(EmbeddingError::OrtInit)
+}
+
+/// Smoke-test entry point used by tests/embeddings.rs. Loads the bundled
+/// MiniLM model, embeds a fixed string, and returns the raw 384-dim vector.
+///
+/// The caller (the test) asserts vector length and L2 norm. Returns
+/// `Err(ModelMissing)` cleanly if the model isn't bundled yet (#192 not
+/// done) so the test can skip rather than fail.
+#[cfg(feature = "embeddings")]
+pub fn smoke_test(resource_dir: Option<&Path>) -> Result<Vec<f32>, EmbeddingError> {
+    use fastembed::{
+        InitOptionsUserDefined, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel,
+    };
+
+    ensure_runtime_initialized(resource_dir)?;
+    let dir = model_dir(resource_dir)?;
+    let read = |name: &str| std::fs::read(dir.join(name));
+    let model = UserDefinedEmbeddingModel::new(
+        read("model.onnx")?,
+        TokenizerFiles {
+            tokenizer_file: read("tokenizer.json")?,
+            config_file: read("config.json")?,
+            special_tokens_map_file: read("special_tokens_map.json")?,
+            tokenizer_config_file: read("tokenizer_config.json")?,
+        },
+    );
+    let mut embedder = TextEmbedding::try_new_from_user_defined(
+        model,
+        InitOptionsUserDefined::default(),
+    )
+    .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
+    let mut out = embedder
+        .embed(vec!["VaultCore semantic search smoke test"], None)
+        .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
+    out.pop().ok_or_else(|| {
+        EmbeddingError::Fastembed("empty embedding batch".into())
+    })
+}

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -56,6 +56,11 @@ pub use reindex::{
     ReindexProgress, CHECKPOINT_FILE, CHECKPOINT_VERSION,
 };
 
+#[cfg(feature = "embeddings")]
+mod query;
+#[cfg(feature = "embeddings")]
+pub use query::{semantic_search_query, QueryHandles, SemanticHit};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -61,6 +61,11 @@ mod query;
 #[cfg(feature = "embeddings")]
 pub use query::{semantic_search_query, QueryHandles, SemanticHit};
 
+#[cfg(feature = "embeddings")]
+mod hybrid;
+#[cfg(feature = "embeddings")]
+pub use hybrid::{rrf_fuse, FusedHit, RRF_K};
+
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     #[error("ONNX Runtime dylib not found at any candidate path")]

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -152,14 +152,36 @@ pub fn ensure_runtime_initialized(
         };
         #[cfg(feature = "embeddings")]
         {
+            use ort::environment::GlobalThreadPoolOptions;
             let builder = match ort::init_from(path.to_string_lossy().into_owned()) {
                 Ok(b) => b,
                 Err(e) => return Err(format!("ort::init_from failed: {e}")),
             };
+            // #197: cap ORT inference at 2 intra-op + 1 inter-op threads
+            // and route through a dedicated ORT-managed pool. Once the
+            // env owns a global thread pool, fastembed's per-session
+            // `with_intra_threads(available_parallelism())` is silently
+            // overridden (`DisablePerSessionThreads` runs in the session
+            // commit path), so we get the cap without patching fastembed.
+            // The cap keeps embed-on-save from contending with Tantivy's
+            // rayon pool for cores under bulk-save bursts.
+            let pool_opts = match GlobalThreadPoolOptions::default()
+                .with_intra_threads(2)
+                .and_then(|o| o.with_inter_threads(1))
+            {
+                Ok(o) => o,
+                Err(e) => return Err(format!("ORT thread-pool config failed: {e}")),
+            };
+            let builder = builder.with_global_thread_pool(pool_opts);
             // `commit` returns `false` if a global environment already exists.
             // That is not a hard error for us (idempotent init across tests
-            // and Tauri setup callbacks), so we don't fail the OnceLock.
-            let _ = builder.commit();
+            // and Tauri setup callbacks), so we don't fail the OnceLock —
+            // the cached config still applies for the env that did win.
+            if !builder.commit() {
+                log::warn!(
+                    "ORT environment already committed; #197 thread-pool caps may not apply"
+                );
+            }
             Ok(())
         }
         #[cfg(not(feature = "embeddings"))]

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -351,7 +351,12 @@ mod tests {
         }
         samples.sort();
         let p50 = samples[Q / 2];
-        eprintln!("semantic_search p50 over {Q} queries @ {N} vectors: {p50:?}");
+        let p99 = samples[(Q * 99) / 100];
+        eprintln!(
+            "BENCH_JSON {{\"name\":\"semantic_search_100k\",\"p50_ms\":{:.3},\"p99_ms\":{:.3},\"n\":{Q},\"vectors\":{N}}}",
+            p50.as_secs_f64() * 1000.0,
+            p99.as_secs_f64() * 1000.0,
+        );
         assert!(
             p50 < Duration::from_millis(5),
             "p50 latency too slow: {p50:?}",

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -76,7 +76,7 @@ pub fn semantic_search_query(
     if snap.is_empty() {
         return Ok(Vec::new());
     }
-    let vec = handles.service.embed(text)?;
+    let vec = handles.service.embed_query(text)?;
     if vec.len() != super::DIM {
         return Err(EmbeddingError::InvalidArgument(format!(
             "embedding dim mismatch: got {}, expected {}",
@@ -176,7 +176,11 @@ mod tests {
             ("math.md", "Eigenvalues of a symmetric matrix are always real numbers."),
         ];
         for (path, text) in docs {
-            let v = svc.embed(text).unwrap();
+            // Seed via the indexing path — same prefix semantics as
+            // `embed_coordinator::run_embed_batch` uses in production, so
+            // the subspace matches what `semantic_search_query` below
+            // produces from `embed_query`.
+            let v = svc.embed_passage(text).unwrap();
             snap.insert(PathBuf::from(path), 0, &v);
         }
         drop(snap);
@@ -214,7 +218,9 @@ mod tests {
         let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
         let snap = sink.snapshot();
         for i in 0..5u64 {
-            let v = svc.embed(&format!("note number {i} with unique content")).unwrap();
+            let v = svc
+                .embed_passage(&format!("note number {i} with unique content"))
+                .unwrap();
             snap.insert(PathBuf::from(format!("n-{i}.md")), 0, &v);
         }
         drop(snap);

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -38,6 +38,23 @@ pub struct SemanticHit {
     pub score: f32,
 }
 
+/// Minimum cosine similarity for a vec-leg hit to leave this module.
+/// HNSW always returns its k nearest neighbours regardless of how far
+/// away they are — on small vaults the nearest neighbour can still be
+/// near-orthogonal noise, which then rides into the RRF top-k on rank
+/// alone and confuses users ("why does my search for 'katze' surface a
+/// note that says 'test lol dasd'?"). 0.3 is a conservative floor on
+/// L2-normalised MiniLM: real semantic matches on English prose sit at
+/// 0.4–0.8, and anything below ~0.3 is near-orthogonal — dropping it
+/// loses nothing but noise.
+pub const MIN_SEMANTIC_SCORE: f32 = 0.3;
+
+fn drop_noise_hits(hits: Vec<SemanticHit>) -> Vec<SemanticHit> {
+    hits.into_iter()
+        .filter(|h| h.score >= MIN_SEMANTIC_SCORE)
+        .collect()
+}
+
 /// Embed `text`, query the index for the top `k` nearest chunks, and
 /// convert distances to similarity scores. Returns an empty vec for an
 /// empty query or empty index — never errors on either; that case is
@@ -68,14 +85,17 @@ pub fn semantic_search_query(
         )));
     }
     let hits = snap.query_with_paths(&vec, k);
-    Ok(hits
+    let mapped: Vec<SemanticHit> = hits
         .into_iter()
         .map(|(p, idx, dist)| SemanticHit {
             path: p.to_string_lossy().into_owned(),
             chunk_index: idx,
             score: 1.0 - dist,
         })
-        .collect())
+        .collect();
+    // Filter near-orthogonal noise BEFORE returning so both the direct
+    // `semantic_search` IPC and the hybrid fusion path see a clean list.
+    Ok(drop_noise_hits(mapped))
 }
 
 #[cfg(test)]
@@ -204,6 +224,30 @@ mod tests {
             let hits = semantic_search_query(&h, "note", k).unwrap();
             assert!(hits.len() <= k, "k={k} returned {} hits", hits.len());
         }
+    }
+
+    #[test]
+    fn drop_noise_hits_removes_subthreshold_scores() {
+        // The filter drops hits below MIN_SEMANTIC_SCORE (noise-adjacent
+        // neighbours HNSW returns on small vaults) while keeping hits at
+        // the threshold and above. Order within the kept set is preserved
+        // because HNSW already hands them to us in rank order.
+        let hits = vec![
+            SemanticHit { path: "a.md".into(), chunk_index: 0, score: 0.82 },
+            SemanticHit { path: "b.md".into(), chunk_index: 0, score: MIN_SEMANTIC_SCORE - 0.01 },
+            SemanticHit { path: "c.md".into(), chunk_index: 0, score: MIN_SEMANTIC_SCORE },
+            SemanticHit { path: "d.md".into(), chunk_index: 0, score: 0.05 },
+            SemanticHit { path: "e.md".into(), chunk_index: 0, score: -0.2 },
+        ];
+        let kept = drop_noise_hits(hits);
+        let paths: Vec<&str> = kept.iter().map(|h| h.path.as_str()).collect();
+        assert_eq!(paths, vec!["a.md", "c.md"]);
+    }
+
+    #[test]
+    fn drop_noise_hits_empty_passthrough() {
+        let kept = drop_noise_hits(Vec::new());
+        assert!(kept.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/embeddings/query.rs
+++ b/src-tauri/src/embeddings/query.rs
@@ -1,0 +1,316 @@
+//! `query` (#202) — text-input top-k search composing `EmbeddingService`
+//! (#194) and `VectorIndex` (#198). Sits one layer above the raw HNSW so
+//! IPC handlers (and the future hybrid-search fusion in #203) can ask
+//! "find the nearest k chunks to this query string" without touching the
+//! embed / index plumbing themselves.
+//!
+//! Concurrency: the returned `QueryHandles` is `Send + Sync` and cheap to
+//! clone (two `Arc`s). The embed call serialises through
+//! `EmbeddingService`'s internal `Mutex` — see #205 for ORT session
+//! tuning that addresses the contention with the embed-on-save / reindex
+//! workers under bursty queries.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use super::{EmbeddingError, EmbeddingService, HnswSink};
+
+/// Combined handle the IPC layer needs to answer `semantic_search` —
+/// the embedder for the query text plus the sink that owns the live
+/// `VectorIndex` snapshot. Wrapped together so `VaultState` only adds
+/// one new `Mutex<Option<_>>` field rather than two parallel ones.
+pub struct QueryHandles {
+    pub service: Arc<EmbeddingService>,
+    pub sink: Arc<HnswSink>,
+}
+
+/// One ranked semantic-search hit. Path + chunk-index identifies the
+/// span; `score` is cosine similarity in `[-1, 1]` (≈ `[0, 1]` for
+/// real English prose) — higher = more similar. `id` is intentionally
+/// omitted: HNSW internal u32 ids are reassigned on compaction (#200),
+/// so leaking them across an async IPC boundary is a footgun.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticHit {
+    pub path: String,
+    pub chunk_index: usize,
+    pub score: f32,
+}
+
+/// Embed `text`, query the index for the top `k` nearest chunks, and
+/// convert distances to similarity scores. Returns an empty vec for an
+/// empty query or empty index — never errors on either; that case is
+/// expected during reindex bring-up before any chunks have landed.
+///
+/// Distance → score: `score = 1.0 - distance` because `DistDot` returns
+/// `1 - cos_sim` on L2-normalised vectors. The score is left in its raw
+/// `[-1, 1]` range so downstream RRF fusion (#203) can keep the
+/// "0 = orthogonal" reading.
+pub fn semantic_search_query(
+    handles: &QueryHandles,
+    text: &str,
+    k: usize,
+) -> Result<Vec<SemanticHit>, EmbeddingError> {
+    if text.trim().is_empty() || k == 0 {
+        return Ok(Vec::new());
+    }
+    let snap = handles.sink.snapshot();
+    if snap.is_empty() {
+        return Ok(Vec::new());
+    }
+    let vec = handles.service.embed(text)?;
+    if vec.len() != super::DIM {
+        return Err(EmbeddingError::InvalidArgument(format!(
+            "embedding dim mismatch: got {}, expected {}",
+            vec.len(),
+            super::DIM
+        )));
+    }
+    let hits = snap.query_with_paths(&vec, k);
+    Ok(hits
+        .into_iter()
+        .map(|(p, idx, dist)| SemanticHit {
+            path: p.to_string_lossy().into_owned(),
+            chunk_index: idx,
+            score: 1.0 - dist,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embeddings::{Chunker, VectorIndex};
+    use std::path::PathBuf;
+
+    fn try_load() -> Option<(Arc<EmbeddingService>, Arc<Chunker>)> {
+        let svc = EmbeddingService::load(None).ok()?;
+        let chk = Chunker::load(None).ok()?;
+        Some((svc, chk))
+    }
+
+    fn handles_with(sink: Arc<HnswSink>, svc: Arc<EmbeddingService>) -> QueryHandles {
+        QueryHandles { service: svc, sink }
+    }
+
+    #[test]
+    fn empty_query_returns_empty_without_embedding() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let h = handles_with(sink, svc);
+        assert!(semantic_search_query(&h, "", 5).unwrap().is_empty());
+        assert!(semantic_search_query(&h, "   ", 5).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_index_returns_empty_not_panic() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let h = handles_with(sink, svc);
+        let hits = semantic_search_query(&h, "anything at all", 10).unwrap();
+        assert!(hits.is_empty(), "expected no hits on empty index, got {hits:?}");
+    }
+
+    #[test]
+    fn k_zero_returns_empty() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let h = handles_with(sink, svc);
+        assert!(semantic_search_query(&h, "anything", 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn semantically_close_text_outranks_unrelated() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 16));
+
+        // Seed the index with several small notes via the live embedder so
+        // the test exercises the real embedding pipeline end-to-end.
+        // HNSW graph traversal can return fewer than k hits on very small
+        // indices (< ~5 points) due to layer-entry sparsity — seeding 6
+        // puts us safely past that floor.
+        let snap = sink.snapshot();
+        let docs = [
+            ("cats.md", "Cats are independent creatures that purr when content."),
+            ("dogs.md", "Dogs are loyal pack animals that wag their tails when happy."),
+            ("rust.md", "Rust async runtimes use cooperative scheduling and futures."),
+            ("recipe.md", "Bake the sourdough at 240 degrees for forty minutes."),
+            ("music.md", "Jazz improvisation builds on cycling chord progressions."),
+            ("math.md", "Eigenvalues of a symmetric matrix are always real numbers."),
+        ];
+        for (path, text) in docs {
+            let v = svc.embed(text).unwrap();
+            snap.insert(PathBuf::from(path), 0, &v);
+        }
+        drop(snap);
+
+        let h = handles_with(sink, svc);
+        let hits = semantic_search_query(&h, "feline body language", 3).unwrap();
+        assert!(!hits.is_empty(), "expected at least one hit");
+        // The cat note must rank first for a feline-related query.
+        assert_eq!(hits[0].path, "cats.md", "expected cats first, got {hits:?}");
+        // Scores must be non-increasing.
+        for w in hits.windows(2) {
+            assert!(
+                w[0].score >= w[1].score - 1e-6,
+                "scores not non-increasing: {} < {}",
+                w[0].score,
+                w[1].score
+            );
+        }
+        // Top score for a related query should be clearly positive.
+        assert!(
+            hits[0].score > 0.3,
+            "top score suspiciously low: {} for {}",
+            hits[0].score,
+            hits[0].path
+        );
+    }
+
+    #[test]
+    fn k_caps_result_count() {
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), 8));
+        let snap = sink.snapshot();
+        for i in 0..5u64 {
+            let v = svc.embed(&format!("note number {i} with unique content")).unwrap();
+            snap.insert(PathBuf::from(format!("n-{i}.md")), 0, &v);
+        }
+        drop(snap);
+
+        let h = handles_with(sink, svc);
+        for k in [1usize, 3, 5] {
+            let hits = semantic_search_query(&h, "note", k).unwrap();
+            assert!(hits.len() <= k, "k={k} returned {} hits", hits.len());
+        }
+    }
+
+    #[test]
+    fn handles_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<QueryHandles>();
+        assert_send_sync::<Arc<QueryHandles>>();
+    }
+
+    #[test]
+    fn semantic_hit_serializes_to_camel_case() {
+        let h = SemanticHit {
+            path: "a/b.md".into(),
+            chunk_index: 3,
+            score: 0.42,
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains("\"chunkIndex\":3"), "got: {json}");
+        assert!(json.contains("\"score\":0.42"), "got: {json}");
+    }
+
+    /// Ensure VectorIndex is queryable via the helper — exercises the
+    /// path/sink composition without involving the live embedder. Uses
+    /// hand-crafted unit vectors so the test runs even without the
+    /// bundled model.
+    #[test]
+    fn helper_composes_sink_snapshot_correctly() {
+        // We can't construct an EmbeddingService without the model, so
+        // this test only verifies the snapshot-query side of the pipeline
+        // by calling VectorIndex directly. The text→embed→query pipeline
+        // is covered by `semantically_close_text_outranks_unrelated`.
+        let idx = VectorIndex::new(4);
+        let mut v = vec![0f32; super::super::DIM];
+        v[0] = 1.0;
+        idx.insert(PathBuf::from("only.md"), 0, &v);
+        let hits = idx.query_with_paths(&v, 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, PathBuf::from("only.md"));
+    }
+
+    /// AC #4 for #202 — p50 query latency under 5 ms at 100k vectors
+    /// (pre-fusion, i.e. HNSW + mapping-lookup only, no BM25 / RRF).
+    /// The per-query breakdown measured here is:
+    ///   - `service.embed` (~15 ms on cold ORT, ~2–5 ms warm)
+    ///   - `VectorIndex::query_with_paths` with k=10, ef_search=64
+    ///     (~100–500 µs against real-clustered data)
+    ///
+    /// The bench is `#[ignore]` because it builds 100k vectors and loads
+    /// the full MiniLM model. Run with
+    /// `cargo test --release --features embeddings -- --ignored bench_semantic_query`.
+    #[test]
+    #[ignore]
+    fn bench_semantic_query_p50_under_5ms() {
+        use std::time::{Duration, Instant};
+        const N: usize = 100_000;
+        const Q: usize = 100;
+
+        let Some((svc, _chk)) = try_load() else {
+            eprintln!("SKIP: model not bundled");
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(HnswSink::open(tmp.path().to_path_buf(), N));
+
+        // Synthetic corpus — unit vectors derived from a simple hash.
+        // Real embedding distributions cluster tighter than uniform noise,
+        // so this is the pessimistic case for HNSW recall + traversal.
+        let snap = sink.snapshot();
+        let mut items: Vec<(PathBuf, usize, Vec<f32>)> = Vec::with_capacity(N);
+        for i in 0..N as u64 {
+            let mut s = i.wrapping_mul(0x9E3779B97F4A7C15);
+            let mut v = Vec::with_capacity(super::super::DIM);
+            for _ in 0..super::super::DIM {
+                s ^= s << 13;
+                s ^= s >> 7;
+                s ^= s << 17;
+                let bits = (s >> 32) as u32;
+                v.push((bits as f32 / u32::MAX as f32) * 2.0 - 1.0);
+            }
+            let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in &mut v {
+                *x /= n;
+            }
+            items.push((PathBuf::from(format!("/v/{i}.md")), 0, v));
+        }
+        snap.bulk_insert(items);
+        drop(snap);
+
+        let h = handles_with(sink, svc);
+        // Warm-up: one embed + one query to prime ORT + HNSW caches.
+        let _ = semantic_search_query(&h, "warm up the embedder", 10).unwrap();
+
+        let probes: Vec<String> = (0..Q)
+            .map(|i| format!("query number {i} about various topics"))
+            .collect();
+        let mut samples = Vec::with_capacity(Q);
+        for p in &probes {
+            let t0 = Instant::now();
+            let _ = semantic_search_query(&h, p, 10).unwrap();
+            samples.push(t0.elapsed());
+        }
+        samples.sort();
+        let p50 = samples[Q / 2];
+        eprintln!("semantic_search p50 over {Q} queries @ {N} vectors: {p50:?}");
+        assert!(
+            p50 < Duration::from_millis(5),
+            "p50 latency too slow: {p50:?}",
+        );
+    }
+}

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -946,6 +946,13 @@ mod tests {
                 elapsed,
                 (100_000.0 / per_sec) / 60.0,
             );
+            // #207: the reindex bench is a total-wall-clock measurement;
+            // we publish files/sec instead of p50 so the harness can
+            // compare against a baseline throughput floor.
+            eprintln!(
+                "BENCH_JSON {{\"name\":\"reindex_throughput\",\"files_per_sec\":{per_sec:.3},\"files\":{done},\"elapsed_ms\":{:.1}}}",
+                elapsed.as_secs_f64() * 1000.0,
+            );
 
             assert_eq!(done, n_files, "every file must reach the sink");
             // Floor: 3.0 files/sec. On the 100k target this would be

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -1,0 +1,672 @@
+//! `reindex` (#201 PR-B) — resumable initial-embed worker.
+//!
+//! The embed-on-save coordinator (#196) only touches files the user edits
+//! in the current session. For a vault that's been around since before
+//! Semantic Search was enabled, we need a one-shot pass that walks every
+//! `.md` file, hashes it, and enqueues stale/new files through the same
+//! `EmbedCoordinator` pipeline as live edits. Unchanged files are
+//! short-circuited by a content-hash checkpoint so a mid-reindex crash /
+//! relaunch continues where it left off instead of redoing 40k files.
+//!
+//! ## Worker shape
+//!
+//! - Dedicated `std::thread` (not `tokio::spawn_blocking`) — walking,
+//!   hashing and the checkpoint flush are blocking I/O, and we don't
+//!   need a runtime in here because the `enqueue` callback handed in by
+//!   the caller is synchronous (it just wraps `EmbedCoordinator::enqueue`,
+//!   which already does a `try_send`).
+//! - `Arc<AtomicBool>` cancel flag polled between files — a 100k-reindex
+//!   must surrender within one file's worth of work (≤ a few ms).
+//! - `ReindexProgress` events are invoked via a caller-provided closure;
+//!   production wiring bridges that to a Tauri `embed://reindex_progress`
+//!   event (the IPC layer, not this module, holds the AppHandle).
+//!
+//! ## Checkpoint shape
+//!
+//! A single JSON file under `<vault>/.vaultcore/embeddings/`:
+//!
+//! ```json
+//! { "version": 1, "entries": { "folder/note.md": "<sha256hex>", ... } }
+//! ```
+//!
+//! Keys are vault-relative paths with forward slashes so the checkpoint
+//! survives a vault rename on the same OS. Values are the sha256 hex of
+//! the file bytes at the last successful enqueue. Flushed every
+//! `FLUSH_EVERY` enqueues and once more on exit (cancel or done) so the
+//! worst-case re-work after a crash is ~100 files.
+//!
+//! A corrupt or version-mismatched checkpoint is treated as "no prior
+//! progress" (logged at warn level, no hard failure). Concretely: a JSON
+//! parse error, a missing `version`, or `version != CHECKPOINT_VERSION`
+//! all yield a fresh empty checkpoint, and the full reindex runs. That
+//! keeps the feature robust across upgrades without a migration path.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use walkdir::{DirEntry, WalkDir};
+
+use crate::hash::hash_bytes;
+
+/// Filename of the checkpoint JSON under `<vault>/.vaultcore/embeddings/`.
+pub const CHECKPOINT_FILE: &str = "reindex.checkpoint.json";
+/// Current on-disk layout version. Bumped when the schema changes in a
+/// breaking way; older versions load as empty (force full re-walk).
+pub const CHECKPOINT_VERSION: u32 = 1;
+/// Flush cadence: every N successful enqueues we atomically write the
+/// checkpoint. Trades worst-case re-work (≤ N files) against disk churn.
+const FLUSH_EVERY: usize = 100;
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReindexPhase {
+    /// Enumerating `.md` files under the vault root.
+    Scan,
+    /// Hashing + enqueuing stale files.
+    Index,
+    /// Worker exited normally, every file processed.
+    Done,
+    /// Worker exited due to a user cancel; checkpoint was flushed.
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ReindexProgress {
+    /// Files processed (hashed) so far.
+    pub done: usize,
+    /// Total files discovered during scan. Zero while `phase == Scan`.
+    pub total: usize,
+    /// Subset of `done` that matched checkpoint hash — no enqueue.
+    pub skipped: usize,
+    /// Subset of `done` that was actually enqueued for embedding.
+    pub embedded: usize,
+    pub phase: ReindexPhase,
+    /// Linearly-extrapolated seconds remaining. `None` while scanning or
+    /// when the worker is idle (done == 0 or total - done == 0).
+    pub eta_seconds: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct CheckpointFile {
+    version: u32,
+    /// vault-relative forward-slash path → sha256 hex of file bytes
+    entries: HashMap<String, String>,
+}
+
+impl Default for CheckpointFile {
+    fn default() -> Self {
+        Self { version: CHECKPOINT_VERSION, entries: HashMap::new() }
+    }
+}
+
+/// Cancellation + join handle for a running reindex. Returned by
+/// [`start_reindex`] and typically parked in `VaultState` so a second
+/// reindex request cancels the first before spawning.
+pub struct ReindexHandle {
+    cancel: Arc<AtomicBool>,
+    join: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ReindexHandle {
+    /// Set the cancel flag. The worker polls it between files; callers
+    /// that want to block until the worker exits should follow with
+    /// [`join`](Self::join).
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::Release);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.load(Ordering::Acquire)
+    }
+
+    /// Wait for the worker thread to exit. Safe to call multiple times;
+    /// subsequent calls are a no-op.
+    pub fn join(&self) {
+        if let Some(h) = self.join.lock().expect("reindex join lock").take() {
+            let _ = h.join();
+        }
+    }
+
+    /// Convenience: cancel then join. Used on vault switch so the old
+    /// worker doesn't keep mutating the freshly-replaced coordinator.
+    pub fn cancel_and_join(&self) {
+        self.cancel();
+        self.join();
+    }
+}
+
+/// Spawn the reindex worker. The returned handle holds the cancel flag
+/// and the thread join; drop it without joining to detach, or call
+/// `cancel_and_join` for cooperative shutdown.
+///
+/// - `enqueue(path, content) -> bool`: invoked for every file whose hash
+///   differs from the checkpoint. The closure must be non-blocking
+///   (wraps `EmbedCoordinator::enqueue`). Returns `true` iff the content
+///   landed — the checkpoint is only updated on `true`, so a transient
+///   `Closed` result will be retried on the next reindex.
+/// - `on_progress(ReindexProgress)`: invoked on every phase change and
+///   after every file. Production wiring emits a Tauri event; tests
+///   push into a Mutex<Vec<_>>.
+pub fn start_reindex<F, P>(
+    vault_root: PathBuf,
+    checkpoint_dir: PathBuf,
+    enqueue: F,
+    on_progress: P,
+) -> Arc<ReindexHandle>
+where
+    F: Fn(&Path, String) -> bool + Send + Sync + 'static,
+    P: Fn(ReindexProgress) + Send + Sync + 'static,
+{
+    let cancel = Arc::new(AtomicBool::new(false));
+    let handle = Arc::new(ReindexHandle {
+        cancel: Arc::clone(&cancel),
+        join: Mutex::new(None),
+    });
+
+    let join = std::thread::Builder::new()
+        .name("vc-reindex".into())
+        .spawn(move || {
+            run(vault_root, checkpoint_dir, cancel, enqueue, on_progress);
+        })
+        .expect("spawn reindex thread");
+
+    *handle.join.lock().expect("reindex join lock") = Some(join);
+    handle
+}
+
+fn run<F, P>(
+    vault_root: PathBuf,
+    checkpoint_dir: PathBuf,
+    cancel: Arc<AtomicBool>,
+    enqueue: F,
+    on_progress: P,
+) where
+    F: Fn(&Path, String) -> bool,
+    P: Fn(ReindexProgress),
+{
+    let _ = std::fs::create_dir_all(&checkpoint_dir);
+    let checkpoint_path = checkpoint_dir.join(CHECKPOINT_FILE);
+    let mut checkpoint = load_checkpoint(&checkpoint_path);
+
+    on_progress(ReindexProgress {
+        done: 0,
+        total: 0,
+        skipped: 0,
+        embedded: 0,
+        phase: ReindexPhase::Scan,
+        eta_seconds: None,
+    });
+
+    let files: Vec<PathBuf> = WalkDir::new(&vault_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_excluded(e))
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().is_file()
+                && e.path()
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+        })
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    let total = files.len();
+
+    let started = Instant::now();
+    let mut done = 0usize;
+    let mut skipped = 0usize;
+    let mut embedded = 0usize;
+    let mut since_flush = 0usize;
+
+    // Initial Index emission so the frontend can swap the statusbar from
+    // "Scanning" to "0 / total" before the first file completes.
+    on_progress(ReindexProgress {
+        done: 0,
+        total,
+        skipped: 0,
+        embedded: 0,
+        phase: ReindexPhase::Index,
+        eta_seconds: None,
+    });
+
+    for abs in files {
+        if cancel.load(Ordering::Acquire) {
+            break;
+        }
+        let rel_key = rel_key(&vault_root, &abs);
+        let (did_skip, did_embed) = process_file(&abs, &rel_key, &mut checkpoint, &enqueue);
+        if did_skip {
+            skipped += 1;
+        }
+        if did_embed {
+            embedded += 1;
+            since_flush += 1;
+        }
+        done += 1;
+
+        emit_progress(&on_progress, done, total, skipped, embedded, started);
+
+        if since_flush >= FLUSH_EVERY {
+            if let Err(e) = save_checkpoint(&checkpoint_path, &checkpoint) {
+                log::warn!("reindex: checkpoint flush failed: {e}");
+            }
+            since_flush = 0;
+        }
+    }
+
+    if let Err(e) = save_checkpoint(&checkpoint_path, &checkpoint) {
+        log::warn!("reindex: final checkpoint save failed: {e}");
+    }
+
+    let phase = if cancel.load(Ordering::Acquire) {
+        ReindexPhase::Cancelled
+    } else {
+        ReindexPhase::Done
+    };
+    on_progress(ReindexProgress {
+        done,
+        total,
+        skipped,
+        embedded,
+        phase,
+        eta_seconds: None,
+    });
+}
+
+/// Hash, compare, enqueue. Returns `(did_skip, did_embed)`. Exactly one
+/// of the two is true when the file was readable; both false on read
+/// error or non-UTF-8 content (we log and move on).
+fn process_file<F>(
+    abs: &Path,
+    rel_key: &str,
+    checkpoint: &mut CheckpointFile,
+    enqueue: &F,
+) -> (bool, bool)
+where
+    F: Fn(&Path, String) -> bool,
+{
+    let bytes = match std::fs::read(abs) {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!("reindex: read {} failed: {e}", abs.display());
+            return (false, false);
+        }
+    };
+    let hash = hash_bytes(&bytes);
+
+    if checkpoint.entries.get(rel_key) == Some(&hash) {
+        return (true, false);
+    }
+
+    let content = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("reindex: {} not utf-8 ({e}); skipping", abs.display());
+            return (false, false);
+        }
+    };
+
+    if enqueue(abs, content) {
+        checkpoint.entries.insert(rel_key.to_string(), hash);
+        (false, true)
+    } else {
+        (false, false)
+    }
+}
+
+fn emit_progress<P: Fn(ReindexProgress)>(
+    on_progress: &P,
+    done: usize,
+    total: usize,
+    skipped: usize,
+    embedded: usize,
+    started: Instant,
+) {
+    let eta_seconds = if done > 0 && total > done {
+        let elapsed = started.elapsed().as_secs_f64();
+        let per = elapsed / done as f64;
+        Some((per * (total - done) as f64) as u64)
+    } else {
+        None
+    };
+    on_progress(ReindexProgress {
+        done,
+        total,
+        skipped,
+        embedded,
+        phase: ReindexPhase::Index,
+        eta_seconds,
+    });
+}
+
+fn rel_key(vault_root: &Path, abs: &Path) -> String {
+    abs.strip_prefix(vault_root)
+        .unwrap_or(abs)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn is_excluded(entry: &DirEntry) -> bool {
+    let name = entry.file_name().to_str().unwrap_or("");
+    entry.depth() > 0 && name.starts_with('.')
+}
+
+fn load_checkpoint(path: &Path) -> CheckpointFile {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return CheckpointFile::default(),
+    };
+    match serde_json::from_str::<CheckpointFile>(&raw) {
+        Ok(c) if c.version == CHECKPOINT_VERSION => c,
+        Ok(c) => {
+            log::warn!(
+                "reindex checkpoint version {} unsupported (expected {}); starting fresh",
+                c.version,
+                CHECKPOINT_VERSION
+            );
+            CheckpointFile::default()
+        }
+        Err(e) => {
+            log::warn!("reindex checkpoint corrupt ({e}); starting fresh");
+            CheckpointFile::default()
+        }
+    }
+}
+
+fn save_checkpoint(path: &Path, checkpoint: &CheckpointFile) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string(checkpoint)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    fn write_md(root: &Path, rel: &str, body: &str) -> PathBuf {
+        let p = root.join(rel);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    fn wait_until<F: Fn() -> bool>(cond: F, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        cond()
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        enqueued: Mutex<Vec<(PathBuf, String)>>,
+        progress: Mutex<Vec<ReindexProgress>>,
+    }
+
+    impl Recorder {
+        fn enqueued_paths(&self) -> Vec<PathBuf> {
+            self.enqueued
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(p, _)| p.clone())
+                .collect()
+        }
+        fn last_phase(&self) -> Option<ReindexPhase> {
+            self.progress.lock().unwrap().last().map(|p| p.phase.clone())
+        }
+    }
+
+    fn run_reindex_blocking(
+        vault: &Path,
+        ckpt_dir: &Path,
+    ) -> (Arc<Recorder>, Arc<ReindexHandle>) {
+        let rec = Arc::new(Recorder::default());
+        let enqueue_rec = Arc::clone(&rec);
+        let progress_rec = Arc::clone(&rec);
+        let handle = start_reindex(
+            vault.to_path_buf(),
+            ckpt_dir.to_path_buf(),
+            move |path, content| {
+                enqueue_rec
+                    .enqueued
+                    .lock()
+                    .unwrap()
+                    .push((path.to_path_buf(), content));
+                true
+            },
+            move |p| progress_rec.progress.lock().unwrap().push(p),
+        );
+        handle.join();
+        (rec, handle)
+    }
+
+    #[test]
+    fn checkpoint_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(CHECKPOINT_FILE);
+        let mut ckpt = CheckpointFile::default();
+        ckpt.entries.insert("a/b.md".into(), "deadbeef".into());
+        ckpt.entries.insert("c.md".into(), "cafebabe".into());
+        save_checkpoint(&path, &ckpt).unwrap();
+
+        let loaded = load_checkpoint(&path);
+        assert_eq!(loaded.version, CHECKPOINT_VERSION);
+        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(loaded.entries.get("a/b.md").map(String::as_str), Some("deadbeef"));
+    }
+
+    #[test]
+    fn corrupt_checkpoint_starts_fresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(CHECKPOINT_FILE);
+        std::fs::write(&path, "this is not json {{{").unwrap();
+        let loaded = load_checkpoint(&path);
+        assert!(loaded.entries.is_empty());
+        assert_eq!(loaded.version, CHECKPOINT_VERSION);
+    }
+
+    #[test]
+    fn version_mismatch_starts_fresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(CHECKPOINT_FILE);
+        std::fs::write(&path, r#"{"version":999,"entries":{"x.md":"h"}}"#).unwrap();
+        let loaded = load_checkpoint(&path);
+        assert!(loaded.entries.is_empty());
+    }
+
+    #[test]
+    fn first_run_enqueues_every_md_file() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "a.md", "note one");
+        write_md(vault.path(), "sub/b.md", "note two");
+        write_md(vault.path(), "sub/c.md", "note three");
+        // Non-md: must be ignored.
+        write_md(vault.path(), "ignored.txt", "not markdown");
+
+        let (rec, _h) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(rec.enqueued_paths().len(), 3);
+        assert_eq!(rec.last_phase(), Some(ReindexPhase::Done));
+    }
+
+    #[test]
+    fn skips_unchanged_files_on_second_run() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "a.md", "stable");
+        write_md(vault.path(), "b.md", "also stable");
+
+        let (rec1, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(rec1.enqueued_paths().len(), 2);
+
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(
+            rec2.enqueued_paths().len(),
+            0,
+            "second run must not re-enqueue unchanged files"
+        );
+        // Last progress reports all files skipped.
+        let last = rec2.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last.done, 2);
+        assert_eq!(last.skipped, 2);
+        assert_eq!(last.embedded, 0);
+        assert_eq!(last.phase, ReindexPhase::Done);
+    }
+
+    #[test]
+    fn re_enqueues_stale_file_when_hash_changes() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        let a = write_md(vault.path(), "a.md", "v1");
+        write_md(vault.path(), "b.md", "unchanged");
+
+        let (_rec1, _) = run_reindex_blocking(vault.path(), ckpt.path());
+
+        // Modify a.md — hash changes, b.md stays pinned.
+        std::fs::write(&a, "v2-totally-different").unwrap();
+
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        let paths = rec2.enqueued_paths();
+        assert_eq!(paths.len(), 1, "only the stale file re-enqueues, got {paths:?}");
+        assert!(paths[0].ends_with("a.md"));
+    }
+
+    #[test]
+    fn skips_dot_directories() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "note.md", "real");
+        write_md(vault.path(), ".vaultcore/ignored.md", "should be skipped");
+        write_md(vault.path(), ".git/also.md", "also skipped");
+        write_md(vault.path(), ".obsidian/cfg.md", "obsidian config");
+
+        let (rec, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        let paths = rec.enqueued_paths();
+        assert_eq!(paths.len(), 1);
+        assert!(paths[0].ends_with("note.md"));
+    }
+
+    #[test]
+    fn empty_vault_emits_done_with_zero_total() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        let (rec, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(rec.enqueued_paths().len(), 0);
+        let last = rec.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last.total, 0);
+        assert_eq!(last.done, 0);
+        assert_eq!(last.phase, ReindexPhase::Done);
+    }
+
+    #[test]
+    fn cancellation_stops_worker_and_persists_progress() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        for i in 0..400 {
+            write_md(vault.path(), &format!("n-{i:04}.md"), &format!("body {i}"));
+        }
+
+        let rec = Arc::new(Recorder::default());
+        let enqueue_rec = Arc::clone(&rec);
+        let progress_rec = Arc::clone(&rec);
+        // Slow the enqueue so we can observe cancellation mid-stream.
+        let handle = start_reindex(
+            vault.path().to_path_buf(),
+            ckpt.path().to_path_buf(),
+            move |path, content| {
+                std::thread::sleep(Duration::from_millis(2));
+                enqueue_rec
+                    .enqueued
+                    .lock()
+                    .unwrap()
+                    .push((path.to_path_buf(), content));
+                true
+            },
+            move |p| progress_rec.progress.lock().unwrap().push(p),
+        );
+        // Let it process a chunk then cancel.
+        assert!(wait_until(
+            || rec.enqueued.lock().unwrap().len() >= 20,
+            Duration::from_secs(10),
+        ));
+        handle.cancel();
+        handle.join();
+
+        let enqueued = rec.enqueued.lock().unwrap().len();
+        assert!(
+            enqueued < 400,
+            "cancellation must stop before processing all 400 files (got {enqueued})"
+        );
+        let last = rec.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last.phase, ReindexPhase::Cancelled);
+
+        // Checkpoint flushed — a second run picks up where the first left off
+        // (skipped == already-processed count, new enqueues cover the tail).
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        let last2 = rec2.progress.lock().unwrap().last().cloned().unwrap();
+        assert_eq!(last2.total, 400);
+        assert_eq!(last2.done, 400);
+        assert!(
+            last2.skipped >= enqueued - 1,
+            "resumed run must skip at least what PR-1 already flushed: enq={enqueued}, skip={}",
+            last2.skipped
+        );
+    }
+
+    /// Lost-enqueue guard: if the caller's enqueue closure returns false
+    /// (simulating `EmbedCoordinator::enqueue` → `Closed`), the checkpoint
+    /// must NOT record that file, so the next run retries it.
+    #[test]
+    fn failed_enqueue_is_retried_next_run() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        write_md(vault.path(), "a.md", "hello");
+
+        let rec = Arc::new(Recorder::default());
+        let enqueue_rec = Arc::clone(&rec);
+        let progress_rec = Arc::clone(&rec);
+        let handle = start_reindex(
+            vault.path().to_path_buf(),
+            ckpt.path().to_path_buf(),
+            move |path, content| {
+                enqueue_rec
+                    .enqueued
+                    .lock()
+                    .unwrap()
+                    .push((path.to_path_buf(), content));
+                false // simulate Closed
+            },
+            move |p| progress_rec.progress.lock().unwrap().push(p),
+        );
+        handle.join();
+        assert_eq!(rec.enqueued.lock().unwrap().len(), 1);
+
+        // Second run: enqueue is still empty (checkpoint didn't record).
+        let (rec2, _) = run_reindex_blocking(vault.path(), ckpt.path());
+        assert_eq!(
+            rec2.enqueued.lock().unwrap().len(),
+            1,
+            "stale file with no checkpoint entry must be retried"
+        );
+    }
+}

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -61,6 +61,27 @@ pub const CHECKPOINT_VERSION: u32 = 1;
 /// Flush cadence: every N successful enqueues we atomically write the
 /// checkpoint. Trades worst-case re-work (≤ N files) against disk churn.
 const FLUSH_EVERY: usize = 100;
+/// #201 PR-D — reindex reader batch size. The reader accumulates up to
+/// this many (path, content) pairs before committing them to the
+/// embedder in a single `enqueue_bulk` call. Net effect: the embedder's
+/// drain window sees ~N files worth of chunks per wake-up instead of 1-4,
+/// which collapses ORT per-call setup overhead and lets `run_embed_batch`
+/// actually run sub-batches of 64.
+///
+/// 32 is a balance: small enough that a cancel is observed within ~1-2 s
+/// worth of work (cancel flag is polled between batches), large enough
+/// that the embedder gets ~96 chunks to batch across sub-calls.
+const REINDEX_BATCH_SIZE: usize = 32;
+/// #201 PR-D — RAM backpressure. If the embedder's pending map already
+/// holds this many entries, the reader parks briefly before reading more
+/// files. Keeps a 100k-vault reindex from piling the entire set of file
+/// bodies into the map if disk reads outrun ORT inference.
+///
+/// 256 × avg ~5 KB body = ~1.3 MB in-flight — negligible vs the 500 MB
+/// active-semantic budget (see CLAUDE.md). Raising this number trades
+/// lower bursty CPU overhead for more RAM held; lowering it starves the
+/// embedder during I/O-bound phases.
+const PENDING_HIGH_WATER: usize = 256;
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -144,23 +165,50 @@ impl ReindexHandle {
 /// and the thread join; drop it without joining to detach, or call
 /// `cancel_and_join` for cooperative shutdown.
 ///
-/// - `enqueue(path, content) -> bool`: invoked for every file whose hash
-///   differs from the checkpoint. The closure must be non-blocking
-///   (wraps `EmbedCoordinator::enqueue`). Returns `true` iff the content
-///   landed — the checkpoint is only updated on `true`, so a transient
-///   `Closed` result will be retried on the next reindex.
+/// - `enqueue_bulk(batch) -> bool`: invoked with up to `REINDEX_BATCH_SIZE`
+///   `(path, content)` pairs whose hashes differ from the checkpoint.
+///   The closure must be non-blocking (wraps `EmbedCoordinator::enqueue_bulk`).
+///   Returns `true` iff the whole batch landed in the pending map —
+///   the checkpoint is only updated on `true`, so a transient `Closed`
+///   result will be retried on the next reindex.
 /// - `on_progress(ReindexProgress)`: invoked on every phase change and
 ///   after every file. Production wiring emits a Tauri event; tests
 ///   push into a Mutex<Vec<_>>.
 pub fn start_reindex<F, P>(
     vault_root: PathBuf,
     checkpoint_dir: PathBuf,
-    enqueue: F,
+    enqueue_bulk: F,
     on_progress: P,
 ) -> Arc<ReindexHandle>
 where
-    F: Fn(&Path, String) -> bool + Send + Sync + 'static,
+    F: Fn(Vec<(PathBuf, String)>) -> bool + Send + Sync + 'static,
     P: Fn(ReindexProgress) + Send + Sync + 'static,
+{
+    start_reindex_with_backpressure(
+        vault_root,
+        checkpoint_dir,
+        enqueue_bulk,
+        on_progress,
+        || 0,
+    )
+}
+
+/// #201 PR-D — same as `start_reindex` but with a RAM-backpressure hook.
+/// `pending_size` is polled after every flush; when it exceeds
+/// `PENDING_HIGH_WATER` the reader sleeps briefly before reading the
+/// next file. Production wiring passes a closure that reads
+/// `EmbedCoordinator::pending_len`; tests may pass `|| 0`.
+pub fn start_reindex_with_backpressure<F, P, B>(
+    vault_root: PathBuf,
+    checkpoint_dir: PathBuf,
+    enqueue_bulk: F,
+    on_progress: P,
+    pending_size: B,
+) -> Arc<ReindexHandle>
+where
+    F: Fn(Vec<(PathBuf, String)>) -> bool + Send + Sync + 'static,
+    P: Fn(ReindexProgress) + Send + Sync + 'static,
+    B: Fn() -> usize + Send + Sync + 'static,
 {
     let cancel = Arc::new(AtomicBool::new(false));
     let handle = Arc::new(ReindexHandle {
@@ -171,7 +219,14 @@ where
     let join = std::thread::Builder::new()
         .name("vc-reindex".into())
         .spawn(move || {
-            run(vault_root, checkpoint_dir, cancel, enqueue, on_progress);
+            run(
+                vault_root,
+                checkpoint_dir,
+                cancel,
+                enqueue_bulk,
+                on_progress,
+                pending_size,
+            );
         })
         .expect("spawn reindex thread");
 
@@ -179,15 +234,17 @@ where
     handle
 }
 
-fn run<F, P>(
+fn run<F, P, B>(
     vault_root: PathBuf,
     checkpoint_dir: PathBuf,
     cancel: Arc<AtomicBool>,
-    enqueue: F,
+    enqueue_bulk: F,
     on_progress: P,
+    pending_size: B,
 ) where
-    F: Fn(&Path, String) -> bool,
+    F: Fn(Vec<(PathBuf, String)>) -> bool,
     P: Fn(ReindexProgress),
+    B: Fn() -> usize,
 {
     let _ = std::fs::create_dir_all(&checkpoint_dir);
     let checkpoint_path = checkpoint_dir.join(CHECKPOINT_FILE);
@@ -223,6 +280,13 @@ fn run<F, P>(
     let mut embedded = 0usize;
     let mut since_flush = 0usize;
 
+    // Pending batch: files whose hash is stale and are queued to the
+    // embedder on the next flush. Tuple form: (abs_path, rel_key, content,
+    // hash). `hash` is kept here so we only write it to the checkpoint
+    // once the bulk enqueue reports success.
+    let mut batch: Vec<(PathBuf, String, String, String)> =
+        Vec::with_capacity(REINDEX_BATCH_SIZE);
+
     // Initial Index emission so the frontend can swap the statusbar from
     // "Scanning" to "0 / total" before the first file completes.
     on_progress(ReindexProgress {
@@ -234,21 +298,61 @@ fn run<F, P>(
         eta_seconds: None,
     });
 
+    let flush = |batch: &mut Vec<(PathBuf, String, String, String)>,
+                     checkpoint: &mut CheckpointFile,
+                     embedded: &mut usize,
+                     since_flush: &mut usize| {
+        if batch.is_empty() {
+            return;
+        }
+        let items: Vec<(PathBuf, String)> = batch
+            .iter()
+            .map(|(abs, _, c, _)| (abs.clone(), c.clone()))
+            .collect();
+        let ok = enqueue_bulk(items);
+        if ok {
+            for (_abs, rel_key, _content, hash) in batch.drain(..) {
+                checkpoint.entries.insert(rel_key, hash);
+                *embedded += 1;
+                *since_flush += 1;
+            }
+        } else {
+            // Enqueue failed — do NOT write the checkpoint. The next
+            // reindex run will re-hash these files and retry. Drain so
+            // the buffer is empty for the next iteration; the (path,
+            // content) tuples drop unused.
+            batch.clear();
+        }
+    };
+
     for abs in files {
         if cancel.load(Ordering::Acquire) {
             break;
         }
-        let rel_key = rel_key(&vault_root, &abs);
-        let (did_skip, did_embed) = process_file(&abs, &rel_key, &mut checkpoint, &enqueue);
-        if did_skip {
-            skipped += 1;
+        // RAM backpressure: park the reader while the embedder drains.
+        // Poll the cancel flag inside the park loop so a cancel during a
+        // full pending map is observed within ~20 ms.
+        while pending_size() > PENDING_HIGH_WATER {
+            if cancel.load(Ordering::Acquire) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
         }
-        if did_embed {
-            embedded += 1;
-            since_flush += 1;
+        if cancel.load(Ordering::Acquire) {
+            break;
+        }
+        let rel_key_str = rel_key(&vault_root, &abs);
+        match classify_file(&abs, &rel_key_str, &checkpoint) {
+            FileAction::Skip => skipped += 1,
+            FileAction::Embed { content, hash } => {
+                batch.push((abs.clone(), rel_key_str, content, hash));
+                if batch.len() >= REINDEX_BATCH_SIZE {
+                    flush(&mut batch, &mut checkpoint, &mut embedded, &mut since_flush);
+                }
+            }
+            FileAction::Error => {}
         }
         done += 1;
-
         emit_progress(&on_progress, done, total, skipped, embedded, started);
 
         if since_flush >= FLUSH_EVERY {
@@ -257,6 +361,11 @@ fn run<F, P>(
             }
             since_flush = 0;
         }
+    }
+
+    // Drain the tail batch (files left over after the last full-batch flush).
+    if !cancel.load(Ordering::Acquire) {
+        flush(&mut batch, &mut checkpoint, &mut embedded, &mut since_flush);
     }
 
     if let Err(e) = save_checkpoint(&checkpoint_path, &checkpoint) {
@@ -278,45 +387,38 @@ fn run<F, P>(
     });
 }
 
-/// Hash, compare, enqueue. Returns `(did_skip, did_embed)`. Exactly one
-/// of the two is true when the file was readable; both false on read
-/// error or non-UTF-8 content (we log and move on).
-fn process_file<F>(
-    abs: &Path,
-    rel_key: &str,
-    checkpoint: &mut CheckpointFile,
-    enqueue: &F,
-) -> (bool, bool)
-where
-    F: Fn(&Path, String) -> bool,
-{
+/// Outcome of the cheap read + hash step. `Skip` and `Error` are the
+/// terminal states; `Embed` hands the decoded content back to the reader
+/// so it can be accumulated into the next batch without re-reading.
+enum FileAction {
+    Skip,
+    Embed { content: String, hash: String },
+    Error,
+}
+
+/// Read a file's bytes, hash them, and decide what to do. No side effects:
+/// the reader owns the checkpoint write and the bulk enqueue so that a
+/// failed batch doesn't leak half-applied state.
+fn classify_file(abs: &Path, rel_key: &str, checkpoint: &CheckpointFile) -> FileAction {
     let bytes = match std::fs::read(abs) {
         Ok(b) => b,
         Err(e) => {
             log::warn!("reindex: read {} failed: {e}", abs.display());
-            return (false, false);
+            return FileAction::Error;
         }
     };
     let hash = hash_bytes(&bytes);
-
     if checkpoint.entries.get(rel_key) == Some(&hash) {
-        return (true, false);
+        return FileAction::Skip;
     }
-
     let content = match String::from_utf8(bytes) {
         Ok(s) => s,
         Err(e) => {
             log::warn!("reindex: {} not utf-8 ({e}); skipping", abs.display());
-            return (false, false);
+            return FileAction::Error;
         }
     };
-
-    if enqueue(abs, content) {
-        checkpoint.entries.insert(rel_key.to_string(), hash);
-        (false, true)
-    } else {
-        (false, false)
-    }
+    FileAction::Embed { content, hash }
 }
 
 fn emit_progress<P: Fn(ReindexProgress)>(
@@ -446,12 +548,11 @@ mod tests {
         let handle = start_reindex(
             vault.to_path_buf(),
             ckpt_dir.to_path_buf(),
-            move |path, content| {
-                enqueue_rec
-                    .enqueued
-                    .lock()
-                    .unwrap()
-                    .push((path.to_path_buf(), content));
+            move |batch| {
+                let mut g = enqueue_rec.enqueued.lock().unwrap();
+                for (p, c) in batch {
+                    g.push((p, c));
+                }
                 true
             },
             move |p| progress_rec.progress.lock().unwrap().push(p),
@@ -593,13 +694,12 @@ mod tests {
         let handle = start_reindex(
             vault.path().to_path_buf(),
             ckpt.path().to_path_buf(),
-            move |path, content| {
-                std::thread::sleep(Duration::from_millis(2));
-                enqueue_rec
-                    .enqueued
-                    .lock()
-                    .unwrap()
-                    .push((path.to_path_buf(), content));
+            move |batch| {
+                std::thread::sleep(Duration::from_millis(2 * batch.len() as u64));
+                let mut g = enqueue_rec.enqueued.lock().unwrap();
+                for (p, c) in batch {
+                    g.push((p, c));
+                }
                 true
             },
             move |p| progress_rec.progress.lock().unwrap().push(p),
@@ -633,6 +733,233 @@ mod tests {
         );
     }
 
+    /// #201 PR-D — RAM backpressure. While the pending_size() closure
+    /// reports a saturated map, the reader must NOT read new files;
+    /// once the closure reports below-high-water, the reader resumes.
+    #[test]
+    fn backpressure_pauses_reader_until_pending_drains() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
+
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        for i in 0..50 {
+            write_md(vault.path(), &format!("n-{i:04}.md"), "body");
+        }
+
+        let fake_pending = Arc::new(AtomicUsize::new(10_000)); // far above high-water
+        let enqueued = Arc::new(AtomicUsize::new(0));
+        let released = Arc::new(AtomicBool::new(false));
+
+        let fp_cb = Arc::clone(&fake_pending);
+        let enq_cb = Arc::clone(&enqueued);
+        let handle = start_reindex_with_backpressure(
+            vault.path().to_path_buf(),
+            ckpt.path().to_path_buf(),
+            move |batch| {
+                enq_cb.fetch_add(batch.len(), AtomicOrdering::SeqCst);
+                true
+            },
+            |_p| {},
+            move || fp_cb.load(AtomicOrdering::SeqCst),
+        );
+
+        // Give the reader a beat to park.
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(
+            enqueued.load(AtomicOrdering::SeqCst),
+            0,
+            "reader must not enqueue while pending is saturated"
+        );
+
+        // Release: drop fake pending below high-water.
+        fake_pending.store(0, AtomicOrdering::SeqCst);
+        released.store(true, AtomicOrdering::SeqCst);
+        handle.join();
+
+        assert_eq!(
+            enqueued.load(AtomicOrdering::SeqCst),
+            50,
+            "every file must reach the embedder once backpressure lifts"
+        );
+    }
+
+    /// #201 PR-D — the reader must submit work in bulks, not per-file.
+    /// A regression to per-file `enqueue` (one closure call per md) would
+    /// make the bulk API worthless and dramatically slow reindex on
+    /// hardware where ORT inference isn't the bottleneck.
+    #[test]
+    fn reader_flushes_in_bulks_not_per_file() {
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        // Enough files to guarantee at least one full batch plus a tail.
+        let n_files = REINDEX_BATCH_SIZE + 5;
+        for i in 0..n_files {
+            write_md(vault.path(), &format!("n-{i:04}.md"), &format!("body {i}"));
+        }
+
+        let batch_sizes = Arc::new(Mutex::new(Vec::<usize>::new()));
+        let batch_sizes_cb = Arc::clone(&batch_sizes);
+        let handle = start_reindex(
+            vault.path().to_path_buf(),
+            ckpt.path().to_path_buf(),
+            move |batch| {
+                batch_sizes_cb.lock().unwrap().push(batch.len());
+                true
+            },
+            |_p| {},
+        );
+        handle.join();
+
+        let sizes = batch_sizes.lock().unwrap();
+        assert!(
+            !sizes.is_empty(),
+            "enqueue_bulk must be called at least once"
+        );
+        // Full-size batch appears at least once (the head of the run).
+        assert!(
+            sizes.iter().any(|&s| s == REINDEX_BATCH_SIZE),
+            "expected at least one full-size batch, got sizes {sizes:?}"
+        );
+        // Total items across calls equals the file count.
+        let total: usize = sizes.iter().sum();
+        assert_eq!(total, n_files);
+        // No call has more than REINDEX_BATCH_SIZE items.
+        assert!(sizes.iter().all(|&s| s <= REINDEX_BATCH_SIZE));
+    }
+
+    /// #201 PR-D — throughput bench. Generates a synthetic vault of N
+    /// files (~500 words each) and measures end-to-end wall-clock to
+    /// embed them all via the real `EmbeddingService` + `Chunker` +
+    /// `HnswSink` + `EmbedCoordinator`. Asserts a files-per-second floor.
+    ///
+    /// Two sizes:
+    /// - default: 200 files (runs in ~30-60s on a modern laptop)
+    /// - `LARGE_REINDEX_BENCH=1`: 2000 files (~5-10 min), predictive for
+    ///   the 100k AC via linear extrapolation.
+    ///
+    /// `#[ignore]` so `cargo test` never picks it up. Run with:
+    /// `cargo test --features embeddings -- --ignored bench_reindex_throughput --nocapture`
+    ///
+    /// Throughput is bounded by ORT inference at intra=2/inter=1 (#197);
+    /// this bench measures the *wrapping* pipeline overhead, not ORT
+    /// itself. The floor is set to catch regressions in the reader loop,
+    /// chunking, enqueue path, and sink store. Do NOT raise the ORT
+    /// thread caps to "improve" this number.
+    #[test]
+    #[ignore]
+    fn bench_reindex_throughput() {
+        use crate::embeddings::{Chunker, EmbedCoordinator, EmbeddingService, HnswSink, VectorSink};
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+        let Some(svc) = EmbeddingService::load(None).ok() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let Some(chk) = Chunker::load(None).ok() else {
+            eprintln!("SKIP: chunker assets not bundled");
+            return;
+        };
+
+        let n_files: usize = if std::env::var("LARGE_REINDEX_BENCH").is_ok() {
+            2000
+        } else {
+            200
+        };
+
+        let vault = tempfile::tempdir().unwrap();
+        let ckpt = tempfile::tempdir().unwrap();
+        let sink_dir = tempfile::tempdir().unwrap();
+
+        // ~500 word markdown body — realistic note size. Vary seeds so
+        // embeddings aren't identical (would short-circuit HNSW).
+        let body_template: String = (0..500).map(|i| format!("word{} ", i)).collect();
+        let gen_start = Instant::now();
+        for i in 0..n_files {
+            let body = format!("# Note {i}\n\n{body_template} unique-{i}\n");
+            write_md(vault.path(), &format!("n-{i:05}.md"), &body);
+        }
+        eprintln!("generated {n_files} files in {:?}", gen_start.elapsed());
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let processed = Arc::new(AtomicUsize::new(0));
+        let sink_processed = Arc::clone(&processed);
+
+        rt.block_on(async move {
+            // Counting wrapper around HnswSink so we can wait for all N
+            // files to actually reach the sink (not just the enqueue).
+            struct CountingHnswSink {
+                inner: HnswSink,
+                counter: Arc<AtomicUsize>,
+            }
+            impl VectorSink for CountingHnswSink {
+                fn store(&self, path: &Path, pairs: Vec<(crate::embeddings::Chunk, Vec<f32>)>) {
+                    self.inner.store(path, pairs);
+                    self.counter.fetch_add(1, AtomicOrdering::SeqCst);
+                }
+                fn delete(&self, path: &Path) {
+                    self.inner.delete(path);
+                }
+            }
+
+            let sink: Arc<dyn VectorSink> = Arc::new(CountingHnswSink {
+                inner: HnswSink::open(sink_dir.path().to_path_buf(), n_files),
+                counter: Arc::clone(&sink_processed),
+            });
+            let coord = Arc::new(EmbedCoordinator::spawn(svc, chk, sink));
+            let coord_enq = Arc::clone(&coord);
+
+            let total_start = Instant::now();
+            let handle = start_reindex(
+                vault.path().to_path_buf(),
+                ckpt.path().to_path_buf(),
+                move |batch| match coord_enq.enqueue_bulk(batch) {
+                    Ok(_) => true,
+                    Err(_) => false,
+                },
+                |_p| {},
+            );
+            handle.join();
+
+            // Wait for the embedder to drain every file into the sink.
+            let timeout = std::time::Duration::from_secs(600);
+            let deadline = Instant::now() + timeout;
+            while Instant::now() < deadline {
+                if processed.load(AtomicOrdering::SeqCst) >= n_files {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            let done = processed.load(AtomicOrdering::SeqCst);
+            let elapsed = total_start.elapsed();
+            let per_sec = done as f64 / elapsed.as_secs_f64();
+            eprintln!(
+                "\n=== #201 PR-D bench ===\n\
+                 files:      {done} / {n_files}\n\
+                 wall-clock: {:?}\n\
+                 throughput: {per_sec:.1} files/sec\n\
+                 extrap. 100k: {:.1} min\n",
+                elapsed,
+                (100_000.0 / per_sec) / 60.0,
+            );
+
+            assert_eq!(done, n_files, "every file must reach the sink");
+            // Floor: 3.0 files/sec. On the 100k target this would be
+            // ~9.3 hours — far above the 60 min AC — so any run passing
+            // this floor leaves generous headroom. Tighter floor post-
+            // tuning in a follow-up.
+            const FLOOR_FILES_PER_SEC: f64 = 3.0;
+            assert!(
+                per_sec >= FLOOR_FILES_PER_SEC,
+                "throughput regression: {per_sec:.2} files/sec < floor {FLOOR_FILES_PER_SEC}"
+            );
+        });
+    }
+
     /// Lost-enqueue guard: if the caller's enqueue closure returns false
     /// (simulating `EmbedCoordinator::enqueue` → `Closed`), the checkpoint
     /// must NOT record that file, so the next run retries it.
@@ -648,12 +975,11 @@ mod tests {
         let handle = start_reindex(
             vault.path().to_path_buf(),
             ckpt.path().to_path_buf(),
-            move |path, content| {
-                enqueue_rec
-                    .enqueued
-                    .lock()
-                    .unwrap()
-                    .push((path.to_path_buf(), content));
+            move |batch| {
+                let mut g = enqueue_rec.enqueued.lock().unwrap();
+                for (p, c) in batch {
+                    g.push((p, c));
+                }
                 false // simulate Closed
             },
             move |p| progress_rec.progress.lock().unwrap().push(p),

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -56,8 +56,14 @@ use crate::hash::hash_bytes;
 /// Filename of the checkpoint JSON under `<vault>/.vaultcore/embeddings/`.
 pub const CHECKPOINT_FILE: &str = "reindex.checkpoint.json";
 /// Current on-disk layout version. Bumped when the schema changes in a
-/// breaking way; older versions load as empty (force full re-walk).
-pub const CHECKPOINT_VERSION: u32 = 1;
+/// breaking way or when the embedding model changes — older versions load
+/// as empty (force full re-walk).
+///
+/// - v1: initial format.
+/// - v2: (#233) model swap from MiniLM to multilingual-e5-small. Hashes
+///   in the checkpoint refer to files whose embeddings are now in the
+///   wrong subspace; the only safe recovery is a full reindex.
+pub const CHECKPOINT_VERSION: u32 = 2;
 /// Flush cadence: every N successful enqueues we atomically write the
 /// checkpoint. Trades worst-case re-work (≤ N files) against disk churn.
 const FLUSH_EVERY: usize = 100;

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -1,0 +1,135 @@
+//! `EmbeddingService` (#194) — single-instance, thread-safe text → 384-d
+//! vector pipeline used by every backend caller (embed-on-save, reindex,
+//! query). The model is loaded once via fastembed and held behind a Mutex
+//! that serialises inference calls. fastembed's `TextEmbedding` is not
+//! `Sync` (it owns an `ort::Session` with interior mutability), so the
+//! Mutex wrap is required to satisfy `Send + Sync`.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use fastembed::{
+    InitOptionsUserDefined, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel,
+};
+
+use super::{ensure_runtime_initialized, model_dir, EmbeddingError};
+
+/// Bundled-model embedding pipeline. Construct once per process via
+/// `EmbeddingService::load`, then share the resulting `Arc` everywhere.
+pub struct EmbeddingService {
+    inner: Mutex<TextEmbedding>,
+}
+
+impl EmbeddingService {
+    /// Load the bundled MiniLM model. Wraps the ORT runtime initialisation
+    /// so it is safe to call before or after `embeddings::bootstrap`.
+    pub fn load(resource_dir: Option<&Path>) -> Result<Arc<Self>, EmbeddingError> {
+        ensure_runtime_initialized(resource_dir)?;
+        let dir = model_dir(resource_dir)?;
+        let read = |name: &str| std::fs::read(dir.join(name));
+        let model = UserDefinedEmbeddingModel::new(
+            read("model.onnx")?,
+            TokenizerFiles {
+                tokenizer_file: read("tokenizer.json")?,
+                config_file: read("config.json")?,
+                special_tokens_map_file: read("special_tokens_map.json")?,
+                tokenizer_config_file: read("tokenizer_config.json")?,
+            },
+        );
+        let embedder = TextEmbedding::try_new_from_user_defined(
+            model,
+            InitOptionsUserDefined::default(),
+        )
+        .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
+        Ok(Arc::new(Self {
+            inner: Mutex::new(embedder),
+        }))
+    }
+
+    /// Embed a single string. Returns a 384-dim L2-normalised vector.
+    pub fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        let mut batch = self.embed_batch(&[text])?;
+        batch.pop().ok_or_else(|| {
+            EmbeddingError::Fastembed("empty embedding batch".into())
+        })
+    }
+
+    /// Embed a batch of strings in one inference pass.
+    pub fn embed_batch(
+        &self,
+        texts: &[&str],
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| EmbeddingError::Fastembed("mutex poisoned".into()))?;
+        let owned: Vec<String> = texts.iter().map(|s| s.to_string()).collect();
+        guard
+            .embed(owned, None)
+            .map_err(|e| EmbeddingError::Fastembed(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: skip when the bundled assets aren't present yet (e.g. on a
+    /// fresh checkout where `cargo build` hasn't run).
+    fn try_load() -> Option<Arc<EmbeddingService>> {
+        EmbeddingService::load(None).ok()
+    }
+
+    #[test]
+    fn embed_returns_384_l2_normalised_vector() {
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let v = svc.embed("hello world").unwrap();
+        assert_eq!(v.len(), 384);
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 0.01, "L2 norm: {norm}");
+    }
+
+    #[test]
+    fn batch_matches_per_item() {
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let single = svc.embed("the quick brown fox").unwrap();
+        let batch = svc.embed_batch(&["the quick brown fox"]).unwrap();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0], single);
+    }
+
+    #[test]
+    fn semantically_close_strings_have_high_cosine_similarity() {
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let a = svc.embed("how do cats communicate").unwrap();
+        let b = svc.embed("feline body language").unwrap();
+        let c = svc.embed("rust async runtime internals").unwrap();
+        let cos = |x: &[f32], y: &[f32]| -> f32 {
+            x.iter().zip(y).map(|(a, b)| a * b).sum()
+        };
+        let close = cos(&a, &b);
+        let far = cos(&a, &c);
+        assert!(
+            close > far + 0.1,
+            "expected close > far + 0.1, got close={close}, far={far}"
+        );
+    }
+
+    #[test]
+    fn service_is_send_and_sync() {
+        // Compile-time assertion — if this changes, callers in tokio
+        // workers (#196) and rayon (#198) would break.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<EmbeddingService>();
+        assert_send_sync::<Arc<EmbeddingService>>();
+    }
+}

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -286,4 +286,58 @@ mod tests {
         assert_send_sync::<EmbeddingService>();
         assert_send_sync::<Arc<EmbeddingService>>();
     }
+
+    /// #207 AC #1 — single-note embed latency p50/p99. Warm, steady-state
+    /// (ORT session already loaded, arena stable). Emits a JSON line to
+    /// stderr for `scripts/run-benchmarks.sh` to collect.
+    ///
+    /// `#[ignore]` because it needs the bundled model and should only
+    /// run through the benchmark harness. Run with:
+    /// `cargo test --release --features embeddings -- --ignored bench_single_embed --nocapture`.
+    #[test]
+    #[ignore]
+    fn bench_single_embed_p50_p99() {
+        use std::time::{Duration, Instant};
+        const WARMUP: usize = 20;
+        const N: usize = 200;
+
+        let Some(svc) = try_load() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+
+        // Representative prose — varied length so we exercise the tokenizer's
+        // padding + truncation paths, not just the shortest possible input.
+        let probes: Vec<String> = (0..N)
+            .map(|i| {
+                format!(
+                    "note {i} about markdown workflows, cross-linking between \
+                     files, and incremental indexing of a personal knowledge vault"
+                )
+            })
+            .collect();
+        for p in probes.iter().take(WARMUP) {
+            let _ = svc.embed(p).unwrap();
+        }
+
+        let mut samples = Vec::with_capacity(N);
+        for p in &probes {
+            let t0 = Instant::now();
+            let _ = svc.embed(p).unwrap();
+            samples.push(t0.elapsed());
+        }
+        samples.sort();
+        let p50 = samples[N / 2];
+        let p99 = samples[(N * 99) / 100];
+        eprintln!("BENCH_JSON {{\"name\":\"single_embed\",\"p50_ms\":{:.3},\"p99_ms\":{:.3},\"n\":{N}}}",
+            p50.as_secs_f64() * 1000.0,
+            p99.as_secs_f64() * 1000.0);
+        // Loose ceiling: 20 ms p50 is well above warm ORT inference for
+        // MiniLM-L6-v2 on any modern CPU. The harness's regression check
+        // catches real drift against the committed baseline.
+        assert!(
+            p50 < Duration::from_millis(20),
+            "single_embed p50 too slow: {p50:?}"
+        );
+    }
 }

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -36,9 +36,13 @@ impl EmbeddingService {
                 tokenizer_config_file: read("tokenizer_config.json")?,
             },
         );
+        // Cap fastembed's tokenizer at 256 to match MiniLM-L6-v2's training
+        // sequence length and the chunker's window size (#195). The crate
+        // default is 512, which would let oversized inputs through and
+        // silently degrade embedding quality.
         let embedder = TextEmbedding::try_new_from_user_defined(
             model,
-            InitOptionsUserDefined::default(),
+            InitOptionsUserDefined::default().with_max_length(256),
         )
         .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
         Ok(Arc::new(Self {

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -19,12 +19,23 @@ use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams, Tr
 use super::session::{build_minilm_session, register_cpu_arena_if_needed};
 use super::{ensure_runtime_initialized, model_dir, EmbeddingError};
 
-/// MiniLM-L6-v2 output dimensionality. Matches `embeddings::vector_index::DIM`.
+/// Embedding output dimensionality — 384 for both MiniLM-L6 and
+/// multilingual-e5-small. Matches `embeddings::vector_index::DIM`.
 const EMBED_DIM: usize = 384;
 
-/// Matches the tokenizer cap fastembed used via `with_max_length(256)` and
-/// MiniLM's training `max_seq_length`.
+/// Tokenizer cap. Both bundled models train at 512, but VaultCore notes
+/// rarely exceed 256 tokens per chunk and we keep the lower cap to bound
+/// peak memory + latency under bulk reindex (#205 budget). Chunking
+/// (`chunking.rs`) is sized accordingly.
 const MAX_SEQ_LEN: usize = 256;
+
+/// e5 prefix protocol (#233). The intfloat/multilingual-e5 family was
+/// trained with these literal prefixes — applying them lets the model put
+/// queries and passages in the same retrieval-friendly subspace. Stripping
+/// them, or using the same one for both, measurably degrades retrieval.
+/// See: https://huggingface.co/intfloat/multilingual-e5-small#faq
+const E5_QUERY_PREFIX: &str = "query: ";
+const E5_PASSAGE_PREFIX: &str = "passage: ";
 
 pub struct EmbeddingService {
     inner: Mutex<Inner>,
@@ -33,14 +44,15 @@ pub struct EmbeddingService {
 struct Inner {
     tokenizer: Tokenizer,
     session: Session,
-    /// Some MiniLM exports omit `token_type_ids` (all-MiniLM is BERT-style
-    /// and always has it, but we probe to stay portable to alternative
-    /// models bundled via `VAULTCORE_MODEL_DIR`).
+    /// Some exports omit `token_type_ids` (BERT-style models declare it,
+    /// XLM-RoBERTa-style — including e5 — does not). We probe the session
+    /// inputs to stay portable across both families and any future model
+    /// bundled via `VAULTCORE_MODEL_DIR`.
     need_token_type_ids: bool,
 }
 
 impl EmbeddingService {
-    /// Load the bundled MiniLM model. Triggers `ensure_runtime_initialized`
+    /// Load the bundled embedding model. Triggers `ensure_runtime_initialized`
     /// and registers the env-level CPU arena allocator before building the
     /// session — both are idempotent.
     pub fn load(resource_dir: Option<&Path>) -> Result<Arc<Self>, EmbeddingError> {
@@ -70,13 +82,26 @@ impl EmbeddingService {
                 direction: tokenizers::TruncationDirection::Right,
             }))
             .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+        // Resolve pad token from the tokenizer's own vocab — XLM-RoBERTa
+        // (e5) uses `<pad>` (id 1), BERT-style (MiniLM) uses `[PAD]` (id 0).
+        // Hardcoding either silently corrupts attention on the other family
+        // by padding with a real content token. Probe both candidates and
+        // pick the first one the vocab knows.
+        let (pad_token, pad_id) = ["<pad>", "[PAD]"]
+            .iter()
+            .find_map(|t| tokenizer.token_to_id(t).map(|id| ((*t).to_string(), id)))
+            .ok_or_else(|| {
+                EmbeddingError::Tokenizer(
+                    "tokenizer vocab declares neither <pad> nor [PAD]".into(),
+                )
+            })?;
         tokenizer.with_padding(Some(PaddingParams {
             strategy: PaddingStrategy::BatchLongest,
             direction: tokenizers::PaddingDirection::Right,
             pad_to_multiple_of: None,
-            pad_id: 0,
+            pad_id,
             pad_type_id: 0,
-            pad_token: "[PAD]".to_string(),
+            pad_token,
         }));
 
         Ok(Arc::new(Self {
@@ -88,12 +113,51 @@ impl EmbeddingService {
         }))
     }
 
-    /// Embed a single string. Returns a 384-d L2-normalised vector.
+    /// Embed a single string verbatim — no e5 prefix is applied. Prefer
+    /// `embed_query` / `embed_passage` over this primitive: bare embeds
+    /// against e5 land in a different subspace than the indexed passages
+    /// and silently degrade retrieval quality. Kept public for benchmarks
+    /// and the smoke test, where the prefix is irrelevant.
     pub fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
         let mut batch = self.embed_batch(&[text])?;
         batch
             .pop()
             .ok_or_else(|| EmbeddingError::Inference("empty embedding batch".into()))
+    }
+
+    /// Embed a user query with the e5 `"query: "` prefix. Use this on the
+    /// query path (semantic search input). See module-level e5 prefix note.
+    pub fn embed_query(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        self.embed(&format!("{E5_QUERY_PREFIX}{text}"))
+    }
+
+    /// Embed an indexed passage with the e5 `"passage: "` prefix. Use this
+    /// on the indexing path (every chunk that lands in the vector index).
+    pub fn embed_passage(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        self.embed(&format!("{E5_PASSAGE_PREFIX}{text}"))
+    }
+
+    /// Batched query embed — same prefix semantics as `embed_query`.
+    pub fn embed_query_batch(
+        &self,
+        texts: &[&str],
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let prefixed: Vec<String> =
+            texts.iter().map(|t| format!("{E5_QUERY_PREFIX}{t}")).collect();
+        let refs: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
+        self.embed_batch(&refs)
+    }
+
+    /// Batched passage embed — same prefix semantics as `embed_passage`.
+    /// The indexing pipeline (`reindex.rs`) calls this for every batch.
+    pub fn embed_passage_batch(
+        &self,
+        texts: &[&str],
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let prefixed: Vec<String> =
+            texts.iter().map(|t| format!("{E5_PASSAGE_PREFIX}{t}")).collect();
+        let refs: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
+        self.embed_batch(&refs)
     }
 
     /// Embed a batch of strings in one inference pass. Returns one 384-d
@@ -161,10 +225,11 @@ impl EmbeddingService {
             .run(inputs)
             .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
 
-        // MiniLM exports expose the token-level hidden states either as
+        // ONNX exports expose the token-level hidden states either as
         // `last_hidden_state` (standard HF export) or as `output_0` / the
         // first output (some quantised exports strip names). Pick the first
-        // 3-D float output to stay robust.
+        // 3-D float output to stay robust across both BERT-style (MiniLM)
+        // and XLM-RoBERTa-style (e5) graphs.
         let (_name, first) = outputs
             .iter()
             .find(|(_, v)| {
@@ -266,17 +331,23 @@ mod tests {
             eprintln!("SKIP: embeddings not bundled");
             return;
         };
-        let a = svc.embed("how do cats communicate").unwrap();
-        let b = svc.embed("feline body language").unwrap();
-        let c = svc.embed("rust async runtime internals").unwrap();
+        // Ask + passage prefixes — mirrors the production query path so we
+        // benchmark the actual subspace the index uses.
+        let a = svc.embed_query("how do cats communicate").unwrap();
+        let b = svc.embed_passage("feline body language").unwrap();
+        let c = svc.embed_passage("rust async runtime internals").unwrap();
         let cos = |x: &[f32], y: &[f32]| -> f32 {
             x.iter().zip(y).map(|(a, b)| a * b).sum()
         };
         let close = cos(&a, &b);
         let far = cos(&a, &c);
+        // Margin calibrated for multilingual-e5-small (#233): the model
+        // uses a tighter cosine range than MiniLM did — same *ordering*,
+        // smaller absolute gap. 0.05 keeps the semantic signal clear
+        // while not being miscalibrated for the current model.
         assert!(
-            close > far + 0.1,
-            "expected close > far + 0.1, got close={close}, far={far}"
+            close > far + 0.05,
+            "expected close > far + 0.05, got close={close}, far={far}"
         );
     }
 
@@ -332,11 +403,12 @@ mod tests {
         eprintln!("BENCH_JSON {{\"name\":\"single_embed\",\"p50_ms\":{:.3},\"p99_ms\":{:.3},\"n\":{N}}}",
             p50.as_secs_f64() * 1000.0,
             p99.as_secs_f64() * 1000.0);
-        // Loose ceiling: 20 ms p50 is well above warm ORT inference for
-        // MiniLM-L6-v2 on any modern CPU. The harness's regression check
-        // catches real drift against the committed baseline.
+        // Loose ceiling: 20 ms p50 was the MiniLM-era headroom; e5-small
+        // is ~5x larger so warm p50 climbs accordingly. We raise the cap
+        // to 100 ms as an absolute sanity ceiling — the real regression
+        // detector is `scripts/bench-regression.py` against `baseline.json`.
         assert!(
-            p50 < Duration::from_millis(20),
+            p50 < Duration::from_millis(100),
             "single_embed p50 too slow: {p50:?}"
         );
     }

--- a/src-tauri/src/embeddings/service.rs
+++ b/src-tauri/src/embeddings/service.rs
@@ -1,76 +1,226 @@
-//! `EmbeddingService` (#194) — single-instance, thread-safe text → 384-d
-//! vector pipeline used by every backend caller (embed-on-save, reindex,
-//! query). The model is loaded once via fastembed and held behind a Mutex
-//! that serialises inference calls. fastembed's `TextEmbedding` is not
-//! `Sync` (it owns an `ort::Session` with interior mutability), so the
-//! Mutex wrap is required to satisfy `Send + Sync`.
+//! `EmbeddingService` (#194, rewritten for #205) — single-instance,
+//! thread-safe text → 384-d pipeline. Owns a `tokenizers::Tokenizer` and an
+//! `ort::Session` directly (no fastembed wrapper), so we control session
+//! options — specifically `memory_pattern=false` and
+//! `arena_extend_strategy=kSameAsRequested` (see `session.rs`).
+//!
+//! The session is held behind a Mutex because `ort::Session::run` takes
+//! `&mut self`, matching fastembed's previous `TextEmbedding` which wasn't
+//! `Sync` either.
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use fastembed::{
-    InitOptionsUserDefined, TextEmbedding, TokenizerFiles, UserDefinedEmbeddingModel,
-};
+use ndarray::{Array1, Array2, Axis};
+use ort::session::{Session, SessionInputValue};
+use ort::value::Tensor;
+use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams, TruncationStrategy};
 
+use super::session::{build_minilm_session, register_cpu_arena_if_needed};
 use super::{ensure_runtime_initialized, model_dir, EmbeddingError};
 
-/// Bundled-model embedding pipeline. Construct once per process via
-/// `EmbeddingService::load`, then share the resulting `Arc` everywhere.
+/// MiniLM-L6-v2 output dimensionality. Matches `embeddings::vector_index::DIM`.
+const EMBED_DIM: usize = 384;
+
+/// Matches the tokenizer cap fastembed used via `with_max_length(256)` and
+/// MiniLM's training `max_seq_length`.
+const MAX_SEQ_LEN: usize = 256;
+
 pub struct EmbeddingService {
-    inner: Mutex<TextEmbedding>,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    tokenizer: Tokenizer,
+    session: Session,
+    /// Some MiniLM exports omit `token_type_ids` (all-MiniLM is BERT-style
+    /// and always has it, but we probe to stay portable to alternative
+    /// models bundled via `VAULTCORE_MODEL_DIR`).
+    need_token_type_ids: bool,
 }
 
 impl EmbeddingService {
-    /// Load the bundled MiniLM model. Wraps the ORT runtime initialisation
-    /// so it is safe to call before or after `embeddings::bootstrap`.
+    /// Load the bundled MiniLM model. Triggers `ensure_runtime_initialized`
+    /// and registers the env-level CPU arena allocator before building the
+    /// session — both are idempotent.
     pub fn load(resource_dir: Option<&Path>) -> Result<Arc<Self>, EmbeddingError> {
         ensure_runtime_initialized(resource_dir)?;
+        register_cpu_arena_if_needed()?;
+
         let dir = model_dir(resource_dir)?;
-        let read = |name: &str| std::fs::read(dir.join(name));
-        let model = UserDefinedEmbeddingModel::new(
-            read("model.onnx")?,
-            TokenizerFiles {
-                tokenizer_file: read("tokenizer.json")?,
-                config_file: read("config.json")?,
-                special_tokens_map_file: read("special_tokens_map.json")?,
-                tokenizer_config_file: read("tokenizer_config.json")?,
-            },
-        );
-        // Cap fastembed's tokenizer at 256 to match MiniLM-L6-v2's training
-        // sequence length and the chunker's window size (#195). The crate
-        // default is 512, which would let oversized inputs through and
-        // silently degrade embedding quality.
-        let embedder = TextEmbedding::try_new_from_user_defined(
-            model,
-            InitOptionsUserDefined::default().with_max_length(256),
-        )
-        .map_err(|e| EmbeddingError::Fastembed(e.to_string()))?;
+        let onnx_bytes = std::fs::read(dir.join("model.onnx"))?;
+        let session = build_minilm_session(&onnx_bytes)?;
+
+        let need_token_type_ids = session
+            .inputs()
+            .iter()
+            .any(|i| i.name() == "token_type_ids");
+
+        let tokenizer_bytes = std::fs::read(dir.join("tokenizer.json"))?;
+        let mut tokenizer = Tokenizer::from_bytes(&tokenizer_bytes)
+            .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+        // Override tokenizer.json's baked-in caps (training-time Fixed-128
+        // padding + max_length-128 truncation — see chunking.rs) so the
+        // tokenizer can pad/truncate at MAX_SEQ_LEN instead.
+        tokenizer
+            .with_truncation(Some(TruncationParams {
+                max_length: MAX_SEQ_LEN,
+                strategy: TruncationStrategy::LongestFirst,
+                stride: 0,
+                direction: tokenizers::TruncationDirection::Right,
+            }))
+            .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+        tokenizer.with_padding(Some(PaddingParams {
+            strategy: PaddingStrategy::BatchLongest,
+            direction: tokenizers::PaddingDirection::Right,
+            pad_to_multiple_of: None,
+            pad_id: 0,
+            pad_type_id: 0,
+            pad_token: "[PAD]".to_string(),
+        }));
+
         Ok(Arc::new(Self {
-            inner: Mutex::new(embedder),
+            inner: Mutex::new(Inner {
+                tokenizer,
+                session,
+                need_token_type_ids,
+            }),
         }))
     }
 
-    /// Embed a single string. Returns a 384-dim L2-normalised vector.
+    /// Embed a single string. Returns a 384-d L2-normalised vector.
     pub fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
         let mut batch = self.embed_batch(&[text])?;
-        batch.pop().ok_or_else(|| {
-            EmbeddingError::Fastembed("empty embedding batch".into())
-        })
+        batch
+            .pop()
+            .ok_or_else(|| EmbeddingError::Inference("empty embedding batch".into()))
     }
 
-    /// Embed a batch of strings in one inference pass.
-    pub fn embed_batch(
-        &self,
-        texts: &[&str],
-    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+    /// Embed a batch of strings in one inference pass. Returns one 384-d
+    /// L2-normalised vector per input, in the same order.
+    pub fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut guard = self
             .inner
             .lock()
-            .map_err(|_| EmbeddingError::Fastembed("mutex poisoned".into()))?;
-        let owned: Vec<String> = texts.iter().map(|s| s.to_string()).collect();
-        guard
-            .embed(owned, None)
-            .map_err(|e| EmbeddingError::Fastembed(e.to_string()))
+            .map_err(|_| EmbeddingError::Inference("mutex poisoned".into()))?;
+        let Inner {
+            tokenizer,
+            session,
+            need_token_type_ids,
+        } = &mut *guard;
+
+        let owned: Vec<String> = texts.iter().map(|s| (*s).to_string()).collect();
+        let encodings = tokenizer
+            .encode_batch(owned, true)
+            .map_err(|e| EmbeddingError::Tokenizer(e.to_string()))?;
+
+        let batch = encodings.len();
+        let seq_len = encodings
+            .iter()
+            .map(|e| e.get_ids().len())
+            .max()
+            .unwrap_or(0);
+        if seq_len == 0 {
+            return Ok(vec![vec![0.0; EMBED_DIM]; batch]);
+        }
+
+        let mut input_ids = Array2::<i64>::zeros((batch, seq_len));
+        let mut attn_mask = Array2::<i64>::zeros((batch, seq_len));
+        let mut type_ids = Array2::<i64>::zeros((batch, seq_len));
+        for (row, enc) in encodings.iter().enumerate() {
+            for (col, &id) in enc.get_ids().iter().enumerate() {
+                input_ids[[row, col]] = id as i64;
+            }
+            for (col, &m) in enc.get_attention_mask().iter().enumerate() {
+                attn_mask[[row, col]] = m as i64;
+            }
+            for (col, &t) in enc.get_type_ids().iter().enumerate() {
+                type_ids[[row, col]] = t as i64;
+            }
+        }
+
+        let ids_tensor = Tensor::from_array(input_ids)
+            .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
+        let attn_tensor = Tensor::from_array(attn_mask.clone())
+            .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
+        let mut inputs: Vec<(&str, SessionInputValue<'_>)> = vec![
+            ("input_ids", ids_tensor.into()),
+            ("attention_mask", attn_tensor.into()),
+        ];
+        let type_tensor;
+        if *need_token_type_ids {
+            type_tensor = Tensor::from_array(type_ids)
+                .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
+            inputs.push(("token_type_ids", type_tensor.into()));
+        }
+
+        let outputs = session
+            .run(inputs)
+            .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
+
+        // MiniLM exports expose the token-level hidden states either as
+        // `last_hidden_state` (standard HF export) or as `output_0` / the
+        // first output (some quantised exports strip names). Pick the first
+        // 3-D float output to stay robust.
+        let (_name, first) = outputs
+            .iter()
+            .find(|(_, v)| {
+                v.try_extract_tensor::<f32>()
+                    .map(|(shape, _)| shape.len() == 3)
+                    .unwrap_or(false)
+            })
+            .ok_or_else(|| {
+                EmbeddingError::Inference("no 3-D f32 output in session result".into())
+            })?;
+        let (shape, data) = first
+            .try_extract_tensor::<f32>()
+            .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
+        if shape.len() != 3 {
+            return Err(EmbeddingError::Inference(format!(
+                "expected [batch, seq, hidden] but got shape {shape:?}"
+            )));
+        }
+        let (b, s, h) = (shape[0] as usize, shape[1] as usize, shape[2] as usize);
+        if b != batch || s != seq_len || h != EMBED_DIM {
+            return Err(EmbeddingError::Inference(format!(
+                "unexpected output shape [{b}, {s}, {h}] for batch={batch} seq={seq_len} hidden={EMBED_DIM}"
+            )));
+        }
+
+        // Mean-pool across seq axis, masked by attention_mask, then L2.
+        let mut out = Vec::with_capacity(batch);
+        for bi in 0..batch {
+            let mut pooled = Array1::<f32>::zeros(EMBED_DIM);
+            let mut count: f32 = 0.0;
+            for si in 0..seq_len {
+                let m = attn_mask[[bi, si]];
+                if m == 0 {
+                    continue;
+                }
+                count += 1.0;
+                let base = (bi * seq_len + si) * EMBED_DIM;
+                for hi in 0..EMBED_DIM {
+                    pooled[hi] += data[base + hi];
+                }
+            }
+            if count > 0.0 {
+                pooled.mapv_inplace(|x| x / count);
+            }
+            let norm = pooled
+                .view()
+                .map(|x| x * x)
+                .sum_axis(Axis(0))
+                .into_scalar()
+                .sqrt();
+            if norm > f32::EPSILON {
+                pooled.mapv_inplace(|x| x / norm);
+            }
+            out.push(pooled.to_vec());
+        }
+        Ok(out)
     }
 }
 
@@ -78,8 +228,6 @@ impl EmbeddingService {
 mod tests {
     use super::*;
 
-    /// Helper: skip when the bundled assets aren't present yet (e.g. on a
-    /// fresh checkout where `cargo build` hasn't run).
     fn try_load() -> Option<Arc<EmbeddingService>> {
         EmbeddingService::load(None).ok()
     }
@@ -105,7 +253,11 @@ mod tests {
         let single = svc.embed("the quick brown fox").unwrap();
         let batch = svc.embed_batch(&["the quick brown fox"]).unwrap();
         assert_eq!(batch.len(), 1);
-        assert_eq!(batch[0], single);
+        // Allow tiny numeric drift from pooling order; real identity
+        // expected since the input tensor is identical.
+        for (a, b) in single.iter().zip(batch[0].iter()) {
+            assert!((a - b).abs() < 1e-5, "drift between single and batch: {a} vs {b}");
+        }
     }
 
     #[test]
@@ -130,8 +282,6 @@ mod tests {
 
     #[test]
     fn service_is_send_and_sync() {
-        // Compile-time assertion — if this changes, callers in tokio
-        // workers (#196) and rayon (#198) would break.
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<EmbeddingService>();
         assert_send_sync::<Arc<EmbeddingService>>();

--- a/src-tauri/src/embeddings/session.rs
+++ b/src-tauri/src/embeddings/session.rs
@@ -1,0 +1,130 @@
+//! ORT session plumbing for #205 — owns the two session-level tunings the
+//! fastembed wrapper didn't expose:
+//!
+//! - `SessionBuilder::with_memory_pattern(false)` — ORT's memory-pattern
+//!   planner pre-allocates a worst-case activation arena on first run. For
+//!   MiniLM's dynamic batch dim that arena sticks around for the process's
+//!   lifetime. Disabling it lets activations re-use allocations across runs
+//!   without the up-front spike.
+//!
+//! - `arena_extend_strategy = kSameAsRequested` on the CPU allocator. The
+//!   default `kNextPowerOfTwo` doubles the arena each time it grows, which
+//!   overshoots wildly for our fixed `[batch × seq × hidden]` workload.
+//!   `kSameAsRequested` grows by exactly the amount asked for.
+//!
+//! The arena strategy isn't exposed on ORT's Rust SessionBuilder for CPU
+//! (only on CUDA/ROCm/CANN builders), so we register a custom allocator at
+//! the process-global environment via `CreateAndRegisterAllocator` and have
+//! every session opt into it with `with_env_allocators()`.
+
+use std::sync::OnceLock;
+
+use ort::environment::get_environment;
+use ort::error::status_to_result;
+use ort::session::Session;
+use ort::session::builder::{GraphOptimizationLevel, SessionBuilder};
+use ort::{AsPointer, api};
+
+use super::EmbeddingError;
+
+/// `kSameAsRequested` per `include/onnxruntime_c_api.h`:
+/// ```c
+/// enum ArenaExtendStrategy { kNextPowerOfTwo = 0, kSameAsRequested = 1 };
+/// ```
+const ARENA_EXTEND_SAME_AS_REQUESTED: std::os::raw::c_int = 1;
+
+/// Registered once per process; subsequent calls are no-ops. Wraps unsafe
+/// FFI so callers stay in safe Rust.
+static ARENA_REGISTERED: OnceLock<()> = OnceLock::new();
+
+fn status(status: ort_sys::OrtStatusPtr, label: &str) -> Result<(), EmbeddingError> {
+    // SAFETY: `status` is either null (success) or a pointer owned by ORT
+    // that `status_to_result` consumes.
+    unsafe { status_to_result(status) }
+        .map_err(|e| EmbeddingError::OrtInit(format!("{label}: {e}")))
+}
+
+/// Register a CPU arena allocator on the global ORT environment with
+/// `arena_extend_strategy=kSameAsRequested`. Must be called after
+/// `ort::init_from(...).commit()` but before any session is committed. A
+/// session then uses this allocator by calling `with_env_allocators()` on
+/// its builder (see `build_minilm_session`).
+///
+/// Errors propagate as `EmbeddingError::OrtInit` with the ORT status
+/// string so bootstrap failures remain visible in logs.
+pub(super) fn register_cpu_arena_if_needed() -> Result<(), EmbeddingError> {
+    if ARENA_REGISTERED.get().is_some() {
+        return Ok(());
+    }
+
+    let env = get_environment().map_err(|e| EmbeddingError::OrtInit(e.to_string()))?;
+    let env_ptr = env.ptr().cast_mut();
+    let a = api();
+
+    // SAFETY: each FFI call has its pointer-out param inspected before use.
+    // Both `mem_info` and `arena_cfg` are released on every exit path —
+    // ORT copies their contents into the env during registration, so
+    // releasing after the call is correct per the C API docs.
+    unsafe {
+        let mut mem_info: *mut ort_sys::OrtMemoryInfo = std::ptr::null_mut();
+        status(
+            (a.CreateCpuMemoryInfo)(
+                ort_sys::OrtAllocatorType::OrtArenaAllocator,
+                ort_sys::OrtMemType::OrtMemTypeDefault,
+                &mut mem_info,
+            ),
+            "CreateCpuMemoryInfo",
+        )?;
+
+        // CreateArenaCfg(max_mem=0, arena_extend_strategy=1, initial_chunk_size_bytes=-1, max_dead_bytes_per_chunk=-1)
+        //   max_mem=0 → no arena size cap (default heuristic)
+        //   initial_chunk_size_bytes=-1 / max_dead_bytes_per_chunk=-1 → defaults
+        let mut arena_cfg: *mut ort_sys::OrtArenaCfg = std::ptr::null_mut();
+        let cfg_status = (a.CreateArenaCfg)(
+            0,
+            ARENA_EXTEND_SAME_AS_REQUESTED,
+            -1,
+            -1,
+            &mut arena_cfg,
+        );
+        if let Err(e) = status(cfg_status, "CreateArenaCfg") {
+            (a.ReleaseMemoryInfo)(mem_info);
+            return Err(e);
+        }
+
+        let register_status =
+            (a.CreateAndRegisterAllocator)(env_ptr, mem_info, arena_cfg);
+
+        // Release builders regardless of outcome.
+        (a.ReleaseArenaCfg)(arena_cfg);
+        (a.ReleaseMemoryInfo)(mem_info);
+
+        status(register_status, "CreateAndRegisterAllocator")?;
+    }
+
+    let _ = ARENA_REGISTERED.set(());
+    Ok(())
+}
+
+/// Commit a MiniLM-L6-v2 session from raw ONNX bytes, applying the #205
+/// memory tunings. `register_cpu_arena_if_needed` must have been called
+/// first (idempotent — `ensure_runtime_initialized` does this).
+pub(super) fn build_minilm_session(onnx_bytes: &[u8]) -> Result<Session, EmbeddingError> {
+    let builder: SessionBuilder = Session::builder()
+        .map_err(|e| EmbeddingError::OrtInit(e.to_string()))?;
+    // Level3 = every available graph optimization, matching fastembed's
+    // previous default so accepted perf characteristics carry over.
+    let builder = builder
+        .with_optimization_level(GraphOptimizationLevel::Level3)
+        .map_err(|e| EmbeddingError::OrtInit(e.to_string()))?
+        .with_memory_pattern(false)
+        .map_err(|e| EmbeddingError::OrtInit(e.to_string()))?
+        .with_env_allocators()
+        .map_err(|e| EmbeddingError::OrtInit(e.to_string()))?;
+    // No per-session thread config: #197 installs a global thread pool on
+    // the env, which makes ORT call `DisablePerSessionThreads` in the
+    // commit path. Any `with_intra_threads` here would be silently ignored.
+    builder
+        .commit_from_memory(onnx_bytes)
+        .map_err(|e| EmbeddingError::OrtInit(e.to_string()))
+}

--- a/src-tauri/src/embeddings/sink.rs
+++ b/src-tauri/src/embeddings/sink.rs
@@ -4,23 +4,333 @@
 //! touching the queue.
 //!
 //! Lifecycle contract: callers invoke `store(path, ...)` once per
-//! coalesced save. The sink is responsible for replacing any prior
-//! vectors associated with `path` (upsert semantics) — #200 will add an
-//! explicit delete hook for rename/delete paths; for now an
-//! upsert-replace is sufficient because every save produces a fresh
-//! chunk set for the same path.
+//! coalesced save. The sink replaces any prior vectors associated with
+//! `path` (upsert semantics). `delete(path)` (#201) is the explicit hook
+//! for rename/delete dispatch — `store` already implies "drop prior
+//! vectors then insert", but `delete` skips the embed work entirely.
 
 use std::path::Path;
+#[cfg(feature = "embeddings")]
+use std::path::PathBuf;
+#[cfg(feature = "embeddings")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "embeddings")]
+use std::sync::{Arc, RwLock};
 
 use super::Chunk;
+#[cfg(feature = "embeddings")]
+use super::VectorIndex;
 
 pub trait VectorSink: Send + Sync {
     fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>);
+    /// Drop every vector associated with `path`. Default is a no-op so
+    /// callers built before #201 (e.g. `NoopSink`) still compile without
+    /// per-impl boilerplate.
+    fn delete(&self, _path: &Path) {}
 }
 
-/// Discards everything. Used while #198 is still pending.
+/// Discards everything. Used while #198 was pending and still useful for
+/// tests that want to exercise the coordinator without an HNSW dep.
 pub struct NoopSink;
 
 impl VectorSink for NoopSink {
     fn store(&self, _path: &Path, _chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {}
+}
+
+/// `HnswSink` (#201 PR-A) — production sink backed by an in-memory
+/// `VectorIndex` plus on-disk persistence under
+/// `<vault>/.vaultcore/embeddings/`. Every embedded save replaces prior
+/// vectors for the path; explicit `delete` tombstones them; compaction
+/// fires off-thread when the index crosses #200's gating thresholds.
+///
+/// Concurrency: the inner index is held as `Arc<RwLock<Arc<VectorIndex>>>`
+/// so reads (queries) take a brief read lock to clone the inner `Arc`
+/// and then operate lock-free against that snapshot. Writes (compaction)
+/// take the write lock once to swap in a fresh index. Stores and deletes
+/// only need a read lock + the snapshot's own internal locks.
+///
+/// Drop semantics: the sink saves to disk on `Drop`, on a detached
+/// background thread so vault switch / app close doesn't freeze the UI
+/// for the seconds it takes to dump 100k vectors. The trade-off is that
+/// a save in flight when the OS reaps the process is incomplete; the
+/// next launch falls back to `load_or_empty` and the lost embeddings
+/// will be re-emitted on next save (or by the #201 PR-B reindex worker).
+#[cfg(feature = "embeddings")]
+pub struct HnswSink {
+    index: Arc<RwLock<Arc<VectorIndex>>>,
+    save_dir: PathBuf,
+    /// CAS guard against starting a second compaction while one is in
+    /// flight. Set to `true` by the thread that wins the race; cleared
+    /// when the compaction finishes (and self-checks one more time).
+    compacting: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "embeddings")]
+impl HnswSink {
+    /// Open or create the on-disk vector index at `save_dir`. Falls back
+    /// to an empty index on missing/corrupt files (#199 AC #3).
+    pub fn open(save_dir: PathBuf, capacity_hint: usize) -> Self {
+        let _ = std::fs::create_dir_all(&save_dir);
+        let index = VectorIndex::load_or_empty(&save_dir, capacity_hint);
+        Self {
+            index: Arc::new(RwLock::new(Arc::new(index))),
+            save_dir,
+            compacting: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Take a cheap snapshot of the inner index. Read-only callers
+    /// (queries, save-on-Drop) use this to avoid holding the outer
+    /// `RwLock` for the duration of work.
+    pub fn snapshot(&self) -> Arc<VectorIndex> {
+        Arc::clone(&self.index.read().expect("index lock"))
+    }
+
+    /// Persist the current snapshot synchronously. Used by tests and the
+    /// future periodic-flush path (#201 PR-B).
+    pub fn save_now(&self) -> Result<(), super::EmbeddingError> {
+        self.snapshot().save(&self.save_dir)
+    }
+
+    fn maybe_compact(&self) {
+        let snap = self.snapshot();
+        if !snap.should_compact() {
+            return;
+        }
+        if self
+            .compacting
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let index_lock = Arc::clone(&self.index);
+        let compacting = Arc::clone(&self.compacting);
+        std::thread::spawn(move || {
+            match snap.compact_into_fresh() {
+                Ok(fresh) => {
+                    let fresh_arc = Arc::new(fresh);
+                    if let Ok(mut guard) = index_lock.write() {
+                        let live = fresh_arc.live_len();
+                        *guard = fresh_arc;
+                        log::info!("VectorIndex compacted; live={live}");
+                    }
+                }
+                Err(e) => log::warn!("compaction failed: {e}"),
+            }
+            compacting.store(false, Ordering::Release);
+            // Trailing self-check: if more deletes piled up while we
+            // were rebuilding, the next sink.delete() call won't always
+            // observe should_compact() as true (it might if more
+            // deletes landed). Probe once here so a steady delete
+            // stream doesn't have to wait for a fresh user save to
+            // notice.
+            if let Ok(g) = index_lock.read() {
+                if g.should_compact() {
+                    log::info!("VectorIndex still over compaction threshold post-rebuild");
+                }
+            }
+        });
+    }
+}
+
+#[cfg(feature = "embeddings")]
+impl VectorSink for HnswSink {
+    fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {
+        if chunks_with_vectors.is_empty() {
+            return;
+        }
+        let snap = self.snapshot();
+        snap.mark_deleted(path);
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = chunks_with_vectors
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_chunk, v))| (path.to_path_buf(), i, v))
+            .collect();
+        snap.bulk_insert(items);
+        self.maybe_compact();
+    }
+
+    fn delete(&self, path: &Path) {
+        let snap = self.snapshot();
+        if snap.mark_deleted(path) > 0 {
+            self.maybe_compact();
+        }
+    }
+}
+
+#[cfg(feature = "embeddings")]
+impl Drop for HnswSink {
+    fn drop(&mut self) {
+        let snap = self.snapshot();
+        let dir = self.save_dir.clone();
+        std::thread::spawn(move || {
+            if let Err(e) = snap.save(&dir) {
+                log::warn!("HnswSink save on drop failed: {e}");
+            }
+        });
+    }
+}
+
+#[cfg(all(test, feature = "embeddings"))]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    fn unit_vec(seed: u64) -> Vec<f32> {
+        let mut s = seed.wrapping_mul(0x9E3779B97F4A7C15);
+        let mut out = Vec::with_capacity(384);
+        for _ in 0..384 {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            let bits = (s >> 32) as u32;
+            let f = (bits as f32 / u32::MAX as f32) * 2.0 - 1.0;
+            out.push(f);
+        }
+        let n: f32 = out.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in &mut out {
+            *x /= n;
+        }
+        out
+    }
+
+    fn pair(seed: u64) -> (Chunk, Vec<f32>) {
+        (
+            Chunk {
+                text: format!("seed-{seed}"),
+                byte_offset: 0,
+            },
+            unit_vec(seed),
+        )
+    }
+
+    fn wait_until<F: Fn() -> bool>(cond: F, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        cond()
+    }
+
+    #[test]
+    fn store_then_query_finds_vector() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let path = PathBuf::from("a.md");
+        sink.store(&path, vec![pair(1)]);
+
+        let snap = sink.snapshot();
+        let hits = snap.query_with_paths(&unit_vec(1), 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, path);
+    }
+
+    #[test]
+    fn store_replaces_prior_vectors_for_same_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let path = PathBuf::from("dup.md");
+        sink.store(&path, vec![pair(1), pair(2)]);
+        sink.store(&path, vec![pair(3)]);
+
+        let snap = sink.snapshot();
+        // Old chunks tombstoned, only seed-3 remains live.
+        assert_eq!(snap.live_len(), 1);
+        // Query for the old vectors must not return them.
+        let hits = snap.query_with_paths(&unit_vec(1), 5);
+        assert!(hits.iter().all(|(_, _, d)| *d > 0.01),
+            "old chunk should not be a near-zero hit, got {hits:?}");
+    }
+
+    #[test]
+    fn delete_marks_path_tombstoned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        let p = PathBuf::from("gone.md");
+        sink.store(&p, vec![pair(7)]);
+        sink.delete(&p);
+
+        let snap = sink.snapshot();
+        assert_eq!(snap.live_len(), 0);
+        assert_eq!(snap.tombstone_count(), 1);
+        let hits = snap.query_with_paths(&unit_vec(7), 5);
+        assert!(hits.iter().all(|(path, _, _)| path != &p));
+    }
+
+    #[test]
+    fn delete_on_unknown_path_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        sink.delete(Path::new("never-stored.md"));
+        assert_eq!(sink.snapshot().len(), 0);
+    }
+
+    #[test]
+    fn save_on_drop_persists_then_reloads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        {
+            let sink = HnswSink::open(dir.clone(), 8);
+            sink.store(&PathBuf::from("persisted.md"), vec![pair(42)]);
+            // Sink dropped here — Drop spawns a save thread.
+        }
+        // Wait for the save file to appear.
+        let mapping = dir.join("vectors.mapping.json");
+        assert!(
+            wait_until(|| mapping.exists(), Duration::from_secs(5)),
+            "save-on-Drop never wrote {}",
+            mapping.display(),
+        );
+        // Wait briefly for the data dump to finish too — file_dump writes
+        // graph + data + mapping in sequence, and our preflight check
+        // requires both binary files present.
+        let data = dir.join("vectors.hnsw.data");
+        assert!(wait_until(|| data.exists(), Duration::from_secs(2)));
+        std::thread::sleep(Duration::from_millis(50));
+
+        let reopened = HnswSink::open(dir, 8);
+        let snap = reopened.snapshot();
+        assert_eq!(snap.len(), 1);
+        let hits = snap.query_with_paths(&unit_vec(42), 1);
+        assert_eq!(hits[0].0, PathBuf::from("persisted.md"));
+    }
+
+    #[test]
+    fn compaction_runs_when_threshold_crossed_and_keeps_index_queryable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 400);
+        // Cross both gates: >64 tombstones AND >20% ratio.
+        // 400 inserts, 100 deletes = 25%.
+        for i in 0..400u64 {
+            sink.store(&PathBuf::from(format!("c-{i}.md")), vec![pair(i)]);
+        }
+        for i in 0..100u64 {
+            sink.delete(&PathBuf::from(format!("c-{i}.md")));
+        }
+        // After the last delete, maybe_compact() spawns a thread.
+        // Wait for the rebuild to swap in a fresh index (live_len == 300,
+        // tombstones cleared).
+        let ok = wait_until(
+            || {
+                let s = sink.snapshot();
+                s.tombstone_count() == 0 && s.len() == 300
+            },
+            Duration::from_secs(15),
+        );
+        assert!(
+            ok,
+            "compaction never landed: live={}, tombs={}, total={}",
+            sink.snapshot().live_len(),
+            sink.snapshot().tombstone_count(),
+            sink.snapshot().len()
+        );
+        // A surviving path is still queryable.
+        let hits = sink.snapshot().query_with_paths(&unit_vec(200), 1);
+        assert_eq!(hits[0].0, PathBuf::from("c-200.md"));
+    }
 }

--- a/src-tauri/src/embeddings/sink.rs
+++ b/src-tauri/src/embeddings/sink.rs
@@ -1,0 +1,26 @@
+//! `VectorSink` — where embedded chunk vectors land. Defined as a trait so
+//! the embed-on-save coordinator (#196) can ship today against a no-op,
+//! and #198's HNSW-backed implementation can drop in later without
+//! touching the queue.
+//!
+//! Lifecycle contract: callers invoke `store(path, ...)` once per
+//! coalesced save. The sink is responsible for replacing any prior
+//! vectors associated with `path` (upsert semantics) — #200 will add an
+//! explicit delete hook for rename/delete paths; for now an
+//! upsert-replace is sufficient because every save produces a fresh
+//! chunk set for the same path.
+
+use std::path::Path;
+
+use super::Chunk;
+
+pub trait VectorSink: Send + Sync {
+    fn store(&self, path: &Path, chunks_with_vectors: Vec<(Chunk, Vec<f32>)>);
+}
+
+/// Discards everything. Used while #198 is still pending.
+pub struct NoopSink;
+
+impl VectorSink for NoopSink {
+    fn store(&self, _path: &Path, _chunks_with_vectors: Vec<(Chunk, Vec<f32>)>) {}
+}

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -74,10 +74,20 @@ struct MappingFile {
     tombstones: Vec<u32>,
 }
 
-/// Bumped to 2 in #200 to add the `tombstones` field. v1 dumps still load
-/// (the field defaults to empty) and silently upgrade on next save.
-const MAPPING_VERSION: u32 = 2;
-const MAPPING_VERSION_MIN: u32 = 1;
+/// Mapping-dump wire version.
+///
+/// - v1: initial format.
+/// - v2: (#200) added `tombstones` field.
+/// - v3: (#233) model swap from MiniLM to multilingual-e5-small. The 384-d
+///   vector geometry is unchanged but the *embedding subspace* is
+///   incompatible — old vectors would retrieve nonsense against new
+///   queries. Bumping both `MAPPING_VERSION` and `MAPPING_VERSION_MIN` to
+///   3 forces `load()` to reject pre-e5 dumps, which `load_or_empty()`
+///   absorbs as a fresh rebuild from embeddings (AC #3). The orphaned
+///   `vectors.hnsw.{graph,data}` from the old run stay on disk briefly;
+///   the first save after the rebuild overwrites them by basename.
+const MAPPING_VERSION: u32 = 3;
+const MAPPING_VERSION_MIN: u32 = 3;
 
 /// Closure-backed `FilterT` with no allocation. Only kept as a doc anchor
 /// — actual call sites use a closure passed by reference, which the
@@ -905,34 +915,54 @@ mod tests {
     }
 
     #[test]
-    fn load_v1_mapping_silently_upgrades() {
-        // Hand-craft a v1 dump: save a v2 file then rewrite the mapping
-        // file to a v1-shaped JSON without the `tombstones` field.
+    fn load_pre_v3_mapping_is_rejected_so_caller_rebuilds() {
+        // #233 — when the embedding model swapped from MiniLM to e5, the
+        // existing 384-d vectors in v1/v2 dumps lived in an incompatible
+        // subspace. We bumped both `MAPPING_VERSION` and
+        // `MAPPING_VERSION_MIN` to 3 specifically so that pre-existing
+        // dumps are *rejected* on load — the caller (`load_or_empty`)
+        // then absorbs the error and rebuilds from the embedder. This
+        // test pins that rejection so a future "be lenient" patch doesn't
+        // silently start loading mismatched vectors.
         let tmp = tempfile::tempdir().expect("tempdir");
         let idx = VectorIndex::new(4);
         for i in 0..4u64 {
-            idx.insert(PathBuf::from(format!("v1-{i}.md")), 0, &unit_vec(i));
+            idx.insert(PathBuf::from(format!("legacy-{i}.md")), 0, &unit_vec(i));
         }
         idx.save(tmp.path()).expect("save");
 
-        let v1_json = serde_json::json!({
-            "version": 1,
-            "entries": [
-                ["v1-0.md", 0],
-                ["v1-1.md", 0],
-                ["v1-2.md", 0],
-                ["v1-3.md", 0],
-            ],
-        });
-        std::fs::write(
-            tmp.path().join("vectors.mapping.json"),
-            serde_json::to_vec(&v1_json).unwrap(),
-        )
-        .expect("write v1 mapping");
+        for legacy_version in [1u32, 2u32] {
+            let mapping = serde_json::json!({
+                "version": legacy_version,
+                "entries": [
+                    ["legacy-0.md", 0],
+                    ["legacy-1.md", 0],
+                    ["legacy-2.md", 0],
+                    ["legacy-3.md", 0],
+                ],
+            });
+            std::fs::write(
+                tmp.path().join("vectors.mapping.json"),
+                serde_json::to_vec(&mapping).unwrap(),
+            )
+            .expect("write legacy mapping");
 
-        let loaded = VectorIndex::load(tmp.path()).expect("v1 load");
-        assert_eq!(loaded.len(), 4);
-        assert_eq!(loaded.tombstone_count(), 0);
+            let err = match VectorIndex::load(tmp.path()) {
+                Err(e) => e,
+                Ok(_) => panic!(
+                    "pre-v3 mapping must be rejected so load_or_empty rebuilds"
+                ),
+            };
+            let msg = err.to_string();
+            assert!(
+                msg.contains("mapping version unsupported"),
+                "unexpected error for v{legacy_version}: {msg}"
+            );
+
+            // load_or_empty absorbs the rejection and yields a fresh empty index.
+            let recovered = VectorIndex::load_or_empty(tmp.path(), 4);
+            assert_eq!(recovered.len(), 0);
+        }
     }
 
     #[test]

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -1,0 +1,334 @@
+//! `VectorIndex` (#198) — in-memory HNSW approximate nearest-neighbour
+//! index over 384-dim chunk embeddings, backed by `hnsw_rs` 0.3.4 with
+//! cosine distance.
+//!
+//! Scope of this ticket is the standalone API (insert / query / id
+//! mapping) plus the AC benchmarks. Wiring `EmbedCoordinator`'s
+//! `VectorSink` to an actual `VectorIndex` (replacing `NoopSink`) is
+//! tracked in #201; persistence to disk is #199; tombstones are #200.
+//!
+//! Concurrency: `Hnsw<f32, DistDot>` is `Send + Sync` (per its
+//! upstream trait bounds), and we put a single `RwLock` around the
+//! `id → (path, chunk_index)` mapping. So the eventual integration can
+//! safely share `Arc<VectorIndex>` between the embed worker (writes)
+//! and the query IPC handlers (reads).
+
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+// Use DistDot (not DistCosine): both give the same ranking on L2-normalised
+// vectors, but only DistDot has the AVX2/SSE2 SIMD path in anndists. The
+// distance values are mathematically identical (1 - dot product) for unit
+// inputs, which `EmbeddingService` always produces (#194).
+use hnsw_rs::prelude::{DistDot, Hnsw};
+
+/// Embedding dimensionality — locked by `EmbeddingService` (MiniLM-L6-v2).
+pub const DIM: usize = 384;
+
+/// HNSW hyperparameters. Sourced from #188 research; trade-offs live in
+/// the paper (Malkov & Yashunin 2018).
+const M: usize = 16; // max neighbour connections per layer
+const EF_CONSTRUCTION: usize = 200;
+const NB_LAYER: usize = 16; // hard cap; the graph picks its own per insert
+/// Default `ef_search` — quality/latency knob exposed per query.
+pub const DEFAULT_EF_SEARCH: usize = 64;
+
+/// In-memory HNSW vector index. Construct via `VectorIndex::new`,
+/// `insert(path, chunk_idx, vec)` to add, `query(vec, k)` to retrieve.
+pub struct VectorIndex {
+    hnsw: Hnsw<'static, f32, DistDot>,
+    /// `id → (vault-relative or absolute path, chunk index within file)`.
+    /// Indexed densely by `id` as the HNSW caller assigns ids monotonically
+    /// from the `mapping` length. Behind a `RwLock` so concurrent reads
+    /// during insert don't block beyond the brief lookup.
+    mapping: RwLock<Vec<(PathBuf, usize)>>,
+}
+
+impl VectorIndex {
+    /// Build an empty index sized for `capacity_hint` vectors. The hint
+    /// only affects allocation tables — real growth past it is supported,
+    /// just less efficient. Pass the expected total chunk count.
+    pub fn new(capacity_hint: usize) -> Self {
+        let hnsw = Hnsw::<f32, DistDot>::new(
+            M,
+            capacity_hint.max(16),
+            NB_LAYER,
+            EF_CONSTRUCTION,
+            DistDot {},
+        );
+        Self {
+            hnsw,
+            mapping: RwLock::new(Vec::with_capacity(capacity_hint)),
+        }
+    }
+
+    /// Insert a single chunk vector. Returns the assigned id.
+    /// Panics if `vec.len() != DIM`.
+    pub fn insert(&self, path: PathBuf, chunk_index: usize, vec: &[f32]) -> u32 {
+        assert_eq!(vec.len(), DIM, "vector dim mismatch: got {}", vec.len());
+        let id = {
+            let mut m = self.mapping.write().expect("mapping lock");
+            let id = m.len();
+            m.push((path, chunk_index));
+            id
+        };
+        self.hnsw.insert((vec, id));
+        u32::try_from(id).expect("vector index overflowed u32")
+    }
+
+    /// Bulk-insert N chunk vectors in parallel via `hnsw_rs`'s rayon-backed
+    /// `parallel_insert`. Used by the initial reindex (#201) and bench
+    /// harness; ~10× faster than streaming `insert` calls. Returns the
+    /// first id assigned (subsequent ids are contiguous).
+    pub fn bulk_insert(&self, items: Vec<(PathBuf, usize, Vec<f32>)>) -> u32 {
+        if items.is_empty() {
+            return 0;
+        }
+        let first_id = {
+            let mut m = self.mapping.write().expect("mapping lock");
+            let first = m.len();
+            for (p, c, v) in items.iter() {
+                assert_eq!(v.len(), DIM, "vector dim mismatch: got {}", v.len());
+                m.push((p.clone(), *c));
+            }
+            first
+        };
+        let with_ids: Vec<(&Vec<f32>, usize)> = items
+            .iter()
+            .enumerate()
+            .map(|(off, (_, _, v))| (v, first_id + off))
+            .collect();
+        self.hnsw.parallel_insert(&with_ids);
+        u32::try_from(first_id).expect("vector index overflowed u32")
+    }
+
+    /// Top-`k` nearest neighbours. Returns `(id, cosine_distance)` pairs
+    /// sorted by ascending distance (closest first). Distances live in
+    /// `[0, 2]` because `DistDot` returns `1 - cos_sim`.
+    pub fn query(&self, vec: &[f32], k: usize) -> Vec<(u32, f32)> {
+        self.query_with_ef(vec, k, DEFAULT_EF_SEARCH)
+    }
+
+    /// Like `query` but with an explicit `ef_search` knob. Higher = more
+    /// recall, more cost. Useful for the upcoming hybrid-search tuning
+    /// in #208.
+    pub fn query_with_ef(&self, vec: &[f32], k: usize, ef_search: usize) -> Vec<(u32, f32)> {
+        assert_eq!(vec.len(), DIM, "vector dim mismatch: got {}", vec.len());
+        self.hnsw
+            .search(vec, k, ef_search.max(k))
+            .into_iter()
+            .map(|n| (n.d_id as u32, n.distance))
+            .collect()
+    }
+
+    /// Same as `query` but resolves ids to `(path, chunk_index)` for
+    /// downstream callers that don't want to round-trip through the
+    /// mapping table themselves.
+    pub fn query_with_paths(
+        &self,
+        vec: &[f32],
+        k: usize,
+    ) -> Vec<(PathBuf, usize, f32)> {
+        let hits = self.query(vec, k);
+        let m = self.mapping.read().expect("mapping lock");
+        hits.into_iter()
+            .map(|(id, d)| {
+                let (p, idx) = m[id as usize].clone();
+                (p, idx, d)
+            })
+            .collect()
+    }
+
+    /// Number of inserted vectors.
+    pub fn len(&self) -> usize {
+        self.mapping.read().expect("mapping lock").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    /// Cheap deterministic unit-vector generator for tests / benches.
+    /// Uses xorshift64 seeded from `seed` so we don't pull in a `rand`
+    /// dep just for tests.
+    fn unit_vec(seed: u64) -> Vec<f32> {
+        let mut s = seed.wrapping_mul(0x9E3779B97F4A7C15);
+        let mut out = Vec::with_capacity(DIM);
+        for _ in 0..DIM {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            // Map u64 → f32 in [-1, 1] via the high bits.
+            let bits = (s >> 32) as u32;
+            let f = (bits as f32 / u32::MAX as f32) * 2.0 - 1.0;
+            out.push(f);
+        }
+        let norm: f32 = out.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in &mut out {
+            *x /= norm;
+        }
+        out
+    }
+
+    #[test]
+    fn insert_then_query_returns_self_with_zero_distance() {
+        let idx = VectorIndex::new(8);
+        let v = unit_vec(1);
+        let id = idx.insert(PathBuf::from("a.md"), 0, &v);
+        assert_eq!(id, 0);
+        let hits = idx.query(&v, 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, 0);
+        // DistDot on a unit vector against itself: ≈ 0 (FP noise).
+        assert!(hits[0].1 < 1e-4, "self-distance not ~0: {}", hits[0].1);
+    }
+
+    #[test]
+    fn query_orders_by_distance() {
+        let idx = VectorIndex::new(16);
+        for i in 0..16 {
+            idx.insert(PathBuf::from(format!("v-{i}.md")), 0, &unit_vec(i as u64));
+        }
+        let probe = unit_vec(3);
+        let hits = idx.query(&probe, 5);
+        assert_eq!(hits.len(), 5);
+        for w in hits.windows(2) {
+            assert!(
+                w[0].1 <= w[1].1 + 1e-6,
+                "results not non-decreasing: {} > {}",
+                w[0].1,
+                w[1].1
+            );
+        }
+        // Self-match must be the closest.
+        assert_eq!(hits[0].0, 3);
+    }
+
+    #[test]
+    fn query_respects_k_limit() {
+        let idx = VectorIndex::new(32);
+        for i in 0..32 {
+            idx.insert(PathBuf::from(format!("v-{i}.md")), 0, &unit_vec(i as u64));
+        }
+        for k in [1usize, 3, 7, 16] {
+            let hits = idx.query(&unit_vec(99), k);
+            assert!(hits.len() <= k, "k={k} returned {} hits", hits.len());
+        }
+    }
+
+    #[test]
+    fn id_to_path_roundtrip() {
+        let idx = VectorIndex::new(4);
+        idx.insert(PathBuf::from("notes/a.md"), 0, &unit_vec(10));
+        idx.insert(PathBuf::from("notes/a.md"), 1, &unit_vec(11));
+        idx.insert(PathBuf::from("notes/b.md"), 0, &unit_vec(12));
+        let probe = unit_vec(11);
+        let hits = idx.query_with_paths(&probe, 3);
+        assert_eq!(hits.len(), 3);
+        assert_eq!(hits[0].0, PathBuf::from("notes/a.md"));
+        assert_eq!(hits[0].1, 1);
+    }
+
+    #[test]
+    fn concurrent_insert_and_query_is_sound() {
+        let idx = Arc::new(VectorIndex::new(64));
+        // Seed with a few so concurrent queries have something to find.
+        for i in 0..8 {
+            idx.insert(PathBuf::from(format!("seed-{i}.md")), 0, &unit_vec(i));
+        }
+        let mut handles = Vec::new();
+        for t in 0..4 {
+            let idx = Arc::clone(&idx);
+            handles.push(std::thread::spawn(move || {
+                for i in 0..16 {
+                    let seed = (t as u64) * 1000 + i;
+                    idx.insert(PathBuf::from(format!("t{t}-{i}.md")), 0, &unit_vec(seed));
+                }
+            }));
+        }
+        for t in 0..4 {
+            let idx = Arc::clone(&idx);
+            handles.push(std::thread::spawn(move || {
+                for i in 0..16 {
+                    let _ = idx.query(&unit_vec((t as u64) * 100 + i as u64), 5);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        // 8 seed + 4 threads × 16 inserts.
+        assert_eq!(idx.len(), 8 + 4 * 16);
+    }
+
+    #[test]
+    fn vector_index_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<VectorIndex>();
+        assert_send_sync::<Arc<VectorIndex>>();
+    }
+
+    /// AC #2 build benchmark — 10k × 384d vectors in <1 s on a reference
+    /// laptop, using `parallel_insert` (the bulk reindex path #201 will
+    /// take). Marked `#[ignore]` because it allocates ~15 MB of vectors
+    /// + graph and saturates CPU. Threshold is 1500 ms to absorb CI
+    /// noise; the spec target is 1 s on the dev machine.
+    #[test]
+    #[ignore]
+    fn bench_build_10k_under_1500ms() {
+        const N: usize = 10_000;
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = (0..N as u64)
+            .map(|i| (PathBuf::from(format!("/v/{i}.md")), 0, unit_vec(i)))
+            .collect();
+        let idx = VectorIndex::new(N);
+        let t0 = Instant::now();
+        idx.bulk_insert(items);
+        let took = t0.elapsed();
+        eprintln!("VectorIndex bulk build: {N} × {DIM}d in {took:?}");
+        assert!(
+            took < Duration::from_millis(1500),
+            "build too slow: {took:?} for {N} vectors",
+        );
+    }
+
+    /// AC #3 query benchmark. The ticket asks for p50 < 100 µs at 10k
+    /// scale; in practice with `DistDot`+SIMD on AVX2 we measure ~500 µs
+    /// for k=10/ef=64 over uniformly-random unit vectors (worst case for
+    /// HNSW recall — real embeddings cluster much better, which lets the
+    /// graph short-circuit faster). The 1 ms threshold here is the
+    /// "doesn't regress" bar; the spec p99 target is tracked under #205
+    /// (ORT session tuning) and #208 (semantic quality), both of which
+    /// will tune `M` / `ef_search` against real corpora.
+    #[test]
+    #[ignore]
+    fn bench_query_p50_under_1ms() {
+        const N: usize = 10_000;
+        const Q: usize = 1_000;
+        let idx = VectorIndex::new(N);
+        for i in 0..N as u64 {
+            idx.insert(PathBuf::from(format!("/v/{i}.md")), 0, &unit_vec(i));
+        }
+        let probes: Vec<Vec<f32>> = (0..Q as u64).map(|i| unit_vec(i + 1_000_000)).collect();
+        let mut samples = Vec::with_capacity(Q);
+        for p in &probes {
+            let t0 = Instant::now();
+            let _ = idx.query(p, 10);
+            samples.push(t0.elapsed());
+        }
+        samples.sort();
+        let p50 = samples[Q / 2];
+        eprintln!("VectorIndex query p50 over {Q} probes: {p50:?}");
+        assert!(
+            p50 < Duration::from_millis(1),
+            "query p50 too slow: {p50:?}",
+        );
+    }
+}

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -13,14 +13,19 @@
 //! safely share `Arc<VectorIndex>` between the embed worker (writes)
 //! and the query IPC handlers (reads).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 // Use DistDot (not DistCosine): both give the same ranking on L2-normalised
 // vectors, but only DistDot has the AVX2/SSE2 SIMD path in anndists. The
 // distance values are mathematically identical (1 - dot product) for unit
 // inputs, which `EmbeddingService` always produces (#194).
+use hnsw_rs::api::AnnT;
+use hnsw_rs::hnswio::{HnswIo, ReloadOptions};
 use hnsw_rs::prelude::{DistDot, Hnsw};
+use serde::{Deserialize, Serialize};
+
+use super::EmbeddingError;
 
 /// Embedding dimensionality — locked by `EmbeddingService` (MiniLM-L6-v2).
 pub const DIM: usize = 384;
@@ -32,6 +37,36 @@ const EF_CONSTRUCTION: usize = 200;
 const NB_LAYER: usize = 16; // hard cap; the graph picks its own per insert
 /// Default `ef_search` — quality/latency knob exposed per query.
 pub const DEFAULT_EF_SEARCH: usize = 64;
+
+/// Filename stem used by `Hnsw::file_dump` — emits `<DUMP_BASENAME>.hnsw.graph`
+/// and `<DUMP_BASENAME>.hnsw.data` next to a sibling `<DUMP_MAPPING>` file.
+const DUMP_BASENAME: &str = "vectors";
+const DUMP_MAPPING: &str = "vectors.mapping.json";
+
+#[derive(Serialize, Deserialize)]
+struct MappingFile {
+    /// Bumped if the on-disk layout changes incompatibly.
+    version: u32,
+    entries: Vec<(PathBuf, usize)>,
+}
+
+const MAPPING_VERSION: u32 = 1;
+
+/// Magic bytes hnsw_rs writes at the start of the data file (`MAGICDATAP`)
+/// and the graph file (`MAGICDESCR_*`). We re-check them before delegating
+/// to `load_hnsw_with_dist` because that function panics via `assert_eq!`
+/// on a bad data-file magic — a corrupt dump must surface as a recoverable
+/// `Err` so `load_or_empty` can rebuild from embeddings (#199 AC #3).
+const MAGIC_DATA: u32 = 0xa67f_0000;
+const MAGIC_DESCR_VALID: [u32; 3] = [0x002a_677f, 0x002a_6771, 0x002a_6779];
+
+fn read_u32_ne(path: &Path) -> std::io::Result<u32> {
+    use std::io::Read;
+    let mut f = std::fs::File::open(path)?;
+    let mut buf = [0u8; 4];
+    f.read_exact(&mut buf)?;
+    Ok(u32::from_ne_bytes(buf))
+}
 
 /// In-memory HNSW vector index. Construct via `VectorIndex::new`,
 /// `insert(path, chunk_idx, vec)` to add, `query(vec, k)` to retrieve.
@@ -146,6 +181,111 @@ impl VectorIndex {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Persist the index to `dir` (created if missing). Writes three files:
+    /// `vectors.hnsw.graph`, `vectors.hnsw.data`, `vectors.mapping.json`.
+    /// Mapping is written atomically (tmp + rename); the hnsw_rs dump is not
+    /// atomic but `load_or_empty` rebuilds on read failure (#199 AC #3).
+    pub fn save(&self, dir: &Path) -> Result<(), EmbeddingError> {
+        std::fs::create_dir_all(dir)?;
+        self.hnsw
+            .file_dump(dir, DUMP_BASENAME)
+            .map_err(|e| EmbeddingError::Io(std::io::Error::other(format!(
+                "hnsw file_dump failed: {e}"
+            ))))?;
+        let m = self.mapping.read().expect("mapping lock");
+        let payload = MappingFile {
+            version: MAPPING_VERSION,
+            entries: m.clone(),
+        };
+        let json = serde_json::to_vec(&payload).map_err(|e| {
+            EmbeddingError::Io(std::io::Error::other(format!("mapping serialize: {e}")))
+        })?;
+        let final_path = dir.join(DUMP_MAPPING);
+        let tmp_path = dir.join(format!("{DUMP_MAPPING}.tmp"));
+        std::fs::write(&tmp_path, &json)?;
+        std::fs::rename(&tmp_path, &final_path)?;
+        Ok(())
+    }
+
+    /// Reload a previously dumped index from `dir`. Returns
+    /// `Err(EmbeddingError::Io)` if any of the three files are missing or
+    /// the dump is corrupt — callers should prefer `load_or_empty`.
+    ///
+    /// # mmap + lifetime
+    ///
+    /// `hnsw_rs::HnswIo::load_hnsw` returns `Hnsw<'b, ..>` constrained by
+    /// the `&'a mut self` it was called on (`'a: 'b`). With mmap enabled
+    /// the returned `Hnsw` holds borrowed slices into the `DataMap` owned
+    /// by `HnswIo`, so the two structs must share a lifetime. To keep
+    /// `VectorIndex.hnsw: Hnsw<'static, ..>` we `Box::leak` the `HnswIo`,
+    /// which is sound because there is at most one live `VectorIndex` per
+    /// app session (vault re-open creates a fresh process state in #201)
+    /// and `HnswIo` is a tiny struct holding the directory path and the
+    /// `DataMap`.
+    pub fn load(dir: &Path) -> Result<Self, EmbeddingError> {
+        let mapping_path = dir.join(DUMP_MAPPING);
+        let mapping_bytes = std::fs::read(&mapping_path)?;
+        let mapping: MappingFile = serde_json::from_slice(&mapping_bytes).map_err(|e| {
+            EmbeddingError::Io(std::io::Error::other(format!("mapping parse: {e}")))
+        })?;
+        if mapping.version != MAPPING_VERSION {
+            return Err(EmbeddingError::Io(std::io::Error::other(format!(
+                "mapping version mismatch: got {}, want {}",
+                mapping.version, MAPPING_VERSION
+            ))));
+        }
+
+        // Preflight magic-byte check on both dump files. hnsw_rs panics
+        // (assert_eq!) on a bad data-file magic, so without this the
+        // recovery path in `load_or_empty` would crash the app instead of
+        // rebuilding (#199 AC #3).
+        let graph_path = dir.join(format!("{DUMP_BASENAME}.hnsw.graph"));
+        let data_path = dir.join(format!("{DUMP_BASENAME}.hnsw.data"));
+        let graph_magic = read_u32_ne(&graph_path)?;
+        let data_magic = read_u32_ne(&data_path)?;
+        if !MAGIC_DESCR_VALID.contains(&graph_magic) {
+            return Err(EmbeddingError::Io(std::io::Error::other(format!(
+                "bad graph-file magic: 0x{graph_magic:08x}"
+            ))));
+        }
+        if data_magic != MAGIC_DATA {
+            return Err(EmbeddingError::Io(std::io::Error::other(format!(
+                "bad data-file magic: 0x{data_magic:08x}"
+            ))));
+        }
+
+        let io: &'static mut HnswIo = Box::leak(Box::new(HnswIo::new_with_options(
+            dir,
+            DUMP_BASENAME,
+            ReloadOptions::new(true),
+        )));
+        let hnsw: Hnsw<'static, f32, DistDot> = io.load_hnsw().map_err(|e| {
+            EmbeddingError::Io(std::io::Error::other(format!("hnsw load: {e}")))
+        })?;
+
+        Ok(Self {
+            hnsw,
+            mapping: RwLock::new(mapping.entries),
+        })
+    }
+
+    /// Try to `load(dir)`. On any failure (missing files, corruption, dim
+    /// mismatch) log a warning and return a fresh empty index sized to
+    /// `capacity_hint`. This is the recovery path the embed coordinator
+    /// uses on startup — invariant per AC #3 (Corruption-Handling: Bei
+    /// ungültigem Dump Rebuild aus Embeddings).
+    pub fn load_or_empty(dir: &Path, capacity_hint: usize) -> Self {
+        match Self::load(dir) {
+            Ok(idx) => idx,
+            Err(e) => {
+                log::warn!(
+                    "VectorIndex::load_or_empty: rebuilding empty index ({e})"
+                );
+                Self::new(capacity_hint)
+            }
+        }
     }
 }
 
@@ -329,6 +469,123 @@ mod tests {
         assert!(
             p50 < Duration::from_millis(1),
             "query p50 too slow: {p50:?}",
+        );
+    }
+
+    // ---- #199: persistence ---------------------------------------------------
+
+    #[test]
+    fn save_and_load_roundtrip_preserves_query_results() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(32);
+        for i in 0..32u64 {
+            idx.insert(PathBuf::from(format!("notes/{i}.md")), (i % 4) as usize, &unit_vec(i));
+        }
+        let probe = unit_vec(7);
+        let before = idx.query_with_paths(&probe, 5);
+
+        idx.save(tmp.path()).expect("save");
+        // Confirm the dump emitted the three expected files.
+        for f in ["vectors.hnsw.graph", "vectors.hnsw.data", "vectors.mapping.json"] {
+            assert!(
+                tmp.path().join(f).exists(),
+                "missing dump file {f}",
+            );
+        }
+
+        let loaded = VectorIndex::load(tmp.path()).expect("load");
+        assert_eq!(loaded.len(), idx.len());
+        let after = loaded.query_with_paths(&probe, 5);
+        assert_eq!(before.len(), after.len());
+        // Same id mapping → same (path, chunk) for identical ranks.
+        for (b, a) in before.iter().zip(after.iter()) {
+            assert_eq!(b.0, a.0, "path mismatch after reload");
+            assert_eq!(b.1, a.1, "chunk index mismatch after reload");
+            assert!((b.2 - a.2).abs() < 1e-5, "distance drift: {} vs {}", b.2, a.2);
+        }
+    }
+
+    #[test]
+    fn load_or_empty_returns_fresh_when_dir_is_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::load_or_empty(tmp.path(), 8);
+        assert!(idx.is_empty());
+        // Brand-new index must still be usable.
+        idx.insert(PathBuf::from("a.md"), 0, &unit_vec(1));
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn load_or_empty_recovers_from_corrupted_data_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(16);
+        for i in 0..16u64 {
+            idx.insert(PathBuf::from(format!("v-{i}.md")), 0, &unit_vec(i));
+        }
+        idx.save(tmp.path()).expect("save");
+
+        // Truncate the data file to simulate on-disk corruption (#199 AC #3).
+        let data_path = tmp.path().join("vectors.hnsw.data");
+        std::fs::write(&data_path, b"garbage").expect("truncate");
+
+        let recovered = VectorIndex::load_or_empty(tmp.path(), 16);
+        assert!(recovered.is_empty(), "expected empty index after corrupt load");
+        recovered.insert(PathBuf::from("after.md"), 0, &unit_vec(99));
+        assert_eq!(recovered.len(), 1);
+    }
+
+    #[test]
+    fn load_rejects_mismatched_mapping_version() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(4);
+        idx.insert(PathBuf::from("x.md"), 0, &unit_vec(1));
+        idx.save(tmp.path()).expect("save");
+
+        // Hand-write a mapping file with an unsupported version.
+        std::fs::write(
+            tmp.path().join("vectors.mapping.json"),
+            br#"{"version":99,"entries":[]}"#,
+        )
+        .expect("rewrite mapping");
+        match VectorIndex::load(tmp.path()) {
+            Ok(_) => panic!("expected version mismatch error"),
+            Err(e) => assert!(
+                format!("{e}").contains("version"),
+                "expected version error, got: {e}",
+            ),
+        }
+    }
+
+    /// AC #4 — load at 100k scale. Spec target is <100 ms but the
+    /// `hnsw_rs` 0.3.4 format parses every point's graph data (neighbour
+    /// lists per layer) serially during `load_hnsw`, even with mmap
+    /// enabled — mmap only defers reading the data-file vectors. On a
+    /// reference dev box (Ryzen 7, NVMe) this lands around 600–800 ms;
+    /// the regression bar here is set to 1500 ms. Squeezing further
+    /// toward the spec target would mean either a custom on-disk format
+    /// or upstream work in `hnsw_rs`, both tracked as follow-ups under
+    /// #207 (benchmark harness drives the call).
+    #[test]
+    #[ignore]
+    fn bench_load_100k_under_1500ms() {
+        const N: usize = 100_000;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = (0..N as u64)
+            .map(|i| (PathBuf::from(format!("/v/{i}.md")), 0, unit_vec(i)))
+            .collect();
+        let idx = VectorIndex::new(N);
+        idx.bulk_insert(items);
+        idx.save(tmp.path()).expect("save");
+        drop(idx);
+
+        let t0 = Instant::now();
+        let loaded = VectorIndex::load(tmp.path()).expect("load");
+        let took = t0.elapsed();
+        eprintln!("VectorIndex load {N} vectors in {took:?}");
+        assert_eq!(loaded.len(), N);
+        assert!(
+            took < Duration::from_millis(1500),
+            "load too slow: {took:?} for {N} vectors",
         );
     }
 }

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -13,6 +13,7 @@
 //! safely share `Arc<VectorIndex>` between the embed worker (writes)
 //! and the query IPC handlers (reads).
 
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
@@ -21,6 +22,7 @@ use std::sync::RwLock;
 // distance values are mathematically identical (1 - dot product) for unit
 // inputs, which `EmbeddingService` always produces (#194).
 use hnsw_rs::api::AnnT;
+use hnsw_rs::filter::FilterT;
 use hnsw_rs::hnswio::{HnswIo, ReloadOptions};
 use hnsw_rs::prelude::{DistDot, Hnsw};
 use serde::{Deserialize, Serialize};
@@ -38,6 +40,24 @@ const NB_LAYER: usize = 16; // hard cap; the graph picks its own per insert
 /// Default `ef_search` — quality/latency knob exposed per query.
 pub const DEFAULT_EF_SEARCH: usize = 64;
 
+/// #200 — compaction trigger thresholds (read by the embed coordinator
+/// in #201; constants live here so callers and tests share one source).
+/// Compact when *both* conditions hold: ratio of tombstoned to total ids
+/// exceeds `COMPACTION_RATIO_THRESHOLD` AND absolute count exceeds
+/// `COMPACTION_MIN_TOMBSTONES`. The absolute floor avoids pathological
+/// rebuilds on tiny vaults (1 of 4 deletes shouldn't trigger a rebuild).
+pub const COMPACTION_RATIO_THRESHOLD: f32 = 0.20;
+pub const COMPACTION_MIN_TOMBSTONES: usize = 64;
+
+/// Tombstone-aware overshoot for `query_with_ef` (#200): when tombstones
+/// are present we ask hnsw for `k + min(tombstones, OVERSHOOT_CAP * k)`
+/// candidates and let the `FilterT` pass drop tombstoned ids. Uses
+/// hnsw_rs's native `search_filter` so the filter runs inside the graph
+/// walk; the overshoot is what guarantees we still return up to `k`
+/// surviving hits. Cap keeps cost bounded when tombstone ratio is huge
+/// — compaction should already be running by then.
+const TOMBSTONE_OVERSHOOT_CAP: usize = 4;
+
 /// Filename stem used by `Hnsw::file_dump` — emits `<DUMP_BASENAME>.hnsw.graph`
 /// and `<DUMP_BASENAME>.hnsw.data` next to a sibling `<DUMP_MAPPING>` file.
 const DUMP_BASENAME: &str = "vectors";
@@ -48,9 +68,27 @@ struct MappingFile {
     /// Bumped if the on-disk layout changes incompatibly.
     version: u32,
     entries: Vec<(PathBuf, usize)>,
+    /// #200 — tombstoned ids. Optional in the wire format so v1 dumps
+    /// (which predate tombstones) still load with an implicit empty set.
+    #[serde(default)]
+    tombstones: Vec<u32>,
 }
 
-const MAPPING_VERSION: u32 = 1;
+/// Bumped to 2 in #200 to add the `tombstones` field. v1 dumps still load
+/// (the field defaults to empty) and silently upgrade on next save.
+const MAPPING_VERSION: u32 = 2;
+const MAPPING_VERSION_MIN: u32 = 1;
+
+/// Closure-backed `FilterT` with no allocation. Only kept as a doc anchor
+/// — actual call sites use a closure passed by reference, which the
+/// blanket `impl<F: Fn(&DataId)->bool> FilterT for F` covers.
+struct TombstoneFilter<'a>(&'a HashSet<u32>);
+impl FilterT for TombstoneFilter<'_> {
+    fn hnsw_filter(&self, id: &usize) -> bool {
+        // FilterT keeps ids that return true.
+        !self.0.contains(&(*id as u32))
+    }
+}
 
 /// Magic bytes hnsw_rs writes at the start of the data file (`MAGICDATAP`)
 /// and the graph file (`MAGICDESCR_*`). We re-check them before delegating
@@ -77,6 +115,16 @@ pub struct VectorIndex {
     /// from the `mapping` length. Behind a `RwLock` so concurrent reads
     /// during insert don't block beyond the brief lookup.
     mapping: RwLock<Vec<(PathBuf, usize)>>,
+    /// #200 — reverse index `path → ids`, kept in sync with `mapping`
+    /// so `mark_deleted(path)` is O(chunks-per-file) instead of O(N).
+    /// Locked separately because deletes only touch this + tombstones,
+    /// not the mapping table itself.
+    path_to_ids: RwLock<HashMap<PathBuf, Vec<u32>>>,
+    /// #200 — tombstoned ids; filtered out of every `query` and dropped
+    /// during `compact_into_fresh`. `RwLock<HashSet>` (not DashSet) since
+    /// reads dominate and writers are rare and serialised through the
+    /// embed coordinator's delete path.
+    tombstones: RwLock<HashSet<u32>>,
 }
 
 impl VectorIndex {
@@ -94,6 +142,8 @@ impl VectorIndex {
         Self {
             hnsw,
             mapping: RwLock::new(Vec::with_capacity(capacity_hint)),
+            path_to_ids: RwLock::new(HashMap::new()),
+            tombstones: RwLock::new(HashSet::new()),
         }
     }
 
@@ -104,9 +154,15 @@ impl VectorIndex {
         let id = {
             let mut m = self.mapping.write().expect("mapping lock");
             let id = m.len();
-            m.push((path, chunk_index));
+            m.push((path.clone(), chunk_index));
             id
         };
+        self.path_to_ids
+            .write()
+            .expect("path_to_ids lock")
+            .entry(path)
+            .or_default()
+            .push(id as u32);
         self.hnsw.insert((vec, id));
         u32::try_from(id).expect("vector index overflowed u32")
     }
@@ -121,10 +177,13 @@ impl VectorIndex {
         }
         let first_id = {
             let mut m = self.mapping.write().expect("mapping lock");
+            let mut p2i = self.path_to_ids.write().expect("path_to_ids lock");
             let first = m.len();
-            for (p, c, v) in items.iter() {
+            for (off, (p, c, v)) in items.iter().enumerate() {
                 assert_eq!(v.len(), DIM, "vector dim mismatch: got {}", v.len());
+                let id = (first + off) as u32;
                 m.push((p.clone(), *c));
+                p2i.entry(p.clone()).or_default().push(id);
             }
             first
         };
@@ -147,11 +206,27 @@ impl VectorIndex {
     /// Like `query` but with an explicit `ef_search` knob. Higher = more
     /// recall, more cost. Useful for the upcoming hybrid-search tuning
     /// in #208.
+    ///
+    /// When tombstones are present the call goes through hnsw_rs's
+    /// `search_filter` so the per-id check runs inside the graph walk;
+    /// `k` is overshot by `min(tombstones, k * TOMBSTONE_OVERSHOOT_CAP)`
+    /// because `search_filter` itself does not back-fill — without
+    /// overshoot a query whose top-k are all tombstoned would return
+    /// fewer than `k` hits even when survivors exist further out (#200).
     pub fn query_with_ef(&self, vec: &[f32], k: usize, ef_search: usize) -> Vec<(u32, f32)> {
         assert_eq!(vec.len(), DIM, "vector dim mismatch: got {}", vec.len());
-        self.hnsw
-            .search(vec, k, ef_search.max(k))
-            .into_iter()
+        let tomb = self.tombstones.read().expect("tombstones lock");
+        let raw = if tomb.is_empty() {
+            self.hnsw.search(vec, k, ef_search.max(k))
+        } else {
+            let overshoot = tomb.len().min(k.saturating_mul(TOMBSTONE_OVERSHOOT_CAP));
+            let k_eff = k.saturating_add(overshoot);
+            let filter = TombstoneFilter(&tomb);
+            self.hnsw
+                .search_filter(vec, k_eff, ef_search.max(k_eff), Some(&filter))
+        };
+        raw.into_iter()
+            .take(k)
             .map(|n| (n.d_id as u32, n.distance))
             .collect()
     }
@@ -183,6 +258,126 @@ impl VectorIndex {
         self.len() == 0
     }
 
+    /// #200 — count of inserted (non-tombstoned) vectors. Use over
+    /// `len()` when callers care about *live* vectors (e.g. ratio
+    /// calculations).
+    pub fn live_len(&self) -> usize {
+        self.len().saturating_sub(self.tombstone_count())
+    }
+
+    /// #200 — number of tombstoned ids. O(1).
+    pub fn tombstone_count(&self) -> usize {
+        self.tombstones.read().expect("tombstones lock").len()
+    }
+
+    /// #200 — `tombstones / total`. Returns 0 on an empty index.
+    /// Read by the embed coordinator (#201) to decide when to compact.
+    pub fn tombstone_ratio(&self) -> f32 {
+        let total = self.len();
+        if total == 0 {
+            return 0.0;
+        }
+        self.tombstone_count() as f32 / total as f32
+    }
+
+    /// #200 — true if compaction's gating conditions are met. Pulled out
+    /// so callers (and tests) don't have to duplicate the AND of ratio
+    /// and absolute-floor.
+    pub fn should_compact(&self) -> bool {
+        self.tombstone_count() >= COMPACTION_MIN_TOMBSTONES
+            && self.tombstone_ratio() > COMPACTION_RATIO_THRESHOLD
+    }
+
+    /// #200 — mark every chunk-id for `path` as deleted. Returns the
+    /// number of new tombstones added (already-tombstoned ids are not
+    /// double-counted). O(chunks-per-file) thanks to `path_to_ids`.
+    ///
+    /// HNSW data is not removed; queries filter via `FilterT` and a
+    /// future `compact_into_fresh` rebuilds the graph without the
+    /// tombstoned points.
+    pub fn mark_deleted(&self, path: &Path) -> usize {
+        let p2i = self.path_to_ids.read().expect("path_to_ids lock");
+        let Some(ids) = p2i.get(path) else { return 0 };
+        let mut added = 0;
+        let mut ts = self.tombstones.write().expect("tombstones lock");
+        for &id in ids {
+            if ts.insert(id) {
+                added += 1;
+            }
+        }
+        added
+    }
+
+    /// #200 — true if `id` has been tombstoned. Used by hybrid-search
+    /// callers (#203) that already have ids and want to skip extra work.
+    pub fn is_tombstoned(&self, id: u32) -> bool {
+        self.tombstones.read().expect("tombstones lock").contains(&id)
+    }
+
+    /// #200 — rebuild the index without tombstoned points. Walks every
+    /// HNSW layer one at a time to avoid pinning a long-lived read lock
+    /// against `points_by_layer` (which would block concurrent inserts
+    /// from the embed worker for the whole rebuild). Returns a fresh
+    /// `VectorIndex` with dense ids `0..live_len`; the caller is
+    /// responsible for atomically swapping it in (#201 wires this to an
+    /// `Arc<RwLock<Arc<VectorIndex>>>` handover).
+    ///
+    /// New ids are *not* the old ids: callers that cache id-keyed state
+    /// outside the index must invalidate after compaction. Path/chunk
+    /// identity is preserved.
+    pub fn compact_into_fresh(&self) -> Result<Self, EmbeddingError> {
+        // Snapshot tombstones once. The embed worker can still tombstone
+        // mid-rebuild; those new tombstones land in the new index's
+        // `tombstones` set on the next coordinator tick (post-swap).
+        let tomb_snapshot: HashSet<u32> = self
+            .tombstones
+            .read()
+            .expect("tombstones lock")
+            .clone();
+        let mapping_snapshot: Vec<(PathBuf, usize)> = self
+            .mapping
+            .read()
+            .expect("mapping lock")
+            .clone();
+
+        let live_capacity = mapping_snapshot.len().saturating_sub(tomb_snapshot.len());
+        let fresh = Self::new(live_capacity.max(16));
+
+        // Walk layers one at a time. `get_layer_iterator` holds a read
+        // lock on `points_by_layer` for the iterator's lifetime — by
+        // dropping the iterator between layers we let any concurrent
+        // `insert` from the embed worker make progress.
+        let indexation = self.hnsw.get_point_indexation();
+        let nb_layers = indexation.get_max_level_observed() as usize + 1;
+        // (origin_id, vector) buffer reused across layers.
+        let mut survivors: Vec<(u32, Vec<f32>)> =
+            Vec::with_capacity(live_capacity);
+        for l in 0..nb_layers {
+            let iter = indexation.get_layer_iterator(l);
+            for point in iter {
+                let origin_id = point.get_origin_id() as u32;
+                if tomb_snapshot.contains(&origin_id) {
+                    continue;
+                }
+                survivors.push((origin_id, point.get_v().to_vec()));
+            }
+            // iterator drops here — read lock released before next layer.
+        }
+
+        // Re-insert in original-id order so the new dense ids are stable
+        // across multiple compactions of the same content.
+        survivors.sort_by_key(|(id, _)| *id);
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = survivors
+            .into_iter()
+            .map(|(old_id, vec)| {
+                let (p, c) = mapping_snapshot[old_id as usize].clone();
+                (p, c, vec)
+            })
+            .collect();
+        fresh.bulk_insert(items);
+        Ok(fresh)
+    }
+
     /// Persist the index to `dir` (created if missing). Writes three files:
     /// `vectors.hnsw.graph`, `vectors.hnsw.data`, `vectors.mapping.json`.
     /// Mapping is written atomically (tmp + rename); the hnsw_rs dump is not
@@ -195,9 +390,18 @@ impl VectorIndex {
                 "hnsw file_dump failed: {e}"
             ))))?;
         let m = self.mapping.read().expect("mapping lock");
+        let mut tomb: Vec<u32> = self
+            .tombstones
+            .read()
+            .expect("tombstones lock")
+            .iter()
+            .copied()
+            .collect();
+        tomb.sort_unstable();
         let payload = MappingFile {
             version: MAPPING_VERSION,
             entries: m.clone(),
+            tombstones: tomb,
         };
         let json = serde_json::to_vec(&payload).map_err(|e| {
             EmbeddingError::Io(std::io::Error::other(format!("mapping serialize: {e}")))
@@ -230,10 +434,10 @@ impl VectorIndex {
         let mapping: MappingFile = serde_json::from_slice(&mapping_bytes).map_err(|e| {
             EmbeddingError::Io(std::io::Error::other(format!("mapping parse: {e}")))
         })?;
-        if mapping.version != MAPPING_VERSION {
+        if mapping.version < MAPPING_VERSION_MIN || mapping.version > MAPPING_VERSION {
             return Err(EmbeddingError::Io(std::io::Error::other(format!(
-                "mapping version mismatch: got {}, want {}",
-                mapping.version, MAPPING_VERSION
+                "mapping version unsupported: got {}, supported {}..={}",
+                mapping.version, MAPPING_VERSION_MIN, MAPPING_VERSION
             ))));
         }
 
@@ -265,9 +469,19 @@ impl VectorIndex {
             EmbeddingError::Io(std::io::Error::other(format!("hnsw load: {e}")))
         })?;
 
+        // Rebuild path_to_ids from the loaded mapping. Tombstones come
+        // straight from the dump (or empty on a v1 file).
+        let mut p2i: HashMap<PathBuf, Vec<u32>> = HashMap::new();
+        for (id, (path, _chunk)) in mapping.entries.iter().enumerate() {
+            p2i.entry(path.clone()).or_default().push(id as u32);
+        }
+        let tombstones: HashSet<u32> = mapping.tombstones.into_iter().collect();
+
         Ok(Self {
             hnsw,
             mapping: RwLock::new(mapping.entries),
+            path_to_ids: RwLock::new(p2i),
+            tombstones: RwLock::new(tombstones),
         })
     }
 
@@ -587,5 +801,214 @@ mod tests {
             took < Duration::from_millis(1500),
             "load too slow: {took:?} for {N} vectors",
         );
+    }
+
+    // ---- #200: tombstones + compaction --------------------------------------
+
+    #[test]
+    fn mark_deleted_filters_id_from_query() {
+        let idx = VectorIndex::new(16);
+        for i in 0..16u64 {
+            idx.insert(PathBuf::from(format!("v-{i}.md")), 0, &unit_vec(i));
+        }
+        // Tombstone the exact path we'll probe for; the self-match must
+        // disappear from the result set.
+        let target = PathBuf::from("v-7.md");
+        let added = idx.mark_deleted(&target);
+        assert_eq!(added, 1, "expected one chunk tombstoned for v-7.md");
+        let hits = idx.query_with_paths(&unit_vec(7), 5);
+        assert!(
+            hits.iter().all(|(p, _, _)| p != &target),
+            "tombstoned path leaked into query results: {hits:?}",
+        );
+    }
+
+    #[test]
+    fn mark_deleted_handles_multi_chunk_paths() {
+        let idx = VectorIndex::new(8);
+        // Three chunks of one note plus two unrelated notes.
+        idx.insert(PathBuf::from("multi.md"), 0, &unit_vec(1));
+        idx.insert(PathBuf::from("multi.md"), 1, &unit_vec(2));
+        idx.insert(PathBuf::from("multi.md"), 2, &unit_vec(3));
+        idx.insert(PathBuf::from("other-a.md"), 0, &unit_vec(4));
+        idx.insert(PathBuf::from("other-b.md"), 0, &unit_vec(5));
+        let added = idx.mark_deleted(Path::new("multi.md"));
+        assert_eq!(added, 3, "all 3 chunks of multi.md must be tombstoned");
+        // Re-marking is a no-op (idempotent).
+        assert_eq!(idx.mark_deleted(Path::new("multi.md")), 0);
+        // Probing each multi-chunk seed must never return multi.md.
+        for seed in 1..=3u64 {
+            let hits = idx.query_with_paths(&unit_vec(seed), 5);
+            assert!(
+                hits.iter().all(|(p, _, _)| p != Path::new("multi.md")),
+                "seed {seed} returned tombstoned path: {hits:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn tombstone_count_and_ratio_track_deletes() {
+        let idx = VectorIndex::new(10);
+        for i in 0..10u64 {
+            idx.insert(PathBuf::from(format!("n-{i}.md")), 0, &unit_vec(i));
+        }
+        assert_eq!(idx.tombstone_count(), 0);
+        assert!((idx.tombstone_ratio() - 0.0).abs() < 1e-6);
+        idx.mark_deleted(Path::new("n-1.md"));
+        idx.mark_deleted(Path::new("n-2.md"));
+        assert_eq!(idx.tombstone_count(), 2);
+        assert!((idx.tombstone_ratio() - 0.2).abs() < 1e-6);
+        assert_eq!(idx.live_len(), 8);
+    }
+
+    #[test]
+    fn should_compact_requires_both_ratio_and_floor() {
+        // Tiny vault: 4 inserts, 1 delete = 25% ratio but only 1 tombstone
+        // — under the absolute floor. should_compact must be false.
+        let small = VectorIndex::new(4);
+        for i in 0..4u64 {
+            small.insert(PathBuf::from(format!("s-{i}.md")), 0, &unit_vec(i));
+        }
+        small.mark_deleted(Path::new("s-0.md"));
+        assert!(!small.should_compact(), "small vault must not trigger compaction");
+
+        // Bigger vault: cross both bars.
+        let big = VectorIndex::new(400);
+        for i in 0..400u64 {
+            big.insert(PathBuf::from(format!("b-{i}.md")), 0, &unit_vec(i));
+        }
+        // 100 deletes / 400 = 25% > 20% threshold; 100 > 64 floor.
+        for i in 0..100 {
+            big.mark_deleted(&PathBuf::from(format!("b-{i}.md")));
+        }
+        assert!(big.should_compact(), "big vault crossed both gates");
+    }
+
+    #[test]
+    fn tombstones_persist_across_save_load() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(8);
+        for i in 0..8u64 {
+            idx.insert(PathBuf::from(format!("p-{i}.md")), 0, &unit_vec(i));
+        }
+        idx.mark_deleted(Path::new("p-2.md"));
+        idx.mark_deleted(Path::new("p-5.md"));
+        idx.save(tmp.path()).expect("save");
+
+        let loaded = VectorIndex::load(tmp.path()).expect("load");
+        assert_eq!(loaded.tombstone_count(), 2);
+        assert!(loaded.is_tombstoned(2));
+        assert!(loaded.is_tombstoned(5));
+        // And the post-reload query honors them.
+        let hits = loaded.query_with_paths(&unit_vec(2), 5);
+        assert!(hits.iter().all(|(p, _, _)| p != Path::new("p-2.md")));
+    }
+
+    #[test]
+    fn load_v1_mapping_silently_upgrades() {
+        // Hand-craft a v1 dump: save a v2 file then rewrite the mapping
+        // file to a v1-shaped JSON without the `tombstones` field.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let idx = VectorIndex::new(4);
+        for i in 0..4u64 {
+            idx.insert(PathBuf::from(format!("v1-{i}.md")), 0, &unit_vec(i));
+        }
+        idx.save(tmp.path()).expect("save");
+
+        let v1_json = serde_json::json!({
+            "version": 1,
+            "entries": [
+                ["v1-0.md", 0],
+                ["v1-1.md", 0],
+                ["v1-2.md", 0],
+                ["v1-3.md", 0],
+            ],
+        });
+        std::fs::write(
+            tmp.path().join("vectors.mapping.json"),
+            serde_json::to_vec(&v1_json).unwrap(),
+        )
+        .expect("write v1 mapping");
+
+        let loaded = VectorIndex::load(tmp.path()).expect("v1 load");
+        assert_eq!(loaded.len(), 4);
+        assert_eq!(loaded.tombstone_count(), 0);
+    }
+
+    #[test]
+    fn compact_drops_tombstoned_and_preserves_others() {
+        let idx = VectorIndex::new(20);
+        for i in 0..20u64 {
+            idx.insert(PathBuf::from(format!("c-{i}.md")), 0, &unit_vec(i));
+        }
+        // Tombstone every odd id.
+        for i in (1..20u64).step_by(2) {
+            idx.mark_deleted(&PathBuf::from(format!("c-{i}.md")));
+        }
+        let surviving_paths: Vec<PathBuf> = (0..20u64)
+            .step_by(2)
+            .map(|i| PathBuf::from(format!("c-{i}.md")))
+            .collect();
+
+        let fresh = idx.compact_into_fresh().expect("compact");
+        assert_eq!(fresh.len(), 10, "compacted size must equal live count");
+        assert_eq!(fresh.tombstone_count(), 0);
+        // Every survivor's path must be queryable; tombstoned paths must
+        // be unreachable (not just hidden).
+        for seed in (0..20u64).step_by(2) {
+            let hits = fresh.query_with_paths(&unit_vec(seed), 1);
+            assert_eq!(hits.len(), 1);
+            assert_eq!(hits[0].0, PathBuf::from(format!("c-{seed}.md")));
+        }
+        // Sanity: every fresh entry maps to a surviving path.
+        let fresh_paths: Vec<PathBuf> = (0..fresh.len() as u64)
+            .map(|seed| fresh.query_with_paths(&unit_vec(seed * 2), 1)[0].0.clone())
+            .collect();
+        for p in fresh_paths {
+            assert!(surviving_paths.contains(&p), "stray path after compact: {p:?}");
+        }
+    }
+
+    /// AC test for #200: tombstone half of a 10k-vector index, run
+    /// queries, assert no tombstoned ids leak. `#[ignore]` because the
+    /// HNSW build is the slow part (~1 s in release, much more in debug)
+    /// — run via `cargo test --release -- --ignored`.
+    #[test]
+    #[ignore]
+    fn delete_50pct_of_10k_returns_no_tombstoned_results() {
+        const N: usize = 10_000;
+        const Q: usize = 100;
+        let items: Vec<(PathBuf, usize, Vec<f32>)> = (0..N as u64)
+            .map(|i| (PathBuf::from(format!("/v/{i}.md")), 0, unit_vec(i)))
+            .collect();
+        let idx = VectorIndex::new(N);
+        idx.bulk_insert(items);
+        // Tombstone every even id by path.
+        for i in (0..N as u64).step_by(2) {
+            idx.mark_deleted(&PathBuf::from(format!("/v/{i}.md")));
+        }
+        assert!(idx.tombstone_count() >= N / 2);
+
+        let probes: Vec<Vec<f32>> = (0..Q as u64)
+            .map(|i| unit_vec(i + 9_000_000))
+            .collect();
+        for p in &probes {
+            let hits = idx.query(p, 10);
+            for (id, _) in &hits {
+                assert!(
+                    !idx.is_tombstoned(*id),
+                    "tombstoned id {id} leaked into query results",
+                );
+            }
+        }
+
+        // And after compaction the index must be half-sized and usable.
+        let fresh = idx.compact_into_fresh().expect("compact");
+        assert_eq!(fresh.len(), N / 2);
+        assert_eq!(fresh.tombstone_count(), 0);
+        for p in probes.iter().take(10) {
+            let hits = fresh.query(p, 10);
+            assert!(hits.len() <= 10);
+        }
     }
 }

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -388,6 +388,50 @@ impl VectorIndex {
         Ok(fresh)
     }
 
+    /// #235 — yield every live (non-tombstoned) chunk via callback. Used
+    /// by the embedding-graph builder to enumerate source vectors
+    /// without copying the whole index.
+    ///
+    /// Walks HNSW layers one at a time and drops each layer's iterator
+    /// before stepping to the next — same pattern as `compact_into_fresh`,
+    /// for the same reason: holding a single iterator across all layers
+    /// would pin the `points_by_layer` read lock for the full walk and
+    /// stall concurrent inserts from the embed worker.
+    ///
+    /// Tombstones are snapshotted once at entry; ids tombstoned during
+    /// the walk continue to be yielded (consistent snapshot semantics).
+    /// Mapping is read once per yield to resolve `(path, chunk_index)`.
+    pub fn for_each_live<F>(&self, mut f: F)
+    where
+        F: FnMut(u32, &Path, usize, &[f32]),
+    {
+        let tomb_snapshot: HashSet<u32> = self
+            .tombstones
+            .read()
+            .expect("tombstones lock")
+            .clone();
+        let mapping_snapshot = self.mapping.read().expect("mapping lock").clone();
+
+        let indexation = self.hnsw.get_point_indexation();
+        let nb_layers = indexation.get_max_level_observed() as usize + 1;
+        for l in 0..nb_layers {
+            let iter = indexation.get_layer_iterator(l);
+            for point in iter {
+                let origin_id = point.get_origin_id() as u32;
+                if tomb_snapshot.contains(&origin_id) {
+                    continue;
+                }
+                let Some((path, chunk_idx)) =
+                    mapping_snapshot.get(origin_id as usize)
+                else {
+                    continue;
+                };
+                f(origin_id, path.as_path(), *chunk_idx, point.get_v());
+            }
+            // iterator drops here — read lock released before next layer.
+        }
+    }
+
     /// Persist the index to `dir` (created if missing). Writes three files:
     /// `vectors.hnsw.graph`, `vectors.hnsw.data`, `vectors.mapping.json`.
     /// Mapping is written atomically (tmp + rename); the hnsw_rs dump is not

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,6 +142,7 @@ pub fn run() {
             commands::search::search_fulltext,
             commands::search::search_filename,
             commands::search::semantic_search,
+            commands::search::hybrid_search,
             commands::search::rebuild_index,
             commands::links::get_backlinks,
             commands::links::get_outgoing_links,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,6 +70,12 @@ pub struct VaultState {
     /// `write_file` skips the embed dispatch silently in that case.
     #[cfg(feature = "embeddings")]
     pub embed_coordinator: Arc<Mutex<Option<embeddings::EmbedCoordinator>>>,
+    /// Running reindex worker (#201 PR-B), if any. The `reindex_vault`
+    /// command cancels the previous handle before spawning a new one,
+    /// and `open_vault` cancels on vault switch so the old worker can't
+    /// write to the freshly-replaced coordinator's checkpoint.
+    #[cfg(feature = "embeddings")]
+    pub reindex_handle: Arc<Mutex<Option<Arc<embeddings::ReindexHandle>>>>,
 }
 
 impl Default for VaultState {
@@ -82,6 +88,8 @@ impl Default for VaultState {
             index_coordinator: Arc::new(Mutex::new(None)),
             #[cfg(feature = "embeddings")]
             embed_coordinator: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "embeddings")]
+            reindex_handle: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -107,6 +115,10 @@ pub fn run() {
             commands::vault::get_recent_vaults,
             commands::vault::get_vault_stats,
             commands::vault::repair_vault_index,
+            #[cfg(feature = "embeddings")]
+            commands::vault::reindex_vault,
+            #[cfg(feature = "embeddings")]
+            commands::vault::cancel_reindex,
             commands::files::read_file,
             commands::files::write_file,
             commands::files::create_file,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,11 @@ pub struct VaultState {
     pub watcher_handle: Arc<Mutex<Option<Debouncer<RecommendedWatcher, RecommendedCache>>>>,
     /// Tantivy IndexCoordinator — created lazily on first open_vault call.
     pub index_coordinator: Arc<Mutex<Option<indexer::IndexCoordinator>>>,
+    /// Embed-on-save coordinator (#196). `None` when the embeddings
+    /// feature is off, the model isn't bundled, or ORT init failed.
+    /// `write_file` skips the embed dispatch silently in that case.
+    #[cfg(feature = "embeddings")]
+    pub embed_coordinator: Arc<Mutex<Option<embeddings::EmbedCoordinator>>>,
 }
 
 impl Default for VaultState {
@@ -75,6 +80,8 @@ impl Default for VaultState {
             vault_reachable: Arc::new(Mutex::new(false)),
             watcher_handle: Arc::new(Mutex::new(None)),
             index_coordinator: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "embeddings")]
+            embed_coordinator: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,6 +153,10 @@ pub fn run() {
             commands::links::get_resolved_attachments,
             commands::links::get_local_graph,
             commands::links::get_link_graph,
+            #[cfg(feature = "embeddings")]
+            commands::embedding_graph::get_embedding_graph,
+            #[cfg(not(feature = "embeddings"))]
+            commands::embedding_graph_stub::get_embedding_graph,
             commands::tags::list_tags,
             commands::tags::get_tag_occurrences,
             commands::bookmarks::load_bookmarks,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,9 @@ pub mod watcher;
 pub mod merge;
 pub mod indexer;
 
+#[cfg(feature = "embeddings")]
+pub mod embeddings;
+
 #[cfg(test)]
 mod tests;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,12 @@ pub struct VaultState {
     /// write to the freshly-replaced coordinator's checkpoint.
     #[cfg(feature = "embeddings")]
     pub reindex_handle: Arc<Mutex<Option<Arc<embeddings::ReindexHandle>>>>,
+    /// Embed service + HNSW sink pair (#202) used by the `semantic_search`
+    /// IPC command. The sink Arc here aliases the one held by
+    /// `embed_coordinator` (upcast as `Arc<dyn VectorSink>`), so queries
+    /// see the same live `VectorIndex` the embed worker writes to.
+    #[cfg(feature = "embeddings")]
+    pub query_handles: Arc<Mutex<Option<Arc<embeddings::QueryHandles>>>>,
 }
 
 impl Default for VaultState {
@@ -90,6 +96,8 @@ impl Default for VaultState {
             embed_coordinator: Arc::new(Mutex::new(None)),
             #[cfg(feature = "embeddings")]
             reindex_handle: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "embeddings")]
+            query_handles: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -133,6 +141,7 @@ pub fn run() {
             commands::vault::merge_external_change,
             commands::search::search_fulltext,
             commands::search::search_filename,
+            commands::search::semantic_search,
             commands::search::rebuild_index,
             commands::links::get_backlinks,
             commands::links::get_outgoing_links,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,15 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .manage(VaultState::default())
+        .setup(|_app| {
+            #[cfg(feature = "embeddings")]
+            {
+                if let Err(e) = embeddings::bootstrap(&_app.handle()) {
+                    log::warn!("embeddings bootstrap failed: {e}");
+                }
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::vault::open_vault,
             commands::vault::get_recent_vaults,

--- a/src-tauri/src/tests/embedding_graph.rs
+++ b/src-tauri/src/tests/embedding_graph.rs
@@ -1,0 +1,329 @@
+//! #235 — unit tests for `compute_embedding_graph`.
+//!
+//! Drives the pure builder with synthetic `VectorIndex` fixtures so the
+//! tests don't depend on the actual embedding model being bundled. All
+//! similarities are constructed analytically: unit vectors along
+//! disjoint axes (cosine 0) or mixed along two axes with known weights
+//! (cosine = dot product since inputs are L2-normalised).
+//!
+//! Behaviours guarded:
+//! - Threshold filters low-similarity pairs.
+//! - `top_k` caps neighbours per source.
+//! - Edges are undirected and deduplicated.
+//! - Edge weight = **max** chunk-pair cosine (not mean, not last-write).
+//! - Self-loops (source-chunk hitting itself or a sibling chunk of the
+//!   same note) never emit an edge.
+//! - Empty index yields an empty graph.
+//! - Nodes come from the VectorIndex path set; a note that exists in
+//!   `FileIndex` but has no embedding does NOT appear as a node.
+
+#![cfg(feature = "embeddings")]
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::embedding_graph::compute_embedding_graph;
+use crate::commands::links::{GraphEdge, LocalGraph};
+use crate::embeddings::{VectorIndex, DIM};
+use crate::indexer::memory::{FileIndex, FileMeta};
+use crate::indexer::tag_index::TagIndex;
+
+/// Empty `Path` is the no-op vault root that lets tests use
+/// already-relative `PathBuf::from("a.md")` fixtures —
+/// `strip_prefix("")` succeeds and returns the original path unchanged.
+const NO_VAULT_ROOT: &str = "";
+
+/// Build a 384-dim unit vector with non-zero components only at the
+/// given `(axis, weight)` positions. Weights must be pre-arranged so
+/// that `sum(w_i^2) == 1` — caller's responsibility.
+fn mixed_unit(components: &[(usize, f32)]) -> Vec<f32> {
+    let mut v = vec![0f32; DIM];
+    for (axis, w) in components {
+        assert!(*axis < DIM, "axis {axis} out of range");
+        v[*axis] = *w;
+    }
+    // Cheap sanity check — catches miscalibrated weights in fixtures.
+    let norm_sq: f32 = v.iter().map(|x| x * x).sum();
+    assert!(
+        (norm_sq - 1.0).abs() < 1e-5,
+        "fixture vector not unit-norm: {norm_sq:.6}"
+    );
+    v
+}
+
+/// Unit vector along a single axis.
+fn axis_unit(axis: usize) -> Vec<f32> {
+    mixed_unit(&[(axis, 1.0)])
+}
+
+fn empty_file_index() -> FileIndex {
+    FileIndex::new()
+}
+
+fn file_index_with(paths: &[&str]) -> FileIndex {
+    let mut fi = FileIndex::new();
+    for rel in paths {
+        fi.insert(
+            PathBuf::from(format!("/vault/{rel}")),
+            FileMeta {
+                relative_path: (*rel).to_string(),
+                hash: "h".into(),
+                title: (*rel).into(),
+                aliases: Vec::new(),
+            },
+        );
+    }
+    fi
+}
+
+fn edge_pairs(g: &LocalGraph) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = g
+        .edges
+        .iter()
+        .map(|e| (e.from.clone(), e.to.clone()))
+        .collect();
+    out.sort();
+    out
+}
+
+fn edge_weight(g: &LocalGraph, a: &str, b: &str) -> Option<f32> {
+    g.edges.iter().find_map(|e| {
+        let same = (e.from == a && e.to == b) || (e.from == b && e.to == a);
+        if same {
+            e.weight
+        } else {
+            None
+        }
+    })
+}
+
+// ── tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_vector_index_yields_empty_graph() {
+    let vi = VectorIndex::new(4);
+    let fi = empty_file_index();
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.0);
+
+    assert!(g.nodes.is_empty(), "expected no nodes, got {:?}", g.nodes);
+    assert!(g.edges.is_empty(), "expected no edges, got {:?}", g.edges);
+}
+
+#[test]
+fn threshold_filters_low_similarity_edges() {
+    // a.md + b.md live near axis 0 (cos ≈ 0.9987).
+    // c.md lives on axis 7 (cos with a/b = 0).
+    let vi = VectorIndex::new(8);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("b.md"),
+        0,
+        &mixed_unit(&[(0, 0.95), (1, 0.3122499)]), // 0.95^2 + 0.3122499^2 ≈ 1.0
+    );
+    vi.insert(PathBuf::from("c.md"), 0, &axis_unit(7));
+
+    let fi = file_index_with(&["a.md", "b.md", "c.md"]);
+    let ti = TagIndex::new();
+
+    // threshold 0.7 → only a↔b edge survives.
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.7);
+
+    let pairs = edge_pairs(&g);
+    assert_eq!(
+        pairs,
+        vec![("a.md".to_string(), "b.md".to_string())],
+        "expected single a↔b edge above threshold, got {pairs:?}"
+    );
+}
+
+#[test]
+fn top_k_caps_neighbors_per_source() {
+    // a.md is near three other notes b/c/d with distinct similarities.
+    // With top_k=1 we keep only the single best neighbor of `a`.
+    let vi = VectorIndex::new(8);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("b.md"),
+        0,
+        &mixed_unit(&[(0, 0.99), (1, 0.0199_f32.sqrt())]), // cos ≈ 0.99
+    );
+    vi.insert(
+        PathBuf::from("c.md"),
+        0,
+        &mixed_unit(&[(0, 0.95), (1, 0.3122499)]), // cos ≈ 0.95
+    );
+    vi.insert(
+        PathBuf::from("d.md"),
+        0,
+        &mixed_unit(&[(0, 0.90), (1, 0.4358899)]), // cos ≈ 0.90
+    );
+
+    let fi = file_index_with(&["a.md", "b.md", "c.md", "d.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 1, 0.80);
+
+    // Because edges are undirected and every pair (b,c,d) is also >0.80
+    // with each other, the top-1-per-source budget yields exactly three
+    // edges after deduplication: one per source picks one best neighbour;
+    // symmetric duplicates collapse to the same (lo, hi) entry.
+    // Specifically: a→b, b→a (dupe), c→?, d→? — the resulting unique
+    // edge set has cardinality at most 4 and must contain a↔b (the
+    // tightest pair). Precise count depends on the tie-break but must
+    // never exceed sources.
+    assert!(
+        g.edges.len() <= 4,
+        "top_k=1 per source should cap edges (≤4 unique), got {}",
+        g.edges.len()
+    );
+    assert!(
+        edge_weight(&g, "a.md", "b.md").is_some(),
+        "a↔b (tightest) must survive the top-1 cap; got {:?}",
+        edge_pairs(&g)
+    );
+}
+
+#[test]
+fn edges_are_undirected_and_deduplicated() {
+    // Two notes on nearly-identical vectors — every direction of the
+    // k-NN finds the pair. Result must still be exactly one edge.
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("b.md"),
+        0,
+        &mixed_unit(&[(0, 0.98), (1, 0.19899749)]),
+    );
+
+    let fi = file_index_with(&["a.md", "b.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.5);
+
+    assert_eq!(g.edges.len(), 1, "expected 1 unique edge, got {:?}", g.edges);
+    let e = &g.edges[0];
+    assert!(e.from < e.to, "edge should be normalized lo<hi: {e:?}");
+}
+
+#[test]
+fn edge_weight_is_max_chunk_pair_similarity() {
+    // `a.md` has two chunks:
+    //   chunk 0 — axis 0 (matches `b.md`'s single axis-0 chunk at cos 1.0)
+    //   chunk 1 — axis 5 (matches `c.md` at cos 1.0)
+    //
+    // `b.md` has only chunk 0 on axis 0 (cos with a-chunk0 = 1.0).
+    // `b.md` also has chunk 1 on axis 5 rotated slightly — a weaker
+    //   match against a-chunk1 at cos 0.5.
+    //
+    // The edge a↔b must carry the MAX chunk-pair cosine (1.0), not the
+    // mean (0.75) or the last-written value.
+    let vi = VectorIndex::new(8);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(PathBuf::from("a.md"), 1, &axis_unit(5));
+    vi.insert(PathBuf::from("b.md"), 0, &axis_unit(0)); // cos(a0,b0)=1.0
+    vi.insert(
+        PathBuf::from("b.md"),
+        1,
+        &mixed_unit(&[(5, 0.5), (6, 0.75_f32.sqrt())]), // cos(a1,b1)=0.5
+    );
+
+    let fi = file_index_with(&["a.md", "b.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.4);
+
+    let w = edge_weight(&g, "a.md", "b.md").expect("a↔b edge must exist");
+    assert!(
+        (w - 1.0).abs() < 0.01,
+        "expected edge weight == max chunk-pair cosine ≈ 1.0, got {w:.4}"
+    );
+}
+
+#[test]
+fn self_edges_excluded() {
+    // Single note, multiple chunks. No edge should be emitted to itself.
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(PathBuf::from("a.md"), 1, &axis_unit(1));
+    vi.insert(PathBuf::from("a.md"), 2, &axis_unit(2));
+
+    let fi = file_index_with(&["a.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.0);
+
+    assert!(
+        g.edges.is_empty(),
+        "a.md must not edge to itself; got {:?}",
+        g.edges
+    );
+    // The node itself should still appear so the graph isn't empty.
+    let ids: Vec<&str> = g.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(ids, vec!["a.md"]);
+}
+
+#[test]
+fn nodes_come_from_vector_index_only() {
+    // `orphan.md` exists in FileIndex but has no chunks in VectorIndex
+    // → it must NOT appear in the embedding graph (no semantic position).
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("indexed.md"), 0, &axis_unit(0));
+
+    let fi = file_index_with(&["indexed.md", "orphan.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 10, 0.0);
+
+    let ids: Vec<&str> = g.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["indexed.md"],
+        "only notes with embeddings belong in the embedding graph"
+    );
+}
+
+#[test]
+fn paths_are_stripped_to_vault_relative_ids() {
+    // VectorIndex stores absolute paths (the embed coordinator passes
+    // abs paths from `dispatch_embed_update`). The graph payload uses
+    // vault-relative paths — `\\` normalised to `/` — so the frontend
+    // can key into FileIndex / TagIndex consistently with link-mode.
+    //
+    // Plan-agent flagged this as the highest-impact correctness bug:
+    // without the strip, every node id would be the absolute path and
+    // tag/path lookups in the UI silently miss.
+    let vault_root = PathBuf::from("/vault");
+    let vi = VectorIndex::new(4);
+    vi.insert(PathBuf::from("/vault/notes/a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("/vault/notes/b.md"),
+        0,
+        &mixed_unit(&[(0, 0.98), (1, 0.19899749)]),
+    );
+
+    let fi = file_index_with(&["notes/a.md", "notes/b.md"]);
+    let ti = TagIndex::new();
+
+    let g = compute_embedding_graph(&vi, &fi, &ti, &vault_root, 10, 0.5);
+
+    let ids: Vec<&str> = g.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(ids, vec!["notes/a.md", "notes/b.md"]);
+    assert_eq!(g.edges.len(), 1);
+    let e = &g.edges[0];
+    assert_eq!(e.from, "notes/a.md");
+    assert_eq!(e.to, "notes/b.md");
+}
+
+/// Guard: a GraphEdge without a weight (link-graph case) is still a
+/// valid construction — we haven't accidentally made the field
+/// mandatory. This keeps link-graph code paths compiling.
+#[test]
+fn graph_edge_without_weight_still_constructs() {
+    let e = GraphEdge {
+        from: "a".into(),
+        to: "b".into(),
+        weight: None,
+    };
+    assert!(e.weight.is_none());
+}

--- a/src-tauri/src/tests/embeddings.rs
+++ b/src-tauri/src/tests/embeddings.rs
@@ -1,0 +1,31 @@
+//! Smoke test for the embeddings stack (#190).
+//!
+//! Skipped silently when the runtime dylib (#191) or the bundled model (#192)
+//! is not yet present; runs end-to-end once both ship.
+
+#[cfg(feature = "embeddings")]
+#[test]
+fn embedding_smoke_test() {
+    use crate::embeddings;
+
+    // Best-effort discovery via the same paths the runtime would use in dev
+    // (`CARGO_MANIFEST_DIR/resources/...`). No AppHandle in unit tests.
+    let runtime = embeddings::runtime_path(None);
+    let model = embeddings::model_dir(None);
+    if runtime.is_err() || model.is_err() {
+        eprintln!(
+            "SKIP embedding_smoke_test: runtime={:?} model={:?}",
+            runtime.is_ok(),
+            model.is_ok()
+        );
+        return;
+    }
+
+    let v = embeddings::smoke_test(None).expect("smoke test failed");
+    assert_eq!(v.len(), 384, "MiniLM-L6-v2 must yield 384-dim vectors");
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        (norm - 1.0).abs() < 0.01,
+        "expected L2-normalized embedding, got norm {norm}"
+    );
+}

--- a/src-tauri/src/tests/files.rs
+++ b/src-tauri/src/tests/files.rs
@@ -147,6 +147,73 @@ fn write_file_round_trip_with_read_file() {
     assert_eq!(contents, "roundtrip");
 }
 
+// --- #196 embed-on-save: save-RTT regression -----------------------------
+
+/// Regression guard for #196 AC: "Save-RTT unverändert". The embed hook is
+/// sync, non-blocking, and must add far less than the 16 ms keystroke
+/// budget to a single save. We assert the median of 100 saves with a
+/// no-op-sink coordinator stays within 1 ms of the median without one.
+/// 1 ms is generous on purpose so CI noise doesn't flake; if this trips,
+/// profile the hook — something is doing unexpected work.
+#[cfg(feature = "embeddings")]
+#[test]
+fn embed_hook_does_not_regress_save_rtt() {
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    tokio_test_block_on(async {
+        async fn run(state: &VaultState, dir: &std::path::Path, label: &str) -> Duration {
+            const N: usize = 100;
+            let mut samples = Vec::with_capacity(N);
+            for i in 0..N {
+                let path = dir.join(format!("{label}-{i}.md"));
+                let t0 = Instant::now();
+                write_file_impl(
+                    state,
+                    path.to_string_lossy().into_owned(),
+                    format!("rtt sample {i}\n").repeat(20),
+                )
+                .await
+                .unwrap();
+                samples.push(t0.elapsed());
+            }
+            samples.sort();
+            samples[N / 2]
+        }
+
+        // Baseline: no embed coordinator registered.
+        let dir_baseline = tempdir().unwrap();
+        let state_baseline = state_with_vault(dir_baseline.path());
+        let median_no_hook = run(&state_baseline, dir_baseline.path(), "noop").await;
+
+        // With hook: register a coordinator backed by a NoopSink. Skip
+        // cleanly if the model isn't bundled (CI without resources).
+        let Some(svc) = crate::embeddings::EmbeddingService::load(None).ok() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let Some(chk) = crate::embeddings::Chunker::load(None).ok() else {
+            eprintln!("SKIP: tokenizer not bundled");
+            return;
+        };
+        let dir_hook = tempdir().unwrap();
+        let state_hook = state_with_vault(dir_hook.path());
+        {
+            let sink: Arc<dyn crate::embeddings::VectorSink> =
+                Arc::new(crate::embeddings::NoopSink);
+            let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
+            *state_hook.embed_coordinator.lock().unwrap() = Some(coord);
+        }
+        let median_with_hook = run(&state_hook, dir_hook.path(), "hook").await;
+
+        let delta = median_with_hook.saturating_sub(median_no_hook);
+        assert!(
+            delta < Duration::from_millis(1),
+            "embed hook regressed save RTT: median delta = {delta:?} (baseline {median_no_hook:?}, hook {median_with_hook:?})"
+        );
+    });
+}
+
 // --- _impl helpers: mirror the tauri::command bodies ---------------------
 //
 // Keep these byte-for-byte logically identical to commands/files.rs.
@@ -209,5 +276,58 @@ async fn write_file_impl(
         std::io::ErrorKind::StorageFull => VaultError::DiskFull,
         _ => VaultError::Io(e),
     })?;
+
+    // Mirror commands/files.rs::write_file: dispatch index + embed updates
+    // after the disk write succeeds. Both are best-effort and silently
+    // skip when the relevant coordinator isn't registered in state.
+    dispatch_index_updates_test(state, &final_path, &content).await;
+    #[cfg(feature = "embeddings")]
+    dispatch_embed_update_test(state, final_path.clone(), &content);
+
     Ok(crate::hash::hash_bytes(bytes))
+}
+
+async fn dispatch_index_updates_test(
+    state: &VaultState,
+    abs_path: &std::path::Path,
+    content: &str,
+) {
+    use crate::indexer::IndexCmd;
+    let vault_root = {
+        let Ok(guard) = state.current_vault.lock() else { return };
+        match guard.as_ref() {
+            Some(p) => p.clone(),
+            None => return,
+        }
+    };
+    let Ok(rel) = abs_path.strip_prefix(&vault_root) else { return };
+    let rel_path = rel.to_string_lossy().replace('\\', "/");
+    let tx = {
+        let Ok(guard) = state.index_coordinator.lock() else { return };
+        match guard.as_ref() {
+            Some(c) => c.tx.clone(),
+            None => return,
+        }
+    };
+    let _ = tx
+        .send(IndexCmd::UpdateLinks { rel_path: rel_path.clone(), content: content.to_string() })
+        .await;
+    let _ = tx
+        .send(IndexCmd::UpdateTags { rel_path, content: content.to_string() })
+        .await;
+}
+
+#[cfg(feature = "embeddings")]
+fn dispatch_embed_update_test(
+    state: &VaultState,
+    abs_path: std::path::PathBuf,
+    content: &str,
+) {
+    let handles = {
+        let Ok(guard) = state.embed_coordinator.lock() else { return };
+        guard.as_ref().map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
+    };
+    let Some((tx, pending)) = handles else { return };
+    let probe = crate::embeddings::EmbedCoordinator { tx, pending };
+    let _ = probe.enqueue(abs_path, content.to_string());
 }

--- a/src-tauri/src/tests/files.rs
+++ b/src-tauri/src/tests/files.rs
@@ -214,6 +214,66 @@ fn embed_hook_does_not_regress_save_rtt() {
     });
 }
 
+/// AC for #197 ("Bulk-Write-Stresstest, 100 Saves in 10 s, no p99
+/// keystroke-latency regression"). Spreads 100 saves over ~10 s with a
+/// **real** EmbeddingService so the ORT thread-pool cap (`intra=2,
+/// inter=1`) is genuinely exercised under sustained inference load. The
+/// assertion is a comfortable absolute p99 bound rather than a delta —
+/// 50 ms is well below the spec's 100 ms "open note" budget and gives
+/// CI noise plenty of headroom while still tripping on a real
+/// regression (e.g. fastembed defaulting back to per-session unbounded
+/// threads).
+///
+/// `#[ignore]` because real ML inference is slow and CPU-heavy — opt
+/// into it explicitly with `cargo test -- --ignored`.
+#[cfg(feature = "embeddings")]
+#[test]
+#[ignore]
+fn save_rtt_p99_under_bulk_embed_pressure() {
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    tokio_test_block_on(async {
+        let Some(svc) = crate::embeddings::EmbeddingService::load(None).ok() else {
+            eprintln!("SKIP: embeddings not bundled");
+            return;
+        };
+        let Some(chk) = crate::embeddings::Chunker::load(None).ok() else {
+            eprintln!("SKIP: tokenizer not bundled");
+            return;
+        };
+        let dir = tempdir().unwrap();
+        let state = state_with_vault(dir.path());
+        {
+            let sink: Arc<dyn crate::embeddings::VectorSink> =
+                Arc::new(crate::embeddings::NoopSink);
+            let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
+            *state.embed_coordinator.lock().unwrap() = Some(coord);
+        }
+
+        const N: usize = 100;
+        const TOTAL: Duration = Duration::from_secs(10);
+        let inter_save = TOTAL / N as u32;
+        let mut samples = Vec::with_capacity(N);
+        for i in 0..N {
+            let path = dir.path().join(format!("bulk-{i}.md"));
+            let body = format!("bulk save {i}\n").repeat(40);
+            let t0 = Instant::now();
+            write_file_impl(&state, path.to_string_lossy().into_owned(), body)
+                .await
+                .unwrap();
+            samples.push(t0.elapsed());
+            tokio::time::sleep(inter_save).await;
+        }
+        samples.sort();
+        let p99 = samples[(N as f64 * 0.99) as usize - 1];
+        assert!(
+            p99 < Duration::from_millis(50),
+            "save RTT p99 = {p99:?} exceeded 50 ms budget under sustained embed pressure",
+        );
+    });
+}
+
 // --- _impl helpers: mirror the tauri::command bodies ---------------------
 //
 // Keep these byte-for-byte logically identical to commands/files.rs.

--- a/src-tauri/src/tests/indexer.rs
+++ b/src-tauri/src/tests/indexer.rs
@@ -135,19 +135,16 @@ mod orphan_cleanup_tests {
     /// before it is guaranteed to have been applied and the reader reloaded.
     async fn wait_for_drain(coord: &IndexCoordinator) {
         // The channel has capacity 1024, so we can't rely on backpressure.
-        // Instead: poll `reader.searcher().num_docs()` stability — it goes
-        // up on each Commit the writer processes. We send a no-op Commit and
-        // wait briefly, which is enough for the writer's `ReloadPolicy::
-        // OnCommitWithDelay` (default 100ms) to publish the new view.
+        // Send a no-op Commit and wait for the writer's `OnCommitWithDelay`
+        // (default ~100 ms) reader reload to publish. The 2 s ceiling is
+        // generous so the test tolerates CPU pressure from sibling
+        // real-ML embedding tests in the same suite.
         coord
             .tx
             .send(IndexCmd::Commit)
             .await
             .expect("drain Commit send");
-        // OnCommitWithDelay is ~100ms — give it a comfortable margin so the
-        // reader.reload() inside the writer task definitely lands before we
-        // query num_docs.
-        tokio::time::sleep(Duration::from_millis(400)).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
     }
 
     fn path_hits(index: &Index, reader: &IndexReader, path_str: &str) -> usize {

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -20,3 +20,5 @@ mod vault_walk;
 mod embeddings;
 #[cfg(feature = "embeddings")]
 mod semantic_quality;
+#[cfg(feature = "embeddings")]
+mod embedding_graph;

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -16,3 +16,5 @@ mod aliases;
 mod snippets;
 mod file_index_contention;
 mod vault_walk;
+#[cfg(feature = "embeddings")]
+mod embeddings;

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -18,3 +18,5 @@ mod file_index_contention;
 mod vault_walk;
 #[cfg(feature = "embeddings")]
 mod embeddings;
+#[cfg(feature = "embeddings")]
+mod semantic_quality;

--- a/src-tauri/src/tests/semantic_quality.rs
+++ b/src-tauri/src/tests/semantic_quality.rs
@@ -1,20 +1,28 @@
 //! #208 — Semantic quality sanity test.
+//! #233 — Extended with DE fixtures + queries to guard the multilingual
+//! retrieval path. MiniLM-L6 is English-only and collapses DE inputs onto
+//! the noise floor — these tests are the regression guard that forced the
+//! swap to `multilingual-e5-small`.
 //!
 //! Guards against silent retrieval-quality regressions in the embedding
-//! stack. Uses the five mini-docs from research #188
+//! stack. EN corpus: five mini-docs from research #188
 //! (`pizza_dough`, `bread_baking`, `cat_behavior`, `machine_learning`,
-//! `sourdough_starter`) as a ground-truth corpus with two
-//! cluster-crossing queries.
+//! `sourdough_starter`). DE corpus: three mini-docs covering disjoint
+//! topics (`hund_verhalten`, `pizza_teig_de`, `maschinelles_lernen_de`).
 //!
 //! Runs as a regular CI job (no `#[ignore]`). Skips cleanly when the
-//! MiniLM model isn't bundled, consistent with every other test in this
+//! model isn't bundled, consistent with every other test in this
 //! module — no CI flakes on hosts without the model.
 //!
-//! Similarity is MiniLM L2-normalised dot product (== cosine) and we
-//! brute-force all 5 docs rather than going through HNSW/RRF. This is
-//! deliberate: we're testing the *embedding quality*, not the index or
+//! Similarity is L2-normalised dot product (== cosine) and we
+//! brute-force the full fixture set rather than going through HNSW/RRF.
+//! Deliberate: we're testing the *embedding quality*, not the index or
 //! the fuser. If a regression here ever aligns suspiciously with an HNSW
 //! change, that's the signal that HNSW has drifted, not the embedder.
+//!
+//! Uses `embed_query` / `embed_passage` (added in #233) because e5 needs
+//! `"query: "` / `"passage: "` prefixes — applying them symmetrically
+//! reduces quality significantly per the e5 model card.
 
 #![cfg(feature = "embeddings")]
 
@@ -43,6 +51,21 @@ const FIXTURES: &[(&str, &str)] = &[
     ),
 ];
 
+const DE_FIXTURES: &[(&str, &str)] = &[
+    (
+        "hund_verhalten",
+        include_str!("../../tests/fixtures/semantic_quality/hund_verhalten.md"),
+    ),
+    (
+        "pizza_teig_de",
+        include_str!("../../tests/fixtures/semantic_quality/pizza_teig_de.md"),
+    ),
+    (
+        "maschinelles_lernen_de",
+        include_str!("../../tests/fixtures/semantic_quality/maschinelles_lernen_de.md"),
+    ),
+];
+
 /// Dot product — vectors are MiniLM-L2-normalised so this is cosine similarity.
 fn cos(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| x * y).sum()
@@ -52,12 +75,23 @@ fn cos(a: &[f32], b: &[f32]) -> f32 {
 /// descending. Returns `None` when the model isn't bundled (so tests
 /// can skip cleanly on CI hosts without the model resource).
 fn rank_fixtures(query: &str) -> Option<Vec<(&'static str, f32)>> {
+    rank_set(query, FIXTURES)
+}
+
+fn rank_de(query: &str) -> Option<Vec<(&'static str, f32)>> {
+    rank_set(query, DE_FIXTURES)
+}
+
+fn rank_set(
+    query: &str,
+    fixtures: &'static [(&'static str, &'static str)],
+) -> Option<Vec<(&'static str, f32)>> {
     let svc = EmbeddingService::load(None).ok()?;
-    let q = svc.embed(query).expect("query embed failed");
-    let mut scored: Vec<(&'static str, f32)> = FIXTURES
+    let q = svc.embed_query(query).expect("query embed failed");
+    let mut scored: Vec<(&'static str, f32)> = fixtures
         .iter()
         .map(|(name, body)| {
-            let v = svc.embed(body).expect("fixture embed failed");
+            let v = svc.embed_passage(body).expect("fixture embed failed");
             (*name, cos(&q, &v))
         })
         .collect();
@@ -93,8 +127,53 @@ fn feline_communication_top1_is_cat_with_margin() {
         "expected top-1 == `cat_behavior`, got {ranked:?}"
     );
     let margin = ranked[0].1 - ranked[1].1;
+    // 0.10 margin threshold — multilingual-e5-small (#233) runs a tighter
+    // cosine spread than the MiniLM-era 0.2 assumed. Top-1 still dominates
+    // clearly (measured ~0.12 margin on the committed fixtures); 0.10
+    // leaves slack for inference-order noise while catching a real
+    // regression to the sub-0.05 "noise floor" band.
     assert!(
-        margin > 0.2,
-        "expected cosine margin > 0.2, got {margin:.4} (ranked: {ranked:?})"
+        margin > 0.10,
+        "expected cosine margin > 0.10, got {margin:.4} (ranked: {ranked:?})"
+    );
+}
+
+// #233 — DE quality gate. MiniLM fails these because DE queries cluster
+// at the noise floor (~0.30–0.34 cosine across all topics, margins ~0);
+// e5-small-multilingual separates topics cleanly. Margin threshold 0.10
+// is conservative vs. EN 0.20 — multilingual models spread DE somewhat
+// tighter than native-EN MiniLM does EN, but still well above noise.
+
+#[test]
+fn de_query_hundeerziehung_top1_is_hund_with_margin() {
+    let Some(ranked) = rank_de("Wie erziehe ich einen Hund richtig?") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    assert_eq!(
+        ranked[0].0, "hund_verhalten",
+        "expected top-1 == `hund_verhalten`, got {ranked:?}"
+    );
+    let margin = ranked[0].1 - ranked[1].1;
+    assert!(
+        margin > 0.10,
+        "expected DE cosine margin > 0.10, got {margin:.4} (ranked: {ranked:?})"
+    );
+}
+
+#[test]
+fn de_query_neuronale_netze_top1_is_ml_with_margin() {
+    let Some(ranked) = rank_de("Was sind neuronale Netze im maschinellen Lernen?") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    assert_eq!(
+        ranked[0].0, "maschinelles_lernen_de",
+        "expected top-1 == `maschinelles_lernen_de`, got {ranked:?}"
+    );
+    let margin = ranked[0].1 - ranked[1].1;
+    assert!(
+        margin > 0.10,
+        "expected DE cosine margin > 0.10, got {margin:.4} (ranked: {ranked:?})"
     );
 }

--- a/src-tauri/src/tests/semantic_quality.rs
+++ b/src-tauri/src/tests/semantic_quality.rs
@@ -1,0 +1,100 @@
+//! #208 — Semantic quality sanity test.
+//!
+//! Guards against silent retrieval-quality regressions in the embedding
+//! stack. Uses the five mini-docs from research #188
+//! (`pizza_dough`, `bread_baking`, `cat_behavior`, `machine_learning`,
+//! `sourdough_starter`) as a ground-truth corpus with two
+//! cluster-crossing queries.
+//!
+//! Runs as a regular CI job (no `#[ignore]`). Skips cleanly when the
+//! MiniLM model isn't bundled, consistent with every other test in this
+//! module — no CI flakes on hosts without the model.
+//!
+//! Similarity is MiniLM L2-normalised dot product (== cosine) and we
+//! brute-force all 5 docs rather than going through HNSW/RRF. This is
+//! deliberate: we're testing the *embedding quality*, not the index or
+//! the fuser. If a regression here ever aligns suspiciously with an HNSW
+//! change, that's the signal that HNSW has drifted, not the embedder.
+
+#![cfg(feature = "embeddings")]
+
+use crate::embeddings::EmbeddingService;
+
+const FIXTURES: &[(&str, &str)] = &[
+    (
+        "pizza_dough",
+        include_str!("../../tests/fixtures/semantic_quality/pizza_dough.md"),
+    ),
+    (
+        "bread_baking",
+        include_str!("../../tests/fixtures/semantic_quality/bread_baking.md"),
+    ),
+    (
+        "cat_behavior",
+        include_str!("../../tests/fixtures/semantic_quality/cat_behavior.md"),
+    ),
+    (
+        "machine_learning",
+        include_str!("../../tests/fixtures/semantic_quality/machine_learning.md"),
+    ),
+    (
+        "sourdough_starter",
+        include_str!("../../tests/fixtures/semantic_quality/sourdough_starter.md"),
+    ),
+];
+
+/// Dot product — vectors are MiniLM-L2-normalised so this is cosine similarity.
+fn cos(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// Embed the fixtures + query and return `(name, score)` pairs sorted
+/// descending. Returns `None` when the model isn't bundled (so tests
+/// can skip cleanly on CI hosts without the model resource).
+fn rank_fixtures(query: &str) -> Option<Vec<(&'static str, f32)>> {
+    let svc = EmbeddingService::load(None).ok()?;
+    let q = svc.embed(query).expect("query embed failed");
+    let mut scored: Vec<(&'static str, f32)> = FIXTURES
+        .iter()
+        .map(|(name, body)| {
+            let v = svc.embed(body).expect("fixture embed failed");
+            (*name, cos(&q, &v))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    Some(scored)
+}
+
+#[test]
+fn italian_flatbread_top3_contains_pizza_and_bread() {
+    let Some(ranked) = rank_fixtures("Italian flatbread techniques") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    let top3: Vec<&str> = ranked.iter().take(3).map(|(n, _)| *n).collect();
+    assert!(
+        top3.contains(&"pizza_dough"),
+        "expected `pizza_dough` in top-3, got {ranked:?}"
+    );
+    assert!(
+        top3.contains(&"bread_baking"),
+        "expected `bread_baking` in top-3, got {ranked:?}"
+    );
+}
+
+#[test]
+fn feline_communication_top1_is_cat_with_margin() {
+    let Some(ranked) = rank_fixtures("how do felines communicate") else {
+        eprintln!("SKIP: embeddings not bundled");
+        return;
+    };
+    assert_eq!(
+        ranked[0].0, "cat_behavior",
+        "expected top-1 == `cat_behavior`, got {ranked:?}"
+    );
+    let margin = ranked[0].1 - ranked[1].1;
+    assert!(
+        margin > 0.2,
+        "expected cosine margin > 0.2, got {margin:.4} (ranked: {ranked:?})"
+    );
+}

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -23,6 +23,8 @@ use tokio::time::sleep;
 
 use crate::WriteIgnoreList;
 use crate::indexer::IndexCmd;
+#[cfg(feature = "embeddings")]
+use crate::embeddings::EmbedOp;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -95,6 +97,7 @@ pub fn spawn_watcher(
     write_ignore: Arc<Mutex<WriteIgnoreList>>,
     vault_reachable: Arc<Mutex<bool>>,
     index_tx: Option<tokio::sync::mpsc::Sender<IndexCmd>>,
+    #[cfg(feature = "embeddings")] embed_tx: Option<tokio::sync::mpsc::Sender<EmbedOp>>,
 ) -> Debouncer<RecommendedWatcher, RecommendedCache> {
     let vault_path_clone = vault_path.clone();
     let vault_reachable_for_error = vault_reachable.clone();
@@ -106,7 +109,15 @@ pub fn spawn_watcher(
         None,
         move |result: DebounceEventResult| match result {
             Ok(events) => {
-                process_events(&app_for_events, &write_ignore, &vault_path_clone, &index_tx, events);
+                process_events(
+                    &app_for_events,
+                    &write_ignore,
+                    &vault_path_clone,
+                    &index_tx,
+                    #[cfg(feature = "embeddings")]
+                    &embed_tx,
+                    events,
+                );
             }
             Err(errors) => {
                 for error in errors {
@@ -209,6 +220,7 @@ fn process_events(
     write_ignore: &Arc<Mutex<WriteIgnoreList>>,
     vault_path: &Path,
     index_tx: &Option<tokio::sync::mpsc::Sender<IndexCmd>>,
+    #[cfg(feature = "embeddings")] embed_tx: &Option<tokio::sync::mpsc::Sender<EmbedOp>>,
     events: Vec<DebouncedEvent>,
 ) {
     // Step 1: Filter dot-prefixed paths
@@ -254,6 +266,16 @@ fn process_events(
             dispatch_link_graph_cmd(tx, vault_path, &ev);
             // Step 5b: Dispatch tag-index commands (TAG-01/02)
             dispatch_tag_index_cmd(tx, vault_path, &ev);
+        }
+
+        // Step 5c (#201 PR-A): Tombstone vectors for externally-deleted
+        // and externally-renamed markdown files. Internal deletes go via
+        // commands::files which dispatches its own EmbedOp::Delete (see
+        // delete_file / rename_file / move_file), so this catches only
+        // events that bypass the write-ignore list — i.e. external tools.
+        #[cfg(feature = "embeddings")]
+        if let Some(tx) = embed_tx {
+            dispatch_embed_delete_cmd(tx, vault_path, &ev);
         }
 
         if let Some(payload) = map_event_to_payload(vault_path, &ev) {
@@ -445,6 +467,48 @@ pub(crate) fn dispatch_tag_index_cmd(
         }
         EventKind::Remove(_) => {
             try_send_or_warn(tx, IndexCmd::RemoveTags { rel_path });
+        }
+        _ => {}
+    }
+}
+
+/// #201 PR-A — dispatch `EmbedOp::Delete` for Remove / rename-from events
+/// on markdown paths. We only tombstone; creates & modifies rely on the
+/// save path (write_file dispatches Embed) and the reindex worker (#201
+/// PR-B) to re-embed externally-touched content. `try_send` so a full
+/// channel just drops — the worker state stays consistent because a
+/// subsequent reindex pass will clean up any missed tombstones.
+#[cfg(feature = "embeddings")]
+fn dispatch_embed_delete_cmd(
+    tx: &tokio::sync::mpsc::Sender<EmbedOp>,
+    vault_path: &Path,
+    ev: &DebouncedEvent,
+) {
+    let primary_path = match ev.paths.first() {
+        Some(p) => p,
+        None => return,
+    };
+    if primary_path
+        .extension()
+        .map_or(true, |ext| !ext.eq_ignore_ascii_case("md"))
+    {
+        return;
+    }
+    // Only in-vault paths; same guard as map_event_to_payload.
+    if !primary_path.starts_with(vault_path) {
+        return;
+    }
+
+    match &ev.kind {
+        EventKind::Remove(_) => {
+            let _ = tx.try_send(EmbedOp::Delete(primary_path.clone()));
+        }
+        EventKind::Modify(ModifyKind::Name(_)) => {
+            // Rename — the OLD path's vectors must be tombstoned. The
+            // NEW path (paths[1]) doesn't need an embed here; the user
+            // will save it via write_file which embeds via the save
+            // dispatch.
+            let _ = tx.try_send(EmbedOp::Delete(primary_path.clone()));
         }
         _ => {}
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "resources/onnxruntime/": "onnxruntime/"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,8 @@
     "active": true,
     "targets": "all",
     "resources": {
-      "resources/onnxruntime/": "onnxruntime/"
+      "resources/onnxruntime/": "onnxruntime/",
+      "resources/models/": "models/"
     },
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tests/fixtures/semantic_quality/bread_baking.md
+++ b/src-tauri/tests/fixtures/semantic_quality/bread_baking.md
@@ -1,0 +1,12 @@
+# Bread Baking
+
+Bread baking transforms a simple mixture of flour, water, salt, and yeast
+into a risen loaf through a sequence of fermentation and thermal steps.
+The dough is mixed, kneaded to develop the gluten network, and allowed a
+bulk proof during which yeast produces carbon dioxide and the gluten
+tightens. After shaping, a final proof lets the loaf relax and expand;
+the baker scores the surface to control the direction of oven spring. In
+a hot oven with steam the loaf gelatinises the starches, sets the crumb,
+caramelises the crust via the Maillard reaction, and loses residual
+moisture. Classic techniques — hearth baking, Dutch-oven baking, and
+stone-deck flatbread baking — are all variants of the same fundamentals.

--- a/src-tauri/tests/fixtures/semantic_quality/cat_behavior.md
+++ b/src-tauri/tests/fixtures/semantic_quality/cat_behavior.md
@@ -1,0 +1,15 @@
+# Cat Behavior
+
+Domestic cats communicate through a rich vocabulary of vocalisations, body
+postures, and scent marks. A low rumbling purr commonly signals contentment
+but can also appear in stressed or injured cats as a self-soothing
+mechanism. Ear position and tail carriage convey mood reliably: upright
+forward-facing ears with a relaxed vertical tail indicates confidence,
+while flattened ears and a puffed-up tail indicate fear or imminent
+aggression. A slow blink from a cat directed at a person is widely
+interpreted as a gesture of trust and affection, sometimes called a
+"cat kiss." Kneading with the front paws, often accompanied by purring,
+is a kitten behaviour retained into adulthood and expresses comfort.
+Meowing in adult cats is almost exclusively directed at humans, not at
+other cats, suggesting it is a learned feline-to-human communication
+channel.

--- a/src-tauri/tests/fixtures/semantic_quality/hund_verhalten.md
+++ b/src-tauri/tests/fixtures/semantic_quality/hund_verhalten.md
@@ -1,0 +1,12 @@
+# Hundeverhalten
+
+Hunde sind Rudeltiere und zeigen ein breites Spektrum an sozialen
+Verhaltensweisen. Sie kommunizieren über Körpersprache, Gesichtsausdruck,
+Lautäußerungen wie Bellen und Winseln sowie über Geruchsmarkierungen.
+Welpen lernen die Kommunikationsregeln ihres Rudels durch Nachahmung
+ihrer Mutter und der Wurfgeschwister. Erwachsene Hunde zeigen Unterwerfung
+durch eingeklappte Ruten und geduckte Haltung, während aufgerichtetes
+Fell und starrer Blick als Drohgebärden gelten. Artgerechte Auslastung
+durch Bewegung, Kopftraining und Sozialkontakt ist entscheidend für das
+Wohlbefinden und verhindert problematisches Verhalten wie übermäßiges
+Bellen oder destruktives Kauen.

--- a/src-tauri/tests/fixtures/semantic_quality/machine_learning.md
+++ b/src-tauri/tests/fixtures/semantic_quality/machine_learning.md
@@ -1,0 +1,14 @@
+# Machine Learning
+
+Machine learning is the study of algorithms that improve their performance
+on a task by learning patterns from data rather than following explicitly
+written rules. Supervised learning fits a model to labelled input/output
+pairs; unsupervised learning discovers structure in unlabelled data;
+reinforcement learning optimises a policy through reward signals from an
+environment. Training typically minimises a loss function via gradient
+descent over the parameters of a differentiable model such as a neural
+network, while validation on held-out data guards against overfitting.
+Feature engineering, regularisation, and careful data splits are as
+important to generalisation as model capacity itself. Modern practice
+leans heavily on large pretrained transformer models fine-tuned for
+downstream tasks in language, vision, and increasingly multimodal domains.

--- a/src-tauri/tests/fixtures/semantic_quality/maschinelles_lernen_de.md
+++ b/src-tauri/tests/fixtures/semantic_quality/maschinelles_lernen_de.md
@@ -1,0 +1,13 @@
+# Maschinelles Lernen
+
+Maschinelles Lernen bezeichnet Verfahren, bei denen Algorithmen Muster
+aus Daten extrahieren, statt fest programmiert zu werden. Beim
+überwachten Lernen trainiert man ein Modell anhand von Eingabe-Ausgabe-
+Paaren, beim unüberwachten Lernen werden Strukturen in unbeschrifteten
+Daten entdeckt. Das Training minimiert typischerweise eine Verlustfunktion
+mittels Gradientenabstieg über die Parameter eines differenzierbaren
+Modells, häufig eines neuronalen Netzes. Regularisierung und sorgfältige
+Trennung von Trainings- und Validierungsdaten schützen vor
+Überanpassung. In der modernen Praxis dominieren große, vortrainierte
+Transformer-Modelle, die für nachgelagerte Aufgaben wie Textklassifikation,
+maschinelle Übersetzung oder Bilderkennung feinjustiert werden.

--- a/src-tauri/tests/fixtures/semantic_quality/pizza_dough.md
+++ b/src-tauri/tests/fixtures/semantic_quality/pizza_dough.md
@@ -1,0 +1,12 @@
+# Pizza Dough
+
+Neapolitan pizza dough is a high-hydration, low-yeast Italian flatbread
+base made from "00" flour, water, salt, and a small amount of fresh yeast.
+The hydration typically sits between 60% and 65%, producing a soft, slack
+dough that develops gluten through a long autolyse rather than intensive
+kneading. After bulk fermentation at room temperature the dough is divided
+into 250 g balls, proofed for a further 6 to 8 hours, and hand-stretched
+into thin discs preserving a raised cornicione at the rim. Cooked on a
+preheated stone or steel at 450 °C the flatbread blisters and chars in
+60 to 90 seconds, yielding the leopard-spotted crust characteristic of a
+Naples-style pizza.

--- a/src-tauri/tests/fixtures/semantic_quality/pizza_teig_de.md
+++ b/src-tauri/tests/fixtures/semantic_quality/pizza_teig_de.md
@@ -1,0 +1,12 @@
+# Pizzateig
+
+Ein klassischer neapolitanischer Pizzateig besteht aus wenigen Zutaten:
+Mehl, Wasser, Salz und Hefe. Die Hydration liegt typischerweise zwischen
+60 und 70 Prozent, je nach Mehlqualität und gewünschter Krume. Nach dem
+Kneten folgt eine lange, kalte Stockgare im Kühlschrank über 24 bis 72
+Stunden – dabei entwickelt der Teig sein charakteristisches Aroma durch
+langsame Gärung. Kurz vor dem Backen wird der Teig zu Bällchen geformt
+und bei Raumtemperatur nochmals aufgehen gelassen. Ausgezogen werden die
+Teiglinge von Hand, ohne Nudelholz, um die Randbildung (Cornicione) zu
+erhalten. Gebacken wird idealerweise im Holzofen bei rund 450 Grad
+Celsius für 60 bis 90 Sekunden.

--- a/src-tauri/tests/fixtures/semantic_quality/sourdough_starter.md
+++ b/src-tauri/tests/fixtures/semantic_quality/sourdough_starter.md
@@ -1,0 +1,13 @@
+# Sourdough Starter
+
+A sourdough starter is a living culture of wild yeasts and lactic acid
+bacteria maintained in a flour-and-water medium, used to leaven bread
+without commercial yeast. A starter is established by mixing equal parts
+flour and water and feeding it daily for 5 to 10 days until it reliably
+doubles in volume between feedings. Once mature, the culture can be kept
+on the counter with twice-daily feedings or in the fridge with weekly
+feedings. A dark liquid layer called hooch on top of a hungry starter
+signals alcohol produced by the yeast and is a sign it is time to feed.
+The balance between Lactobacillus species and the resident yeast
+(often Saccharomyces or Kazachstania) determines the final flavour —
+warmer hydration schedules favour tang, cooler schedules favour mildness.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,7 +13,8 @@
     pickVaultFolder,
     repairVaultIndex,
   } from "./ipc/commands";
-  import { listenIndexProgress } from "./ipc/events";
+  import { listenIndexProgress, listenReindexProgress } from "./ipc/events";
+  import { reindexStore } from "./store/reindexStore";
   import { isVaultError, vaultErrorCopy } from "./types/errors";
   import type { RecentVault } from "./types/vault";
   import "./types/e2e-hook";
@@ -24,6 +25,7 @@
 
   let recent: RecentVault[] = $state([]);
   let unlistenProgress: (() => void) | null = null;
+  let unlistenReindex: (() => void) | null = null;
 
   // Custom CSS snippets (#64): keep one HTMLStyleElement per enabled snippet
   // mounted at the top of document.head, tagged with data-snippet="<filename>".
@@ -176,6 +178,12 @@
       progressStore.update(payload.current, payload.total, payload.current_file);
     });
 
+    // #201: pipe semantic-reindex progress events into the reindexStore so
+    // the statusbar overlay and settings modal can reflect live state.
+    unlistenReindex = await listenReindexProgress((payload) => {
+      reindexStore.apply(payload);
+    });
+
     // E2E test hook: expose loadVault + switchVault on window so WebDriver
     // specs can bypass the native file picker. Gated behind VITE_E2E=1 so
     // the hook is completely absent from normal release builds (tree-shaken
@@ -269,6 +277,7 @@
 
   onDestroy(() => {
     unlistenProgress?.();
+    unlistenReindex?.();
     unsubSnippets();
   });
 </script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,7 @@
     openVault,
     pickVaultFolder,
     repairVaultIndex,
+    reindexVault,
   } from "./ipc/commands";
   import { listenIndexProgress, listenReindexProgress } from "./ipc/events";
   import { reindexStore } from "./store/reindexStore";
@@ -246,6 +247,26 @@
         if (!view) return "";
         return view.state.doc.toString();
       };
+      // #204: subscribe once to the reindex-done signal so E2E specs can
+      // wait for embeddings to be queryable before running a semantic-only
+      // search. We keep a single listener for the lifetime of the window
+      // and broadcast the terminal phase to any pending waiter.
+      const { listenReindexProgress: listenReindex } = await import("./ipc/events");
+      const waiters: Array<(result: "done" | "cancelled") => void> = [];
+      await listenReindex((payload) => {
+        if (payload.phase === "done" || payload.phase === "cancelled") {
+          const pending = waiters.splice(0);
+          for (const resolve of pending) resolve(payload.phase);
+        }
+      });
+      const reindexAndWaitDone = (): Promise<void> =>
+        new Promise((resolve, reject) => {
+          waiters.push((phase) => {
+            if (phase === "done") resolve();
+            else reject(new Error(`reindex ended with phase=${phase}`));
+          });
+          reindexVault().catch(reject);
+        });
       window.__e2e__ = {
         loadVault,
         switchVault,
@@ -256,6 +277,7 @@
         finishProgress,
         typeInActiveEditor,
         getActiveDocText,
+        reindexAndWaitDone,
       };
     }
 

--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -11,6 +11,7 @@
   import { listenFileChange } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import type { LocalGraph, GraphNode } from "../../types/links";
+  import { clusterGraph } from "./clusterGraph";
 
   // ── Persistence ─────────────────────────────────────────────────────────────
   const CAMERA_KEY_PREFIX = "vaultcore-graph-camera-";
@@ -20,6 +21,8 @@
   // #235 — embedding-mode persistence keys.
   const MODE_KEY_PREFIX = "vaultcore-graph-mode-";
   const THRESHOLD_KEY_PREFIX = "vaultcore-graph-threshold-";
+  // #237 — second embedding-mode slider: cluster-collapse threshold.
+  const CLUSTER_KEY_PREFIX = "vaultcore-graph-cluster-";
 
   // #235 — embedding-mode constants. `top_k` is fixed in v1; widen the
   // slider to 0.30 so users can deliberately surface looser relations
@@ -31,6 +34,16 @@
   const EMBEDDING_THRESHOLD_MAX = 0.95;
   const EMBEDDING_THRESHOLD_DEFAULT = 0.7;
   const EMBEDDING_THRESHOLD_STEP = 0.05;
+
+  // #237 — cluster slider. Right edge (= 1.0) disables clustering. Min
+  // value sits at 0.55 so the user never sees an effectively useless
+  // sub-edge-threshold range; the actual lower bound is clamped to the
+  // current edge threshold at runtime (clusterThresholdMin below).
+  const CLUSTER_THRESHOLD_ABS_MIN = 0.55;
+  const CLUSTER_THRESHOLD_MAX = 1.0;
+  const CLUSTER_THRESHOLD_DEFAULT = 1.0;
+  const CLUSTER_THRESHOLD_STEP = 0.05;
+  const CLUSTER_DEBOUNCE_MS = 200;
 
   /**
    * Small synchronous string hash — used to key per-vault localStorage slots.
@@ -180,6 +193,26 @@
     }
   }
 
+  function loadClusterThreshold(vaultPath: string): number {
+    try {
+      const raw = localStorage.getItem(CLUSTER_KEY_PREFIX + hashVaultPath(vaultPath));
+      if (!raw) return CLUSTER_THRESHOLD_DEFAULT;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) return CLUSTER_THRESHOLD_DEFAULT;
+      return Math.min(CLUSTER_THRESHOLD_MAX, Math.max(CLUSTER_THRESHOLD_ABS_MIN, n));
+    } catch {
+      return CLUSTER_THRESHOLD_DEFAULT;
+    }
+  }
+
+  function saveClusterThreshold(vaultPath: string, t: number): void {
+    try {
+      localStorage.setItem(CLUSTER_KEY_PREFIX + hashVaultPath(vaultPath), String(t));
+    } catch {
+      /* ignore */
+    }
+  }
+
   // ── State ───────────────────────────────────────────────────────────────────
   let vaultPath = $state<string | null>(null);
   let tabs = $state<Tab[]>([]);
@@ -206,6 +239,14 @@
   // a distinct empty state so users know to wait for indexing rather
   // than lower the threshold.
   let embeddingsUnavailable = $state<boolean>(false);
+  // #237 — 1.0 = clustering off; any lower value collapses notes whose
+  // pairwise cosine similarity clears this threshold. Two values: the
+  // instant slider reading (shown on the UI) and the debounced applied
+  // value (fed into the render pipeline). Separating them keeps the
+  // thumb responsive while avoiding per-mousemove sim rebuilds.
+  let embeddingClusterThreshold = $state<number>(CLUSTER_THRESHOLD_DEFAULT);
+  let embeddingClusterThresholdApplied = $state<number>(CLUSTER_THRESHOLD_DEFAULT);
+  let clusterTimer: ReturnType<typeof setTimeout> | null = null;
 
   let unlistenFileChange: UnlistenFn | null = null;
   let refetchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -230,6 +271,9 @@
         frozen = loadFrozen(vaultPath);
         mode = loadMode(vaultPath);
         embeddingThreshold = loadThreshold(vaultPath);
+        const loadedCluster = loadClusterThreshold(vaultPath);
+        embeddingClusterThreshold = loadedCluster;
+        embeddingClusterThresholdApplied = loadedCluster;
       }
       // Vault identity changed → refetch with full relayout.
       datasetVersion += 1;
@@ -253,6 +297,33 @@
       return t.filePath.slice(vaultPath.length + 1);
     }
     return null;
+  });
+
+  // Cluster slider's effective lower bound — clamped to the edge threshold
+  // so the user never gets a slider range that can't cluster anything
+  // (edges below `embeddingThreshold` are filtered out backend-side and
+  // therefore never union a cluster; with cluster_threshold < edge_threshold
+  // every surviving edge would collapse into a single mega-cluster).
+  const clusterThresholdMin = $derived.by<number>(() => {
+    return Math.max(CLUSTER_THRESHOLD_ABS_MIN, embeddingThreshold);
+  });
+
+  // Effective cluster threshold feeding the render pipeline. Uses the
+  // debounced `Applied` value and clamps it to the current edge threshold
+  // so a below-edge cluster_threshold doesn't accidentally collapse every
+  // surviving edge into a mega-cluster.
+  const effectiveClusterThreshold = $derived.by<number>(() => {
+    return Math.max(clusterThresholdMin, embeddingClusterThresholdApplied);
+  });
+
+  // #237 — clustered view handed to GraphCanvas. In link mode or when the
+  // slider is at the off position this is a reference passthrough so the
+  // canvas-side memo/equality checks don't see a new object per tick.
+  const renderedData = $derived.by<LocalGraph | null>(() => {
+    if (!data) return null;
+    if (mode !== "embedding") return data;
+    if (effectiveClusterThreshold >= CLUSTER_THRESHOLD_MAX) return data;
+    return clusterGraph(data, effectiveClusterThreshold).graph;
   });
 
   // Available tag/folder filter options derived from the current dataset.
@@ -426,6 +497,24 @@
     }, THRESHOLD_DEBOUNCE_MS);
   }
 
+  function onClusterChange(next: number): void {
+    const clamped = Math.min(
+      CLUSTER_THRESHOLD_MAX,
+      Math.max(CLUSTER_THRESHOLD_ABS_MIN, next),
+    );
+    embeddingClusterThreshold = clamped;
+    if (vaultPath) saveClusterThreshold(vaultPath, clamped);
+    // Debounce the render-feeding `Applied` value so rapid slider drags
+    // don't rebuild the force simulation on every mousemove. Clustering
+    // itself is a pure O(N+E) pass — the expensive downstream work is
+    // sigma + d3-force reacting to a new node/edge set.
+    if (clusterTimer) clearTimeout(clusterTimer);
+    clusterTimer = setTimeout(() => {
+      clusterTimer = null;
+      embeddingClusterThresholdApplied = clamped;
+    }, CLUSTER_DEBOUNCE_MS);
+  }
+
   function onCameraChange(cam: SavedCamera): void {
     if (vaultPath) saveCamera(vaultPath, cam);
   }
@@ -509,6 +598,7 @@
     unlistenFileChange?.();
     if (refetchTimer) clearTimeout(refetchTimer);
     if (thresholdTimer) clearTimeout(thresholdTimer);
+    if (clusterTimer) clearTimeout(clusterTimer);
   });
 </script>
 
@@ -549,6 +639,24 @@
         />
         <span class="vc-graph-threshold-value">{embeddingThreshold.toFixed(2)}</span>
       </label>
+      <label class="vc-graph-threshold" title="Fasst ähnliche Notizen zu einem Oberbegriff zusammen. Rechts (1.00) = aus.">
+        <span class="vc-graph-threshold-label">Cluster</span>
+        <input
+          type="range"
+          min={clusterThresholdMin}
+          max={CLUSTER_THRESHOLD_MAX}
+          step={CLUSTER_THRESHOLD_STEP}
+          value={Math.max(clusterThresholdMin, embeddingClusterThreshold)}
+          oninput={(e) =>
+            onClusterChange(Number((e.target as HTMLInputElement).value))}
+          aria-label="Cluster-Schwellwert"
+        />
+        <span class="vc-graph-threshold-value">
+          {embeddingClusterThreshold >= CLUSTER_THRESHOLD_MAX
+            ? "aus"
+            : Math.max(clusterThresholdMin, embeddingClusterThreshold).toFixed(2)}
+        </span>
+      </label>
     {/if}
   </div>
   {#if errorMessage}
@@ -565,7 +673,7 @@
     </div>
   {:else}
     <GraphCanvas
-      {data}
+      data={renderedData}
       activeId={activeRelPath}
       {savedCamera}
       dimForNode={(id) => dimForNode(id)}

--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -7,7 +7,7 @@
   import { DEFAULT_FORCE_SETTINGS, type ForceSettings } from "./graphRender";
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore, type Tab, GRAPH_TAB_PATH } from "../../store/tabStore";
-  import { getLinkGraph } from "../../ipc/commands";
+  import { getEmbeddingGraph, getLinkGraph } from "../../ipc/commands";
   import { listenFileChange } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import type { LocalGraph, GraphNode } from "../../types/links";
@@ -17,6 +17,20 @@
   const FILTER_KEY_PREFIX = "vaultcore-graph-filters-";
   const FORCES_KEY_PREFIX = "vaultcore-graph-forces-";
   const FROZEN_KEY_PREFIX = "vaultcore-graph-frozen-";
+  // #235 — embedding-mode persistence keys.
+  const MODE_KEY_PREFIX = "vaultcore-graph-mode-";
+  const THRESHOLD_KEY_PREFIX = "vaultcore-graph-threshold-";
+
+  // #235 — embedding-mode constants. `top_k` is fixed in v1; widen the
+  // slider to 0.30 so users can deliberately surface looser relations
+  // (multilingual-e5-small real semantic matches sit at 0.4–0.8 per the
+  // semantic-search noise floor in `query.rs`).
+  type GraphMode = "link" | "embedding";
+  const EMBEDDING_TOP_K = 10;
+  const EMBEDDING_THRESHOLD_MIN = 0.3;
+  const EMBEDDING_THRESHOLD_MAX = 0.95;
+  const EMBEDDING_THRESHOLD_DEFAULT = 0.7;
+  const EMBEDDING_THRESHOLD_STEP = 0.05;
 
   /**
    * Small synchronous string hash — used to key per-vault localStorage slots.
@@ -129,6 +143,43 @@
     }
   }
 
+  function loadMode(vaultPath: string): GraphMode {
+    try {
+      const raw = localStorage.getItem(MODE_KEY_PREFIX + hashVaultPath(vaultPath));
+      return raw === "embedding" ? "embedding" : "link";
+    } catch {
+      return "link";
+    }
+  }
+
+  function saveMode(vaultPath: string, m: GraphMode): void {
+    try {
+      localStorage.setItem(MODE_KEY_PREFIX + hashVaultPath(vaultPath), m);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function loadThreshold(vaultPath: string): number {
+    try {
+      const raw = localStorage.getItem(THRESHOLD_KEY_PREFIX + hashVaultPath(vaultPath));
+      if (!raw) return EMBEDDING_THRESHOLD_DEFAULT;
+      const n = Number(raw);
+      if (!Number.isFinite(n)) return EMBEDDING_THRESHOLD_DEFAULT;
+      return Math.min(EMBEDDING_THRESHOLD_MAX, Math.max(EMBEDDING_THRESHOLD_MIN, n));
+    } catch {
+      return EMBEDDING_THRESHOLD_DEFAULT;
+    }
+  }
+
+  function saveThreshold(vaultPath: string, t: number): void {
+    try {
+      localStorage.setItem(THRESHOLD_KEY_PREFIX + hashVaultPath(vaultPath), String(t));
+    } catch {
+      /* ignore */
+    }
+  }
+
   // ── State ───────────────────────────────────────────────────────────────────
   let vaultPath = $state<string | null>(null);
   let tabs = $state<Tab[]>([]);
@@ -145,9 +196,30 @@
   let frozen = $state<boolean>(false);
   let forcesPanelOpen = $state<boolean>(false);
 
+  // #235 — embedding-mode state.
+  let mode = $state<GraphMode>("link");
+  let embeddingThreshold = $state<number>(EMBEDDING_THRESHOLD_DEFAULT);
+  // Discriminator for "embeddings not initialised" vs "no edges over
+  // threshold": the backend returns an empty payload for the former
+  // (vault not open, embeddings subsystem missing, sink empty). When in
+  // embedding mode and the response has zero nodes, we surface that as
+  // a distinct empty state so users know to wait for indexing rather
+  // than lower the threshold.
+  let embeddingsUnavailable = $state<boolean>(false);
+
   let unlistenFileChange: UnlistenFn | null = null;
   let refetchTimer: ReturnType<typeof setTimeout> | null = null;
   const REFETCH_DEBOUNCE_MS = 300;
+  // Threshold-slider drag → debounce IPC re-queries so dragging doesn't
+  // spam the backend. 200ms is the smallest debounce that feels
+  // responsive while still coalescing typical drag traffic.
+  const THRESHOLD_DEBOUNCE_MS = 200;
+  let thresholdTimer: ReturnType<typeof setTimeout> | null = null;
+  // Monotonic request id — only the latest in-flight refetch is allowed
+  // to commit its response to `data`. Without this, a slow link-graph
+  // load racing a fast embedding-graph swap would overwrite the newer
+  // result with the stale one.
+  let inflightRequestId = 0;
 
   const unsubVault = vaultStore.subscribe((s) => {
     if (s.currentPath !== vaultPath) {
@@ -156,6 +228,8 @@
         filters = loadFilters(vaultPath);
         forces = loadForces(vaultPath);
         frozen = loadFrozen(vaultPath);
+        mode = loadMode(vaultPath);
+        embeddingThreshold = loadThreshold(vaultPath);
       }
       // Vault identity changed → refetch with full relayout.
       datasetVersion += 1;
@@ -292,21 +366,64 @@
   async function refetch(): Promise<void> {
     if (!vaultPath) {
       data = { nodes: [], edges: [] };
+      embeddingsUnavailable = false;
       return;
     }
+    inflightRequestId += 1;
+    const requestId = inflightRequestId;
     loading = true;
     errorMessage = null;
+    const currentMode = mode;
+    const currentThreshold = embeddingThreshold;
     try {
-      data = await getLinkGraph();
+      const result =
+        currentMode === "embedding"
+          ? await getEmbeddingGraph(EMBEDDING_TOP_K, currentThreshold)
+          : await getLinkGraph();
+      // Stale-response guard: a newer refetch superseded this one.
+      if (requestId !== inflightRequestId) return;
+      data = result;
+      // In embedding mode, an empty-node payload is the backend's
+      // signal that embeddings aren't ready (sink missing, vault not
+      // open for embeddings yet, etc.). Link mode hits the same empty
+      // state only for truly empty vaults, which has its own message.
+      embeddingsUnavailable =
+        currentMode === "embedding" && result.nodes.length === 0;
     } catch (err) {
+      if (requestId !== inflightRequestId) return;
       errorMessage =
         err && typeof err === "object" && "message" in err
           ? String((err as { message: unknown }).message)
           : "Graph konnte nicht geladen werden.";
       data = { nodes: [], edges: [] };
+      embeddingsUnavailable = false;
     } finally {
-      loading = false;
+      if (requestId === inflightRequestId) loading = false;
     }
+  }
+
+  function onModeChange(next: GraphMode): void {
+    if (next === mode) return;
+    mode = next;
+    if (vaultPath) saveMode(vaultPath, next);
+    // Full dataset swap — force a layout re-seed so nodes don't animate
+    // from link-graph positions into embedding-graph positions.
+    datasetVersion += 1;
+    scheduleRefetch();
+  }
+
+  function onThresholdChange(next: number): void {
+    const clamped = Math.min(
+      EMBEDDING_THRESHOLD_MAX,
+      Math.max(EMBEDDING_THRESHOLD_MIN, next),
+    );
+    embeddingThreshold = clamped;
+    if (vaultPath) saveThreshold(vaultPath, clamped);
+    if (thresholdTimer) clearTimeout(thresholdTimer);
+    thresholdTimer = setTimeout(() => {
+      thresholdTimer = null;
+      void refetch();
+    }, THRESHOLD_DEBOUNCE_MS);
   }
 
   function onCameraChange(cam: SavedCamera): void {
@@ -391,17 +508,60 @@
     unsubTabsContent();
     unlistenFileChange?.();
     if (refetchTimer) clearTimeout(refetchTimer);
+    if (thresholdTimer) clearTimeout(thresholdTimer);
   });
 </script>
 
 <svelte:document onkeydown={handleKeydown} />
 
 <div class="vc-graph-view" role="region" aria-label="Graph-Ansicht">
+  <div class="vc-graph-mode-toolbar" role="group" aria-label="Graph-Modus">
+    <div class="vc-graph-mode-pills">
+      <button
+        type="button"
+        class="vc-graph-mode-pill"
+        class:vc-graph-mode-pill--active={mode === "link"}
+        onclick={() => onModeChange("link")}
+        aria-pressed={mode === "link"}
+        title="Link-basierter Graph (Wiki-Links)"
+      >Links</button>
+      <button
+        type="button"
+        class="vc-graph-mode-pill"
+        class:vc-graph-mode-pill--active={mode === "embedding"}
+        onclick={() => onModeChange("embedding")}
+        aria-pressed={mode === "embedding"}
+        title="Semantischer Graph (Embedding-Ähnlichkeit)"
+      >Semantisch</button>
+    </div>
+    {#if mode === "embedding"}
+      <label class="vc-graph-threshold">
+        <span class="vc-graph-threshold-label">Schwellwert</span>
+        <input
+          type="range"
+          min={EMBEDDING_THRESHOLD_MIN}
+          max={EMBEDDING_THRESHOLD_MAX}
+          step={EMBEDDING_THRESHOLD_STEP}
+          value={embeddingThreshold}
+          oninput={(e) =>
+            onThresholdChange(Number((e.target as HTMLInputElement).value))}
+          aria-label="Cosine-Schwellwert"
+        />
+        <span class="vc-graph-threshold-value">{embeddingThreshold.toFixed(2)}</span>
+      </label>
+    {/if}
+  </div>
   {#if errorMessage}
     <div class="vc-graph-empty">{errorMessage}</div>
   {:else if !data || data.nodes.length === 0}
     <div class="vc-graph-empty">
-      {loading ? "Graph wird geladen..." : "Keine Notizen im Vault."}
+      {#if loading}
+        Graph wird geladen...
+      {:else if mode === "embedding" && embeddingsUnavailable}
+        Semantischer Graph nicht verfügbar — Embeddings sind noch nicht erstellt.
+      {:else}
+        Keine Notizen im Vault.
+      {/if}
     </div>
   {:else}
     <GraphCanvas
@@ -503,5 +663,63 @@
     color: var(--color-accent);
     border-color: var(--color-accent);
     background: var(--color-accent-bg);
+  }
+  .vc-graph-mode-toolbar {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 11;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 4px 8px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+  }
+  .vc-graph-mode-pills {
+    display: inline-flex;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .vc-graph-mode-pill {
+    padding: 4px 10px;
+    background: transparent;
+    border: none;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .vc-graph-mode-pill + .vc-graph-mode-pill {
+    border-left: 1px solid var(--color-border);
+  }
+  .vc-graph-mode-pill:hover {
+    color: var(--color-accent);
+  }
+  .vc-graph-mode-pill--active {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+  .vc-graph-threshold {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: var(--color-text-muted);
+  }
+  .vc-graph-threshold-label {
+    user-select: none;
+  }
+  .vc-graph-threshold input[type="range"] {
+    width: 110px;
+    accent-color: var(--color-accent);
+  }
+  .vc-graph-threshold-value {
+    width: 28px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text);
   }
 </style>

--- a/src/components/Graph/__tests__/clusterGraph.test.ts
+++ b/src/components/Graph/__tests__/clusterGraph.test.ts
@@ -1,0 +1,194 @@
+// Pure-function tests for the embedding-mode clustering helper (#237).
+//
+// `clusterGraph` takes a LocalGraph produced by `get_embedding_graph` plus
+// a cluster-threshold slider value, and collapses any connected component
+// whose internal edges all clear the threshold into a single super-node.
+// No sigma / graphology imports — the helper is pure so we test it flat.
+
+import { describe, expect, it } from "vitest";
+import type { LocalGraph } from "../../../types/links";
+import { clusterGraph, CLUSTER_NODE_ID_PREFIX } from "../clusterGraph";
+
+function node(id: string, label: string, backlinkCount = 0) {
+  return { id, label, path: id, backlinkCount, resolved: true };
+}
+
+function edge(from: string, to: string, weight?: number) {
+  return weight === undefined ? { from, to } : { from, to, weight };
+}
+
+describe("clusterGraph", () => {
+  it("passes through unchanged when threshold >= 1.0", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md", 0.95)],
+    };
+    const out = clusterGraph(raw, 1.0);
+    expect(out.graph.nodes).toEqual(raw.nodes);
+    expect(out.graph.edges).toEqual(raw.edges);
+    expect(out.clusters.size).toBe(0);
+  });
+
+  it("passes through link-mode graphs (edges without weight) regardless of threshold", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md")],
+    };
+    const out = clusterGraph(raw, 0.5);
+    expect(out.graph.nodes).toEqual(raw.nodes);
+    expect(out.graph.edges).toEqual(raw.edges);
+    expect(out.clusters.size).toBe(0);
+  });
+
+  it("collapses a single high-weight pair into one super-node and drops its intra-edge", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md", 0.8)],
+    };
+    const out = clusterGraph(raw, 0.7);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.edges).toHaveLength(0);
+    expect(out.graph.nodes[0]!.id.startsWith(CLUSTER_NODE_ID_PREFIX)).toBe(true);
+    expect(out.clusters.size).toBe(1);
+  });
+
+  it("uses the min member id to derive the cluster id (stable across slider ticks)", () => {
+    const raw: LocalGraph = {
+      nodes: [node("z.md", "Z"), node("a.md", "A"), node("m.md", "M")],
+      edges: [
+        edge("z.md", "a.md", 0.9),
+        edge("a.md", "m.md", 0.85),
+        edge("z.md", "m.md", 0.82),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.id).toBe(`${CLUSTER_NODE_ID_PREFIX}a.md`);
+    const info = out.clusters.get(`${CLUSTER_NODE_ID_PREFIX}a.md`);
+    expect(info?.members).toEqual(["a.md", "m.md", "z.md"]);
+  });
+
+  it("picks the representative as the member with the highest sum of intra-cluster weights", () => {
+    // Weights: (a,b)=0.9, (a,c)=0.9, (b,c)=0.75
+    // Sums: a = 1.8, b = 1.65, c = 1.65 → a wins.
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B"), node("c.md", "C")],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("a.md", "c.md", 0.9),
+        edge("b.md", "c.md", 0.75),
+      ],
+    };
+    const out = clusterGraph(raw, 0.7);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.label.startsWith("A")).toBe(true);
+    expect(out.graph.nodes[0]!.label).toContain("+2");
+  });
+
+  it("breaks representative ties by backlinkCount then alphabetical id", () => {
+    // Weights tie all pairs at 0.8 so weight sums tie; b has highest backlinks.
+    const raw: LocalGraph = {
+      nodes: [
+        node("a.md", "Alpha", 1),
+        node("b.md", "Beta", 5),
+        node("c.md", "Gamma", 1),
+      ],
+      edges: [
+        edge("a.md", "b.md", 0.8),
+        edge("a.md", "c.md", 0.8),
+        edge("b.md", "c.md", 0.8),
+      ],
+    };
+    const out = clusterGraph(raw, 0.7);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.label.startsWith("Beta")).toBe(true);
+  });
+
+  it("labels the super-node as '<representative> · +N'", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "Alpha"), node("b.md", "Beta"), node("c.md", "Gamma")],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("a.md", "c.md", 0.85),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.label).toBe("Alpha · +2");
+  });
+
+  it("passes through singleton nodes unchanged (no incident high-weight edges)", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B"), node("lone.md", "Lone")],
+      edges: [edge("a.md", "b.md", 0.9)],
+    };
+    const out = clusterGraph(raw, 0.8);
+    // One cluster node + one lone singleton.
+    expect(out.graph.nodes).toHaveLength(2);
+    const lone = out.graph.nodes.find((n) => n.id === "lone.md");
+    expect(lone).toEqual(node("lone.md", "Lone"));
+  });
+
+  it("aggregates inter-cluster edges with the maximum member-pair weight", () => {
+    // Two clusters: {a,b} (via 0.9) and {c,d} (via 0.9).
+    // Cross edges a-c = 0.6, b-d = 0.65 → super-edge weight = 0.65.
+    const raw: LocalGraph = {
+      nodes: [
+        node("a.md", "A"),
+        node("b.md", "B"),
+        node("c.md", "C"),
+        node("d.md", "D"),
+      ],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("c.md", "d.md", 0.9),
+        edge("a.md", "c.md", 0.6),
+        edge("b.md", "d.md", 0.65),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(2);
+    expect(out.graph.edges).toHaveLength(1);
+    expect(out.graph.edges[0]!.weight).toBeCloseTo(0.65, 6);
+  });
+
+  it("filters self-loops after cluster collapse", () => {
+    // All edges above threshold → everything collapses into one cluster;
+    // every would-be edge becomes a self-loop and must be dropped.
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B"), node("c.md", "C")],
+      edges: [
+        edge("a.md", "b.md", 0.9),
+        edge("b.md", "c.md", 0.9),
+        edge("a.md", "c.md", 0.9),
+      ],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.edges).toHaveLength(0);
+  });
+
+  it("preserves a below-threshold edge between two singletons", () => {
+    const raw: LocalGraph = {
+      nodes: [node("a.md", "A"), node("b.md", "B")],
+      edges: [edge("a.md", "b.md", 0.6)],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(2);
+    expect(out.graph.edges).toHaveLength(1);
+    expect(out.graph.edges[0]).toEqual(raw.edges[0]);
+  });
+
+  it("sums member backlinkCounts onto the super-node so sizing reflects cluster mass", () => {
+    const raw: LocalGraph = {
+      nodes: [
+        node("a.md", "A", 3),
+        node("b.md", "B", 4),
+      ],
+      edges: [edge("a.md", "b.md", 0.9)],
+    };
+    const out = clusterGraph(raw, 0.8);
+    expect(out.graph.nodes).toHaveLength(1);
+    expect(out.graph.nodes[0]!.backlinkCount).toBe(7);
+  });
+});

--- a/src/components/Graph/clusterGraph.ts
+++ b/src/components/Graph/clusterGraph.ts
@@ -1,0 +1,219 @@
+// #237 — second graph-mode slider that collapses groups of highly-similar
+// notes into a single representative super-node ("Oberbegriff").
+//
+// Runs purely in the frontend between the backend IPC response and the
+// sigma/graphology render pass so the slider stays live (no roundtrip per
+// tick). Algorithm is a union-find over the weighted embedding graph:
+//
+//   1. Every edge whose cosine similarity clears `threshold` unions its
+//      endpoints. Lower threshold → more aggressive merging.
+//   2. Each component of size ≥ 2 becomes a super-node whose label
+//      surfaces the most "central" member (highest Σ intra-cluster
+//      weight), and whose backlinkCount is the sum of its members' so
+//      sigma renders it at a size that reflects cluster mass.
+//   3. Edges are rewritten onto super-node ids, self-loops are dropped,
+//      and multi-edges between the same cluster pair collapse to the
+//      max member-pair weight — consistent with the backend's
+//      chunk-pair-max aggregation.
+//
+// At `threshold >= 1.0` the helper is a strict passthrough, so the slider
+// at its right edge reproduces the raw per-note graph byte-for-byte.
+// Link-mode edges have no `weight`, so they never union anything and the
+// helper no-ops regardless of the threshold.
+
+import type { LocalGraph, GraphNode, GraphEdge } from "../../types/links";
+
+/** Super-node ids are prefixed so the surrounding UI can cheaply tell a
+ *  cluster apart from a real note (the Tauri side only ever mints real
+ *  note paths as ids). */
+export const CLUSTER_NODE_ID_PREFIX = "cluster:";
+
+export interface ClusterMembership {
+  /** Member id chosen as visual representative (max Σ intra-cluster weight,
+   *  tiebreak by backlinkCount then alphabetical id). */
+  representative: string;
+  /** All member ids in the cluster, including the representative. */
+  members: string[];
+}
+
+export interface ClusterResult {
+  graph: LocalGraph;
+  /** Keyed by the super-node id. Empty when no clustering was applied. */
+  clusters: Map<string, ClusterMembership>;
+}
+
+/**
+ * Collapse tight embedding components into super-nodes.
+ *
+ * Backwards-compatible shape: callers that only care about the resulting
+ * graph can destructure `.graph`; the `clusters` map is there for UI that
+ * wants to surface membership (e.g. tooltip listing, future expand-on-click).
+ */
+export function clusterGraph(raw: LocalGraph, threshold: number): ClusterResult {
+  // Fast path — slider at rest (= off). Also covers `threshold > 1.0`
+  // for paranoid callers.
+  if (threshold >= 1.0) {
+    return { graph: raw, clusters: new Map() };
+  }
+
+  // Build a parent array keyed by node id.
+  const parent = new Map<string, string>();
+  for (const n of raw.nodes) parent.set(n.id, n.id);
+
+  const find = (x: string): string => {
+    let cur = x;
+    while (parent.get(cur) !== cur) {
+      const p = parent.get(cur)!;
+      const gp = parent.get(p)!;
+      parent.set(cur, gp);
+      cur = gp;
+    }
+    return cur;
+  };
+  const union = (a: string, b: string): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra === rb) return;
+    // Deterministic union: prefer the lexicographically smaller root so
+    // cluster identity is stable across slider ticks.
+    if (ra < rb) parent.set(rb, ra);
+    else parent.set(ra, rb);
+  };
+
+  // Phase 1 — union high-weight edges. Edges without weight never union,
+  // which is how link-mode passthrough falls out naturally.
+  for (const e of raw.edges) {
+    if (typeof e.weight !== "number" || !Number.isFinite(e.weight)) continue;
+    if (e.weight < threshold) continue;
+    if (!parent.has(e.from) || !parent.has(e.to)) continue;
+    union(e.from, e.to);
+  }
+
+  // Phase 2 — group members by root.
+  const byRoot = new Map<string, string[]>();
+  for (const n of raw.nodes) {
+    const r = find(n.id);
+    const arr = byRoot.get(r);
+    if (arr) arr.push(n.id);
+    else byRoot.set(r, [n.id]);
+  }
+
+  // Detect whether anything actually clustered. If every root maps to a
+  // single-member component we can fast-path to passthrough — saves a
+  // surprising amount of churn on big vaults where the slider sits above
+  // the natural similarity ceiling.
+  let hasMultiMember = false;
+  for (const members of byRoot.values()) {
+    if (members.length >= 2) {
+      hasMultiMember = true;
+      break;
+    }
+  }
+  if (!hasMultiMember) {
+    return { graph: raw, clusters: new Map() };
+  }
+
+  // Phase 3 — for each multi-member component pick a representative and
+  // mint the super-node. Singletons pass through as-is.
+  const nodesById = new Map<string, GraphNode>();
+  for (const n of raw.nodes) nodesById.set(n.id, n);
+
+  // Per-member Σ intra-cluster weight — used by the representative picker.
+  const weightSum = new Map<string, number>();
+  for (const e of raw.edges) {
+    if (typeof e.weight !== "number" || !Number.isFinite(e.weight)) continue;
+    if (e.weight < threshold) continue;
+    if (find(e.from) !== find(e.to)) continue;
+    weightSum.set(e.from, (weightSum.get(e.from) ?? 0) + e.weight);
+    weightSum.set(e.to, (weightSum.get(e.to) ?? 0) + e.weight);
+  }
+
+  // Map original id → super-node id (or itself for singletons).
+  const remap = new Map<string, string>();
+  const clusters = new Map<string, ClusterMembership>();
+  const outNodes: GraphNode[] = [];
+
+  // Stable iteration: sort roots so the output node order is deterministic
+  // (nice for tests + snapshot-diff debugging).
+  const rootKeys = Array.from(byRoot.keys()).sort();
+
+  for (const root of rootKeys) {
+    const members = byRoot.get(root)!;
+    if (members.length === 1) {
+      const only = members[0]!;
+      remap.set(only, only);
+      outNodes.push(nodesById.get(only)!);
+      continue;
+    }
+
+    // Representative pick: max Σ weight, tiebreak by backlinkCount desc,
+    // then alphabetical id asc. Using a stable sort on a copy.
+    const ranked = members.slice().sort((a, b) => {
+      const wa = weightSum.get(a) ?? 0;
+      const wb = weightSum.get(b) ?? 0;
+      if (wa !== wb) return wb - wa;
+      const ba = nodesById.get(a)?.backlinkCount ?? 0;
+      const bb = nodesById.get(b)?.backlinkCount ?? 0;
+      if (ba !== bb) return bb - ba;
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+    const rep = ranked[0]!;
+
+    const sortedMembers = members.slice().sort();
+    const clusterId = CLUSTER_NODE_ID_PREFIX + sortedMembers[0]!;
+    const repNode = nodesById.get(rep)!;
+    const sumBacklinks = members.reduce(
+      (acc, m) => acc + (nodesById.get(m)?.backlinkCount ?? 0),
+      0,
+    );
+
+    outNodes.push({
+      id: clusterId,
+      label: `${repNode.label} · +${members.length - 1}`,
+      path: "",
+      backlinkCount: sumBacklinks,
+      resolved: true,
+    });
+
+    clusters.set(clusterId, { representative: rep, members: sortedMembers });
+    for (const m of members) remap.set(m, clusterId);
+  }
+
+  // Phase 4 — rewrite edges. Self-loops drop; duplicates between the same
+  // cluster pair collapse to the max observed member-pair weight (matches
+  // the backend's chunk-pair-max semantics).
+  const edgeByKey = new Map<string, GraphEdge>();
+  const passthrough: GraphEdge[] = [];
+  for (const e of raw.edges) {
+    const from = remap.get(e.from) ?? e.from;
+    const to = remap.get(e.to) ?? e.to;
+    if (from === to) continue;
+
+    // Only edges that touch a cluster need aggregation — passthrough the
+    // rest so link-mode graphs (no weight) keep their original edge list
+    // shape and the existing GraphCanvas equality checks don't thrash.
+    const isCluster = from.startsWith(CLUSTER_NODE_ID_PREFIX) || to.startsWith(CLUSTER_NODE_ID_PREFIX);
+    if (!isCluster) {
+      passthrough.push(e);
+      continue;
+    }
+
+    const lo = from < to ? from : to;
+    const hi = from < to ? to : from;
+    const key = `${lo}|${hi}`;
+    const w = typeof e.weight === "number" && Number.isFinite(e.weight) ? e.weight : 0;
+    const existing = edgeByKey.get(key);
+    if (!existing || (existing.weight ?? 0) < w) {
+      const next: GraphEdge = { from: lo, to: hi };
+      if (w > 0) next.weight = w;
+      edgeByKey.set(key, next);
+    }
+  }
+
+  const outEdges = passthrough.concat(Array.from(edgeByKey.values()));
+
+  return {
+    graph: { nodes: outNodes, edges: outEdges },
+    clusters,
+  };
+}

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -64,7 +64,12 @@ interface SimNode extends SimulationNodeDatum {
   radius: number;
 }
 
-type SimLink = SimulationLinkDatum<SimNode>;
+/** Link datum handed to d3-force. `weight` carries the edge similarity
+ *  (cosine in the 0..1 range) for the embedding-mode graph. Link-mode
+ *  edges leave it undefined — callers fall back to the scalar strength. */
+interface SimLink extends SimulationLinkDatum<SimNode> {
+  weight?: number;
+}
 
 /** Options accepted by `mountGraph` — future-proofed for the #32 global view.
  *  The `| undefined` on every optional member is deliberate: svelte-check runs
@@ -200,8 +205,42 @@ function populateGraph(graph: Graph, data: LocalGraph): void {
   for (const edge of data.edges) {
     if (!graph.hasNode(edge.from) || !graph.hasNode(edge.to)) continue;
     if (graph.hasEdge(edge.from, edge.to)) continue;
-    graph.addEdge(edge.from, edge.to);
+    const attrs: Record<string, unknown> = {};
+    if (typeof edge.weight === "number" && Number.isFinite(edge.weight)) {
+      attrs.weight = edge.weight;
+    }
+    graph.addEdge(edge.from, edge.to, attrs);
   }
+}
+
+// ── Weight-driven visual mapping ───────────────────────────────────────────────
+//
+// Edge weight (cosine similarity) flows through three visuals in embedding
+// mode: d3-force link strength/distance for spatial clustering, and edge
+// thickness/alpha for the rendered line. Link-mode edges carry no weight,
+// so the helpers fall back to a neutral 1.0 multiplier and the original
+// scalar strength/distance stay in effect.
+
+/** Normalize a weight into 0..1. Inputs outside the range clamp. */
+function normalizeWeight(weight: number | undefined): number | null {
+  if (typeof weight !== "number" || !Number.isFinite(weight)) return null;
+  if (weight <= 0) return 0;
+  if (weight >= 1) return 1;
+  return weight;
+}
+
+/** Edge rest length scales inversely with weight — stronger similarity pulls
+ *  nodes closer. Link-mode (weight=null) keeps the historical 80-unit default. */
+function edgeDistanceForWeight(weight: number | null): number {
+  if (weight === null) return 80;
+  return 120 - 80 * weight;
+}
+
+/** Edge pull strength multiplier. Link-mode passes through unchanged (1);
+ *  embedding-mode scales with weight so weak edges barely tug. */
+function edgeStrengthScaleForWeight(weight: number | null): number {
+  if (weight === null) return 1;
+  return 0.25 + 0.75 * weight;
 }
 
 /** Build the d3-force node/link datum arrays from the current graphology
@@ -229,9 +268,12 @@ function buildSimState(
     index.set(id, sim);
   });
   const links: SimLink[] = [];
-  graph.forEachEdge((_edge, _attrs, source, target) => {
+  graph.forEachEdge((_edge, attrs, source, target) => {
     if (index.has(source) && index.has(target)) {
-      links.push({ source, target });
+      const link: SimLink = { source, target };
+      const w = normalizeWeight(attrs.weight as number | undefined);
+      if (w !== null) link.weight = w;
+      links.push(link);
     }
   });
   return { nodes, links, index };
@@ -265,12 +307,21 @@ function applyForceSettings(
     | ReturnType<typeof forceLink<SimNode, SimLink>>
     | undefined;
   if (link) {
-    const strength = Math.min(1, Math.max(0, settings.edgeWeightInfluence));
-    link.strength(strength);
-    // Shorter rest length pulls linked nodes closer — combined with the
-    // capped repulsion range above this produces visible clusters instead
-    // of an evenly-spread globe.
-    link.distance(80);
+    const base = Math.min(1, Math.max(0, settings.edgeWeightInfluence));
+    // Per-edge strength: link-mode edges (no weight) keep the scalar `base`;
+    // embedding-mode edges fold in their cosine similarity so strong pairs
+    // pull hard and weak pairs barely register.
+    link.strength((l) => {
+      const w = normalizeWeight((l as SimLink).weight);
+      return base * edgeStrengthScaleForWeight(w);
+    });
+    // Shorter rest length pulls linked nodes closer. Embedding-mode edges
+    // shrink the rest length with weight so clusters of highly-similar
+    // notes visibly collapse toward each other.
+    link.distance((l) => {
+      const w = normalizeWeight((l as SimLink).weight);
+      return edgeDistanceForWeight(w);
+    });
   }
 
   const center = simulation.force("center") as
@@ -310,7 +361,7 @@ function buildSimulation(
       "link",
       forceLink<SimNode, SimLink>(links)
         .id((n) => n.id)
-        .distance(80),
+        .distance((l) => edgeDistanceForWeight(normalizeWeight((l as SimLink).weight))),
     )
     .force("charge", forceManyBody<SimNode>())
     .force("center", forceCenter<SimNode>(0, 0))
@@ -483,17 +534,30 @@ export function mountGraph(
     return result;
   });
 
-  // Edge reducer — hover dim for non-adjacent edges.
+  // Edge reducer — hover dim + weight-driven thickness/alpha.
+  //
+  // In embedding mode each edge carries a `weight` attr (cosine similarity
+  // in 0..1). Map it to:
+  //   size  : 1  → 3.5  (thicker line for stronger relations)
+  //   alpha : 0.45 → 1.0 (fade weak edges into the background)
+  //
+  // Link-mode edges have no weight — they render with the historical
+  // size=1 / full-opacity color, so the link graph is visually unchanged.
   renderer.setSetting("edgeReducer", (e, attrs) => {
+    const weight = normalizeWeight(attrs.weight as number | undefined);
+    const baseSize = weight === null ? 1 : 1 + weight * 2.5;
+    const baseAlpha = weight === null ? 1 : 0.45 + weight * 0.55;
+    const weightedEdgeColor = baseAlpha < 1 ? applyAlpha(edge, baseAlpha) : edge;
+
     if (!handle.hoveredNode) {
-      return { ...attrs, color: edge, size: 1 };
+      return { ...attrs, color: weightedEdgeColor, size: baseSize };
     }
     const [source, target] = graph.extremities(e);
     const adjacent = source === handle.hoveredNode || target === handle.hoveredNode;
     return {
       ...attrs,
-      color: adjacent ? edge : applyAlpha(edge, 0.2),
-      size: 1,
+      color: adjacent ? weightedEdgeColor : applyAlpha(edge, 0.2),
+      size: baseSize,
     };
   });
 

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -8,6 +8,7 @@
   import TemplatePicker from "../TemplatePicker/TemplatePicker.svelte";
   import RightSidebar from "./RightSidebar.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
+  import ReindexStatusbar from "../Statusbar/ReindexStatusbar.svelte";
   import { tabStore } from "../../store/tabStore";
   import { searchStore } from "../../store/searchStore";
   import { backlinksStore } from "../../store/backlinksStore";
@@ -813,6 +814,9 @@
   onClose={() => { settingsOpen = false; }}
   {onSwitchVault}
 />
+
+<!-- #201: reindex progress overlay. Self-hides while idle. -->
+<ReindexStatusbar />
 
 <style>
   .vc-vault-layout {

--- a/src/components/Search/OmniSearch.svelte
+++ b/src/components/Search/OmniSearch.svelte
@@ -22,10 +22,10 @@
   import { scrollStore } from "../../store/scrollStore";
   import {
     searchFilename,
-    searchFulltext,
+    hybridSearch,
     rebuildIndex,
   } from "../../ipc/commands";
-  import type { FileMatch, SearchResult } from "../../types/search";
+  import type { FileMatch, HybridHit } from "../../types/search";
   import { isVaultError } from "../../types/errors";
   import { extractSnippetMatch } from "../Editor/flashHighlight";
   import QuickSwitcherRow from "./QuickSwitcherRow.svelte";
@@ -109,7 +109,7 @@
   // Content-mode results + counts flow through searchStore so the
   // cross-vault reset + indexStale event subscription keep working.
   let storeState = $state({
-    results: [] as SearchResult[],
+    results: [] as HybridHit[],
     totalFiles: 0,
     isRebuilding: false,
   });
@@ -205,7 +205,10 @@
     }
     searchStore.setSearching(true);
     try {
-      const results = await searchFulltext(trimmed, 100);
+      // #204 — hybrid_search fuses BM25 + HNSW via RRF. Falls back to
+      // BM25-only transparently when embeddings aren't ready, so the UX
+      // stays identical while embeddings bootstrap.
+      const results = await hybridSearch(trimmed, 100);
       if (myGen !== contentSearchGen) return;
       const uniqueFiles = new Set(results.map((r) => r.path)).size;
       searchStore.setResults(results, uniqueFiles);
@@ -275,7 +278,7 @@
     onClose();
   }
 
-  function openContentResult(r: SearchResult) {
+  function openContentResult(r: HybridHit) {
     onOpenFile(r.path);
     const searchText =
       extractSnippetMatch(r.snippet) ?? query.split(" ")[0] ?? "";
@@ -291,7 +294,7 @@
       const hit = activeList[idx] as FileMatch | undefined;
       if (hit) openFileResult(hit);
     } else {
-      const hit = activeList[idx] as SearchResult | undefined;
+      const hit = activeList[idx] as HybridHit | undefined;
       if (hit) openContentResult(hit);
     }
   }
@@ -438,10 +441,10 @@
             <p class="vc-search-results-counter">
               {storeState.results.length} Treffer in {storeState.totalFiles} Dateien
             </p>
-            {#each activeList as result, i (`${(result as SearchResult).path}|${i}`)}
+            {#each activeList as result, i (`${(result as HybridHit).path}|${i}`)}
               <SearchResultRow
-                result={result as SearchResult}
-                onclick={() => openContentResult(result as SearchResult)}
+                result={result as HybridHit}
+                onclick={() => openContentResult(result as HybridHit)}
               />
             {/each}
             {#if storeState.results.length >= 100}

--- a/src/components/Search/SearchResultRow.svelte
+++ b/src/components/Search/SearchResultRow.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
-  import type { SearchResult as SearchResultType } from "../../types/search";
+  import { Sparkles } from "lucide-svelte";
+  import type { HybridHit } from "../../types/search";
 
   interface Props {
-    result: SearchResultType;
+    result: HybridHit;
     onclick: () => void;
   }
 
   let { result, onclick }: Props = $props();
 
   const filename = $derived(result.path.split("/").pop() ?? result.path);
+  // #204 — a hit surfaced only by the semantic leg of hybrid_search gets a
+  // subtle badge so users can tell the result came in via embedding
+  // similarity rather than keyword match. Hits present in both legs are
+  // already explained by the existing snippet highlighting, so no badge.
+  const semanticOnly = $derived(
+    result.vecRank !== undefined && result.bm25Rank === undefined,
+  );
 </script>
 
 <div
@@ -19,7 +27,18 @@
   {onclick}
   onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onclick(); } }}
 >
-  <p class="vc-search-result-filename">{filename}</p>
+  <p class="vc-search-result-filename">
+    <span class="vc-search-result-filename-text">{filename}</span>
+    {#if semanticOnly}
+      <span
+        class="vc-search-result-semantic-indicator"
+        title="Semantischer Treffer"
+        aria-label="Nur semantisch gefunden"
+      >
+        <Sparkles size={12} strokeWidth={2} />
+      </span>
+    {/if}
+  </p>
   <p class="vc-search-result-snippet vc-search-snippet">{@html result.snippet}</p>
 </div>
 
@@ -43,9 +62,24 @@
     font-weight: 700;
     color: var(--color-text);
     margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .vc-search-result-filename-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    min-width: 0;
+  }
+
+  .vc-search-result-semantic-indicator {
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
   }
 
   .vc-search-result-snippet {

--- a/src/components/Search/SearchResultRow.svelte
+++ b/src/components/Search/SearchResultRow.svelte
@@ -9,6 +9,11 @@
 
   let { result, onclick }: Props = $props();
 
+  // #231 — Cosine score below this floor is flagged "weak" (orange) so
+  // drift-y hits read at a glance. Anchor: #208 sanity test puts genuine
+  // semantic matches around 0.7–0.85; BM25-only fallbacks usually < 0.4.
+  const WEAK_MATCH_FLOOR = 0.3;
+
   const filename = $derived(result.path.split("/").pop() ?? result.path);
   // #204 — a hit surfaced only by the semantic leg of hybrid_search gets a
   // subtle badge so users can tell the result came in via embedding
@@ -16,6 +21,18 @@
   // already explained by the existing snippet highlighting, so no badge.
   const semanticOnly = $derived(
     result.vecRank !== undefined && result.bm25Rank === undefined,
+  );
+  // #231 — Match percent shown for every hit that has a vecScore (cosine
+  // similarity, MiniLM is L2-normalised so [-1, 1] in theory but [0, 1]
+  // for any reasonable text pair). Negative clamps to 0 %. BM25-only hits
+  // have no vecScore and therefore no percent.
+  const matchPercent = $derived(
+    result.vecScore === undefined
+      ? undefined
+      : Math.round(Math.max(0, result.vecScore) * 100),
+  );
+  const matchIsWeak = $derived(
+    result.vecScore !== undefined && result.vecScore < WEAK_MATCH_FLOOR,
   );
 </script>
 
@@ -36,6 +53,16 @@
         aria-label="Nur semantisch gefunden"
       >
         <Sparkles size={12} strokeWidth={2} />
+      </span>
+    {/if}
+    {#if matchPercent !== undefined}
+      <span
+        class="vc-search-result-match-percent"
+        class:vc-weak={matchIsWeak}
+        title="Cosine-Ähnlichkeit zur Suchanfrage"
+        aria-label="Match {matchPercent} Prozent"
+      >
+        {matchPercent}%
       </span>
     {/if}
   </p>
@@ -73,6 +100,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 0;
+    flex: 1 1 auto;
   }
 
   .vc-search-result-semantic-indicator {
@@ -80,6 +108,19 @@
     align-items: center;
     color: var(--color-text-muted);
     flex-shrink: 0;
+  }
+
+  .vc-search-result-match-percent {
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+    margin-left: auto;
+  }
+
+  .vc-search-result-match-percent.vc-weak {
+    color: var(--color-warning, #d97706);
   }
 
   .vc-search-result-snippet {

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -14,7 +14,7 @@ import { tick } from "svelte";
 
 vi.mock("../../../ipc/commands", () => ({
   searchFilename: vi.fn(),
-  searchFulltext: vi.fn(),
+  hybridSearch: vi.fn(),
   rebuildIndex: vi.fn(),
 }));
 vi.mock("../../../ipc/events", () => ({
@@ -23,7 +23,7 @@ vi.mock("../../../ipc/events", () => ({
 
 import {
   searchFilename,
-  searchFulltext,
+  hybridSearch,
   rebuildIndex,
 } from "../../../ipc/commands";
 import { vaultStore } from "../../../store/vaultStore";
@@ -87,7 +87,7 @@ describe("OmniSearch (#174)", () => {
 
   it("clicking the content tab switches mode and re-routes the active query", async () => {
     (searchFilename as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     const { container } = mountOpen({ initialMode: "filename" });
     await tick();
 
@@ -103,7 +103,7 @@ describe("OmniSearch (#174)", () => {
     await fireEvent.click(contentTab);
     await tick();
     await Promise.resolve();
-    expect(searchFulltext).toHaveBeenCalled();
+    expect(hybridSearch).toHaveBeenCalled();
   });
 
   // ── Backend dispatch per mode ─────────────────────────────────────────
@@ -119,11 +119,11 @@ describe("OmniSearch (#174)", () => {
     await tick();
     await Promise.resolve();
     expect(searchFilename).toHaveBeenCalledWith("alpha", 20);
-    expect(searchFulltext).not.toHaveBeenCalled();
+    expect(hybridSearch).not.toHaveBeenCalled();
   });
 
-  it("content mode dispatches searchFulltext on input", async () => {
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  it("content mode dispatches hybridSearch on input (#204)", async () => {
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     const { container } = mountOpen({ initialMode: "content" });
     await tick();
     const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
@@ -133,7 +133,7 @@ describe("OmniSearch (#174)", () => {
     // Content mode is debounced (same 200ms as the old SearchPanel) —
     // verify it eventually fires.
     await new Promise((r) => setTimeout(r, 250));
-    expect(searchFulltext).toHaveBeenCalled();
+    expect(hybridSearch).toHaveBeenCalled();
     expect(searchFilename).not.toHaveBeenCalled();
   });
 
@@ -168,7 +168,7 @@ describe("OmniSearch (#174)", () => {
 
   it("clears the rebuild status line on success and flips indexStale off", async () => {
     (rebuildIndex as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     searchStore.setIndexStale(true);
     const { container } = mountOpen({ initialMode: "content" });
     await tick();
@@ -204,7 +204,7 @@ describe("OmniSearch (#174)", () => {
   // ── Tag-prefill ───────────────────────────────────────────────────────
 
   it("initialQuery in content mode is placed in the input and runs the search", async () => {
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     const { container } = mountOpen({
       initialMode: "content",
       initialQuery: "#todo",
@@ -215,8 +215,8 @@ describe("OmniSearch (#174)", () => {
 
     const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
     expect(input.value).toBe("#todo");
-    expect(searchFulltext).toHaveBeenCalled();
-    const args = (searchFulltext as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(hybridSearch).toHaveBeenCalled();
+    const args = (hybridSearch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(args?.[0]).toBe("#todo");
   });
 
@@ -289,9 +289,9 @@ describe("OmniSearch (#174)", () => {
   // debounce fire — the caret must stay where the user left it.
 
   it("preserves the caret position across a debounced content-mode search", async () => {
-    let resolveFulltext!: (v: SearchResult[]) => void;
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      () => new Promise<SearchResult[]>((r) => { resolveFulltext = r; }),
+    let resolveFulltext!: (v: HybridHit[]) => void;
+    (hybridSearch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<HybridHit[]>((r) => { resolveFulltext = r; }),
     );
     const { container } = mountOpen({ initialMode: "content" });
     await tick();
@@ -308,7 +308,7 @@ describe("OmniSearch (#174)", () => {
     // the IPC promise. This is exactly the window where storeState updates
     // used to cascade into a bind:value re-sync that moved the caret.
     await new Promise((r) => setTimeout(r, 260));
-    expect(searchFulltext).toHaveBeenCalled();
+    expect(hybridSearch).toHaveBeenCalled();
     resolveFulltext([]);
     await Promise.resolve();
     await tick();
@@ -321,4 +321,4 @@ describe("OmniSearch (#174)", () => {
 });
 
 // Type re-import so the mock type cast above compiles.
-import type { SearchResult } from "../../../types/search";
+import type { HybridHit } from "../../../types/search";

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -12,6 +12,8 @@
   import { DEFAULT_DAILY_DATE_FORMAT } from "../../lib/dailyNotes";
   import { vaultStore } from "../../store/vaultStore";
   import { snippetsStore } from "../../store/snippetsStore";
+  import { reindexVault, cancelReindex } from "../../ipc/commands";
+  import { reindexStore, isActive as isReindexActive } from "../../store/reindexStore";
   import { formatShortcut } from "../../lib/shortcuts";
   import { commandRegistry, hotkeysEqual, type Command, type HotKey } from "../../lib/commands/registry";
   import { DEFAULT_COMMAND_SPECS } from "../../lib/commands/defaultCommands";
@@ -63,6 +65,8 @@
   let snippetsEnabled = $state<string[]>([]);
   let snippetsLoaded = $state<boolean>(false);
   let refreshingSnippets = $state<boolean>(false);
+  let semanticEnabled = $state<boolean>(false);
+  let reindexActive = $state<boolean>(false);
 
   const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
   const unsubSettings = settingsStore.subscribe((s) => {
@@ -72,6 +76,10 @@
     dailyFolder = s.dailyNotesFolder;
     dailyFormat = s.dailyNotesDateFormat;
     dailyTemplate = s.dailyNotesTemplate;
+    semanticEnabled = s.enableSemanticSearch;
+  });
+  const unsubReindex = reindexStore.subscribe((r) => {
+    reindexActive = isReindexActive(r);
   });
   const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
   const unsubCommands = commandRegistry.subscribe((list) => {
@@ -227,7 +235,25 @@
     }
   }
 
-  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); });
+  /** #201: master toggle for semantic search. Enabling fires the
+   *  background reindex against the open vault; disabling cancels it.
+   *  Both calls are fire-and-forget — the statusbar listens for the
+   *  `embed://reindex_progress` event and surfaces progress. */
+  async function onToggleSemantic(e: Event): Promise<void> {
+    const enabled = (e.target as HTMLInputElement).checked;
+    settingsStore.setEnableSemanticSearch(enabled);
+    try {
+      if (enabled) {
+        if (currentVaultPath) await reindexVault();
+      } else {
+        await cancelReindex();
+      }
+    } catch (err) {
+      console.warn("semantic toggle ipc failed", err);
+    }
+  }
+
+  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); unsubReindex(); });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -409,6 +435,38 @@
         <p class="vc-settings-hint">
           Unterstützte Tokens: <code>YYYY</code>, <code>MM</code>, <code>DD</code>.
           Fehlender Ordner wird beim ersten Öffnen erstellt.
+        </p>
+      </section>
+
+      <!-- Section — Semantische Suche (#201) -->
+      <section class="vc-settings-section" data-testid="settings-semantic">
+        <h3 class="vc-settings-section-title">SEMANTISCHE SUCHE</h3>
+        <div class="vc-settings-row">
+          <label for="semantic-toggle">Semantische Suche aktivieren</label>
+          <label class="vc-snippets-toggle">
+            <input
+              id="semantic-toggle"
+              data-testid="settings-semantic-toggle"
+              type="checkbox"
+              checked={semanticEnabled}
+              onchange={onToggleSemantic}
+              disabled={!currentVaultPath}
+              aria-label="Semantische Suche aktivieren"
+            />
+            <span class="vc-snippets-toggle-track" aria-hidden="true">
+              <span class="vc-snippets-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+        <p class="vc-settings-hint">
+          Erster Index-Lauf kann bei großen Vaults einige Minuten dauern und
+          läuft im Hintergrund. Fortschritt wird in der Statusleiste angezeigt.
+          {#if reindexActive}
+            <strong> Indexierung läuft …</strong>
+          {/if}
+          {#if !currentVaultPath}
+            <br />Öffne zuerst einen Vault, um die semantische Suche zu aktivieren.
+          {/if}
         </p>
       </section>
 

--- a/src/components/Statusbar/ReindexStatusbar.svelte
+++ b/src/components/Statusbar/ReindexStatusbar.svelte
@@ -1,0 +1,197 @@
+<!--
+  #201 PR-C — Statusbar strip that surfaces reindex progress to the user.
+
+  Self-hiding: renders nothing while the store is idle so the vault layout
+  stays clean for the (usually long) steady-state. Becomes visible on the
+  first `scan` / `index` event and disappears again ~3 s after the
+  terminal `done` / `cancelled` event (the timer is the only reason the
+  component needs local state — everything else is driven by the store).
+
+  Positioning: fixed bottom overlay, z-index above the editor but below
+  modals. Doesn't consume a grid row, so the VaultLayout grid stays
+  untouched.
+-->
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { X } from "lucide-svelte";
+  import { reindexStore } from "../../store/reindexStore";
+  import { cancelReindex } from "../../ipc/commands";
+  import type { ReindexPhase } from "../../ipc/events";
+
+  interface ViewModel {
+    visible: boolean;
+    phase: ReindexPhase | "idle";
+    done: number;
+    total: number;
+    skipped: number;
+    embedded: number;
+    etaSeconds: number | null;
+  }
+
+  const initialVm: ViewModel = {
+    visible: false,
+    phase: "idle",
+    done: 0,
+    total: 0,
+    skipped: 0,
+    embedded: 0,
+    etaSeconds: null,
+  };
+
+  let vm = $state<ViewModel>({ ...initialVm });
+  let hideTimer: number | null = null;
+
+  const unsub = reindexStore.subscribe((s) => {
+    if (hideTimer !== null) {
+      window.clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+    const isTerminal = s.phase === "done" || s.phase === "cancelled";
+    vm = {
+      visible: s.phase !== "idle",
+      phase: s.phase,
+      done: s.done,
+      total: s.total,
+      skipped: s.skipped,
+      embedded: s.embedded,
+      etaSeconds: s.etaSeconds,
+    };
+    if (isTerminal) {
+      hideTimer = window.setTimeout(() => {
+        vm = { ...initialVm };
+        hideTimer = null;
+      }, 3000);
+    }
+  });
+
+  onDestroy(() => {
+    if (hideTimer !== null) window.clearTimeout(hideTimer);
+    unsub();
+  });
+
+  function percentFor(v: ViewModel): number {
+    if (v.total <= 0) return 0;
+    return Math.min(100, Math.round((v.done / v.total) * 100));
+  }
+
+  function formatEta(seconds: number | null): string {
+    if (seconds === null || seconds <= 0) return "—";
+    if (seconds < 60) return `${seconds}s`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    if (m < 60) return `${m}m ${s.toString().padStart(2, "0")}s`;
+    const h = Math.floor(m / 60);
+    return `${h}h ${(m % 60).toString().padStart(2, "0")}m`;
+  }
+
+  function label(v: ViewModel): string {
+    switch (v.phase) {
+      case "scan":
+        return "Durchsuche Vault …";
+      case "index":
+        return `${v.done.toLocaleString("de-DE")} / ${v.total.toLocaleString("de-DE")}`;
+      case "done":
+        return `Fertig — ${v.embedded.toLocaleString("de-DE")} Dateien indexiert, ${v.skipped.toLocaleString("de-DE")} übersprungen`;
+      case "cancelled":
+        return `Abgebrochen — ${v.done.toLocaleString("de-DE")} von ${v.total.toLocaleString("de-DE")} bearbeitet`;
+      default:
+        return "";
+    }
+  }
+
+  async function onCancel(): Promise<void> {
+    try {
+      await cancelReindex();
+    } catch (err) {
+      console.warn("cancel reindex ipc failed", err);
+    }
+  }
+</script>
+
+{#if vm.visible}
+  <div class="vc-reindex-bar" role="status" aria-live="polite" data-testid="reindex-statusbar">
+    <div class="vc-reindex-label">Semantik-Index: {label(vm)}</div>
+    {#if vm.phase === "index" && vm.total > 0}
+      <div class="vc-reindex-progress" aria-hidden="true">
+        <div class="vc-reindex-progress-fill" style="width: {percentFor(vm)}%"></div>
+      </div>
+      <div class="vc-reindex-eta">ETA {formatEta(vm.etaSeconds)}</div>
+    {/if}
+    {#if vm.phase === "scan" || vm.phase === "index"}
+      <button
+        type="button"
+        class="vc-reindex-cancel"
+        onclick={onCancel}
+        aria-label="Reindex abbrechen"
+        title="Reindex abbrechen"
+      ><X size={14} /></button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .vc-reindex-bar {
+    position: fixed;
+    left: 50%;
+    bottom: 12px;
+    transform: translateX(-50%);
+    min-width: 320px;
+    max-width: 640px;
+    padding: 6px 10px;
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    column-gap: 10px;
+    align-items: center;
+    background: var(--color-surface, rgba(30, 30, 30, 0.9));
+    color: var(--color-text, #eee);
+    border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+    border-radius: 6px;
+    font-size: 12px;
+    z-index: 40;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  .vc-reindex-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .vc-reindex-progress {
+    height: 4px;
+    background: var(--color-border, rgba(255, 255, 255, 0.12));
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .vc-reindex-progress-fill {
+    height: 100%;
+    background: var(--color-accent, #5aa9ff);
+    transition: width 200ms ease;
+  }
+
+  .vc-reindex-eta {
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-muted, #aaa);
+    white-space: nowrap;
+  }
+
+  .vc-reindex-cancel {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--color-text-muted, #aaa);
+    cursor: pointer;
+  }
+  .vc-reindex-cancel:hover,
+  .vc-reindex-cancel:focus-visible {
+    background: var(--color-border, rgba(255, 255, 255, 0.12));
+    color: var(--color-text, #eee);
+  }
+</style>

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -10,7 +10,7 @@ import type { VaultError } from "../types/errors";
 import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
 import type { DirEntry } from "../types/tree";
-import type { SearchResult, FileMatch } from "../types/search";
+import type { SearchResult, FileMatch, SemanticHit } from "../types/search";
 import type { BacklinkEntry, ParsedLink, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
 
@@ -210,6 +210,23 @@ export async function searchFilename(
 ): Promise<FileMatch[]> {
   try {
     return await invoke<FileMatch[]>("search_filename", { query, limit });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Semantic (vector) search over the HNSW index (#202).
+ * Returns up to `k` nearest chunks to `query` by cosine similarity.
+ * `k` is clamped to [1, 100] on the Rust side. Returns an empty list
+ * when embeddings are disabled or the model is not bundled.
+ */
+export async function semanticSearch(
+  query: string,
+  k: number = 10,
+): Promise<SemanticHit[]> {
+  try {
+    return await invoke<SemanticHit[]>("semantic_search", { query, k });
   } catch (e) {
     throw normalizeError(e);
   }

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -381,6 +381,35 @@ export async function getLinkGraph(): Promise<LocalGraph> {
   }
 }
 
+/**
+ * #235 — embedding-similarity graph for the whole vault. Same payload
+ * shape as `getLinkGraph()` so the renderer can swap data sources
+ * without restructuring; only `edge.weight` is populated (cosine
+ * similarity in [0, 1]).
+ *
+ * `topK` caps neighbours per source note; `threshold` drops edges whose
+ * max chunk-pair cosine falls below it. The backend snapshots the
+ * VectorIndex once and runs the build inside `spawn_blocking`, so the
+ * call is safe to issue from the UI without blocking other IPC traffic.
+ *
+ * Returns an empty payload when the embeddings subsystem is not
+ * initialised; the caller distinguishes "embeddings not ready" from
+ * "no edges over threshold" by checking whether `nodes.length === 0`.
+ */
+export async function getEmbeddingGraph(
+  topK: number,
+  threshold: number,
+): Promise<LocalGraph> {
+  try {
+    return await invoke<LocalGraph>("get_embedding_graph", {
+      topK,
+      threshold,
+    });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function getResolvedAttachments(): Promise<Map<string, string>> {
   try {
     const record = await invoke<Record<string, string>>("get_resolved_attachments");

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -10,7 +10,7 @@ import type { VaultError } from "../types/errors";
 import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
 import type { DirEntry } from "../types/tree";
-import type { SearchResult, FileMatch, SemanticHit } from "../types/search";
+import type { SearchResult, FileMatch, SemanticHit, HybridHit } from "../types/search";
 import type { BacklinkEntry, ParsedLink, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
 
@@ -227,6 +227,24 @@ export async function semanticSearch(
 ): Promise<SemanticHit[]> {
   try {
     return await invoke<SemanticHit[]>("semantic_search", { query, k });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Hybrid search (#203): fuses BM25 (Tantivy) and HNSW (vector) ranks via
+ * Reciprocal Rank Fusion (k=60). Both legs run in parallel on the Rust
+ * blocking pool. `k` is clamped to [1, 100]. Falls back to BM25-only when
+ * embeddings are disabled / not bundled, and to vec-only when the BM25
+ * index is unavailable.
+ */
+export async function hybridSearch(
+  query: string,
+  k: number = 10,
+): Promise<HybridHit[]> {
+  try {
+    return await invoke<HybridHit[]>("hybrid_search", { query, k });
   } catch (e) {
     throw normalizeError(e);
   }

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -520,3 +520,33 @@ export async function renderNoteHtml(
     throw normalizeError(e);
   }
 }
+
+// ── Semantic search (#201) ───────────────────────────────────────────────────
+
+/**
+ * Kick off the resumable initial-embed pass over the currently-open vault.
+ * The backend runs a background worker that walks every `.md` file, hashes
+ * it, and enqueues stale/new files through the embed pipeline. Progress is
+ * emitted via the `embed://reindex_progress` Tauri event — subscribe with
+ * {@link listenReindexProgress}.
+ *
+ * Returns immediately (the command just parks the worker thread). No-op if
+ * the backend was built without the embeddings feature or the bundled
+ * model is missing.
+ */
+export async function reindexVault(): Promise<void> {
+  try {
+    await invoke<void>("reindex_vault");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/** Cancel the in-flight reindex (no-op if none is running). */
+export async function cancelReindex(): Promise<void> {
+  try {
+    await invoke<void>("cancel_reindex");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}

--- a/src/ipc/events.ts
+++ b/src/ipc/events.ts
@@ -81,3 +81,32 @@ export function listenBulkChangeStart(
 export function listenBulkChangeEnd(handler: () => void): Promise<UnlistenFn> {
   return listen(BULK_CHANGE_END_EVENT, () => handler());
 }
+
+// ── Semantic search (#201) ──────────────────────────────────────────────────
+
+export type ReindexPhase = "scan" | "index" | "done" | "cancelled";
+
+export interface ReindexProgressPayload {
+  done: number;
+  total: number;
+  skipped: number;
+  embedded: number;
+  phase: ReindexPhase;
+  eta_seconds: number | null;
+}
+
+export const REINDEX_PROGRESS_EVENT = "embed://reindex_progress";
+
+/**
+ * #201: Subscribe to `embed://reindex_progress` events emitted by the
+ * background reindex worker. One `scan` event fires on start (total=0),
+ * one `index` event fires once the walk finishes (total=N, done=0), then
+ * one per processed file, then a terminal `done` or `cancelled` event.
+ */
+export function listenReindexProgress(
+  handler: (payload: ReindexProgressPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<ReindexProgressPayload>(REINDEX_PROGRESS_EVENT, (event) =>
+    handler(event.payload),
+  );
+}

--- a/src/lib/__tests__/reindexStore.test.ts
+++ b/src/lib/__tests__/reindexStore.test.ts
@@ -1,0 +1,72 @@
+/**
+ * reindexStore tests — payload application, idle reset, isActive helper.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { reindexStore, isActive } from "../../store/reindexStore";
+import type { ReindexProgressPayload } from "../../ipc/events";
+
+const base: ReindexProgressPayload = {
+  done: 0,
+  total: 0,
+  skipped: 0,
+  embedded: 0,
+  phase: "scan",
+  eta_seconds: null,
+};
+
+describe("reindexStore", () => {
+  beforeEach(() => {
+    reindexStore.reset();
+  });
+
+  it("starts idle", () => {
+    const state = get(reindexStore);
+    expect(state.phase).toBe("idle");
+    expect(state.done).toBe(0);
+    expect(state.total).toBe(0);
+    expect(state.etaSeconds).toBeNull();
+    expect(isActive(state)).toBe(false);
+  });
+
+  it("apply() maps snake_case eta_seconds to etaSeconds and mirrors phase", () => {
+    reindexStore.apply({ ...base, phase: "index", total: 100, done: 42, eta_seconds: 17 });
+    const state = get(reindexStore);
+    expect(state.phase).toBe("index");
+    expect(state.done).toBe(42);
+    expect(state.total).toBe(100);
+    expect(state.etaSeconds).toBe(17);
+    expect(isActive(state)).toBe(true);
+  });
+
+  it("isActive() is true only during scan/index", () => {
+    reindexStore.apply({ ...base, phase: "scan" });
+    expect(isActive(get(reindexStore))).toBe(true);
+
+    reindexStore.apply({ ...base, phase: "index" });
+    expect(isActive(get(reindexStore))).toBe(true);
+
+    reindexStore.apply({ ...base, phase: "done", done: 10, total: 10 });
+    expect(isActive(get(reindexStore))).toBe(false);
+
+    reindexStore.apply({ ...base, phase: "cancelled" });
+    expect(isActive(get(reindexStore))).toBe(false);
+  });
+
+  it("reset() returns the store to its initial idle state", () => {
+    reindexStore.apply({ ...base, phase: "index", done: 500, total: 1000 });
+    reindexStore.reset();
+    const state = get(reindexStore);
+    expect(state.phase).toBe("idle");
+    expect(state.done).toBe(0);
+    expect(state.total).toBe(0);
+  });
+
+  it("successive applies overwrite — the store carries only the latest payload", () => {
+    reindexStore.apply({ ...base, phase: "index", done: 10, total: 100, skipped: 2, embedded: 8 });
+    reindexStore.apply({ ...base, phase: "index", done: 20, total: 100, skipped: 2, embedded: 18 });
+    const state = get(reindexStore);
+    expect(state.done).toBe(20);
+    expect(state.embedded).toBe(18);
+  });
+});

--- a/src/lib/__tests__/settingsStore.test.ts
+++ b/src/lib/__tests__/settingsStore.test.ts
@@ -138,4 +138,43 @@ describe("settingsStore", () => {
     expect(state.dailyNotesDateFormat).toBe("YYYY-MM-DD");
     expect(state.dailyNotesTemplate).toBe("");
   });
+
+  // ─── Semantic search (#201) ──────────────────────────────────────────────
+  it("Test 13: enableSemanticSearch defaults to false", async () => {
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    expect(get(settingsStore).enableSemanticSearch).toBe(false);
+  });
+
+  it("Test 14: setEnableSemanticSearch persists 'true' / 'false' to localStorage", async () => {
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    settingsStore.setEnableSemanticSearch(true);
+    expect(get(settingsStore).enableSemanticSearch).toBe(true);
+    expect(localStorage.getItem("vaultcore-semantic-search")).toBe("true");
+    settingsStore.setEnableSemanticSearch(false);
+    expect(get(settingsStore).enableSemanticSearch).toBe(false);
+    expect(localStorage.getItem("vaultcore-semantic-search")).toBe("false");
+  });
+
+  it("Test 15: init reads stored 'true' value and applies it; only exact 'true' counts", async () => {
+    // Part A: stored "true" → enabled
+    localStorage.setItem("vaultcore-semantic-search", "true");
+    const { settingsStore } = await import("../../store/settingsStore");
+    const { get } = await import("svelte/store");
+    settingsStore.init();
+    expect(get(settingsStore).enableSemanticSearch).toBe(true);
+
+    // Part B: any other value (including typo "TRUE" or empty) → disabled.
+    // Guards against a tampered localStorage flipping the flag on via
+    // a truthy-but-non-canonical string.
+    vi.resetModules();
+    setupLocalStorage();
+    localStorage.setItem("vaultcore-semantic-search", "TRUE");
+    const { settingsStore: s2 } = await import("../../store/settingsStore");
+    s2.init();
+    expect(get(s2).enableSemanticSearch).toBe(false);
+  });
 });

--- a/src/store/__tests__/searchStore.refetchAfterRebuild.test.ts
+++ b/src/store/__tests__/searchStore.refetchAfterRebuild.test.ts
@@ -3,38 +3,41 @@
 // queried again and results reflect newly-indexed content without the
 // user having to retype the query.
 //
+// #204 switched the refetch path from searchFulltext (BM25-only) to
+// hybridSearch (RRF-fused). The store control flow is identical — only
+// the underlying IPC call and the result type (HybridHit) changed.
+//
 // We mock the IPC layer so the store exercises its control flow without
 // a Tauri runtime. Each assertion locks in one AC from the ticket.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { get } from "svelte/store";
 
-const searchFulltextMock = vi.fn();
+const hybridSearchMock = vi.fn();
 
 vi.mock("../../ipc/commands", () => ({
-  searchFulltext: (...args: unknown[]) => searchFulltextMock(...args),
+  hybridSearch: (...args: unknown[]) => hybridSearchMock(...args),
 }));
 
 import { searchStore } from "../searchStore";
 
-describe("searchStore.refetchIfQueryNonEmpty (#148)", () => {
+describe("searchStore.refetchIfQueryNonEmpty (#148, rewired in #204)", () => {
   beforeEach(() => {
     searchStore.reset();
-    searchFulltextMock.mockReset();
+    hybridSearchMock.mockReset();
   });
 
   it("re-runs the current query and replaces results", async () => {
     searchStore.setQuery("#yoda");
-    // First rebuild finds one hit; a later rebuild finds two.
-    searchFulltextMock.mockResolvedValueOnce([
-      { path: "a.md", snippet: "", score: 1 },
-      { path: "b.md", snippet: "", score: 1 },
+    hybridSearchMock.mockResolvedValueOnce([
+      { path: "a.md", title: "a", snippet: "", score: 1, matchCount: 0 },
+      { path: "b.md", title: "b", snippet: "", score: 1, matchCount: 0 },
     ]);
 
     await searchStore.refetchIfQueryNonEmpty();
 
-    expect(searchFulltextMock).toHaveBeenCalledTimes(1);
-    expect(searchFulltextMock).toHaveBeenCalledWith("#yoda", 100);
+    expect(hybridSearchMock).toHaveBeenCalledTimes(1);
+    expect(hybridSearchMock).toHaveBeenCalledWith("#yoda", 100);
     const s = get(searchStore);
     expect(s.results).toHaveLength(2);
     expect(s.totalFiles).toBe(2);
@@ -44,18 +47,18 @@ describe("searchStore.refetchIfQueryNonEmpty (#148)", () => {
   it("is a no-op when the query is empty (no fetch issued)", async () => {
     searchStore.setQuery("");
     await searchStore.refetchIfQueryNonEmpty();
-    expect(searchFulltextMock).not.toHaveBeenCalled();
+    expect(hybridSearchMock).not.toHaveBeenCalled();
   });
 
   it("is a no-op when the query is only whitespace", async () => {
     searchStore.setQuery("   ");
     await searchStore.refetchIfQueryNonEmpty();
-    expect(searchFulltextMock).not.toHaveBeenCalled();
+    expect(hybridSearchMock).not.toHaveBeenCalled();
   });
 
   it("marks the index stale and clears isSearching on IndexCorrupt", async () => {
     searchStore.setQuery("#yoda");
-    searchFulltextMock.mockRejectedValueOnce({ kind: "IndexCorrupt", message: "x" });
+    hybridSearchMock.mockRejectedValueOnce({ kind: "IndexCorrupt", message: "x" });
 
     await searchStore.refetchIfQueryNonEmpty();
 
@@ -66,7 +69,7 @@ describe("searchStore.refetchIfQueryNonEmpty (#148)", () => {
 
   it("does not flip indexStale on unrelated errors, but clears isSearching", async () => {
     searchStore.setQuery("#yoda");
-    searchFulltextMock.mockRejectedValueOnce(new Error("network blip"));
+    hybridSearchMock.mockRejectedValueOnce(new Error("network blip"));
 
     await searchStore.refetchIfQueryNonEmpty();
 

--- a/src/store/reindexStore.ts
+++ b/src/store/reindexStore.ts
@@ -1,0 +1,67 @@
+/**
+ * reindexStore — tracks the frontend-visible state of the #201 semantic
+ * reindex worker. Subscribed to by `App.svelte`'s event listener (which
+ * pipes `embed://reindex_progress` payloads into `apply`) and by the
+ * statusbar widget that renders progress to the user.
+ *
+ * Kept deliberately small: the backend already holds the source of
+ * truth (a resumable checkpoint + thread handle); the store only
+ * exposes the latest payload plus a derived `inProgress` flag so the
+ * statusbar can hide itself when idle.
+ *
+ * Pattern: classic writable factory. Do not refactor to Svelte 5
+ * $state runes (same RC-01 constraint as settingsStore).
+ */
+import { writable } from "svelte/store";
+import type { ReindexPhase, ReindexProgressPayload } from "../ipc/events";
+
+export interface ReindexState {
+  phase: ReindexPhase | "idle";
+  done: number;
+  total: number;
+  skipped: number;
+  embedded: number;
+  etaSeconds: number | null;
+}
+
+const initial: ReindexState = {
+  phase: "idle",
+  done: 0,
+  total: 0,
+  skipped: 0,
+  embedded: 0,
+  etaSeconds: null,
+};
+
+function createReindexStore() {
+  const _store = writable<ReindexState>({ ...initial });
+  return {
+    subscribe: _store.subscribe,
+    /** Ingest one `embed://reindex_progress` payload. Maps the snake_case
+     *  wire field to the camelCase `etaSeconds` for Svelte templates. */
+    apply(payload: ReindexProgressPayload): void {
+      _store.set({
+        phase: payload.phase,
+        done: payload.done,
+        total: payload.total,
+        skipped: payload.skipped,
+        embedded: payload.embedded,
+        etaSeconds: payload.eta_seconds,
+      });
+    },
+    /** Reset to idle — used on vault switch or after acknowledging a
+     *  `done`/`cancelled` terminal state so the statusbar retracts. */
+    reset(): void {
+      _store.set({ ...initial });
+    },
+  };
+}
+
+export const reindexStore = createReindexStore();
+
+/** True while the worker is actively scanning or indexing (not idle,
+ *  not terminal). Pure function so callers and tests can derive it
+ *  without a store subscription. */
+export function isActive(state: ReindexState): boolean {
+  return state.phase === "scan" || state.phase === "index";
+}

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -12,14 +12,14 @@
 //   - activeTab:    sidebar tab — "files" (file browser) | "tags"
 
 import { writable } from "svelte/store";
-import type { SearchResult } from "../types/search";
-import { searchFulltext } from "../ipc/commands";
+import type { HybridHit } from "../types/search";
+import { hybridSearch } from "../ipc/commands";
 import { isVaultError } from "../types/errors";
 import { vaultStore } from "./vaultStore";
 
 export interface SearchStoreState {
   query: string;
-  results: SearchResult[];
+  results: HybridHit[];
   /** Total results returned (capped at limit, typically 100). */
   totalMatches: number;
   /** Number of unique file paths in results. */
@@ -62,7 +62,7 @@ function createSearchStore() {
      * Store search results returned by search_fulltext.
      * Also clears isSearching and computes unique file count.
      */
-    setResults: (results: SearchResult[], totalFiles: number) =>
+    setResults: (results: HybridHit[], totalFiles: number) =>
       update((s) => ({
         ...s,
         results,
@@ -101,9 +101,11 @@ function createSearchStore() {
      * Re-execute the current query against the freshly-built index.
      *
      * Called after a successful rebuild (#148). If the query is empty there
-     * is nothing to fetch; otherwise we re-issue `search_fulltext` and replace
+     * is nothing to fetch; otherwise we re-issue `hybrid_search` and replace
      * the results so the panel reflects newly-indexed content without the
-     * user having to edit the query.
+     * user having to edit the query. #204 switched the rebuild refetch from
+     * BM25-only to the RRF-fused hybrid result so the statusbar rebuild path
+     * stays consistent with the live search dispatch in OmniSearch.
      */
     refetchIfQueryNonEmpty: async (): Promise<void> => {
       let query = "";
@@ -114,7 +116,7 @@ function createSearchStore() {
       if (!query.trim()) return;
       update((s) => ({ ...s, isSearching: true }));
       try {
-        const results = await searchFulltext(query, 100);
+        const results = await hybridSearch(query, 100);
         const uniqueFileCount = new Set(results.map((r) => r.path)).size;
         update((s) => ({
           ...s,

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -46,6 +46,10 @@ const K_SIZE = "vaultcore-font-size";
 const K_DAILY_FOLDER = "vaultcore-daily-notes-folder";
 const K_DAILY_FORMAT = "vaultcore-daily-notes-date-format";
 const K_DAILY_TEMPLATE = "vaultcore-daily-notes-template";
+// #201: semantic-search master toggle. When true, the next vault-open
+// triggers an initial reindex; toggling to false cancels any in-flight
+// reindex but does NOT delete prior embeddings.
+const K_SEMANTIC = "vaultcore-semantic-search";
 // Legacy key from the brief attachment-folder era (before embeds). Removed
 // during cleanup so stale entries don't linger in localStorage.
 const K_ATTACHMENT_FOLDER_LEGACY = "vaultcore-attachment-folder";
@@ -60,6 +64,9 @@ export interface SettingsState {
   dailyNotesDateFormat: string;
   /** Vault-relative path to a template file. Empty = no template. */
   dailyNotesTemplate: string;
+  /** #201: master toggle for semantic search. Off by default so the
+   *  reindex never runs until the user opts in. */
+  enableSemanticSearch: boolean;
 }
 
 const initial: SettingsState = {
@@ -69,6 +76,7 @@ const initial: SettingsState = {
   dailyNotesFolder: "",
   dailyNotesDateFormat: DEFAULT_DAILY_DATE_FORMAT,
   dailyNotesTemplate: "",
+  enableSemanticSearch: false,
 };
 
 function isBodyFont(v: unknown): v is BodyFont {
@@ -98,6 +106,7 @@ function readInitial(): SettingsState {
     const dFolder = localStorage.getItem(K_DAILY_FOLDER);
     const dFormat = localStorage.getItem(K_DAILY_FORMAT);
     const dTemplate = localStorage.getItem(K_DAILY_TEMPLATE);
+    const semantic = localStorage.getItem(K_SEMANTIC);
     return {
       fontBody: isBodyFont(b) ? b : initial.fontBody,
       fontMono: isMonoFont(m) ? m : initial.fontMono,
@@ -105,6 +114,7 @@ function readInitial(): SettingsState {
       dailyNotesFolder: sanitizeDailyString(dFolder, initial.dailyNotesFolder),
       dailyNotesDateFormat: sanitizeDailyString(dFormat, initial.dailyNotesDateFormat),
       dailyNotesTemplate: sanitizeDailyString(dTemplate, initial.dailyNotesTemplate),
+      enableSemanticSearch: semantic === "true",
     };
   } catch { return { ...initial }; }
 }
@@ -165,6 +175,13 @@ function createSettingsStore() {
       const v = sanitizeDailyString(value, "");
       _store.update((s) => ({ ...s, dailyNotesTemplate: v }));
       try { localStorage.setItem(K_DAILY_TEMPLATE, v); } catch { /* */ }
+    },
+    /** #201: persist the semantic-search master toggle. The caller owns
+     *  wiring this to `reindexVault` / `cancelReindex`; this setter is
+     *  storage-only so the flag can be read on next launch. */
+    setEnableSemanticSearch(enable: boolean): void {
+      _store.update((s) => ({ ...s, enableSemanticSearch: enable }));
+      try { localStorage.setItem(K_SEMANTIC, String(enable)); } catch { /* */ }
     },
   };
 }

--- a/src/types/e2e-hook.ts
+++ b/src/types/e2e-hook.ts
@@ -16,6 +16,12 @@ export interface E2eHook {
   finishProgress: () => void;
   typeInActiveEditor: (text: string) => Promise<void>;
   getActiveDocText: () => Promise<string>;
+  /** #204: trigger `reindex_vault` and resolve once the reindex worker
+   *  emits a terminal `done` progress event. Used by the hybrid-search
+   *  E2E spec to wait for embeddings to be queryable before running a
+   *  semantic-only query. Rejects on `cancelled` or if the coordinator
+   *  isn't available (embeddings feature off / model failed to load). */
+  reindexAndWaitDone: () => Promise<void>;
 }
 
 declare global {

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -63,6 +63,9 @@ export interface GraphNode {
 export interface GraphEdge {
   from: string;
   to: string;
+  /** Similarity weight in `[0, 1]`. Populated by the embedding-graph
+   * mode (#235); absent on link-graph edges. */
+  weight?: number;
 }
 
 /** Result returned by `get_local_graph`. */

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -24,6 +24,24 @@ export interface SemanticHit {
   score: number;
 }
 
+/** Hybrid (BM25 + HNSW) search hit fused via Reciprocal Rank Fusion (#203).
+ *  `score` is the fused RRF score (sum of `1 / (60 + rank_i)` per source).
+ *  Per-source `*Rank` and `*Score` fields are present only for the source(s)
+ *  that surfaced the hit — both populated means it ranked in both indices. */
+export interface HybridHit {
+  path: string;
+  title: string;
+  score: number;
+  /** HTML with `<b>highlighted</b>` BM25 terms; empty for vec-only hits with
+   *  no BM25 doc found. */
+  snippet: string;
+  matchCount: number;
+  bm25Rank?: number;
+  bm25Score?: number;
+  vecRank?: number;
+  vecScore?: number;
+}
+
 /** A fuzzy filename match result with character positions for highlight. */
 export interface FileMatch {
   /** Vault-relative path with forward-slash separators. */

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -15,6 +15,15 @@ export interface SearchResult {
   matchCount: number;
 }
 
+/** Semantic-search hit from the HNSW vector index (#202).
+ *  Path + chunkIndex identify the span; `score` is cosine similarity in
+ *  `[-1, 1]` (typically `[0, 1]` for English prose) — higher = more similar. */
+export interface SemanticHit {
+  path: string;
+  chunkIndex: number;
+  score: number;
+}
+
 /** A fuzzy filename match result with character positions for highlight. */
 export interface FileMatch {
   /** Vault-relative path with forward-slash separators. */

--- a/tests/SearchResultRow.test.ts
+++ b/tests/SearchResultRow.test.ts
@@ -7,6 +7,12 @@
 //     why it appears → no new information to show.
 //   - If only the vec leg surfaced it, the user gains from knowing this
 //     came in via semantic similarity rather than keyword match.
+//
+// #231 — Additional match-percent badge based on `vecScore` (cosine
+// similarity, naturally [0,1] for L2-normalised MiniLM vectors). Shown
+// for any hit that has a vecScore (vec-only OR hybrid). Hits without a
+// vecScore (BM25-only) get no percent. Below 30 % the badge gains a
+// "weak" modifier so users can tell drift-y hits at a glance.
 
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/svelte";
@@ -14,6 +20,8 @@ import SearchResultRow from "../src/components/Search/SearchResultRow.svelte";
 import type { HybridHit } from "../src/types/search";
 
 const INDICATOR_SELECTOR = ".vc-search-result-semantic-indicator";
+const PERCENT_SELECTOR = ".vc-search-result-match-percent";
+const PERCENT_WEAK_SELECTOR = ".vc-search-result-match-percent.vc-weak";
 
 function makeHit(overrides: Partial<HybridHit>): HybridHit {
   return {
@@ -56,5 +64,60 @@ describe("SearchResultRow semantic indicator (#204)", () => {
     const badge = container.querySelector(INDICATOR_SELECTOR);
     expect(badge).not.toBeNull();
     expect(badge?.getAttribute("aria-label")).toMatch(/semantisch/i);
+  });
+});
+
+describe("SearchResultRow match-percent badge (#231)", () => {
+  it("does not render the percent for BM25-only hits", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ bm25Rank: 0, bm25Score: 5.2 }),
+      onclick: () => {},
+    });
+    expect(container.querySelector(PERCENT_SELECTOR)).toBeNull();
+  });
+
+  it("renders the percent for hybrid hits (both legs)", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({
+        bm25Rank: 0,
+        bm25Score: 5.2,
+        vecRank: 2,
+        vecScore: 0.71,
+      }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(PERCENT_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent?.trim()).toBe("71%");
+    expect(container.querySelector(PERCENT_WEAK_SELECTOR)).toBeNull();
+  });
+
+  it("renders the percent for vec-only hits", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 0, vecScore: 0.83 }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(PERCENT_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent?.trim()).toBe("83%");
+  });
+
+  it("flags scores below the 30% floor as weak", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 5, vecScore: 0.22 }),
+      onclick: () => {},
+    });
+    const weak = container.querySelector(PERCENT_WEAK_SELECTOR);
+    expect(weak).not.toBeNull();
+    expect(weak?.textContent?.trim()).toBe("22%");
+  });
+
+  it("clamps negative cosine to 0%", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 9, vecScore: -0.04 }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(PERCENT_SELECTOR);
+    expect(badge?.textContent?.trim()).toBe("0%");
   });
 });

--- a/tests/SearchResultRow.test.ts
+++ b/tests/SearchResultRow.test.ts
@@ -1,0 +1,60 @@
+// #204 — SearchResultRow renders a subtle indicator when a hit was
+// surfaced only by the semantic (vec) leg of hybrid_search. The ticket
+// AC is: "Result-Rows zeigen dezenten Indicator bei Semantic-Match."
+//
+// We treat "semantic-only" as vecRank != null && bm25Rank == null:
+//   - If BM25 also ranked the hit, the lexical surface already explains
+//     why it appears → no new information to show.
+//   - If only the vec leg surfaced it, the user gains from knowing this
+//     came in via semantic similarity rather than keyword match.
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import SearchResultRow from "../src/components/Search/SearchResultRow.svelte";
+import type { HybridHit } from "../src/types/search";
+
+const INDICATOR_SELECTOR = ".vc-search-result-semantic-indicator";
+
+function makeHit(overrides: Partial<HybridHit>): HybridHit {
+  return {
+    path: "/vault/Note.md",
+    title: "Note",
+    score: 0.1,
+    snippet: "<b>preview</b> text",
+    matchCount: 1,
+    ...overrides,
+  };
+}
+
+describe("SearchResultRow semantic indicator (#204)", () => {
+  it("does not render the indicator for BM25-only hits", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ bm25Rank: 0, bm25Score: 5.2 }),
+      onclick: () => {},
+    });
+    expect(container.querySelector(INDICATOR_SELECTOR)).toBeNull();
+  });
+
+  it("does not render the indicator for hybrid hits that surface in both legs", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({
+        bm25Rank: 0,
+        bm25Score: 5.2,
+        vecRank: 2,
+        vecScore: 0.71,
+      }),
+      onclick: () => {},
+    });
+    expect(container.querySelector(INDICATOR_SELECTOR)).toBeNull();
+  });
+
+  it("renders the indicator when only the vec leg surfaced the hit", () => {
+    const { container } = render(SearchResultRow, {
+      result: makeHit({ vecRank: 0, vecScore: 0.83 }),
+      onclick: () => {},
+    });
+    const badge = container.querySelector(INDICATOR_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("aria-label")).toMatch(/semantisch/i);
+  });
+});


### PR DESCRIPTION
Lands the **Semantic Search v1** epic (#189) onto main. 24 squashed feature PRs, 70 files, +10.6k / −105 LoC.

## What ships

### Embeddings backend (#190 – #208)
- ONNX Runtime bundled as Tauri resource (`build.rs`-driven) behind feature flag `embeddings`.
- `multilingual-e5-small` (XLM-R tokenizer, 384-dim, INT8 quantized) bundled as resource — 30% RAM cut vs. the original MiniLM-L6 baseline.
- `EmbeddingService`: text → 384-d vector with tokenizer-aware chunker for notes longer than 256 tokens.
- ORT thread-pool cap (intra=2, inter=1) to keep CPU footprint bounded.
- `EmbedCoordinator`: embed-on-save async hook, dispatches per file change.
- `VectorIndex`: HNSW-backed (cosine `DistDot` on L2-normalized vectors), persistent mmap reload + corruption recovery, tombstone deletes + compaction primitive.
- `ReindexCoordinator`: resumable reindex worker with on-disk checkpoint, bulk-batch + RAM backpressure, bench harness with `BENCH_JSON` regression gate. Status bar + cancellable from UI.
- `semantic_search` IPC endpoint with monotonic request-id cancellation.
- Hybrid search via Reciprocal Rank Fusion over Tantivy BM25 + HNSW cosine.
- Semantic-quality sanity gate (5 mini-doc fixture) + per-PR bench regression check.

### Search UX (#231)
- Match-percent badge on hybrid search results so users see *why* a hit ranked where it did.

### Graph view — semantic mode (#235, #237)
- Second graph mode **„Semantisch"**: edges from cosine similarity between note embeddings instead of wiki-link traversal. Live `top_k` + `threshold` slider, per-vault persistence.
- Edge thickness, alpha, and d3-force link-strength/distance scale with cosine weight — strong relations visibly cluster, weak ones fade.
- Second slider **„Cluster"**: collapses tightly-related notes into super-nodes ("Oberbegriff") via union-find on high-weight edges. Slider min clamps dynamically to the edge threshold so the UI can't enter a useless sub-edge-threshold range.

## Test coverage
- 316/316 backend Rust tests (was 248 before epic).
- 23/23 frontend Graph specs (11 existing + 12 new for clustering helper).
- `svelte-check`: 0 errors.
- Bench gate runs on every PR touching `embeddings/`; sanity-quality fixture asserts top-1 match for each canonical query.

## Constraints respected
- Zero network calls, zero telemetry — embeddings model is bundled as a Tauri resource and runs entirely on-CPU via local ORT.
- Feature-gated: with `--no-default-features` (or any build that drops `embeddings`), the IPC commands degrade to no-op stubs (`semantic_search` and `get_embedding_graph` both return empty results) so the frontend code path is identical.
- No new dependencies on the frontend stack; sigma + graphology + d3-force already in tree.

## Documented follow-ups (not blocking this merge)
- Heuristic topic-name stack for cluster labels (shared YAML tag → common folder prefix → TF-IDF top term, fall back to current `<rep> · +N`).
- Position-hint plumbing so super-nodes inherit their representative's prior coordinate on cluster recompute.
- Click-to-expand a cluster.
- Graph-build caching keyed by snapshot generation + top_k.
- Edge-weight visual scaling already shipped, but a dedicated legend would help.
- "X of Y notes have embeddings" coverage indicator in the graph empty state.

## Test plan
- [ ] Open a vault with embeddings indexed (see status bar progress on first open).
- [ ] OmniSearch shows the semantic indicator + match percentages on hybrid hits.
- [ ] Graph view → switch to **„Semantisch"** → relations form by cosine similarity.
- [ ] Slide the threshold slider → live filter, no UI freeze.
- [ ] Slide the cluster slider left → notes merge into `<title> · +N` super-nodes; back at 1.0 (`aus`) → identical to per-note view.
- [ ] Reindex flow: trigger from settings, cancel, resume, observe bench-style throughput in the status bar.
- [ ] Build with `--no-default-features` → app starts, semantic features absent, no panics.