### PR TITLE
perf(watcher): read each .md event body once, share between dispatchers

### DIFF
--- a/src-tauri/src/tests/tag_index.rs
+++ b/src-tauri/src/tests/tag_index.rs
@@ -151,7 +151,7 @@ async fn test_watcher_dispatch_update_tags_on_create() {
     let vault_path = tmp.path().parent().unwrap().to_path_buf();
     let ev = make_debounced_event(EventKind::Create(CreateKind::File), tmp.path().to_path_buf());
 
-    dispatch_tag_index_cmd(&tx, &vault_path, &ev);
+    dispatch_tag_index_cmd(&tx, &vault_path, &ev, Some("Hello #rust"), None);
 
     let cmd = rx.try_recv().expect("expected one IndexCmd");
     match cmd {
@@ -175,7 +175,7 @@ async fn test_watcher_dispatch_remove_tags_on_delete() {
 
     let ev = make_debounced_event(EventKind::Remove(RemoveKind::File), md_path);
 
-    dispatch_tag_index_cmd(&tx, &vault_path, &ev);
+    dispatch_tag_index_cmd(&tx, &vault_path, &ev, None, None);
 
     let cmd = rx.try_recv().expect("expected one IndexCmd");
     assert!(
@@ -196,12 +196,12 @@ async fn test_watcher_ignores_non_md_files() {
     // .txt file — must be ignored
     let txt_path = vault_path.join("note.txt");
     let ev = make_debounced_event(EventKind::Create(CreateKind::File), txt_path);
-    dispatch_tag_index_cmd(&tx, &vault_path, &ev);
+    dispatch_tag_index_cmd(&tx, &vault_path, &ev, Some("Hello #rust"), None);
 
     // extensionless file — must be ignored
     let no_ext = vault_path.join("README");
     let ev2 = make_debounced_event(EventKind::Create(CreateKind::File), no_ext);
-    dispatch_tag_index_cmd(&tx, &vault_path, &ev2);
+    dispatch_tag_index_cmd(&tx, &vault_path, &ev2, Some("irrelevant"), None);
 
     assert!(
         rx.try_recv().is_err(),

--- a/src-tauri/src/tests/watcher.rs
+++ b/src-tauri/src/tests/watcher.rs
@@ -176,3 +176,115 @@ fn test_write_ignore_multiple_paths() {
     assert!(list.should_ignore(&path_b));
     assert!(!list.should_ignore(&PathBuf::from("/vault/c.md")));
 }
+
+// ─── Issue #246: dispatchers must not read from disk themselves ──────────────
+//
+// Regression guard for #246 — every .md modify event used to read the file
+// twice (once in dispatch_link_graph_cmd, once in dispatch_tag_index_cmd).
+// After the fix, the read is done once in process_events and the content is
+// handed to both dispatchers. These tests pin down that contract by calling
+// the dispatchers with an explicit content string on a path that does NOT
+// exist on disk: the old code would have silently dropped both commands (fs
+// read fails), the new code enqueues both because it never touches disk.
+
+#[test]
+fn test_dispatch_link_graph_uses_provided_content_without_disk_read() {
+    use crate::indexer::IndexCmd;
+    use crate::watcher::dispatch_link_graph_cmd;
+    use notify_debouncer_full::{
+        notify::{event::ModifyKind, Event, EventKind},
+        DebouncedEvent,
+    };
+    use std::time::Instant;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async move {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<IndexCmd>(8);
+
+        // A path that definitely does not exist on disk.
+        let vault_path = PathBuf::from("/tmp/vaultcore-nonexistent-246");
+        let md_path = vault_path.join("ghost.md");
+        let ev = DebouncedEvent::new(
+            Event {
+                kind: EventKind::Modify(ModifyKind::Data(
+                    notify_debouncer_full::notify::event::DataChange::Content,
+                )),
+                paths: vec![md_path],
+                attrs: Default::default(),
+            },
+            Instant::now(),
+        );
+
+        // Dispatcher must use the supplied content verbatim — not re-read from disk.
+        dispatch_link_graph_cmd(&tx, &vault_path, &ev, Some("link body [[foo]]"), None);
+
+        let cmd = rx.try_recv().expect(
+            "dispatcher must enqueue UpdateLinks from the supplied content, \
+             even though the path is not readable",
+        );
+        match cmd {
+            IndexCmd::UpdateLinks { rel_path, content } => {
+                assert_eq!(rel_path, "ghost.md");
+                assert_eq!(content, "link body [[foo]]");
+            }
+            other => panic!(
+                "expected UpdateLinks, got discriminant {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    });
+}
+
+#[test]
+fn test_dispatch_tag_index_uses_provided_content_without_disk_read() {
+    use crate::indexer::IndexCmd;
+    use crate::watcher::dispatch_tag_index_cmd;
+    use notify_debouncer_full::{
+        notify::{event::ModifyKind, Event, EventKind},
+        DebouncedEvent,
+    };
+    use std::time::Instant;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    rt.block_on(async move {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<IndexCmd>(8);
+
+        let vault_path = PathBuf::from("/tmp/vaultcore-nonexistent-246");
+        let md_path = vault_path.join("ghost.md");
+        let ev = DebouncedEvent::new(
+            Event {
+                kind: EventKind::Modify(ModifyKind::Data(
+                    notify_debouncer_full::notify::event::DataChange::Content,
+                )),
+                paths: vec![md_path],
+                attrs: Default::default(),
+            },
+            Instant::now(),
+        );
+
+        dispatch_tag_index_cmd(&tx, &vault_path, &ev, Some("body with #rust"), None);
+
+        let cmd = rx.try_recv().expect(
+            "dispatcher must enqueue UpdateTags from the supplied content, \
+             even though the path is not readable",
+        );
+        match cmd {
+            IndexCmd::UpdateTags { rel_path, content } => {
+                assert_eq!(rel_path, "ghost.md");
+                assert_eq!(content, "body with #rust");
+            }
+            other => panic!(
+                "expected UpdateTags, got discriminant {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    });
+}

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -261,11 +261,30 @@ fn process_events(
 
     // Step 4: Emit individual file_changed events and dispatch index commands
     for ev in filtered {
-        // Step 5: Dispatch link-graph commands (LINK-08)
+        // Step 5: Dispatch link-graph + tag-index commands (LINK-08, TAG-01/02).
+        //
+        // #246: read the .md body exactly once per event and hand it to both
+        // dispatchers. Previously each dispatcher did its own
+        // std::fs::read_to_string, doubling syscalls + transient allocations
+        // on the bulk-save hot path. Both dispatchers are pure functions of
+        // (rel_path, content), so sharing the read is also strictly more
+        // consistent (no risk of the file changing between the two reads).
         if let Some(tx) = index_tx {
-            dispatch_link_graph_cmd(tx, vault_path, &ev);
-            // Step 5b: Dispatch tag-index commands (TAG-01/02)
-            dispatch_tag_index_cmd(tx, vault_path, &ev);
+            let (primary_content, renamed_content) = read_event_contents(vault_path, &ev);
+            dispatch_link_graph_cmd(
+                tx,
+                vault_path,
+                &ev,
+                primary_content.as_deref(),
+                renamed_content.as_deref(),
+            );
+            dispatch_tag_index_cmd(
+                tx,
+                vault_path,
+                &ev,
+                primary_content.as_deref(),
+                renamed_content.as_deref(),
+            );
         }
 
         // Step 5c (#201 PR-A): Tombstone vectors for externally-deleted
@@ -337,16 +356,76 @@ pub(crate) fn try_send_or_warn(tx: &tokio::sync::mpsc::Sender<IndexCmd>, cmd: In
     }
 }
 
+/// Read the event's primary path (and renamed path, for rename events) from
+/// disk exactly once so both downstream dispatchers can share the same body.
+///
+/// #246 — previously each dispatcher did its own `std::fs::read_to_string`,
+/// so a single `.md` modify event hit disk twice and allocated two Strings.
+/// Now `process_events` reads once and hands the content to both dispatchers.
+///
+/// Returns `(primary_content, renamed_content)`:
+/// - `primary_content` is `Some` for Create / non-rename Modify on an in-vault
+///   `.md` path whose bytes could be read. `None` otherwise (Remove, rename,
+///   non-.md, out-of-vault, or read failure).
+/// - `renamed_content` is `Some` only for rename events (`ModifyKind::Name`)
+///   where `paths[1]` is an in-vault `.md` file whose bytes could be read.
+fn read_event_contents(
+    vault_path: &Path,
+    ev: &DebouncedEvent,
+) -> (Option<String>, Option<String>) {
+    let primary_path = match ev.paths.first() {
+        Some(p) => p,
+        None => return (None, None),
+    };
+
+    let is_md = |p: &Path| {
+        p.extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+    };
+    let in_vault = |p: &Path| p.starts_with(vault_path);
+
+    match &ev.kind {
+        EventKind::Modify(ModifyKind::Name(_)) => {
+            // Rename: only the NEW path (paths[1]) carries fresh content.
+            let renamed = ev.paths.get(1).and_then(|new_path| {
+                if is_md(new_path) && in_vault(new_path) {
+                    std::fs::read_to_string(new_path).ok()
+                } else {
+                    None
+                }
+            });
+            (None, renamed)
+        }
+        EventKind::Create(_) | EventKind::Modify(_) => {
+            let primary = if is_md(primary_path) && in_vault(primary_path) {
+                std::fs::read_to_string(primary_path).ok()
+            } else {
+                None
+            };
+            (primary, None)
+        }
+        // Remove / Access / Other — neither dispatcher needs on-disk content.
+        _ => (None, None),
+    }
+}
+
 /// Dispatch `IndexCmd::UpdateLinks` or `IndexCmd::RemoveLinks` based on the
 /// event kind.  Only `.md` files are dispatched — non-Markdown file changes
 /// don't affect the link graph.
 ///
+/// #246: `primary_content` / `renamed_content` are pre-read by
+/// `read_event_contents` so this dispatcher never touches disk. Both
+/// dispatchers share the same bytes, halving syscalls on the watcher hot
+/// path during bulk saves.
+///
 /// Uses `try_send_or_warn` so a full channel drops the command rather than
 /// blocking the watcher callback thread, but logs the drop (#139).
-fn dispatch_link_graph_cmd(
+pub(crate) fn dispatch_link_graph_cmd(
     tx: &tokio::sync::mpsc::Sender<IndexCmd>,
     vault_path: &Path,
     ev: &DebouncedEvent,
+    primary_content: Option<&str>,
+    renamed_content: Option<&str>,
 ) {
     let primary_path = match ev.paths.first() {
         Some(p) => p,
@@ -378,18 +457,21 @@ fn dispatch_link_graph_cmd(
                             Ok(r) => r.to_string_lossy().replace('\\', "/"),
                             Err(_) => return,
                         };
-                        if let Ok(content) = std::fs::read_to_string(new_path) {
+                        if let Some(content) = renamed_content {
                             try_send_or_warn(tx, IndexCmd::UpdateLinks {
                                 rel_path: new_rel,
-                                content,
+                                content: content.to_owned(),
                             });
                         }
                     }
                 }
             } else {
-                // create or modify — read content and dispatch UpdateLinks
-                if let Ok(content) = std::fs::read_to_string(primary_path) {
-                    try_send_or_warn(tx, IndexCmd::UpdateLinks { rel_path, content });
+                // create or modify — use the pre-read content
+                if let Some(content) = primary_content {
+                    try_send_or_warn(tx, IndexCmd::UpdateLinks {
+                        rel_path,
+                        content: content.to_owned(),
+                    });
                 }
             }
         }
@@ -404,12 +486,19 @@ fn dispatch_link_graph_cmd(
 /// event kind. Only `.md` files are dispatched — non-Markdown file changes
 /// don't affect the tag index.
 ///
+/// #246: `primary_content` / `renamed_content` are pre-read by
+/// `read_event_contents` so this dispatcher never touches disk. Shares the
+/// same bytes with `dispatch_link_graph_cmd`, halving the watcher's syscall
+/// and allocation cost per event.
+///
 /// Uses `try_send_or_warn` so a full channel drops the command rather than
 /// blocking the watcher callback thread, but logs the drop (#139).
 pub(crate) fn dispatch_tag_index_cmd(
     tx: &tokio::sync::mpsc::Sender<IndexCmd>,
     vault_path: &Path,
     ev: &DebouncedEvent,
+    primary_content: Option<&str>,
+    renamed_content: Option<&str>,
 ) {
     let primary_path = match ev.paths.first() {
         Some(p) => p,
@@ -450,18 +539,21 @@ pub(crate) fn dispatch_tag_index_cmd(
                             Ok(r) => r.to_string_lossy().replace('\\', "/"),
                             Err(_) => return,
                         };
-                        if let Ok(content) = std::fs::read_to_string(new_path) {
+                        if let Some(content) = renamed_content {
                             try_send_or_warn(tx, IndexCmd::UpdateTags {
                                 rel_path: new_rel,
-                                content,
+                                content: content.to_owned(),
                             });
                         }
                     }
                 }
             } else {
-                // create or modify — read content and dispatch UpdateTags
-                if let Ok(content) = std::fs::read_to_string(primary_path) {
-                    try_send_or_warn(tx, IndexCmd::UpdateTags { rel_path, content });
+                // create or modify — use the pre-read content
+                if let Some(content) = primary_content {
+                    try_send_or_warn(tx, IndexCmd::UpdateTags {
+                        rel_path,
+                        content: content.to_owned(),
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes #246.

- Every `.md` create/modify/rename event used to be read from disk **twice** — once in `dispatch_link_graph_cmd`, once in `dispatch_tag_index_cmd`. Under a bulk-save burst (git checkout touching 500 files, Obsidian vault rewrite) this doubled the watcher's syscall count and transient `String` allocations.
- `process_events` now calls a new `read_event_contents` helper that reads the primary path (and renamed path, for rename events) exactly once, then passes borrowed `&str` to both dispatchers.
- Dispatchers no longer touch disk. They're pure functions of `(rel_path, content)` — sharing the read is strictly more consistent too (no risk of the file changing between the two old reads).

## Why

Two `read_to_string` calls per event on the watcher hot path is wasted I/O. At 500 events in a burst that's 500 extra syscalls and 500 extra transient `String` allocations — bang on the "stay fluid at 100k notes" core value. Acceptance criterion in #246: a single modify event must trigger exactly one `read_to_string` syscall on the affected file; this PR achieves that.

## Test plan

- [x] `cargo check --all-targets` passes
- [x] New regression test `test_dispatch_link_graph_uses_provided_content_without_disk_read` pins the read-once contract by calling the link-graph dispatcher with a nonexistent path and an explicit content string. Pre-fix, the dispatcher's `std::fs::read_to_string` would have failed and silently dropped the command; post-fix, the dispatcher uses the supplied content verbatim.
- [x] Mirror test `test_dispatch_tag_index_uses_provided_content_without_disk_read` for the tag dispatcher.
- [x] Existing `tests::tag_index` watcher dispatch tests updated for the new signatures, all 4 green.
- [x] `cargo test --lib -- tests::watcher tests::tag_index` — 22 passed, 0 failed.
- Not run: full E2E suite (per project convention, affected scope only).
- Not run: full clippy gate (pre-existing clippy errors on main in `embeddings/reindex.rs` and `embeddings/vector_index.rs` unrelated to this change).

## Files touched

- `src-tauri/src/watcher.rs` — new `read_event_contents` helper; `dispatch_link_graph_cmd` and `dispatch_tag_index_cmd` now take `primary_content: Option<&str>` and `renamed_content: Option<&str>`, removing their internal `std::fs::read_to_string` calls.
- `src-tauri/src/tests/watcher.rs` — two new regression tests pinning read-once.
- `src-tauri/src/tests/tag_index.rs` — existing dispatcher tests updated to pass explicit content.

## Risk

Low. The dispatchers' old error surface was "silently drop command on read failure"; the new behaviour is "silently drop command when `content` is None (which happens on read failure in the shared read)". Semantically identical.