### PR TITLE
fix(editor): skip countsPlugin republish on empty-selection cursor moves

### DIFF
--- a/src/components/Editor/__tests__/countsPlugin.test.ts
+++ b/src/components/Editor/__tests__/countsPlugin.test.ts
@@ -1,0 +1,157 @@
+// Regression tests for issue #251:
+// `countsPlugin` used to bypass its 100ms debounce for every selection-only
+// transaction AND, when the selection was empty (i.e. normal cursor-navigation),
+// recompute word/character counts over the *entire document* via
+// `view.state.doc.toString()` — on every arrow key. On long notes that burns
+// the per-keystroke 16 ms budget.
+//
+// The fix:
+//   - Empty-selection cursor moves (no doc change, selection is collapsed)
+//     MUST NOT recompute counts or publish, because the whole-doc count is
+//     unchanged from its last publish.
+//   - Non-empty-selection drags still publish immediately (drag-tracking).
+//   - Typing still publishes debounced at 100ms.
+//   - When the selection collapses after having been non-empty, the plugin
+//     must publish the whole-doc counts once so the status bar switches back
+//     from "X words selected" to the whole-document label — without running
+//     `doc.toString()` again (cached from the previous whole-doc publish).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EditorView } from "@codemirror/view";
+import { EditorState, EditorSelection, Text } from "@codemirror/state";
+import { countsPlugin, COUNTS_DEBOUNCE_FOR_TESTS } from "../countsPlugin";
+import { countsStore } from "../../../store/countsStore";
+
+function mountView(doc: string): { view: EditorView; parent: HTMLElement } {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({
+    state: EditorState.create({
+      doc,
+      extensions: [countsPlugin("left")],
+    }),
+    parent,
+  });
+  return { view, parent };
+}
+
+describe("countsPlugin — issue #251 cursor-nav debounce bypass", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    countsStore.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    countsStore.reset();
+  });
+
+  it("publishes an initial snapshot on mount", () => {
+    const setSpy = vi.spyOn(countsStore, "set");
+    const { view, parent } = mountView("the quick brown fox");
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy.mock.calls[0]![0]).toBe("left");
+    expect(setSpy.mock.calls[0]![1]).toMatchObject({
+      words: 4,
+      selection: false,
+    });
+    view.destroy();
+    parent.remove();
+  });
+
+  it("does NOT republish or recompute on empty-selection cursor moves", () => {
+    // Build a long doc so that any regression (toString over the whole doc)
+    // is measurable. Content doesn't matter — we assert via spies.
+    const longDoc = "word ".repeat(5_000).trim();
+    const { view, parent } = mountView(longDoc);
+
+    const setSpy = vi.spyOn(countsStore, "set");
+    const toStringSpy = vi.spyOn(Text.prototype, "toString");
+
+    // Simulate 20 arrow-key taps: selection moves, doc doesn't change,
+    // selection stays collapsed.
+    for (let i = 1; i <= 20; i++) {
+      view.dispatch({ selection: EditorSelection.cursor(i) });
+    }
+
+    // Fix: publish MUST NOT be called on empty-selection cursor moves.
+    expect(setSpy).not.toHaveBeenCalled();
+    // And the whole-doc `toString()` MUST NOT run on the cursor-nav hot path.
+    expect(toStringSpy).not.toHaveBeenCalled();
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("publishes immediately for non-empty-selection changes (drag tracking)", () => {
+    const { view, parent } = mountView("alpha beta gamma delta");
+    const setSpy = vi.spyOn(countsStore, "set");
+
+    // Simulate a drag that selects "alpha beta" (chars 0..10).
+    view.dispatch({ selection: EditorSelection.range(0, 10) });
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy.mock.calls[0]![1]).toMatchObject({ selection: true, words: 2 });
+
+    // Extend the selection mid-drag to "alpha beta gamma" (chars 0..16).
+    view.dispatch({ selection: EditorSelection.range(0, 16) });
+    expect(setSpy).toHaveBeenCalledTimes(2);
+    expect(setSpy.mock.calls[1]![1]).toMatchObject({ selection: true, words: 3 });
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("debounces typing at 100ms — a burst yields a single publish", () => {
+    const { view, parent } = mountView("hello");
+    const setSpy = vi.spyOn(countsStore, "set");
+
+    // Five quick inserts within the debounce window.
+    for (let i = 0; i < 5; i++) {
+      view.dispatch({
+        changes: { from: view.state.doc.length, to: view.state.doc.length, insert: "x" },
+      });
+    }
+
+    // Before the debounce fires, no publish.
+    expect(setSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(COUNTS_DEBOUNCE_FOR_TESTS + 1);
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy.mock.calls[0]![1]).toMatchObject({ selection: false });
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("re-publishes whole-doc counts when the selection collapses from non-empty", () => {
+    const { view, parent } = mountView("alpha beta gamma");
+    const setSpy = vi.spyOn(countsStore, "set");
+
+    // Make a selection first so the store reports `selection: true`.
+    view.dispatch({ selection: EditorSelection.range(0, 5) });
+    expect(setSpy).toHaveBeenLastCalledWith(
+      "left",
+      expect.objectContaining({ selection: true }),
+    );
+
+    // Collapse the selection — user clicks away / presses Esc. The status bar
+    // must switch back to the whole-doc label, so one publish with
+    // `selection: false` is expected and is allowed to use cached counts.
+    view.dispatch({ selection: EditorSelection.cursor(0) });
+    expect(setSpy).toHaveBeenLastCalledWith(
+      "left",
+      expect.objectContaining({ selection: false, words: 3 }),
+    );
+
+    // Any further empty-cursor moves must NOT republish.
+    const callsBefore = setSpy.mock.calls.length;
+    view.dispatch({ selection: EditorSelection.cursor(2) });
+    view.dispatch({ selection: EditorSelection.cursor(5) });
+    expect(setSpy.mock.calls.length).toBe(callsBefore);
+
+    view.destroy();
+    parent.remove();
+  });
+});

--- a/src/components/Editor/countsPlugin.ts
+++ b/src/components/Editor/countsPlugin.ts
@@ -2,25 +2,46 @@
 // active document (or current selection) into the Svelte `countsStore`.
 //
 // Debounce: 100ms. Enough to collapse a fast typing burst into a single
-// count computation without feeling laggy. Selection-only transactions
+// count computation without feeling laggy. Non-empty selection changes
 // bypass the debounce so click-and-drag feels instant.
+//
+// Hot-path rule (issue #251):
+//   - Empty-selection cursor moves (arrow-key navigation) DO NOT run a
+//     fresh whole-doc count: the document didn't change, so the previous
+//     whole-doc publish is still correct. We short-circuit without touching
+//     `view.state.doc.toString()` — which scales with document length and
+//     was otherwise called on every keypress on long notes.
+//   - When the selection collapses after having been non-empty, we publish
+//     the cached whole-doc counts once so the status bar can switch its
+//     label back from "X words selected" to the whole-document total.
 
 import { ViewPlugin, type EditorView, type ViewUpdate } from "@codemirror/view";
 import { countsStore, type PaneId } from "../../store/countsStore";
-import { computeCounts } from "../../lib/wordCount";
+import { computeCounts, type Counts } from "../../lib/wordCount";
 
 const DEBOUNCE_MS = 100;
 
-function publish(view: EditorView, paneId: PaneId): void {
+/**
+ * Publish counts for the current selection (if non-empty) or the whole
+ * document (if the selection is collapsed). Returns the whole-doc counts
+ * when it computed them, so the caller can cache them; returns null when
+ * the publish was for a selection and the whole-doc cache is unaffected.
+ */
+function publish(view: EditorView, paneId: PaneId): Counts | null {
   const selection = view.state.selection.main;
   const hasSelection = !selection.empty;
 
-  const text = hasSelection
-    ? view.state.sliceDoc(selection.from, selection.to)
-    : view.state.doc.toString();
+  if (hasSelection) {
+    const text = view.state.sliceDoc(selection.from, selection.to);
+    const { words, characters } = computeCounts(text);
+    countsStore.set(paneId, { words, characters, selection: true });
+    return null;
+  }
 
-  const { words, characters } = computeCounts(text);
-  countsStore.set(paneId, { words, characters, selection: hasSelection });
+  const text = view.state.doc.toString();
+  const counts = computeCounts(text);
+  countsStore.set(paneId, { ...counts, selection: false });
+  return counts;
 }
 
 export function countsPlugin(paneId: PaneId) {
@@ -28,20 +49,47 @@ export function countsPlugin(paneId: PaneId) {
     class {
       private timer: ReturnType<typeof setTimeout> | null = null;
       private view: EditorView;
+      /** Last whole-doc counts — reused when the selection collapses and
+       *  the document hasn't changed, avoiding a fresh `doc.toString()`. */
+      private wholeDocCounts: Counts | null = null;
+      private prevSelectionEmpty = true;
 
       constructor(view: EditorView) {
         this.view = view;
         // Initial snapshot — no debounce, so the bar appears with correct
         // counts as soon as the editor mounts.
-        publish(view, paneId);
+        this.wholeDocCounts = publish(view, paneId);
+        this.prevSelectionEmpty = view.state.selection.main.empty;
       }
 
       update(update: ViewUpdate): void {
         if (!update.docChanged && !update.selectionSet) return;
 
-        // Selection-only updates are cheap and the user expects the count
-        // to track the drag in real time — skip the debounce.
-        if (update.selectionSet && !update.docChanged) {
+        if (!update.docChanged && update.selectionSet) {
+          const nowEmpty = update.state.selection.main.empty;
+          const wasEmpty = this.prevSelectionEmpty;
+          this.prevSelectionEmpty = nowEmpty;
+
+          // Empty-selection cursor move (arrow keys, click to place cursor):
+          // doc unchanged, selection collapsed — the last published whole-doc
+          // counts are still correct, so do nothing.
+          if (nowEmpty && wasEmpty) return;
+
+          // Selection collapsed from non-empty → whole-doc label needs to
+          // reappear. Re-publish cached whole-doc counts without touching
+          // `doc.toString()`.
+          if (nowEmpty && !wasEmpty) {
+            if (this.wholeDocCounts) {
+              countsStore.set(paneId, { ...this.wholeDocCounts, selection: false });
+            } else {
+              this.wholeDocCounts = publish(update.view, paneId);
+            }
+            return;
+          }
+
+          // Non-empty selection change (drag tick, shift-arrow, etc.) —
+          // user expects real-time feedback, so publish immediately and
+          // skip the typing debounce.
           if (this.timer !== null) {
             clearTimeout(this.timer);
             this.timer = null;
@@ -50,10 +98,15 @@ export function countsPlugin(paneId: PaneId) {
           return;
         }
 
+        // Doc changed — debounce to collapse typing bursts. The timer
+        // callback publishes and refreshes the whole-doc cache (when the
+        // selection is collapsed at that moment).
+        this.prevSelectionEmpty = update.state.selection.main.empty;
         if (this.timer !== null) clearTimeout(this.timer);
         this.timer = setTimeout(() => {
           this.timer = null;
-          publish(this.view, paneId);
+          const counts = publish(this.view, paneId);
+          if (counts !== null) this.wholeDocCounts = counts;
         }, DEBOUNCE_MS);
       }
 


### PR DESCRIPTION
## Summary

- Closes #251.
- `countsPlugin` previously called `view.state.doc.toString()` + `computeCounts` on every cursor tick via its debounce-bypass, even when the selection was collapsed and the doc hadn't changed — turning arrow-key navigation on a 50 k-word note into 10-40 ms of work per keystroke.
- New behaviour: empty-selection cursor moves short-circuit (cached whole-doc counts remain correct). Non-empty-selection drags still publish immediately. Typing still publishes debounced at 100 ms. Collapsing a non-empty selection re-publishes cached whole-doc counts so the status bar label flips back from "X words selected" without another `toString()`.

## Why

The header comment justifying the debounce bypass said "user expects the count to track the drag in real time" — but that only applies when there *is* a selection. Empty-selection ticks published the same whole-doc value each time at `O(doc length)` cost, eating the 16 ms keystroke budget on long notes. Correctness is trivial: `docChanged === false` ⇒ counts unchanged.

## Test plan

- [x] New Vitest regression suite `src/components/Editor/__tests__/countsPlugin.test.ts`:
  - Asserts empty-selection cursor moves do NOT call `countsStore.set` nor `Text.prototype.toString` (the actual hot-path bug).
  - Asserts non-empty-selection drags still publish synchronously.
  - Asserts typing publishes once after 100 ms (debounce intact).
  - Asserts collapsing a non-empty selection re-publishes whole-doc counts once.
  - Both "cursor-nav" and "collapse re-publish" tests fail on `main` (committed first as a failing guard in `48d6694`), pass after the fix (`a3d4575`).
- [x] `src/lib/__tests__/wordCount.test.ts` — 26 passing, pure helpers untouched.
- [x] `tsc --noEmit` clean.