### PR TITLE
perf(graph): pause sim + render while tab hidden (#257)

### DIFF
--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -12,6 +12,7 @@
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import type { LocalGraph, GraphNode } from "../../types/links";
   import { clusterGraph } from "./clusterGraph";
+  import { tabContentSignature } from "./graphVisibility";
 
   // ── Persistence ─────────────────────────────────────────────────────────────
   const CAMERA_KEY_PREFIX = "vaultcore-graph-camera-";
@@ -247,6 +248,17 @@
   let embeddingClusterThreshold = $state<number>(CLUSTER_THRESHOLD_DEFAULT);
   let embeddingClusterThresholdApplied = $state<number>(CLUSTER_THRESHOLD_DEFAULT);
   let clusterTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // #257 — visibility tracking. The graph tab is kept mounted (hidden via
+  // style:display=none, see EditorPane.svelte) when not the active tab in
+  // its pane. Without tracking visibility, the d3-force simulation + sigma
+  // render loop keep ticking in the background — 5–15% CPU continuously
+  // while the user is typing in another tab. We pause on hide, resume on
+  // show, and defer any pending refetch triggered while hidden.
+  let rootEl = $state<HTMLDivElement | undefined>();
+  let isVisible = $state<boolean>(true);
+  let pendingRefetchWhileHidden = $state<boolean>(false);
+  let intersectionObserver: IntersectionObserver | null = null;
 
   let unlistenFileChange: UnlistenFn | null = null;
   let refetchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -538,6 +550,17 @@
     if (vaultPath) saveFrozen(vaultPath, next);
   }
 
+  // #257 — combined freeze state fed to the canvas.
+  //   - user-frozen (pin-button in the forces panel), OR
+  //   - graph tab not visible on screen (pauses d3-force + sigma render).
+  // GraphCanvas treats this as a single boolean and calls
+  // setLayoutFrozen(handle, effectivelyFrozen) — stopping the simulation
+  // when true and re-heating it at alpha=0.3 when false, all without
+  // touching the simulation object identity (positions survive).
+  const effectivelyFrozen = $derived.by<boolean>(() => {
+    return frozen || !isVisible;
+  });
+
   function onNodeClick(_id: string, node: GraphNode): void {
     if (!node.resolved || !vaultPath || !node.path) return;
     tabStore.openTab(`${vaultPath}/${node.path}`);
@@ -567,28 +590,68 @@
         payload.kind === "rename" ||
         payload.kind === "modify"
       ) {
+        // Hidden → defer; visible → debounce.
+        if (!isVisible) {
+          pendingRefetchWhileHidden = true;
+          return;
+        }
         scheduleRefetch();
       }
     });
+
+    // #257 — IntersectionObserver handles every "hidden" case uniformly:
+    // tab not active (display:none collapses clientRect to 0), sidebar
+    // rearrangement moving the pane off-screen, app minimized, etc.
+    // rootMargin 0 with threshold 0 = "any pixel on screen counts as
+    // visible", which is what we want (we only need the d3-force ticks
+    // to pay their cost when the graph could actually be seen).
+    if (rootEl && typeof IntersectionObserver !== "undefined") {
+      intersectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          isVisible = entry.isIntersecting;
+        }
+      });
+      intersectionObserver.observe(rootEl);
+    }
   });
 
-  // Detect content changes on open tabs whose lastSavedContent moved. Keeps
-  // behavior parity with LocalGraphPanel's docVersion debounce for global
-  // link structure updates after auto-save.
-  let lastSavedSignatures = new Map<string, string>();
-  const unsubTabsContent = tabStore.subscribe((s) => {
-    let anyChanged = false;
-    const nextSig = new Map<string, string>();
-    for (const t of s.tabs) {
-      if (t.type === "graph") continue;
-      nextSig.set(t.id, t.lastSavedContent);
-      const prev = lastSavedSignatures.get(t.id);
-      if (prev !== undefined && prev !== t.lastSavedContent) {
-        anyChanged = true;
-      }
+  // #257 — catch up on deferred refetches once the tab becomes visible.
+  // A single scheduled refetch covers any number of file-change /
+  // tab-save events that accumulated while hidden.
+  $effect(() => {
+    if (isVisible && pendingRefetchWhileHidden) {
+      pendingRefetchWhileHidden = false;
+      scheduleRefetch();
     }
-    lastSavedSignatures = nextSig;
-    if (anyChanged) scheduleRefetch();
+  });
+
+  // #257 — narrow, cheap content-change detection.
+  //
+  // tabStore emits on every per-keystroke setDirty, cursor move, scroll
+  // update, and hash write. The previous implementation iterated every
+  // tab and string-compared lastSavedContent on every emission — O(tabs *
+  // content-size) per keystroke, on the editor hot path, even when the
+  // graph tab wasn't visible. Swap that for a stable scalar signature
+  // (`id:lastSaved`) that only changes when a tab actually saves. First
+  // emission just seeds the baseline so we don't trigger a redundant
+  // refetch on mount (the onMount below already kicks off the initial
+  // load).
+  let lastTabContentSig: string | null = null;
+  const unsubTabsContent = tabStore.subscribe((s) => {
+    const sig = tabContentSignature(s.tabs);
+    if (lastTabContentSig === null) {
+      lastTabContentSig = sig;
+      return;
+    }
+    if (sig === lastTabContentSig) return;
+    lastTabContentSig = sig;
+    // If the graph tab is hidden, defer the refetch — mark as dirty and
+    // catch up when the tab becomes visible again.
+    if (!isVisible) {
+      pendingRefetchWhileHidden = true;
+      return;
+    }
+    scheduleRefetch();
   });
 
   onDestroy(() => {
@@ -599,12 +662,14 @@
     if (refetchTimer) clearTimeout(refetchTimer);
     if (thresholdTimer) clearTimeout(thresholdTimer);
     if (clusterTimer) clearTimeout(clusterTimer);
+    intersectionObserver?.disconnect();
+    intersectionObserver = null;
   });
 </script>
 
 <svelte:document onkeydown={handleKeydown} />
 
-<div class="vc-graph-view" role="region" aria-label="Graph-Ansicht">
+<div class="vc-graph-view" role="region" aria-label="Graph-Ansicht" bind:this={rootEl}>
   <div class="vc-graph-mode-toolbar" role="group" aria-label="Graph-Modus">
     <div class="vc-graph-mode-pills">
       <button
@@ -681,7 +746,7 @@
       {onCameraChange}
       datasetVersion={datasetVersion}
       forceSettings={forces}
-      {frozen}
+      frozen={effectivelyFrozen}
     />
     <GraphFilters
       state={filters}

--- a/src/components/Graph/__tests__/graphRender.test.ts
+++ b/src/components/Graph/__tests__/graphRender.test.ts
@@ -154,6 +154,37 @@ describe("d3-force integration", () => {
     destroyGraph(handle);
   });
 
+  // #257 — pause/resume cycle used by GraphView when its tab is hidden.
+  // Freeze on hide, unfreeze on show: the simulation object itself must
+  // survive the round-trip (same Simulation instance) so node positions
+  // aren't reshuffled by a fresh seed.
+  it("pause/resume cycle via setLayoutFrozen preserves the simulation instance", () => {
+    const handle = mountGraph(makeContainer(), sampleGraph(), {
+      centerId: "a.md",
+      accentColor: "#ff8800",
+      nodeColor: "#888888",
+      unresolvedColor: "#cccccc",
+      edgeColor: "#eeeeee",
+      forceSettings: DEFAULT_FORCE_SETTINGS,
+    });
+    const simBefore = handle.simulation;
+    expect(simBefore).not.toBeNull();
+
+    // Hide → freeze.
+    setLayoutFrozen(handle, true);
+    expect(handle.frozen).toBe(true);
+    expect(handle.simulation).toBe(simBefore);
+
+    // Show → unfreeze.
+    setLayoutFrozen(handle, false);
+    expect(handle.frozen).toBe(false);
+    expect(handle.simulation).toBe(simBefore);
+    // alpha should have been re-heated for the resume.
+    expect(handle.simulation!.alpha()).toBeGreaterThan(0);
+
+    destroyGraph(handle);
+  });
+
   it("updateGraph with relayout=false preserves positions for nodes present in both datasets", () => {
     const handle = mountGraph(makeContainer(), sampleGraph(), {
       centerId: "a.md",

--- a/src/components/Graph/__tests__/graphVisibility.test.ts
+++ b/src/components/Graph/__tests__/graphVisibility.test.ts
@@ -1,0 +1,63 @@
+// #257 — unit tests for the narrow tabStore signature used by GraphView.
+//
+// The signature MUST be stable across tabStore emissions that are unrelated
+// to saved content (dirty flag flip, cursor move, scroll change, hash
+// write) and MUST change when a tab actually saves.
+
+import { describe, it, expect } from "vitest";
+import { tabContentSignature } from "../graphVisibility";
+
+describe("tabContentSignature (#257)", () => {
+  it("is stable when only non-save fields change (keystroke hot path)", () => {
+    const base = [
+      { id: "a", lastSaved: 1_000, type: "file" as const },
+      { id: "b", lastSaved: 2_000, type: "file" as const },
+    ];
+    const s1 = tabContentSignature(base);
+
+    // Emulate a per-keystroke setDirty emission: lastSaved unchanged,
+    // other fields (not visible to the signature) mutated.
+    const churned = [
+      { id: "a", lastSaved: 1_000, type: "file" as const },
+      { id: "b", lastSaved: 2_000, type: "file" as const },
+    ];
+    const s2 = tabContentSignature(churned);
+
+    expect(s2).toBe(s1);
+  });
+
+  it("changes when any tab's lastSaved timestamp advances (auto-save)", () => {
+    const s1 = tabContentSignature([
+      { id: "a", lastSaved: 1_000, type: "file" as const },
+    ]);
+    const s2 = tabContentSignature([
+      { id: "a", lastSaved: 1_500, type: "file" as const },
+    ]);
+    expect(s2).not.toBe(s1);
+  });
+
+  it("changes when a new file tab is added or an existing one closes", () => {
+    const baseSig = tabContentSignature([
+      { id: "a", lastSaved: 1_000, type: "file" as const },
+    ]);
+    const addedSig = tabContentSignature([
+      { id: "a", lastSaved: 1_000, type: "file" as const },
+      { id: "b", lastSaved: 1_000, type: "file" as const },
+    ]);
+    expect(addedSig).not.toBe(baseSig);
+
+    const removedSig = tabContentSignature([]);
+    expect(removedSig).not.toBe(baseSig);
+  });
+
+  it("ignores graph tabs (they never carry saveable content)", () => {
+    const s1 = tabContentSignature([
+      { id: "a", lastSaved: 1_000, type: "file" as const },
+    ]);
+    const s2 = tabContentSignature([
+      { id: "a", lastSaved: 1_000, type: "file" as const },
+      { id: "g", lastSaved: 9_999, type: "graph" as const },
+    ]);
+    expect(s2).toBe(s1);
+  });
+});

--- a/src/components/Graph/graphVisibility.ts
+++ b/src/components/Graph/graphVisibility.ts
@@ -1,0 +1,43 @@
+// #257 — narrow tabStore subscription helper for GraphView.
+//
+// Background: `GraphView.svelte` used to diff `lastSavedContent` across
+// every tab on every `tabStore` emission to decide whether to schedule a
+// graph refetch. Because `tabStore` emits on per-keystroke `setDirty` and
+// on scroll-position updates, that subscriber ran O(tabs) string-compares
+// on the editor hot path — even when the graph tab wasn't visible.
+//
+// The only signal GraphView actually needs is "did some tab's saved
+// content change?". Saves bump both `lastSaved` (timestamp, scalar) and
+// the base `lastSavedContent` (potentially a large string). Building a
+// signature from the cheap scalar (`id:lastSaved`) gives us a stable key
+// that changes only on actual saves, not on every keystroke.
+//
+// Graph tabs are excluded — they never hold note content.
+
+export interface TabSaveInfo {
+  id: string;
+  type?: "file" | "graph";
+  lastSaved: number;
+}
+
+/**
+ * Cheap signature of the "something saved" state across file tabs.
+ * Graph tabs are ignored. Order-stable for a given tabs array (we walk
+ * the input without sorting — callers pass `state.tabs` which is itself
+ * order-stable per tabStore contract).
+ *
+ * Output is a joined string — comparable with === and cheap to recompute
+ * on every tabStore emission. Storing it as a module-local `string`
+ * lets subscribers short-circuit the common case where the emission is
+ * an unrelated per-tab field flip (isDirty, scrollPos, lastSavedHash).
+ */
+export function tabContentSignature(
+  tabs: ReadonlyArray<TabSaveInfo>,
+): string {
+  const parts: string[] = [];
+  for (const t of tabs) {
+    if (t.type === "graph") continue;
+    parts.push(`${t.id}:${t.lastSaved}`);
+  }
+  return parts.join("|");
+}


### PR DESCRIPTION
## Summary

Fix for #257 — the graph view kept its d3-force simulation and sigma render loop
running even when the graph tab was hidden, burning 5–15% CPU on the UI thread
while the user typed in another tab. Its `tabStore` subscriber also diffed every
tab's `lastSavedContent` on every emission, turning per-keystroke `setDirty`
updates into O(tabs × content-size) work.

## Why

- Graph tabs are kept mounted (display:none) when not active, so without an
  explicit pause the continuous simulation keeps ticking in the background and
  competes for the same 16 ms budget the editor needs.
- `tabStore` emits on every keystroke (`setDirty`) and the content-diff
  subscription was on that hot path regardless of graph visibility.

## Changes

- **Visibility detection** — IntersectionObserver on the GraphView root. Covers
  every hidden case uniformly: tab not active, pane off-screen, window minimized.
- **Pause, don't destroy** — combine visibility with the existing user-frozen
  flag into `effectivelyFrozen`, forwarded as `frozen` to GraphCanvas. That
  funnels through the existing `setLayoutFrozen(handle, frozen)` path which
  `.stop()`s the simulation on hide and re-heats it at `alpha=0.3` on show.
  Same `Simulation` instance survives — node positions don't jump.
- **Deferred refetch** — file-watcher events and cross-tab saves fired while
  hidden collapse into a single `pendingRefetchWhileHidden` flag that a
  `$effect` drains when the tab becomes visible again.
- **Cheap tab-save signature** — `tabContentSignature()` builds a joined
  `id:lastSaved` string from file tabs. `lastSaved` only changes on actual
  saves, so per-keystroke `setDirty` emissions short-circuit. Same pattern as
  #261's `recentsSignature`.

## Retention policy

Graph data (graphology Graph, sigma renderer, d3-force Simulation, SimNode map)
is **retained across hide/show** — pause-only is deliberate. Destroy-on-hide
has more edge cases (WebGL context loss, re-layout flicker, re-seeded positions
on every tab swap) than it's worth for MVP. Full teardown still runs via
`destroyGraph()` in `onDestroy` when the graph tab is actually closed.

## Test plan

- [x] Unit: `tabContentSignature` is stable when only non-save fields change
  and shifts when any tab saves or opens/closes (`graphVisibility.test.ts`).
- [x] Unit: `setLayoutFrozen(true)` → `setLayoutFrozen(false)` round-trip keeps
  the same Simulation instance and re-heats alpha (`graphRender.test.ts`).
- [x] Full Vitest suite — 806/806 green.
- [x] `npx tsc --noEmit` clean, `svelte-check` clean (only 2 pre-existing
  line-clamp CSS warnings unrelated to this change).

Closes #257.