### PR TITLE
fix(embeddings): release model RAM when semantic search is disabled

### DIFF
--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -200,78 +200,18 @@ pub async fn open_vault(
     // embedding assets still succeeds. Drop the previous coordinator
     // before spawning the new one so the old worker shuts down cleanly
     // (mirrors the IndexCoordinator drop-then-replace pattern above).
+    //
+    // #244: only arm the embed stack when the semantic-search toggle is
+    // on. Otherwise the full ~200-400 MB of model weights + ORT session
+    // gets loaded for users who never want semantic search.
     #[cfg(feature = "embeddings")]
     {
-        // #201 PR-B: cancel any in-flight reindex for the prior vault
-        // BEFORE dropping the old coordinator. The reindex worker holds
-        // clones of the prior coordinator's Sender; cancelling lets it
-        // wind down cleanly so the next vault's worker has a fresh
-        // checkpoint to resume from.
-        {
-            let mut guard = state
-                .reindex_handle
-                .lock()
-                .map_err(|_| VaultError::LockPoisoned)?;
-            if let Some(h) = guard.take() {
-                h.cancel();
-            }
-        }
-        {
-            let mut guard = state
-                .embed_coordinator
-                .lock()
-                .map_err(|_| VaultError::LockPoisoned)?;
-            *guard = None;
-        }
-        {
-            let mut guard = state
-                .query_handles
-                .lock()
-                .map_err(|_| VaultError::LockPoisoned)?;
-            *guard = None;
-        }
-        let resource_dir = app.path().resource_dir().ok();
-        let svc = crate::embeddings::EmbeddingService::load(resource_dir.as_deref());
-        let chk = crate::embeddings::Chunker::load(resource_dir.as_deref());
-        match (svc, chk) {
-            (Ok(svc), Ok(chk)) => {
-                use std::sync::Arc;
-                // #201 PR-A: HNSW-backed sink under <vault>/.vaultcore/embeddings/.
-                // capacity_hint of 4×file_count assumes the average note
-                // produces ~4 chunks (#195 splits at 254 content tokens
-                // ≈ 800 words). It only sizes initial allocations — real
-                // growth past it is supported.
-                let embed_dir = canonical.join(".vaultcore").join("embeddings");
-                let cap = vault_info.file_count.saturating_mul(4).max(64);
-                // #202: keep a concrete `Arc<HnswSink>` alongside the
-                // `Arc<dyn VectorSink>` handed to the coordinator so the
-                // `semantic_search` IPC handler can call `snapshot()`
-                // without widening the trait. Both Arcs share one alloc.
-                let sink_concrete = Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
-                let sink: Arc<dyn crate::embeddings::VectorSink> =
-                    Arc::clone(&sink_concrete) as Arc<dyn crate::embeddings::VectorSink>;
-                let svc_for_query = Arc::clone(&svc);
-                let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
-                {
-                    let mut guard = state
-                        .embed_coordinator
-                        .lock()
-                        .map_err(|_| VaultError::LockPoisoned)?;
-                    *guard = Some(coord);
-                }
-                let handles = Arc::new(crate::embeddings::QueryHandles {
-                    service: svc_for_query,
-                    sink: sink_concrete,
-                });
-                let mut guard = state
-                    .query_handles
-                    .lock()
-                    .map_err(|_| VaultError::LockPoisoned)?;
-                *guard = Some(handles);
-            }
-            (Err(e), _) | (_, Err(e)) => {
-                log::warn!("embed-on-save disabled: {e}");
-            }
+        // Always tear down first so the previous vault's coordinator +
+        // query_handles + reindex worker release their handles before we
+        // decide whether to re-arm. Safe to call even on a fresh process.
+        crate::embeddings::teardown_for_disable(&state);
+        if read_semantic_enabled(&app) {
+            spawn_embeddings_for_vault(&app, &state, &canonical, vault_info.file_count)?;
         }
     }
 
@@ -636,4 +576,166 @@ pub async fn cancel_reindex(
         h.cancel();
     }
     Ok(())
+}
+
+// ─── #244: semantic-search toggle ────────────────────────────────────────────
+
+const SEMANTIC_ENABLED_FILENAME: &str = "semantic-enabled.json";
+
+#[derive(Serialize, Deserialize, Default)]
+struct SemanticEnabledFile {
+    enabled: bool,
+}
+
+fn semantic_enabled_path(app: &AppHandle) -> Option<PathBuf> {
+    let dir = app.path().app_data_dir().ok()?;
+    if std::fs::create_dir_all(&dir).is_err() {
+        return None;
+    }
+    Some(dir.join(SEMANTIC_ENABLED_FILENAME))
+}
+
+/// Read the persisted semantic-search toggle. Defaults to `false` on any
+/// I/O or parse failure so a tampered file can't force the expensive
+/// embed-init path on behalf of the user.
+#[cfg_attr(not(feature = "embeddings"), allow(dead_code))]
+pub(crate) fn read_semantic_enabled(app: &AppHandle) -> bool {
+    let Some(file) = semantic_enabled_path(app) else { return false };
+    let Ok(raw) = std::fs::read_to_string(&file) else { return false };
+    serde_json::from_str::<SemanticEnabledFile>(&raw)
+        .map(|f| f.enabled)
+        .unwrap_or(false)
+}
+
+fn write_semantic_enabled(app: &AppHandle, enabled: bool) -> Result<(), VaultError> {
+    let Some(file) = semantic_enabled_path(app) else {
+        return Err(VaultError::Io(std::io::Error::other(
+            "app_data_dir unavailable",
+        )));
+    };
+    let json = serde_json::to_string_pretty(&SemanticEnabledFile { enabled })
+        .map_err(|e| VaultError::Io(std::io::Error::other(e.to_string())))?;
+    std::fs::write(&file, json).map_err(VaultError::Io)
+}
+
+/// Build the embed coordinator + query handles for `vault_root` and park
+/// them in `state`. Assumes the caller already tore down any previous
+/// coordinator via `teardown_for_disable`.
+///
+/// Non-fatal: on `EmbeddingService::load` failure (no dylib, no model,
+/// ORT init failed) the state slots stay `None` and the caller treats
+/// embed-on-save as disabled for this vault. The return is still `Ok`.
+#[cfg(feature = "embeddings")]
+fn spawn_embeddings_for_vault(
+    app: &AppHandle,
+    state: &crate::VaultState,
+    vault_root: &Path,
+    file_count: usize,
+) -> Result<(), VaultError> {
+    let resource_dir = app.path().resource_dir().ok();
+    let svc = crate::embeddings::EmbeddingService::load(resource_dir.as_deref());
+    let chk = crate::embeddings::Chunker::load(resource_dir.as_deref());
+    match (svc, chk) {
+        (Ok(svc), Ok(chk)) => {
+            use std::sync::Arc;
+            // #201 PR-A: HNSW-backed sink under <vault>/.vaultcore/embeddings/.
+            // capacity_hint of 4×file_count assumes the average note
+            // produces ~4 chunks (#195 splits at 254 content tokens
+            // ≈ 800 words). It only sizes initial allocations — real
+            // growth past it is supported.
+            let embed_dir = vault_root.join(".vaultcore").join("embeddings");
+            let cap = file_count.saturating_mul(4).max(64);
+            // #202: keep a concrete `Arc<HnswSink>` alongside the
+            // `Arc<dyn VectorSink>` handed to the coordinator so the
+            // `semantic_search` IPC handler can call `snapshot()`
+            // without widening the trait. Both Arcs share one alloc.
+            let sink_concrete = Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
+            let sink: Arc<dyn crate::embeddings::VectorSink> =
+                Arc::clone(&sink_concrete) as Arc<dyn crate::embeddings::VectorSink>;
+            let svc_for_query = Arc::clone(&svc);
+            let coord = crate::embeddings::EmbedCoordinator::spawn(svc, chk, sink);
+            {
+                let mut guard = state
+                    .embed_coordinator
+                    .lock()
+                    .map_err(|_| VaultError::LockPoisoned)?;
+                *guard = Some(coord);
+            }
+            let handles = Arc::new(crate::embeddings::QueryHandles {
+                service: svc_for_query,
+                sink: sink_concrete,
+            });
+            let mut guard = state
+                .query_handles
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?;
+            *guard = Some(handles);
+        }
+        (Err(e), _) | (_, Err(e)) => {
+            log::warn!("embed-on-save disabled: {e}");
+        }
+    }
+    Ok(())
+}
+
+/// Persist the semantic-search toggle and (re)arm or tear down the
+/// embedding stack for the currently-open vault to match.
+///
+/// Toggle flow:
+/// - `false`: cancel any running reindex, drop `embed_coordinator` and
+///   `query_handles`. The `EmbeddingService` Arc is released so the ONNX
+///   session (model weights + arenas, ~200-400 MB) is freed. The global
+///   ORT env remains mapped for the rest of the process lifetime — that's
+///   an `ort::init_from` design constraint; see #244.
+/// - `true`: if a vault is currently open and the coordinator isn't
+///   already armed, load the service and spawn the coordinator. No-op if
+///   the model isn't bundled.
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn set_semantic_enabled(
+    app: AppHandle,
+    state: tauri::State<'_, crate::VaultState>,
+    enabled: bool,
+) -> Result<(), VaultError> {
+    write_semantic_enabled(&app, enabled)?;
+    if !enabled {
+        crate::embeddings::teardown_for_disable(&state);
+        return Ok(());
+    }
+    // enabled == true: arm the stack iff a vault is open and no
+    // coordinator is already there (idempotent — toggling on-on is safe).
+    let already_armed = {
+        let guard = state
+            .embed_coordinator
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.is_some()
+    };
+    if already_armed {
+        return Ok(());
+    }
+    let vault_root = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.clone()
+    };
+    if let Some(root) = vault_root {
+        let file_count = count_md_files(&root);
+        spawn_embeddings_for_vault(&app, &state, &root, file_count)?;
+    }
+    Ok(())
+}
+
+/// `embeddings` feature disabled → persist the flag but do nothing
+/// else, so the IPC surface and on-disk layout stay stable across builds.
+#[cfg(not(feature = "embeddings"))]
+#[tauri::command]
+pub async fn set_semantic_enabled(
+    app: AppHandle,
+    _state: tauri::State<'_, crate::VaultState>,
+    enabled: bool,
+) -> Result<(), VaultError> {
+    write_semantic_enabled(&app, enabled)
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -67,6 +67,11 @@ mod query;
 pub use query::{semantic_search_query, QueryHandles, SemanticHit};
 
 #[cfg(feature = "embeddings")]
+mod release;
+#[cfg(feature = "embeddings")]
+pub use release::teardown_for_disable;
+
+#[cfg(feature = "embeddings")]
 mod hybrid;
 #[cfg(feature = "embeddings")]
 pub use hybrid::{rrf_fuse, FusedHit, RRF_K};

--- a/src-tauri/src/embeddings/release.rs
+++ b/src-tauri/src/embeddings/release.rs
@@ -1,0 +1,21 @@
+//! #244 — runtime teardown of the embedding stack on semantic-search
+//! disable. Will own the invariant that every `Arc<EmbeddingService>`
+//! held by `VaultState` is dropped so the ONNX session memory (model
+//! weights + arenas) is freed.
+//!
+//! Stub landed first so the regression test in `tests::embedding_release`
+//! has a symbol to call. The stub intentionally does nothing — the real
+//! teardown lands in the follow-up commit and the test flips from red
+//! to green there.
+
+use crate::VaultState;
+
+/// Drop every piece of embedding-related state so the `EmbeddingService`
+/// Arc held inside `QueryHandles` and the `EmbedCoordinator` worker is
+/// released.
+///
+/// TODO(#244): implement. Currently a stub so the failing regression
+/// test in `tests::embedding_release` compiles against a real symbol.
+pub fn teardown_for_disable(_state: &VaultState) {
+    // intentionally empty — real teardown in the next commit
+}

--- a/src-tauri/src/embeddings/release.rs
+++ b/src-tauri/src/embeddings/release.rs
@@ -1,21 +1,46 @@
 //! #244 — runtime teardown of the embedding stack on semantic-search
-//! disable. Will own the invariant that every `Arc<EmbeddingService>`
-//! held by `VaultState` is dropped so the ONNX session memory (model
-//! weights + arenas) is freed.
+//! disable. Owns the invariant that every `Arc<EmbeddingService>` held
+//! by `VaultState` is dropped so the ONNX session memory (model weights
+//! + arenas) is freed.
 //!
-//! Stub landed first so the regression test in `tests::embedding_release`
-//! has a symbol to call. The stub intentionally does nothing — the real
-//! teardown lands in the follow-up commit and the test flips from red
-//! to green there.
+//! The global ORT environment stays mapped for the lifetime of the
+//! process — `ort::init_from().commit()` is a one-shot via the
+//! `RUNTIME_INIT` OnceLock in `embeddings/mod.rs` and the ORT API has
+//! no safe tear-down. Residual cost is the ~35-50 MB of the mapped
+//! libonnxruntime, documented in #244's "out of scope".
 
 use crate::VaultState;
 
 /// Drop every piece of embedding-related state so the `EmbeddingService`
 /// Arc held inside `QueryHandles` and the `EmbedCoordinator` worker is
-/// released.
+/// released. Safe to call repeatedly; each slot is set to `None` whether
+/// or not it was populated.
 ///
-/// TODO(#244): implement. Currently a stub so the failing regression
-/// test in `tests::embedding_release` compiles against a real symbol.
-pub fn teardown_for_disable(_state: &VaultState) {
-    // intentionally empty — real teardown in the next commit
+/// Order matters:
+/// 1. Cancel the reindex worker — its `enqueue_bulk` path clones the
+///    coordinator's `Sender`, and cancelling makes it stop so the clone
+///    drops before we touch the coordinator slot.
+/// 2. Drop `embed_coordinator` — releases the primary `Sender` and the
+///    strong Arc clone of `EmbeddingService` held by the coordinator
+///    struct.
+/// 3. Drop `query_handles` — releases the `Arc<EmbeddingService>` shared
+///    with the semantic/hybrid search IPC handlers.
+///
+/// Once every `Sender` clone outside this module has also dropped
+/// (watcher-held clone replaced on next `open_vault`; any in-flight
+/// `dispatch_embed_update` clone drops when the save IPC returns), the
+/// coordinator worker's `blocking_recv` returns `None` and the task
+/// exits, dropping the last `Arc<EmbeddingService>`.
+pub fn teardown_for_disable(state: &VaultState) {
+    if let Ok(mut guard) = state.reindex_handle.lock() {
+        if let Some(h) = guard.take() {
+            h.cancel();
+        }
+    }
+    if let Ok(mut guard) = state.embed_coordinator.lock() {
+        *guard = None;
+    }
+    if let Ok(mut guard) = state.query_handles.lock() {
+        *guard = None;
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,8 +112,14 @@ pub fn run() {
         .setup(|_app| {
             #[cfg(feature = "embeddings")]
             {
-                if let Err(e) = embeddings::bootstrap(&_app.handle()) {
-                    log::warn!("embeddings bootstrap failed: {e}");
+                // #244: honour the semantic-search toggle on startup. When
+                // off, skip the ORT init entirely — the runtime dylib
+                // mapping itself is deferred until the user flips the
+                // toggle on and `set_semantic_enabled` runs lazy init.
+                if commands::vault::read_semantic_enabled(&_app.handle()) {
+                    if let Err(e) = embeddings::bootstrap(&_app.handle()) {
+                        log::warn!("embeddings bootstrap failed: {e}");
+                    }
                 }
             }
             Ok(())
@@ -127,6 +133,7 @@ pub fn run() {
             commands::vault::reindex_vault,
             #[cfg(feature = "embeddings")]
             commands::vault::cancel_reindex,
+            commands::vault::set_semantic_enabled,
             commands::files::read_file,
             commands::files::write_file,
             commands::files::create_file,

--- a/src-tauri/src/tests/embedding_release.rs
+++ b/src-tauri/src/tests/embedding_release.rs
@@ -1,0 +1,128 @@
+//! #244 — RAM release regression guard.
+//!
+//! Locks in the invariant that disabling semantic search at runtime
+//! drops every `Arc<EmbeddingService>` held by `VaultState`, so the
+//! model weights + ORT session memory are released. See issue #244
+//! for the bug and proposal; the teardown path is
+//! `embeddings::teardown_for_disable(&VaultState)`.
+//!
+//! Skips cleanly when the bundled model isn't available (same pattern
+//! as every other #[cfg(feature = "embeddings")] test in this module).
+
+#![cfg(feature = "embeddings")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::embeddings::{
+    teardown_for_disable, Chunker, EmbedCoordinator, EmbeddingService, HnswSink, QueryHandles,
+    VectorSink,
+};
+use crate::VaultState;
+
+/// Best-effort service load. Returns `None` when the runtime dylib or
+/// the bundled model isn't present (dev machines / CI without resources).
+fn try_load() -> Option<(Arc<EmbeddingService>, Arc<Chunker>)> {
+    let svc = EmbeddingService::load(None).ok()?;
+    let chk = Chunker::load(None).ok()?;
+    Some((svc, chk))
+}
+
+/// Populate `VaultState` with a live embed coordinator + query handles,
+/// exactly as `open_vault` does. Returns a `Weak<EmbeddingService>` clone
+/// the caller can use to probe whether the Arc has been fully dropped.
+fn arm_state(
+    state: &VaultState,
+    svc: Arc<EmbeddingService>,
+    chk: Arc<Chunker>,
+    embed_dir: std::path::PathBuf,
+) -> std::sync::Weak<EmbeddingService> {
+    let svc_for_query = Arc::clone(&svc);
+    let svc_weak = Arc::downgrade(&svc);
+    let sink_concrete = Arc::new(HnswSink::open(embed_dir, 64));
+    let sink: Arc<dyn VectorSink> =
+        Arc::clone(&sink_concrete) as Arc<dyn VectorSink>;
+    let coord = EmbedCoordinator::spawn(svc, chk, sink);
+    {
+        let mut guard = state.embed_coordinator.lock().unwrap();
+        *guard = Some(coord);
+    }
+    {
+        let mut guard = state.query_handles.lock().unwrap();
+        *guard = Some(Arc::new(QueryHandles {
+            service: svc_for_query,
+            sink: sink_concrete,
+        }));
+    }
+    svc_weak
+}
+
+fn wait_weak_dead(weak: &std::sync::Weak<EmbeddingService>, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if weak.upgrade().is_none() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    weak.upgrade().is_none()
+}
+
+/// After `teardown_for_disable`, every slot in `VaultState` that holds
+/// an `Arc<EmbeddingService>` must be cleared AND the worker thread
+/// must exit so its own Arc clone drops. The `Weak` we held from the
+/// original load must no longer upgrade.
+#[test]
+fn teardown_releases_embedding_service_arc() {
+    let Some((svc, chk)) = try_load() else {
+        eprintln!("SKIP teardown_releases_embedding_service_arc: model not bundled");
+        return;
+    };
+
+    // We need a tokio runtime for `EmbedCoordinator::spawn` (it uses
+    // `tokio::task::spawn_blocking`). Build a minimal current-thread runtime
+    // and block the whole test inside it, matching the existing
+    // `embed_coordinator` module tests.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async move {
+        let state = VaultState::default();
+        let tmp = tempfile::tempdir().unwrap();
+        let weak = arm_state(&state, svc, chk, tmp.path().to_path_buf());
+
+        // Sanity: Arc is live right now — the state itself holds two
+        // strong references (coordinator worker + query_handles), so
+        // upgrade must still succeed.
+        assert!(
+            weak.upgrade().is_some(),
+            "pre-teardown: service Arc must still be live",
+        );
+
+        teardown_for_disable(&state);
+
+        // After teardown the three slots must be empty.
+        assert!(
+            state.embed_coordinator.lock().unwrap().is_none(),
+            "embed_coordinator must be None after teardown",
+        );
+        assert!(
+            state.query_handles.lock().unwrap().is_none(),
+            "query_handles must be None after teardown",
+        );
+        assert!(
+            state.reindex_handle.lock().unwrap().is_none(),
+            "reindex_handle must be None after teardown",
+        );
+
+        // The worker holds its own Arc clone and releases it only after
+        // it finishes draining the channel — give it a few hundred ms
+        // for `blocking_recv` to unblock and the task to wind down.
+        assert!(
+            wait_weak_dead(&weak, Duration::from_secs(5)),
+            "post-teardown: EmbeddingService Arc must be fully dropped — {} strong refs remain",
+            weak.strong_count(),
+        );
+    });
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -22,3 +22,5 @@ mod embeddings;
 mod semantic_quality;
 #[cfg(feature = "embeddings")]
 mod embedding_graph;
+#[cfg(feature = "embeddings")]
+mod embedding_release;

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -12,7 +12,7 @@
   import { DEFAULT_DAILY_DATE_FORMAT } from "../../lib/dailyNotes";
   import { vaultStore } from "../../store/vaultStore";
   import { snippetsStore } from "../../store/snippetsStore";
-  import { reindexVault, cancelReindex } from "../../ipc/commands";
+  import { reindexVault, cancelReindex, setSemanticEnabled } from "../../ipc/commands";
   import { reindexStore, isActive as isReindexActive } from "../../store/reindexStore";
   import { formatShortcut } from "../../lib/shortcuts";
   import { commandRegistry, hotkeysEqual, type Command, type HotKey } from "../../lib/commands/registry";
@@ -235,14 +235,21 @@
     }
   }
 
-  /** #201: master toggle for semantic search. Enabling fires the
-   *  background reindex against the open vault; disabling cancels it.
-   *  Both calls are fire-and-forget — the statusbar listens for the
-   *  `embed://reindex_progress` event and surfaces progress. */
+  /** #201 / #244: master toggle for semantic search.
+   *  - Enabling: persist the flag + lazy-init the embedding stack on the
+   *    backend, then kick off the reindex against the open vault.
+   *  - Disabling: persist the flag + tear down the backend embedding
+   *    stack so the ~200-400 MB ONNX session is released; cancel any
+   *    running reindex as the backend already does that internally
+   *    (`teardown_for_disable` cancels the reindex handle) so the
+   *    explicit `cancelReindex` is redundant but harmless.
+   *  The statusbar listens for the `embed://reindex_progress` event and
+   *  surfaces progress. */
   async function onToggleSemantic(e: Event): Promise<void> {
     const enabled = (e.target as HTMLInputElement).checked;
     settingsStore.setEnableSemanticSearch(enabled);
     try {
+      await setSemanticEnabled(enabled);
       if (enabled) {
         if (currentVaultPath) await reindexVault();
       } else {

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -614,3 +614,20 @@ export async function cancelReindex(): Promise<void> {
     throw normalizeError(e);
   }
 }
+
+/**
+ * #244 — persist the semantic-search toggle and (re)arm or tear down
+ * the embedding stack on the backend to match.
+ *
+ * Setting this to `false` at runtime drops the `Arc<EmbeddingService>`
+ * held by the backend so the ~200-400 MB ONNX session is released.
+ * Setting it to `true` lazy-loads the model against the currently open
+ * vault (no-op when no vault is open — re-runs on the next `open_vault`).
+ */
+export async function setSemanticEnabled(enabled: boolean): Promise<void> {
+  try {
+    await invoke<void>("set_semantic_enabled", { enabled });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}


### PR DESCRIPTION
Closes #244.

## Summary

The `enableSemanticSearch` toggle in Settings was frontend-only — localStorage-only. The backend ignored it: `embeddings::bootstrap` dlopened libonnxruntime on every app start, and `EmbeddingService::load` loaded the 118 MB multilingual-e5-small INT8 model into an ONNX session on every `open_vault`, regardless of the flag. Net effect: ~250-400 MB of wasted RAM for users who never wanted semantic search.

## Root cause

`cancel_reindex` only dropped `reindex_handle`. The `embed_coordinator` + `query_handles` slots in `VaultState` kept their `Arc<EmbeddingService>` alive indefinitely — the model weights and ORT session arenas stayed in RAM until the process exited.

## What changed

- **Persistence**: toggle is written to `<app_data>/semantic-enabled.json` so the backend reads the authoritative value on startup (default `false`).
- **Startup gating**: `embeddings::bootstrap` runs only when the persisted flag is true; no ORT init otherwise.
- **Open-vault gating**: `open_vault` tears down any previous vault's embedding stack unconditionally, then only re-arms when the flag is true.
- **New `set_semantic_enabled` IPC**: off drops `embed_coordinator` + `query_handles` + cancels reindex → every `Arc<EmbeddingService>` dies → worker's `blocking_recv` returns None → the session memory is released. On lazy-loads for the currently open vault (idempotent).
- **Frontend toggle**: calls `setSemanticEnabled` before the existing reindex / cancelReindex fire-and-forget.
- **Out of scope** (documented in code + #244): the global ORT env stays mapped for process lifetime. That's a `ort::init_from().commit()` design constraint, not fixable here. Residual ~35-50 MB is accepted.

## Files

- `src-tauri/src/embeddings/release.rs` (new) — `teardown_for_disable(state)`
- `src-tauri/src/embeddings/mod.rs` — re-export
- `src-tauri/src/commands/vault.rs` — flag persistence, `spawn_embeddings_for_vault`, `set_semantic_enabled`, open_vault gating
- `src-tauri/src/lib.rs` — gate bootstrap on the flag, register IPC
- `src/ipc/commands.ts` — `setSemanticEnabled` wrapper
- `src/components/Settings/SettingsModal.svelte` — wire toggle

## Test plan

- [x] TDD: `tests::embedding_release::teardown_releases_embedding_service_arc` — loads the real `EmbeddingService`, populates `VaultState`, holds a `Weak<EmbeddingService>`, calls `teardown_for_disable`, asserts both state slots are `None` and the Weak no longer upgrades (within 5 s for the worker task to exit). First commit lands the test against a stub (fails on main for the right reason); second commit flips it green.
- [x] Full Rust suite with embeddings serial run: 114 passed, 0 failed.
- [x] `pnpm vitest run src/lib/__tests__/settingsStore.test.ts`: 11 passed.
- [x] `pnpm tsc --noEmit`: clean.
- [ ] Manual: launch release build with toggle off vs on, observe RSS delta ≈ model size (~200 MB).