### PR TITLE
perf(layout): stop throwaway vaultStore subscribe/unsub in per-keystroke callbacks (#259)

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
+  import { get } from "svelte/store";
   import { PanelRight, Settings as SettingsIcon } from "lucide-svelte";
   import Sidebar from "../Sidebar/Sidebar.svelte";
   import EditorPane from "../Editor/EditorPane.svelte";
@@ -137,11 +138,9 @@
     e.preventDefault();
     isRightDragging = true;
     rightDragStartX = e.clientX;
-    // Read current width from store
-    let currentWidth = 240;
-    const unsub = backlinksStore.subscribe((s) => { currentWidth = s.width; });
-    unsub();
-    rightDragStartWidth = currentWidth;
+    // Snapshot the current width via get(); avoids the throwaway
+    // subscribe/unsub closure allocation pattern (#259).
+    rightDragStartWidth = get(backlinksStore).width;
   }
 
   // Split pane divider drag
@@ -187,12 +186,11 @@
   onMount(() => {
     unsubBacklinksTab = tabStore.subscribe((state) => {
       const activeTab = state.tabs.find((t) => t.id === state.activeTabId);
-      const vault = (() => {
-        let v: string | null = null;
-        const u = vaultStore.subscribe((s) => { v = s.currentPath; });
-        u();
-        return v;
-      })();
+      // #259: snapshot vault path via get() — tabStore emits on every
+      // per-keystroke mutation (setDirty, scroll, cursor) and a throwaway
+      // vaultStore.subscribe/unsub here would allocate a fresh closure and
+      // run the full subscriber cycle on every keypress.
+      const vault = get(vaultStore).currentPath;
 
       let nextRelPath: string | null;
       if (!activeTab || !vault) {
@@ -200,7 +198,7 @@
       } else {
         const absPath = activeTab.filePath;
         nextRelPath = absPath.startsWith(vault + "/")
-          ? absPath.slice((vault as string).length + 1)
+          ? absPath.slice(vault.length + 1)
           : absPath;
       }
 
@@ -221,9 +219,9 @@
   onMount(() => {
     unsubActiveTabReveal = tabStore.subscribe((state) => {
       const activeTab = state.tabs.find((t) => t.id === state.activeTabId) ?? null;
-      let vault: string | null = null;
-      const u = vaultStore.subscribe((s) => { vault = s.currentPath; });
-      u();
+      // #259: snapshot vault path via get() — see the backlinks-sync
+      // subscription above for the per-keystroke hot-path rationale.
+      const vault = get(vaultStore).currentPath;
       const relPath = resolveRevealRelPath(activeTab, vault);
       if (relPath === lastRevealedRelPath) return;
       lastRevealedRelPath = relPath;
@@ -256,9 +254,7 @@
 
   /** EDIT-11 / D-12: Create "Unbenannte Notiz.md" at vault root and open in a new tab. */
   async function createNewNote() {
-    let vaultPath: string | null = null;
-    const unsub = vaultStore.subscribe((s) => { vaultPath = s.currentPath; });
-    unsub();
+    const vaultPath = get(vaultStore).currentPath;
     if (!vaultPath) return;
     try {
       const newPath = await createFile(vaultPath, "Unbenannte Notiz.md");
@@ -275,9 +271,7 @@
   // palette shortcut always drops the new item at the vault root (the palette
   // is reachable even when no tree row is selected).
   async function createNewCanvas() {
-    let vaultPath: string | null = null;
-    const unsub = vaultStore.subscribe((s) => { vaultPath = s.currentPath; });
-    unsub();
+    const vaultPath = get(vaultStore).currentPath;
     if (!vaultPath) return;
     try {
       const newPath = await createFile(vaultPath, "Untitled.canvas");
@@ -290,9 +284,7 @@
   }
 
   async function createNewFolder() {
-    let vaultPath: string | null = null;
-    const unsub = vaultStore.subscribe((s) => { vaultPath = s.currentPath; });
-    unsub();
+    const vaultPath = get(vaultStore).currentPath;
     if (!vaultPath) return;
     try {
       await createFolder(vaultPath, "");
@@ -319,22 +311,15 @@
    *     new file. Unreadable template silently falls back to empty.
    */
   async function openTodayNote() {
-    let vaultPath: string | null = null;
-    const unsubVault = vaultStore.subscribe((s) => { vaultPath = s.currentPath; });
-    unsubVault();
+    const vaultPath = get(vaultStore).currentPath;
     if (!vaultPath) return;
 
-    let folder = "";
-    let format = DEFAULT_DAILY_DATE_FORMAT;
-    let template = "";
-    const unsubSettings = settingsStore.subscribe((s) => {
-      folder = s.dailyNotesFolder;
-      format = s.dailyNotesDateFormat.trim().length > 0
-        ? s.dailyNotesDateFormat
-        : DEFAULT_DAILY_DATE_FORMAT;
-      template = s.dailyNotesTemplate.trim();
-    });
-    unsubSettings();
+    const settings = get(settingsStore);
+    const folder = settings.dailyNotesFolder;
+    const format = settings.dailyNotesDateFormat.trim().length > 0
+      ? settings.dailyNotesDateFormat
+      : DEFAULT_DAILY_DATE_FORMAT;
+    const template = settings.dailyNotesTemplate.trim();
 
     try {
       // 1. Resolve / create folder chain.
@@ -499,10 +484,7 @@
 
   /** Issue #12: toggle bookmark on the active tab's file path. */
   async function toggleActiveBookmark() {
-    let captured: string | null = null;
-    const u1 = vaultStore.subscribe((s) => { captured = s.currentPath; });
-    u1();
-    const vaultPath: string | null = captured;
+    const vaultPath = get(vaultStore).currentPath;
     if (vaultPath === null) return;
     const active = tabStore.getActiveTab();
     if (!active || active.type === "graph") return;
@@ -555,9 +537,7 @@
       cycleTabNext: () => { tabStore.cycleTab(1); },
       cycleTabPrev: () => { tabStore.cycleTab(-1); },
       closeActiveTab: () => {
-        let activeId: string | null = null;
-        const unsub = tabStore.subscribe((s) => { activeId = s.activeTabId; });
-        unsub();
+        const activeId = get(tabStore).activeTabId;
         if (activeId) tabStore.closeTab(activeId);
       },
       createNewNote: () => { void createNewNote(); },

--- a/tests/VaultLayout.noThrowawaySubs.test.ts
+++ b/tests/VaultLayout.noThrowawaySubs.test.ts
@@ -41,6 +41,7 @@ describe("Issue #259: VaultLayout has no throwaway subscribe/unsub pattern", () 
     let m: RegExpExecArray | null;
     while ((m = starter.exec(src)) !== null) {
       const name = m[1];
+      if (name === undefined) continue;
       // Walk from the opening `(` of `.subscribe(` to its matching `)`.
       let i = m.index + m[0].length; // points just past the opening `(`
       let parenDepth = 1;
@@ -55,7 +56,7 @@ describe("Issue #259: VaultLayout has no throwaway subscribe/unsub pattern", () 
       }
       // Skip optional `;` then whitespace.
       if (src[i] === ";") i++;
-      while (i < src.length && /\s/.test(src[i]!)) i++;
+      while (i < src.length && /\s/.test(src[i] ?? "")) i++;
       const tail = src.slice(i, i + name.length + 4);
       if (new RegExp(`^${name}\\s*\\(\\s*\\)`).test(tail)) {
         offenders.push(src.slice(m.index, i + name.length + 4));

--- a/tests/VaultLayout.noThrowawaySubs.test.ts
+++ b/tests/VaultLayout.noThrowawaySubs.test.ts
@@ -1,0 +1,115 @@
+// Issue #259 regression guard.
+//
+// `VaultLayout.svelte` previously had a pattern like
+//
+//   const unsub = vaultStore.subscribe(v => { vaultPath = v.currentPath; });
+//   unsub();
+//
+// inside per-keystroke `tabStore` subscription callbacks. `tabStore` fires on
+// every `setDirty`, scroll, and cursor update, so this allocated a fresh
+// closure and ran the full subscriber cycle on every keystroke.
+//
+// The fix replaces those immediate-throwaway subscribes with `get(store)`
+// reads (or equivalent non-allocating snapshots). This test pins the source
+// of `VaultLayout.svelte` so the antipattern can't sneak back in.
+//
+// AC from the issue:
+//   "No subscribe(...).unsubscribe() immediate-throwaway pattern in
+//    VaultLayout.svelte (enforced by grep rule or review)."
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const LAYOUT_PATH = resolve(
+  __dirname,
+  "../src/components/Layout/VaultLayout.svelte",
+);
+
+describe("Issue #259: VaultLayout has no throwaway subscribe/unsub pattern", () => {
+  const src = readFileSync(LAYOUT_PATH, "utf8");
+
+  it("does not contain `const <name> = <store>.subscribe(...)` followed by an immediate `<name>()`", () => {
+    // Walk every `const <name> = <something>Store.subscribe(` occurrence,
+    // brace-balance across the arrow body + the closing paren, and check
+    // whether the very next non-trivial token is `<name>()`. We look for the
+    // specific shape the issue calls out, not any subscribe at all — long-
+    // lived subscriptions stored in `unsub*` variables and cleaned up in
+    // `onDestroy` are fine.
+    const starter = /const\s+(\w+)\s*=\s*\w+Store\.subscribe\s*\(/g;
+    const offenders: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = starter.exec(src)) !== null) {
+      const name = m[1];
+      // Walk from the opening `(` of `.subscribe(` to its matching `)`.
+      let i = m.index + m[0].length; // points just past the opening `(`
+      let parenDepth = 1;
+      let braceDepth = 0;
+      while (i < src.length && parenDepth > 0) {
+        const ch = src[i];
+        if (ch === "{") braceDepth++;
+        else if (ch === "}") braceDepth--;
+        else if (ch === "(" && braceDepth === 0) parenDepth++;
+        else if (ch === ")" && braceDepth === 0) parenDepth--;
+        i++;
+      }
+      // Skip optional `;` then whitespace.
+      if (src[i] === ";") i++;
+      while (i < src.length && /\s/.test(src[i]!)) i++;
+      const tail = src.slice(i, i + name.length + 4);
+      if (new RegExp(`^${name}\\s*\\(\\s*\\)`).test(tail)) {
+        offenders.push(src.slice(m.index, i + name.length + 4));
+      }
+    }
+    expect(
+      offenders,
+      offenders.length > 0
+        ? `Found throwaway subscribe/unsub antipattern(s):\n${offenders.join("\n---\n")}`
+        : "",
+    ).toEqual([]);
+  });
+
+  it("does not call `.subscribe(` inside a `tabStore.subscribe(` callback body", () => {
+    // Per-keystroke hot path guard: the tabStore subscription callback must
+    // not open a fresh subscription on another store. Scan each
+    // `tabStore.subscribe((state) => { ... })` body and assert no nested
+    // `.subscribe(` appears. Matches both this specific file's shape and
+    // any future regression that re-introduces it.
+    const callbackBodies = extractTabStoreCallbackBodies(src);
+    expect(callbackBodies.length).toBeGreaterThan(0); // sanity: we do have tabStore subs
+    for (const body of callbackBodies) {
+      expect(
+        body.includes(".subscribe("),
+        `tabStore.subscribe callback body contains a nested .subscribe( call:\n${body}`,
+      ).toBe(false);
+    }
+  });
+});
+
+/**
+ * Extract the body (text between the outermost `{` and matching `}`) of every
+ * `tabStore.subscribe((...args) => { ... })` arrow callback in the given
+ * source. Naive but adequate for this codebase — VaultLayout uses arrow
+ * functions with balanced braces and no unbalanced braces in string literals
+ * inside those bodies.
+ */
+function extractTabStoreCallbackBodies(src: string): string[] {
+  const bodies: string[] = [];
+  const starter = /tabStore\.subscribe\s*\(\s*\(?[^)]*\)?\s*=>\s*\{/g;
+  let m: RegExpExecArray | null;
+  while ((m = starter.exec(src)) !== null) {
+    const bodyStart = m.index + m[0].length;
+    let depth = 1;
+    let i = bodyStart;
+    while (i < src.length && depth > 0) {
+      const ch = src[i];
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+      i++;
+    }
+    if (depth === 0) {
+      bodies.push(src.slice(bodyStart, i - 1));
+    }
+  }
+  return bodies;
+}


### PR DESCRIPTION
## Summary

- `VaultLayout.svelte`'s two `tabStore` subscription callbacks (backlinks-sync, active-tab-reveal) did a `const unsub = vaultStore.subscribe(...); unsub();` dance on every emission just to read the current vault path. `tabStore` fires on every per-keystroke `setDirty` / scroll / cursor mutation, so each keypress allocated a fresh closure and ran the full `vaultStore` subscriber cycle.
- Replaced all six throwaway-subscribe occurrences in the file (two hot-path callbacks plus four one-shot command handlers: `createNewNote`, `createNewCanvas`, `createNewFolder`, `openTodayNote`, `toggleActiveBookmark`, `closeActiveTab`, and the `handleRightDividerMousedown` `backlinksStore` read) with `get(store)` snapshots. Identical semantics, no per-emission closure allocation.
- Added `tests/VaultLayout.noThrowawaySubs.test.ts`: source-level regression guard that (a) finds any `const <name> = <…>Store.subscribe(...)` immediately followed by `<name>()`, and (b) asserts no nested `.subscribe(` call appears inside any `tabStore.subscribe(...)` callback body in the file. Both sub-checks failed against `main` before the fix, both pass now.

## Why

Issue #259 — keystroke-hot-path closure allocation burns budget we can't afford at the <16ms-per-keystroke target. Closing #259.

## Test plan

- [x] `npx vitest run tests/VaultLayout.noThrowawaySubs.test.ts` — 2/2 green (fails on main).
- [x] `npx vitest run src/lib/__tests__/activeTabReveal.test.ts tests/VaultLayout.noThrowawaySubs.test.ts tests/vault.test.ts` — all green (nothing adjacent regresses).
- [x] `npx svelte-check` — 0 errors (same 2 pre-existing `line-clamp` warnings as main).
- WDIO full suite intentionally not run per project testing-scope convention.

## Notes for follow-up (not fixed here)

The same throwaway-subscribe antipattern exists in other files — `src/App.svelte` (×2), `src/components/Graph/GraphView.svelte`, `src/components/Statusbar/ReindexStatusbar.svelte`, `src/components/Editor/CountStatusBar.svelte`, `src/components/CommandPalette/CommandPalette.svelte`, and inside `src/store/tabStore.ts` itself (×2). Out of scope for this PR; worth a separate sweep.

Closes #259