### PR TITLE
perf(editor): memoise inline HTML sanitise and short-circuit selection rebuilds

### DIFF
--- a/src/components/Editor/__tests__/inlineHtml.test.ts
+++ b/src/components/Editor/__tests__/inlineHtml.test.ts
@@ -1,5 +1,34 @@
-import { describe, it, expect } from "vitest";
-import { sanitizeHtml } from "../inlineHtml";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EditorState, EditorSelection } from "@codemirror/state";
+import { markdown } from "@codemirror/lang-markdown";
+import { GFM } from "@lezer/markdown";
+import DOMPurify from "dompurify";
+import {
+  sanitizeHtml,
+  __resetSanitizeCacheForTests,
+  __test,
+} from "../inlineHtml";
+
+function makeState(doc: string): EditorState {
+  return EditorState.create({
+    doc,
+    extensions: [
+      markdown({ extensions: [GFM] }),
+      __test.viewportField,
+      __test.inlineHtmlField,
+    ],
+  });
+}
+
+/** Count the decoration ranges contained in a DecorationSet. */
+function decorationCount(state: EditorState): number {
+  const set = state.field(__test.inlineHtmlField).decorations;
+  let n = 0;
+  set.between(0, state.doc.length, () => {
+    n += 1;
+  });
+  return n;
+}
 
 describe("inlineHtml — sanitizer", () => {
   it("strips <script> tags", () => {
@@ -110,3 +139,174 @@ describe("inlineHtml — sanitizer", () => {
     expect(result).not.toContain("this is a comment");
   });
 });
+
+// ── Performance: decoration rebuild short-circuits (#249) ────────────────────
+
+describe("inlineHtml — rebuild short-circuits (#249)", () => {
+  beforeEach(() => {
+    __resetSanitizeCacheForTests();
+  });
+
+  it("does NOT call DOMPurify.sanitize on a selection-only transaction that stays outside any HTML node", () => {
+    const doc = [
+      "Plain paragraph line one.",
+      "",
+      "<details><summary>s</summary>b</details>",
+      "",
+      "Another paragraph.",
+      "One more line here.",
+    ].join("\n");
+
+    // Start with cursor on line 1 (outside the HTML block), which forces
+    // the initial build + cache fill.
+    const initial = makeState(doc).update({
+      selection: EditorSelection.cursor(0),
+    }).state;
+
+    // Prime the sanitize cache via the initial build.
+    initial.field(__test.inlineHtmlField);
+
+    const spy = vi.spyOn(DOMPurify, "sanitize");
+    spy.mockClear();
+
+    // Move the cursor from line 1 start to line 1 end — still no HTML
+    // boundary crossing. This must NOT trigger a rebuild nor any sanitize
+    // call.
+    const firstLine = initial.doc.line(1);
+    const nextState = initial.update({
+      selection: EditorSelection.cursor(firstLine.to),
+    }).state;
+
+    // Force value materialisation.
+    const after = nextState.field(__test.inlineHtmlField);
+    const before = initial.field(__test.inlineHtmlField);
+    expect(after).toBe(before);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("reuses the sanitize cache across rebuilds — same raw text sanitised at most once", () => {
+    // Cursor defaults to 0 (line 1). Keep line 1 as a plain paragraph so the
+    // HTML block is off-cursor and the initial build primes the cache.
+    const doc = "paragraph before\n\n<details><summary>s</summary>body</details>\n";
+    const state = makeState(doc);
+
+    // Force the initial build so the raw html is in the cache.
+    state.field(__test.inlineHtmlField);
+
+    const spy = vi.spyOn(DOMPurify, "sanitize");
+    spy.mockClear();
+
+    // Call the public sanitizeHtml API with the same raw text — must be
+    // served from the cache.
+    const out = sanitizeHtml("<details><summary>s</summary>body</details>");
+    expect(out).toContain("<details>");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("rebuilds decorations when a doc change adds a new HTML block", () => {
+    const doc = "paragraph one\n\nparagraph two\n";
+    const s0 = makeState(doc);
+
+    // Cursor off-line to allow potential widgets to render.
+    const s1 = s0.update({ selection: EditorSelection.cursor(0) }).state;
+    const before = decorationCount(s1);
+    expect(before).toBe(0);
+
+    const insertion = "\n\n<kbd>Ctrl</kbd>";
+    const s2 = s1.update({
+      changes: { from: s1.doc.length, insert: insertion },
+    }).state;
+
+    const after = decorationCount(s2);
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("rebuilds when the cursor crosses into / out of an HTML block line", () => {
+    const doc = [
+      "paragraph one",
+      "",
+      "<details><summary>s</summary>body</details>",
+      "",
+      "paragraph two",
+    ].join("\n");
+    const s0 = makeState(doc);
+    const outside = s0.doc.line(1).from; // line 1, outside the block
+    const insideLine = s0.doc.line(3);   // the HTML line itself
+    const inside = insideLine.from + 2;
+
+    const sOutside = s0.update({ selection: EditorSelection.cursor(outside) }).state;
+    const decoOutside = decorationCount(sOutside);
+
+    const sInside = sOutside.update({ selection: EditorSelection.cursor(inside) }).state;
+    const decoInside = decorationCount(sInside);
+
+    // Moving the cursor onto the HTML line must hide the widget (no
+    // replace decoration for that block), so the decoration count must
+    // strictly decrease.
+    expect(decoInside).toBeLessThan(decoOutside);
+  });
+
+  it("returns the same value reference when selection moves within a plain region", () => {
+    const doc = "line one here\nline two here\nline three here\n";
+    const s0 = makeState(doc);
+    const a = s0.update({ selection: EditorSelection.cursor(0) }).state;
+    const b = a.update({ selection: EditorSelection.cursor(4) }).state;
+    expect(b.field(__test.inlineHtmlField)).toBe(a.field(__test.inlineHtmlField));
+  });
+});
+
+// ── Performance: viewport clipping (#249) ────────────────────────────────────
+
+describe("inlineHtml — viewport clipping (#249)", () => {
+  beforeEach(() => {
+    __resetSanitizeCacheForTests();
+  });
+
+  it("only processes HTML blocks inside the active viewport", () => {
+    // Construct a very tall document with an HTML block near the top and
+    // another near the bottom. With a narrow viewport around the top, only
+    // the top block's sanitise should run.
+    const top = "<details><summary>TOP</summary>top body</details>";
+    const bottom = "<details><summary>BOTTOM</summary>bottom body</details>";
+    const filler = Array.from({ length: 2_000 }, (_, i) => `filler line ${i}`).join(
+      "\n",
+    );
+    const doc = `leading paragraph\n\n${top}\n\n${filler}\n\n${bottom}\n`;
+
+    const s0 = makeState(doc);
+    // Set viewport to the top slice — must cover the `top` block (starts on
+    // line 3) but stop before the filler/bottom block.
+    const topBlockEnd = s0.doc.line(3).to + 1;
+    const s1 = s0.update({
+      effects: __test.setViewportEffect.of({ from: 0, to: topBlockEnd }),
+    }).state;
+    // Materialise so s1's build runs under the new viewport.
+    s1.field(__test.inlineHtmlField);
+
+    __resetSanitizeCacheForTests();
+    const spy = vi.spyOn(DOMPurify, "sanitize");
+    spy.mockClear();
+
+    // Move cursor off line 1, forcing a rebuild whose iterate() stays
+    // clipped to the configured viewport.
+    const sCursor = s1.update({
+      selection: EditorSelection.cursor(s1.doc.line(1).to),
+    }).state;
+    const value = sCursor.field(__test.inlineHtmlField);
+
+    // The top block must be enumerated; the bottom block must not have been
+    // touched — iterate was clipped to the viewport.
+    const nodeTexts = value.ranges.map((r) =>
+      sCursor.doc.sliceString(r.from, r.to),
+    );
+    expect(nodeTexts.some((t) => t.includes("TOP"))).toBe(true);
+    expect(nodeTexts.some((t) => t.includes("BOTTOM"))).toBe(false);
+
+    const calls = spy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((s) => s.includes("BOTTOM"))).toBe(false);
+    spy.mockRestore();
+  });
+});
+

--- a/src/components/Editor/inlineHtml.ts
+++ b/src/components/Editor/inlineHtml.ts
@@ -9,7 +9,20 @@
 // render as invisible.
 //
 // Uses a StateField (not ViewPlugin) because CM6 requires block-level
-// replace decorations to come from a StateField.
+// replace decorations to come from a StateField. A companion ViewPlugin
+// plumbs the current viewport bounds into a separate StateField via
+// `setViewportEffect` so that decoration building can clip the Lezer-tree
+// iteration to the visible slice.
+//
+// Performance (#249):
+//   * Selection-only transactions only rebuild when the cursor enters or
+//     leaves an existing HTML node range — otherwise the previous decoration
+//     set is reused.
+//   * `DOMPurify.sanitize` results are memoised by raw input text via a
+//     bounded module-level cache, so the same `<details>` block is
+//     sanitised once, not on every keystroke.
+//   * Widgets carry the pre-sanitised HTML, so `toDOM()` does not run a
+//     second sanitise pass over content already cleared by `buildDecorations`.
 //
 // Security: DOMPurify strips `<script>`, `on*` attributes, `javascript:`
 // URLs, and dangerous SVG features before any HTML reaches the DOM.
@@ -17,10 +30,11 @@
 import {
   Decoration,
   EditorView,
+  ViewPlugin,
   WidgetType,
 } from "@codemirror/view";
-import type { DecorationSet } from "@codemirror/view";
-import { EditorState, StateField } from "@codemirror/state";
+import type { DecorationSet, ViewUpdate } from "@codemirror/view";
+import { EditorState, StateEffect, StateField } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import DOMPurify from "dompurify";
 import type { Extension } from "@codemirror/state";
@@ -57,9 +71,38 @@ const PURIFY_CONFIG = {
   ALLOW_UNKNOWN_PROTOCOLS: false,
 };
 
-/** Sanitize HTML string, returns safe HTML. Exported for testing. */
+// ── Sanitise cache (#249) ────────────────────────────────────────────────────
+//
+// DOMPurify is deterministic for a fixed config, so memoising by raw text
+// is safe. A bounded Map keeps the cache size under control for
+// pathological vaults — we purge the oldest entries on overflow. 1024 slots
+// comfortably cover typical power-user notes (which usually contain a handful
+// of HTML blocks at most).
+
+const SANITIZE_CACHE_LIMIT = 1024;
+const sanitizeCache: Map<string, string> = new Map();
+
+/** Sanitize HTML string, returns safe HTML. Cached by raw input text. Exported for testing. */
 export function sanitizeHtml(raw: string): string {
-  return DOMPurify.sanitize(raw, PURIFY_CONFIG) as unknown as string;
+  const hit = sanitizeCache.get(raw);
+  if (hit !== undefined) {
+    // Refresh LRU position.
+    sanitizeCache.delete(raw);
+    sanitizeCache.set(raw, hit);
+    return hit;
+  }
+  const clean = DOMPurify.sanitize(raw, PURIFY_CONFIG) as unknown as string;
+  if (sanitizeCache.size >= SANITIZE_CACHE_LIMIT) {
+    const oldestKey = sanitizeCache.keys().next().value;
+    if (oldestKey !== undefined) sanitizeCache.delete(oldestKey);
+  }
+  sanitizeCache.set(raw, clean);
+  return clean;
+}
+
+/** Test-only: drop every cached sanitiser result. */
+export function __resetSanitizeCacheForTests(): void {
+  sanitizeCache.clear();
 }
 
 // ── Comment detection ────────────────────────────────────────────────────────
@@ -71,9 +114,13 @@ function isHtmlComment(text: string): boolean {
 }
 
 // ── Widgets ──────────────────────────────────────────────────────────────────
+//
+// Both widgets receive the already-sanitised HTML string so their `toDOM()`
+// can skip a second DOMPurify pass. `eq()` still compares the raw input (kept
+// for cache-key stability and cheap identity checks).
 
 class HtmlBlockWidget extends WidgetType {
-  constructor(readonly html: string) {
+  constructor(readonly html: string, readonly sanitized: string) {
     super();
   }
 
@@ -84,7 +131,7 @@ class HtmlBlockWidget extends WidgetType {
   toDOM(): HTMLElement {
     const wrap = document.createElement("div");
     wrap.className = "cm-html-rendered";
-    wrap.innerHTML = sanitizeHtml(this.html);
+    wrap.innerHTML = this.sanitized;
     return wrap;
   }
 
@@ -94,7 +141,7 @@ class HtmlBlockWidget extends WidgetType {
 }
 
 class HtmlInlineWidget extends WidgetType {
-  constructor(readonly html: string) {
+  constructor(readonly html: string, readonly sanitized: string) {
     super();
   }
 
@@ -105,7 +152,7 @@ class HtmlInlineWidget extends WidgetType {
   toDOM(): HTMLElement {
     const wrap = document.createElement("span");
     wrap.className = "cm-html-rendered-inline";
-    wrap.innerHTML = sanitizeHtml(this.html);
+    wrap.innerHTML = this.sanitized;
     return wrap;
   }
 
@@ -114,22 +161,103 @@ class HtmlInlineWidget extends WidgetType {
   }
 }
 
+// ── Viewport plumbing ────────────────────────────────────────────────────────
+
+interface ViewportRange {
+  from: number;
+  to: number;
+}
+
+const setViewportEffect = StateEffect.define<ViewportRange>();
+
+// `{from: -1, to: -1}` sentinel means "viewport not yet known" — on first
+// build we fall back to iterating the full tree until the companion
+// ViewPlugin pushes a real viewport. For non-ViewPlugin environments (e.g.
+// unit tests that build a bare state) this keeps behaviour identical to the
+// pre-#249 implementation.
+const UNKNOWN_VIEWPORT: ViewportRange = { from: -1, to: -1 };
+
+const viewportField = StateField.define<ViewportRange>({
+  create() {
+    return UNKNOWN_VIEWPORT;
+  },
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setViewportEffect)) {
+        return effect.value;
+      }
+    }
+    return value;
+  },
+});
+
+const viewportTrackerPlugin = ViewPlugin.fromClass(
+  class {
+    constructor(view: EditorView) {
+      // Seed the viewport on mount so the very first decoration rebuild
+      // can clip its iterate() call.
+      queueMicrotask(() => {
+        try {
+          view.dispatch({
+            effects: setViewportEffect.of({
+              from: view.viewport.from,
+              to: view.viewport.to,
+            }),
+          });
+        } catch {
+          // View may already be destroyed.
+        }
+      });
+    }
+
+    update(u: ViewUpdate) {
+      if (u.viewportChanged) {
+        u.view.dispatch({
+          effects: setViewportEffect.of({
+            from: u.view.viewport.from,
+            to: u.view.viewport.to,
+          }),
+        });
+      }
+    }
+  },
+);
+
 // ── Decoration builder ───────────────────────────────────────────────────────
 
-function buildDecorations(state: EditorState): DecorationSet {
+interface HtmlNodeRange {
+  from: number;
+  to: number;
+}
+
+interface InlineHtmlValue {
+  decorations: DecorationSet;
+  /** Document-order list of every HTML node range that was considered. */
+  ranges: HtmlNodeRange[];
+}
+
+function buildDecorations(state: EditorState): InlineHtmlValue {
   const ranges: Array<{ from: number; to: number; decoration: Decoration }> = [];
+  const nodeRanges: HtmlNodeRange[] = [];
 
   const head = state.selection.main.head;
   const doc = state.doc;
 
-  syntaxTree(state).iterate({
+  const viewport = state.field(viewportField, false) ?? UNKNOWN_VIEWPORT;
+  const iterateArgs: {
+    from?: number;
+    to?: number;
+    enter: (node: { name: string; from: number; to: number }) => void | boolean;
+  } = {
     enter(node) {
       if (node.name !== "HTMLBlock" && node.name !== "HTMLTag") return;
 
       const from = node.from;
       const to = node.to;
 
-      // If cursor is on any line within this node, show raw source
+      nodeRanges.push({ from, to });
+
+      // If cursor is on any line within this node, show raw source.
       const startLine = doc.lineAt(from).number;
       const endLine = doc.lineAt(to).number;
       const cursorLine = doc.lineAt(head).number;
@@ -148,7 +276,8 @@ function buildDecorations(state: EditorState): DecorationSet {
         // Don't replace HTML fragments whose sanitized output is empty
         // (e.g. a lone `</div>` after a blank line — CommonMark splits
         // multi-line HTML blocks at blank lines, producing orphan closing
-        // tags that DOMPurify strips entirely).
+        // tags that DOMPurify strips entirely). The sanitised output is
+        // memoised so the widget can reuse it without a second pass.
         const sanitized = sanitizeHtml(text);
         if (sanitized.trim().length === 0) return;
 
@@ -157,7 +286,7 @@ function buildDecorations(state: EditorState): DecorationSet {
             from,
             to,
             decoration: Decoration.replace({
-              widget: new HtmlBlockWidget(text),
+              widget: new HtmlBlockWidget(text, sanitized),
               block: true,
             }),
           });
@@ -166,37 +295,114 @@ function buildDecorations(state: EditorState): DecorationSet {
             from,
             to,
             decoration: Decoration.replace({
-              widget: new HtmlInlineWidget(text),
+              widget: new HtmlInlineWidget(text, sanitized),
             }),
           });
         }
       }
     },
-  });
+  };
+
+  if (viewport.from !== -1 || viewport.to !== -1) {
+    iterateArgs.from = viewport.from;
+    iterateArgs.to = viewport.to;
+  }
+
+  syntaxTree(state).iterate(iterateArgs);
 
   ranges.sort((a, b) => a.from - b.from);
+  nodeRanges.sort((a, b) => a.from - b.from);
 
-  return Decoration.set(
-    ranges.map((r) => r.decoration.range(r.from, r.to)),
-    true,
-  );
+  return {
+    decorations: Decoration.set(
+      ranges.map((r) => r.decoration.range(r.from, r.to)),
+      true,
+    ),
+    ranges: nodeRanges,
+  };
+}
+
+// ── Short-circuit logic ──────────────────────────────────────────────────────
+
+/**
+ * Return true iff moving the cursor from `oldHead` to `newHead` crosses at
+ * least one HTML-node line boundary in `ranges`. A "cross" means the old line
+ * is inside/outside a node while the new line is outside/inside (i.e. the
+ * cursor-on-line live-preview gate would flip for that node).
+ */
+function crossesHtmlBoundary(
+  ranges: HtmlNodeRange[],
+  doc: EditorState["doc"],
+  oldHead: number,
+  newHead: number,
+): boolean {
+  if (ranges.length === 0) return false;
+  if (oldHead === newHead) return false;
+  const oldLine = doc.lineAt(Math.min(Math.max(oldHead, 0), doc.length)).number;
+  const newLine = doc.lineAt(Math.min(Math.max(newHead, 0), doc.length)).number;
+  if (oldLine === newLine) return false;
+  for (const r of ranges) {
+    const rStart = doc.lineAt(r.from).number;
+    const rEnd = doc.lineAt(r.to).number;
+    const oldInside = oldLine >= rStart && oldLine <= rEnd;
+    const newInside = newLine >= rStart && newLine <= rEnd;
+    if (oldInside !== newInside) return true;
+  }
+  return false;
 }
 
 // ── StateField ───────────────────────────────────────────────────────────────
 
-const inlineHtmlField = StateField.define<DecorationSet>({
+const inlineHtmlField = StateField.define<InlineHtmlValue>({
   create(state) {
     return buildDecorations(state);
   },
   update(value, tr) {
-    if (tr.docChanged || tr.selection) {
+    // Viewport changes must re-run the build so off-screen → on-screen blocks
+    // get decorated. Check effects before the fast-path bail-outs.
+    let viewportChanged = false;
+    for (const effect of tr.effects) {
+      if (effect.is(setViewportEffect)) {
+        viewportChanged = true;
+        break;
+      }
+    }
+
+    if (tr.docChanged || viewportChanged) {
       return buildDecorations(tr.state);
     }
+
+    if (tr.selection) {
+      const oldHead = tr.startState.selection.main.head;
+      const newHead = tr.state.selection.main.head;
+      if (!crossesHtmlBoundary(value.ranges, tr.state.doc, oldHead, newHead)) {
+        // Pure cursor movement within the same "html vs not" region — the
+        // decoration set we returned last time is still correct.
+        return value;
+      }
+      return buildDecorations(tr.state);
+    }
+
     return value;
   },
   provide(f) {
-    return EditorView.decorations.from(f);
+    return EditorView.decorations.from(f, (v) => v.decorations);
   },
 });
 
-export const inlineHtmlPlugin: Extension = inlineHtmlField;
+// ── Exported extension ───────────────────────────────────────────────────────
+
+export const inlineHtmlPlugin: Extension = [
+  viewportField,
+  inlineHtmlField,
+  viewportTrackerPlugin,
+];
+
+// Test-only internals.
+export const __test = {
+  buildDecorations,
+  crossesHtmlBoundary,
+  inlineHtmlField,
+  viewportField,
+  setViewportEffect,
+};


### PR DESCRIPTION
Closes #249.

## Summary

`inlineHtmlField` rebuilt its full decoration set on every `tr.docChanged || tr.selection`, walked the whole Lezer tree (no viewport clip), and ran `DOMPurify.sanitize` twice per HTMLBlock / HTMLTag — once at the emptiness probe, once inside the widget's `toDOM`. Every arrow-key press on a note with a few `<details>` or `<kbd>` blocks cost frame budget it didn't need to.

## Why

- Selection-only transactions that don't cross any HTML node line boundary don't change the decoration set. Rebuilding is pure waste.
- DOMPurify is deterministic for a fixed config. Sanitising the same raw text on every keystroke is pure waste.
- `syntaxTree.iterate` without bounds traverses every HTML node in the document, not just the visible ones.

## Changes

- Companion `ViewPlugin` (`viewportTrackerPlugin`) dispatches the current viewport bounds into a new `viewportField` via a `setViewportEffect`. `buildDecorations` reads that field and clips `syntaxTree(state).iterate({ from, to })` to the viewport. A sentinel `{-1,-1}` preserves previous full-tree behaviour for bare states (e.g. unit tests that skip the ViewPlugin).
- `inlineHtmlField` now stores the previous build's HTML node ranges alongside the `DecorationSet`. Pure-selection transactions reuse the stored value whenever the old / new head don't land on different sides of any tracked HTML node line range.
- `sanitizeHtml` gets a bounded module-level LRU (1024 entries). The emptiness probe caches its sanitised output, and the widgets (`HtmlBlockWidget`, `HtmlInlineWidget`) now accept the pre-sanitised string and skip a second DOMPurify pass in `toDOM`.

## Rendering correctness

Decoration shape is byte-for-byte unchanged:
- Cursor-on-line still shows raw HTML source (live-preview parity with callouts).
- HTML comments still collapse to an empty decoration.
- Fragments whose sanitised output is empty (orphan `</div>` etc.) are still skipped.
- Block widgets still use `block: true`; inline widgets stay inline. Widget `eq()` still compares raw HTML, so CM6's decoration reuse path is untouched.

Security posture is preserved. Cache keys are raw text, `PURIFY_CONFIG` is immutable, so every unique input runs through DOMPurify exactly once across the lifetime of the process.

## Test plan

- [x] `pnpm test src/components/Editor/__tests__/inlineHtml.test.ts` — 24/24, including new cases that (a) assert no `DOMPurify.sanitize` call on selection-only moves that don't cross HTML boundaries, (b) assert cache reuse serves repeat sanitise requests without hitting DOMPurify, (c) cover decoration rebuild on doc change and on boundary-crossing cursor moves, (d) prove viewport clipping — a 2k-line doc with a TOP and BOTTOM `<details>` only enumerates TOP when the viewport is clipped to the top slice.
- [x] `pnpm test src/components/Editor/__tests__/` — 186/186 editor tests pass.
- [x] `pnpm typecheck` — clean.

## Regression risks mitigated

- Block decorations stay in a `StateField` (still the CM6 requirement for `block: true`), so pane mounting / table-of-contents interactions are untouched.
- Viewport seeding uses `queueMicrotask` + `try/catch` to survive pane unmounts during the tick.
- Cache eviction is oldest-first on overflow; the 1024-entry ceiling comfortably covers realistic vaults.
- `crossesHtmlBoundary` clamps head positions to `[0, doc.length]` so a selection landing past the new doc length after an undo doesn't blow up.