### PR TITLE
perf(editor): cap frontmatter detection to 16 KB head slice — partial fix for #247

### DIFF
--- a/src/components/Editor/__tests__/frontmatterDocToStringStorm.test.ts
+++ b/src/components/Editor/__tests__/frontmatterDocToStringStorm.test.ts
@@ -1,0 +1,357 @@
+// Regression tests for issue #247:
+// Three CodeMirror plugin paths used to serialise the entire document via
+// `doc.toString()` on every keystroke — directly eating the 16 ms keystroke
+// budget on long notes:
+//
+//   1. livePreview.ts buildDecorations — `detectFrontmatter(doc.toString())`
+//      on every docChanged / viewportChanged / selectionSet transaction.
+//   2. frontmatterPlugin.ts buildDecorations (StateField) — same pattern on
+//      every tr.docChanged.
+//   3. frontmatterPlugin.ts frontmatterBoundaryGuard (transactionFilter) —
+//      same pattern on every *input* transaction; stacks with (2).
+//
+// The fix reads only the head of the document (FRONTMATTER_MAX_SLICE bytes)
+// via `doc.sliceString(0, FRONTMATTER_MAX_SLICE)`. Frontmatter is either at
+// offset 0 or absent, and never grows past a few hundred bytes in practice,
+// so a 16 KB head slice is a strict superset of any legitimate frontmatter.
+//
+// The tests below assert:
+//   - `Text.prototype.toString` is NEVER called on the three hot paths.
+//   - Decoration output is unchanged for realistic inputs (parity).
+//   - The StateField still rebuilds on docChanged.
+//   - The boundary guard still rewrites inserts into the frontmatter region.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EditorState, EditorSelection, Text } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import type { DecorationSet } from "@codemirror/view";
+import { markdown } from "@codemirror/lang-markdown";
+import { GFM } from "@lezer/markdown";
+
+import { frontmatterPlugin } from "../frontmatterPlugin";
+import { livePreviewPlugin } from "../livePreview";
+
+function makeState(doc: string): EditorState {
+  return EditorState.create({
+    doc,
+    extensions: [
+      markdown({ extensions: [GFM] }),
+      frontmatterPlugin,
+      livePreviewPlugin,
+    ],
+  });
+}
+
+function mountView(doc: string): { view: EditorView; parent: HTMLElement } {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({
+    state: makeState(doc),
+    parent,
+  });
+  return { view, parent };
+}
+
+// ─── hot-path toString assertion ────────────────────────────────────────────
+
+describe("CM6 frontmatter plugins — no doc.toString() on keystroke (issue #247)", () => {
+  let toStringSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    toStringSpy = vi.spyOn(Text.prototype, "toString");
+  });
+
+  afterEach(() => {
+    toStringSpy.mockRestore();
+  });
+
+  it("does not call Text.toString() on a typing transaction (frontmatter StateField + boundary guard)", () => {
+    // Long body so any full-doc toString() would clearly show up in the spy.
+    const longBody = "word ".repeat(10_000).trim();
+    const doc = `---\ntitle: Hello\n---\n${longBody}`;
+    const { view, parent } = mountView(doc);
+
+    toStringSpy.mockClear();
+
+    // Dispatch a body-side insertion — passes through the boundary guard and
+    // triggers the StateField update because docChanged is true.
+    view.dispatch({
+      changes: { from: view.state.doc.length, to: view.state.doc.length, insert: "x" },
+      userEvent: "input.type",
+    });
+
+    expect(toStringSpy).not.toHaveBeenCalled();
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("does not call Text.toString() on a selection-only transaction (livePreview rebuild path)", () => {
+    // livePreview rebuilds on selectionSet; pre-fix it would call
+    // detectFrontmatter(doc.toString()) on every arrow-key tap.
+    const longBody = "word ".repeat(10_000).trim();
+    const doc = `---\ntitle: Hello\n---\n${longBody}`;
+    const { view, parent } = mountView(doc);
+
+    toStringSpy.mockClear();
+
+    // 5 simulated arrow-key cursor moves in the body.
+    for (let i = 30; i <= 34; i++) {
+      view.dispatch({ selection: EditorSelection.cursor(i) });
+    }
+
+    expect(toStringSpy).not.toHaveBeenCalled();
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("does not call Text.toString() on an input transaction with no frontmatter", () => {
+    // The boundary guard short-circuits when no frontmatter is present, but
+    // pre-fix it still serialised the doc once to make that determination.
+    const longBody = "word ".repeat(10_000).trim();
+    const { view, parent } = mountView(longBody);
+
+    toStringSpy.mockClear();
+
+    view.dispatch({
+      changes: { from: view.state.doc.length, to: view.state.doc.length, insert: "x" },
+      userEvent: "input.type",
+    });
+
+    expect(toStringSpy).not.toHaveBeenCalled();
+
+    view.destroy();
+    parent.remove();
+  });
+});
+
+// ─── parity: frontmatter StateField still rebuilds on docChanged ────────────
+
+function collectBlockRanges(view: EditorView): Array<{ from: number; to: number }> {
+  const ranges: Array<{ from: number; to: number }> = [];
+  // EditorView aggregates decoration facet entries; iterate the resolved set.
+  const state = view.state;
+  const facetValues = state.facet(EditorView.decorations);
+  for (const entry of facetValues) {
+    const set: DecorationSet =
+      typeof entry === "function" ? (entry as (v: EditorView) => DecorationSet)(view) : entry;
+    if (!set) continue;
+    set.between(0, state.doc.length, (from, to, deco) => {
+      if ((deco.spec as { block?: boolean }).block === true) {
+        ranges.push({ from, to });
+      }
+    });
+  }
+  return ranges;
+}
+
+describe("frontmatterPlugin StateField — parity (issue #247)", () => {
+  it("hides the frontmatter block with a single block-replace decoration", () => {
+    const doc = "---\ntitle: Test\n---\n# Body\n";
+    const { view, parent } = mountView(doc);
+
+    const blocks = collectBlockRanges(view);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.from).toBe(0);
+    expect(blocks[0]!.to).toBe("---\ntitle: Test\n---\n".length);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("rebuilds the block decoration when the frontmatter region grows", () => {
+    const doc = "---\ntitle: A\n---\n# Body\n";
+    const { view, parent } = mountView(doc);
+
+    const before = collectBlockRanges(view);
+    expect(before).toHaveLength(1);
+
+    // Insert a new key inside the frontmatter body (before the closing ---).
+    const closingFenceStart = "---\ntitle: A\n".length;
+    view.dispatch({
+      changes: { from: closingFenceStart, insert: "tags: [x]\n" },
+    });
+
+    const after = collectBlockRanges(view);
+    expect(after).toHaveLength(1);
+    expect(after[0]!.to).toBeGreaterThan(before[0]!.to);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("produces no frontmatter block decoration when there is no frontmatter", () => {
+    const doc = "# Plain body\n";
+    const { view, parent } = mountView(doc);
+
+    expect(collectBlockRanges(view)).toHaveLength(0);
+
+    view.destroy();
+    parent.remove();
+  });
+});
+
+// ─── parity: boundary guard still rewrites ──────────────────────────────────
+
+describe("frontmatterBoundaryGuard — parity (issue #247)", () => {
+  it("redirects a Cmd-A + type replacement past the frontmatter block", () => {
+    const doc = "---\ntitle: Test\n---\n# Body\nHello\nWorld\n";
+    const { view, parent } = mountView(doc);
+
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: "X" },
+      userEvent: "input.type",
+    });
+
+    // The boundary guard must keep the frontmatter intact and append "X"
+    // immediately after it.
+    expect(view.state.doc.sliceString(0, view.state.doc.length)).toBe(
+      "---\ntitle: Test\n---\nX",
+    );
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("passes body-only edits through unchanged", () => {
+    const doc = "---\ntitle: T\n---\nAlpha\n";
+    const { view, parent } = mountView(doc);
+    const alphaStart = doc.indexOf("Alpha");
+
+    view.dispatch({
+      changes: { from: alphaStart, to: alphaStart + 5, insert: "Gamma" },
+      userEvent: "input.type",
+    });
+
+    expect(view.state.doc.sliceString(0, view.state.doc.length)).toBe(
+      "---\ntitle: T\n---\nGamma\n",
+    );
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("does not intervene for non-input userEvents", () => {
+    const doc = "---\ntitle: T\n---\n# Body\n";
+    const { view, parent } = mountView(doc);
+
+    view.dispatch({
+      changes: { from: 0, to: 4 },
+      userEvent: "delete.line",
+    });
+
+    // First `---\n` was removed — guard does not rewrite non-input events.
+    expect(view.state.doc.sliceString(0, view.state.doc.length)).toBe(
+      "title: T\n---\n# Body\n",
+    );
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("handles a transaction with a very long body without serialising the doc", () => {
+    // Long body plus an input transaction that touches the head of the doc.
+    // Pre-fix this called detectFrontmatter on tr.startState.doc.toString()
+    // — now bounded to the first 16 KB.
+    const longBody = "word ".repeat(20_000).trim();
+    const doc = `---\ntitle: Long\n---\n${longBody}`;
+    const { view, parent } = mountView(doc);
+
+    const toStringSpy = vi.spyOn(Text.prototype, "toString");
+
+    view.dispatch({
+      changes: { from: 0, to: 0, insert: "X" },
+      userEvent: "input.type",
+    });
+
+    // Guard redirects the insert past the frontmatter region; body stays
+    // intact, frontmatter stays intact.
+    expect(view.state.doc.sliceString(0, 20)).toBe("---\ntitle: Long\n---\n");
+    // The 21st character (first char of body after the redirect) is "X".
+    expect(view.state.doc.sliceString(20, 21)).toBe("X");
+
+    expect(toStringSpy).not.toHaveBeenCalled();
+
+    toStringSpy.mockRestore();
+    view.destroy();
+    parent.remove();
+  });
+});
+
+// ─── livePreview parity ─────────────────────────────────────────────────────
+
+describe("livePreview — frontmatter header-mark suppression (issue #247)", () => {
+  it("does not hide header marks inside the frontmatter region", () => {
+    // Frontmatter closing fence `---` parses as HeaderMark (setext H2). The
+    // livePreview plugin must skip hiding HeaderMarks that fall inside the
+    // frontmatter region — the previous detectFrontmatter(doc.toString())
+    // was load-bearing for this check and the sliced variant must stay
+    // behaviourally identical.
+    const doc = "---\ntitle: T\n---\n# Heading\n";
+    const { view, parent } = mountView(doc);
+
+    // Park the cursor outside the heading line so livePreview would hide
+    // marks. The frontmatter closing `---` lives on line 3; the heading
+    // `#` lives on line 4. Cursor on line 1 (char 0) means both are
+    // off-cursor; only the body `#` must get a hide decoration, not the
+    // frontmatter `---`.
+    view.dispatch({ selection: EditorSelection.cursor(0) });
+
+    const plugin = view.plugin(livePreviewPlugin);
+    expect(plugin).not.toBeNull();
+    const decos = plugin!.decorations;
+
+    // Collect hide-decoration ranges.
+    const hidden: Array<{ from: number; to: number }> = [];
+    decos.between(0, view.state.doc.length, (from, to) => {
+      hidden.push({ from, to });
+    });
+
+    // Frontmatter region is [0, 20) (`---\ntitle: T\n---\n`, 20 chars).
+    // No hide range may overlap [0, 20).
+    const frontmatterEnd = "---\ntitle: T\n---\n".length;
+    for (const r of hidden) {
+      // Non-overlap condition: r.from >= frontmatterEnd OR r.to <= 0.
+      const nonOverlap = r.from >= frontmatterEnd || r.to <= 0;
+      expect(nonOverlap).toBe(true);
+    }
+
+    // The body `#` on line 4 should be hidden (it's outside the frontmatter
+    // and off-cursor).
+    const headingHashPos = doc.indexOf("# Heading");
+    expect(
+      hidden.some((r) => r.from === headingHashPos && r.to >= headingHashPos + 1),
+    ).toBe(true);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("hides all off-cursor HeaderMarks when no frontmatter is present", () => {
+    const doc = "# First\n\n## Second\n\nbody\n";
+    const { view, parent } = mountView(doc);
+
+    // Cursor on line 5 (body) — both headings are off-cursor.
+    const bodyPos = doc.indexOf("body");
+    view.dispatch({ selection: EditorSelection.cursor(bodyPos) });
+
+    const plugin = view.plugin(livePreviewPlugin);
+    const decos = plugin!.decorations;
+
+    const hidden: Array<{ from: number; to: number }> = [];
+    decos.between(0, view.state.doc.length, (from, to) => {
+      hidden.push({ from, to });
+    });
+
+    // Both `#` and `##` must have hide ranges.
+    const firstHashPos = doc.indexOf("# First");
+    const secondHashPos = doc.indexOf("## Second");
+    expect(hidden.some((r) => r.from === firstHashPos)).toBe(true);
+    expect(hidden.some((r) => r.from === secondHashPos)).toBe(true);
+
+    view.destroy();
+    parent.remove();
+  });
+});
+

--- a/src/components/Editor/__tests__/frontmatterDocToStringStorm.test.ts
+++ b/src/components/Editor/__tests__/frontmatterDocToStringStorm.test.ts
@@ -21,7 +21,7 @@
 //   - The StateField still rebuilds on docChanged.
 //   - The boundary guard still rewrites inserts into the frontmatter region.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { EditorState, EditorSelection, Text } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import type { DecorationSet } from "@codemirror/view";
@@ -54,75 +54,93 @@ function mountView(doc: string): { view: EditorView; parent: HTMLElement } {
 
 // ─── hot-path toString assertion ────────────────────────────────────────────
 
+// Threshold: we don't care that CM6 / the boundary guard serialise small Text
+// fragments (inserted chunks, tiny docs in other tests). The regression target
+// is full-document `doc.toString()` — any Text instance whose length is at or
+// above this threshold on the hot path is a smoking gun.
+const BIG_TEXT = 1000;
+
+function spyOnBigTextToString(): { calls: number[]; restore: () => void } {
+  const orig = Text.prototype.toString;
+  const calls: number[] = [];
+  const wrapped = function (this: Text): string {
+    if (this.length >= BIG_TEXT) calls.push(this.length);
+    return orig.call(this);
+  };
+  Text.prototype.toString = wrapped;
+  return {
+    calls,
+    restore: () => {
+      Text.prototype.toString = orig;
+    },
+  };
+}
+
 describe("CM6 frontmatter plugins — no doc.toString() on keystroke (issue #247)", () => {
-  let toStringSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    toStringSpy = vi.spyOn(Text.prototype, "toString");
-  });
-
-  afterEach(() => {
-    toStringSpy.mockRestore();
-  });
-
-  it("does not call Text.toString() on a typing transaction (frontmatter StateField + boundary guard)", () => {
-    // Long body so any full-doc toString() would clearly show up in the spy.
+  it("does not serialise the whole doc on a typing transaction (StateField + boundary guard)", () => {
+    // Long body so any full-doc toString() would clearly show up.
     const longBody = "word ".repeat(10_000).trim();
     const doc = `---\ntitle: Hello\n---\n${longBody}`;
     const { view, parent } = mountView(doc);
 
-    toStringSpy.mockClear();
+    const spy = spyOnBigTextToString();
+    try {
+      // Dispatch a body-side insertion — passes through the boundary guard
+      // and triggers the StateField update because docChanged is true.
+      view.dispatch({
+        changes: { from: view.state.doc.length, to: view.state.doc.length, insert: "x" },
+        userEvent: "input.type",
+      });
 
-    // Dispatch a body-side insertion — passes through the boundary guard and
-    // triggers the StateField update because docChanged is true.
-    view.dispatch({
-      changes: { from: view.state.doc.length, to: view.state.doc.length, insert: "x" },
-      userEvent: "input.type",
-    });
-
-    expect(toStringSpy).not.toHaveBeenCalled();
-
-    view.destroy();
-    parent.remove();
+      expect(spy.calls).toEqual([]);
+    } finally {
+      spy.restore();
+      view.destroy();
+      parent.remove();
+    }
   });
 
-  it("does not call Text.toString() on a selection-only transaction (livePreview rebuild path)", () => {
+  it("does not serialise the whole doc on a selection-only transaction (livePreview rebuild path)", () => {
     // livePreview rebuilds on selectionSet; pre-fix it would call
     // detectFrontmatter(doc.toString()) on every arrow-key tap.
     const longBody = "word ".repeat(10_000).trim();
     const doc = `---\ntitle: Hello\n---\n${longBody}`;
     const { view, parent } = mountView(doc);
 
-    toStringSpy.mockClear();
+    const spy = spyOnBigTextToString();
+    try {
+      // 5 simulated arrow-key cursor moves in the body.
+      for (let i = 30; i <= 34; i++) {
+        view.dispatch({ selection: EditorSelection.cursor(i) });
+      }
 
-    // 5 simulated arrow-key cursor moves in the body.
-    for (let i = 30; i <= 34; i++) {
-      view.dispatch({ selection: EditorSelection.cursor(i) });
+      expect(spy.calls).toEqual([]);
+    } finally {
+      spy.restore();
+      view.destroy();
+      parent.remove();
     }
-
-    expect(toStringSpy).not.toHaveBeenCalled();
-
-    view.destroy();
-    parent.remove();
   });
 
-  it("does not call Text.toString() on an input transaction with no frontmatter", () => {
+  it("does not serialise the whole doc on an input transaction with no frontmatter", () => {
     // The boundary guard short-circuits when no frontmatter is present, but
     // pre-fix it still serialised the doc once to make that determination.
     const longBody = "word ".repeat(10_000).trim();
     const { view, parent } = mountView(longBody);
 
-    toStringSpy.mockClear();
+    const spy = spyOnBigTextToString();
+    try {
+      view.dispatch({
+        changes: { from: view.state.doc.length, to: view.state.doc.length, insert: "x" },
+        userEvent: "input.type",
+      });
 
-    view.dispatch({
-      changes: { from: view.state.doc.length, to: view.state.doc.length, insert: "x" },
-      userEvent: "input.type",
-    });
-
-    expect(toStringSpy).not.toHaveBeenCalled();
-
-    view.destroy();
-    parent.remove();
+      expect(spy.calls).toEqual([]);
+    } finally {
+      spy.restore();
+      view.destroy();
+      parent.remove();
+    }
   });
 });
 
@@ -258,24 +276,25 @@ describe("frontmatterBoundaryGuard — parity (issue #247)", () => {
     const doc = `---\ntitle: Long\n---\n${longBody}`;
     const { view, parent } = mountView(doc);
 
-    const toStringSpy = vi.spyOn(Text.prototype, "toString");
+    const spy = spyOnBigTextToString();
+    try {
+      view.dispatch({
+        changes: { from: 0, to: 0, insert: "X" },
+        userEvent: "input.type",
+      });
 
-    view.dispatch({
-      changes: { from: 0, to: 0, insert: "X" },
-      userEvent: "input.type",
-    });
+      // Guard redirects the insert past the frontmatter region; body stays
+      // intact, frontmatter stays intact.
+      expect(view.state.doc.sliceString(0, 20)).toBe("---\ntitle: Long\n---\n");
+      // The 21st character (first char of body after the redirect) is "X".
+      expect(view.state.doc.sliceString(20, 21)).toBe("X");
 
-    // Guard redirects the insert past the frontmatter region; body stays
-    // intact, frontmatter stays intact.
-    expect(view.state.doc.sliceString(0, 20)).toBe("---\ntitle: Long\n---\n");
-    // The 21st character (first char of body after the redirect) is "X".
-    expect(view.state.doc.sliceString(20, 21)).toBe("X");
-
-    expect(toStringSpy).not.toHaveBeenCalled();
-
-    toStringSpy.mockRestore();
-    view.destroy();
-    parent.remove();
+      expect(spy.calls).toEqual([]);
+    } finally {
+      spy.restore();
+      view.destroy();
+      parent.remove();
+    }
   });
 });
 

--- a/src/components/Editor/frontmatterPlugin.ts
+++ b/src/components/Editor/frontmatterPlugin.ts
@@ -1,9 +1,22 @@
 import { Decoration, EditorView, WidgetType } from "@codemirror/view";
 import type { DecorationSet } from "@codemirror/view";
 import { EditorState, StateField, Transaction } from "@codemirror/state";
-import type { ChangeSpec, Extension } from "@codemirror/state";
+import type { ChangeSpec, Extension, Text } from "@codemirror/state";
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(\r?\n)?/;
+
+/**
+ * #247 — head-slice cap for `detectFrontmatterInDoc`.
+ *
+ * Frontmatter lives at offset 0 or not at all, and in practice never grows
+ * past a few hundred bytes; 16 KB is a comfortable upper bound that avoids
+ * serialising the entire document on every keystroke/selection for the three
+ * hot-path callers (livePreview decoration build, frontmatter StateField
+ * rebuild, frontmatterBoundaryGuard transactionFilter). Before this cap,
+ * each keystroke on a 10 k-word note paid two full-doc `toString()`
+ * allocations, directly eating the 16 ms keystroke budget.
+ */
+const FRONTMATTER_MAX_SLICE = 16384;
 
 export interface FrontmatterRegion {
   from: number;
@@ -15,6 +28,25 @@ export function detectFrontmatter(docText: string): FrontmatterRegion | null {
   const match = FRONTMATTER_RE.exec(docText);
   if (!match) return null;
   return { from: 0, to: match[0].length, body: match[1] ?? "" };
+}
+
+/**
+ * #247 — CM6 hot-path variant of `detectFrontmatter` that reads only the
+ * first `FRONTMATTER_MAX_SLICE` bytes of the document via `doc.sliceString`,
+ * avoiding the full-document `toString()` allocation on every keystroke.
+ *
+ * Safe because frontmatter is at offset 0 or absent, and is strictly bounded
+ * by the closing `---` fence — either the head slice covers the entire
+ * frontmatter region (overwhelmingly common: frontmatter is a few hundred
+ * bytes at most) or the frontmatter is so pathologically large that
+ * rendering would have other problems anyway. The spec promises a few
+ * hundred bytes; the cap here is a 10x+ safety margin.
+ */
+export function detectFrontmatterInDoc(doc: Text): FrontmatterRegion | null {
+  const headLen = Math.min(doc.length, FRONTMATTER_MAX_SLICE);
+  if (headLen === 0) return null;
+  const head = doc.sliceString(0, headLen);
+  return detectFrontmatter(head);
 }
 
 // Empty block widget. The frontmatter region is fully hidden — properties
@@ -40,7 +72,10 @@ class EmptyBlockWidget extends WidgetType {
 const HIDDEN_WIDGET = new EmptyBlockWidget();
 
 function buildDecorations(state: EditorState): DecorationSet {
-  const region = detectFrontmatter(state.doc.toString());
+  // #247 — head-slice variant avoids a full-doc toString() on every
+  // docChanged transaction; frontmatter is bounded to a few hundred bytes
+  // in practice, so the 16 KB head slice is a strict superset.
+  const region = detectFrontmatterInDoc(state.doc);
   if (!region) return Decoration.none;
 
   return Decoration.set([
@@ -82,7 +117,9 @@ const frontmatterBoundaryGuard = EditorState.transactionFilter.of((tr) => {
   const userEvent = tr.annotation(Transaction.userEvent);
   if (!userEvent || !userEvent.startsWith("input")) return tr;
 
-  const region = detectFrontmatter(tr.startState.doc.toString());
+  // #247 — head-slice variant; the filter fires on every input transaction
+  // and previously paid a full-doc toString() allocation every time.
+  const region = detectFrontmatterInDoc(tr.startState.doc);
   if (!region) return tr;
 
   const rewrites: ChangeSpec[] = [];

--- a/src/components/Editor/livePreview.ts
+++ b/src/components/Editor/livePreview.ts
@@ -1,7 +1,7 @@
 import { ViewPlugin, Decoration, type EditorView, type DecorationSet, type ViewUpdate } from "@codemirror/view";
 import { RangeSetBuilder } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
-import { detectFrontmatter } from "./frontmatterPlugin";
+import { detectFrontmatterInDoc } from "./frontmatterPlugin";
 
 const HIDE = Decoration.replace({});
 
@@ -22,7 +22,12 @@ function buildDecorations(view: EditorView): DecorationSet {
   // YAML frontmatter block gets tagged as `HeaderMark`. Skip hiding inside
   // the frontmatter region — otherwise the closing `---` vanishes whenever
   // the cursor sits on a different line.
-  const frontmatter = detectFrontmatter(doc.toString());
+  //
+  // #247 — read only the first ~16 KB of the doc via `sliceString` instead
+  // of serialising the entire document; frontmatter is bounded to a few
+  // hundred bytes in practice. Previously each selection-only arrow-key
+  // transaction paid a full-doc `toString()` allocation here.
+  const frontmatter = detectFrontmatterInDoc(doc);
 
   syntaxTree(view.state).iterate({
     from: view.viewport.from,


### PR DESCRIPTION
Related to #247. Partial fix — 3 of 5 hot-path call sites addressed; the remaining 2 are deferred with reason below.

## Summary

Issue #247 flagged five CM6 plugin paths that serialise the whole document via `doc.toString()` on every keystroke/selection, stacking up to five full-doc allocations plus two full-doc regex passes per transaction on long notes. On a 10 k-word note this comfortably exceeds the 16 ms keystroke budget.

This PR fixes the three **frontmatter** call sites. The other two (`embedPlugin.ts:570`, `wikiLink.ts:110`) are deferred — see below.

## Per-plugin status

| call site | status | approach |
|---|---|---|
| `frontmatterPlugin.ts:43` (StateField buildDecorations) | **fixed** | new `detectFrontmatterInDoc(doc)` helper reads only the first 16 KB via `sliceString` |
| `frontmatterPlugin.ts:85` (frontmatterBoundaryGuard transactionFilter) | **fixed** | same helper |
| `livePreview.ts:25` (ViewPlugin buildDecorations) | **fixed** | same helper |
| `embedPlugin.ts:570` (ViewPlugin buildDecorations) | **deferred** | needs design discussion — viewport clipping interacts with the async note-embed content cache and multi-line canvas/note embeds that may straddle the visible window; doing it wrong produces flickering placeholders or missing decorations on scroll. Worth a follow-up ticket. |
| `wikiLink.ts:110` (ViewPlugin buildDecorations) | **deferred** | needs design discussion — viewport clipping is mechanically straightforward (links are single-line), but correct handling of `text.indexOf('\|', from + 2)` after clipping, plus the refresh dispatch path from `setResolvedLinks`, deserve a dedicated PR rather than being bundled into a last-of-the-batch change. Worth a follow-up ticket. |

## Why

Frontmatter is at offset 0 or absent and is bounded to a few hundred bytes in practice. The new helper slices only `FRONTMATTER_MAX_SLICE = 16 KB` — a 10x+ safety margin over any legitimate frontmatter — and feeds that into the existing `FRONTMATTER_RE` regex. Callers of the public string-taking `detectFrontmatter` (wordCount, frontmatterIO, headings) are untouched so non-hot-path paths keep working on the full text they already compute.

Before: two full-doc `toString()` allocations per keystroke (StateField + boundary guard) plus one per selection move (livePreview). After: three bounded 16 KB slices that skip the entire document tail.

## Test plan

New spec `src/components/Editor/__tests__/frontmatterDocToStringStorm.test.ts` (12 tests, all pass):

- **Hot-path guards** — on a 50 KB-plus document, a typing transaction, a selection-only transaction, and an input transaction with no frontmatter must not invoke `Text.prototype.toString` on any `Text` instance of length >= 1000. The "big-text" threshold filters out the small `inserted` chunks CM6 allocates internally; on `main` the spies catch full-doc toStrings of length 50 003 / 100 020.
- **StateField parity** — block-replace decoration still spans `[0, region.to)`; rebuilds on frontmatter growth; no block decoration when frontmatter is absent.
- **Boundary-guard parity** — Cmd-A + type still redirects past the frontmatter; body-only edits pass through; non-input userEvents (`delete.line`) are untouched.
- **livePreview parity** — HeaderMarks inside the frontmatter region still skipped; off-cursor HeaderMarks in a plain document still hidden.

Tests committed first as a failing regression guard against `main` (commit `0c8bcde`), pass after the fix commits (`1c6d31e`, `d6dc43e`).

- [x] `pnpm test src/components/Editor/__tests__/frontmatterDocToStringStorm.test.ts` — 12/12.
- [x] `pnpm test src/components/Editor/__tests__/` — 198/198 (all editor tests green).
- [x] `pnpm test src/lib/__tests__/frontmatterIO.test.ts src/lib/__tests__/headings.test.ts src/lib/__tests__/wordCount.test.ts` — 83/83 (untouched public API callers).
- [x] `pnpm typecheck` — clean.

## Risk

Low for what's included. Head-slicing is a pure semantic no-op for any document whose frontmatter fits in 16 KB — which is, in practice, all of them. Undo/redo, external file reload, and empty documents are covered by the existing adjacent suites, all green.

The two deferred call sites are higher-risk by design (embed cache invariants, multi-line embed widgets, wiki-link regex across a viewport boundary) and worth their own tickets rather than a rushed bundle here.