### PR TITLE
fix(macos): ad-hoc re-sign bundled libonnxruntime (#242)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -104,19 +104,46 @@ fn ensure_onnxruntime(
     let dest_dir = resources_dir.join("onnxruntime");
     fs::create_dir_all(&dest_dir)?;
     let dest = dest_dir.join(dylib_name);
-    if dest.exists() {
-        return Ok(());
+    if !dest.exists() {
+        println!("cargo:warning=fetching {url}");
+        let archive_bytes = http_get(url)?;
+        verify_sha256(&archive_bytes, sha256)?;
+        if url.ends_with(".tgz") || url.ends_with(".tar.gz") {
+            extract_from_tgz(&archive_bytes, archive_path, &dest)?;
+        } else if url.ends_with(".zip") {
+            extract_from_zip(&archive_bytes, archive_path, &dest)?;
+        } else {
+            return Err(AssetError(format!("unsupported archive extension: {url}")));
+        }
     }
 
-    println!("cargo:warning=fetching {url}");
-    let archive_bytes = http_get(url)?;
-    verify_sha256(&archive_bytes, sha256)?;
-    if url.ends_with(".tgz") || url.ends_with(".tar.gz") {
-        extract_from_tgz(&archive_bytes, archive_path, &dest)?;
-    } else if url.ends_with(".zip") {
-        extract_from_zip(&archive_bytes, archive_path, &dest)?;
-    } else {
-        return Err(AssetError(format!("unsupported archive extension: {url}")));
+    // #242: upstream onnxruntime ships signed by Microsoft (Team UBF8T346G9).
+    // Tauri's bundled host is linker-signed ad-hoc with no Team — the TeamID
+    // mismatch makes AMFI refuse the dlopen at runtime, so embeddings fail
+    // silently in installed builds. Strip the upstream signature back to
+    // ad-hoc so it matches the host's identity. Idempotent: re-running on an
+    // already-ad-hoc dylib is a no-op rewrite. Non-fatal on failure (e.g.
+    // cross-compiling from Linux where `codesign` doesn't exist) — the build
+    // continues and the runtime falls back to the existing signature.
+    if platform.starts_with("macos-") {
+        if let Err(e) = adhoc_resign(&dest) {
+            println!("cargo:warning=macos adhoc re-sign skipped: {e}");
+        }
+    }
+    Ok(())
+}
+
+fn adhoc_resign(path: &Path) -> Result<(), AssetError> {
+    let status = std::process::Command::new("codesign")
+        .args(["--force", "--sign", "-"])
+        .arg(path)
+        .status()
+        .map_err(|e| AssetError(format!("spawn codesign: {e}")))?;
+    if !status.success() {
+        return Err(AssetError(format!(
+            "codesign exited with {:?}",
+            status.code()
+        )));
     }
     Ok(())
 }


### PR DESCRIPTION
Closes #242.

## Summary

- Strip Microsoft's upstream signature from `libonnxruntime.1.23.2.dylib` and re-sign ad-hoc during `build.rs`, so the dylib's signing identity matches Tauri's linker-signed host. Without this, AMFI rejects the runtime `dlopen` in installed `.app` bundles and embeddings fail silently.
- Idempotent: re-signing an already-ad-hoc dylib is a no-op rewrite.
- Cross-compile-safe: a missing/failing `codesign` (e.g. building from Linux) emits `cargo:warning=…` and continues.

## Out of scope

Notarization, Developer-ID, Hardened Runtime, Universal Binary, CI sign pipeline → tracked in #209.

## Test plan

- [x] `cargo check` passes
- [x] After build, `codesign -dv src-tauri/resources/onnxruntime/libonnxruntime.1.23.2.dylib` shows `Signature=adhoc`, `TeamIdentifier=not set`
- [ ] Fresh `pnpm tauri build` → installed `.app` loads embeddings without manual `codesign` step
- [ ] Existing users with poisoned `<vault>/.vaultcore/embeddings/reindex.checkpoint.json` from previously-broken builds need to delete it manually before semantic toggle re-fires (called out as out-of-scope in the issue)