### PR TITLE
fix(files): keep FileIndex + resolved links in sync on rename/move

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -21,6 +21,7 @@
 
 use crate::error::VaultError;
 use crate::hash::hash_bytes;
+use crate::indexer::memory::FileMeta;
 use crate::indexer::{walk_md_files, IndexCmd};
 use crate::VaultState;
 use regex::Regex;
@@ -389,10 +390,66 @@ pub fn rename_file_impl(state: &VaultState, old_path: String, new_name: String) 
 
     std::fs::rename(&canonical_old, &canonical_new).map_err(VaultError::Io)?;
 
+    // #277: update the in-memory FileIndex. The watcher's natural rename
+    // event is suppressed by `write_ignore` above, so without this the
+    // FileIndex would keep the stale OLD rel_path and never learn about
+    // the NEW one — breaking `resolve_link` for the renamed file and
+    // routing clicks on `[[new-name]]` into the frontend's create-at-root
+    // fallback. Only mutate after `fs::rename` succeeds; on disk failure
+    // we intentionally leave the index untouched.
+    sync_file_index_rename(state, &canonical_old, &canonical_new, &vault_root);
+
     Ok(RenameResult {
         new_path: canonical_new.to_string_lossy().into_owned(),
         link_count,
     })
+}
+
+/// Move the FileIndex entry at `canonical_old` to `canonical_new`, preserving
+/// hash/title/aliases and updating `relative_path` to match the new location.
+/// Used by both `rename_file_impl` and `move_file_impl` (#277).
+///
+/// Case-only rename (`canonical_old == canonical_new` on case-insensitive
+/// filesystems): update the stored `relative_path` in place and leave the
+/// entry otherwise intact, so hash/title/aliases survive.
+///
+/// No-op when the old entry is absent — tests that seed an empty index or
+/// renames that race an external rescan must not blow up.
+fn sync_file_index_rename(
+    state: &VaultState,
+    canonical_old: &Path,
+    canonical_new: &Path,
+    vault_root: &Path,
+) {
+    let Ok(mut fi) = state.file_index.write() else { return };
+
+    let new_rel = match canonical_new.strip_prefix(vault_root) {
+        Ok(p) => p.to_string_lossy().replace('\\', "/"),
+        Err(_) => return,
+    };
+
+    // Preserve prior metadata where possible; synthesize a minimal entry if
+    // the index wasn't previously populated for this path (cold-start race).
+    let prior = fi.remove(&canonical_old.to_path_buf());
+    let meta = match prior {
+        Some(mut m) => {
+            m.relative_path = new_rel;
+            m
+        }
+        None => {
+            let title = canonical_new
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            FileMeta {
+                relative_path: new_rel,
+                hash: String::new(),
+                title,
+                aliases: Vec::new(),
+            }
+        }
+    };
+    fi.insert(canonical_new.to_path_buf(), meta);
 }
 
 #[tauri::command]
@@ -408,14 +465,37 @@ pub async fn rename_file(
     // NEW path's vectors get embedded on the next save by the user.
     #[cfg(feature = "embeddings")]
     let old_canonical = std::fs::canonicalize(&old_path).ok();
+    let old_canonical_for_tantivy = std::fs::canonicalize(&old_path).ok();
 
     let result = rename_file_impl(&state, old_path, new_name)?;
+
+    // #277: the watcher would normally dispatch DeleteFile(old) + AddFile(new)
+    // on a rename event, but write_ignore suppresses that for self-mutations.
+    // Dispatch a Tantivy delete for the OLD path so fulltext search stops
+    // returning the stale doc; the NEW path is re-indexed on next user save.
+    if let Some(old) = old_canonical_for_tantivy {
+        dispatch_tantivy_delete(&state, old).await;
+    }
 
     #[cfg(feature = "embeddings")]
     if let Some(p) = old_canonical {
         dispatch_embed_delete(&state, p);
     }
     Ok(result)
+}
+
+/// Enqueue a Tantivy delete for `path`. Called from rename/move paths where
+/// write_ignore would otherwise suppress the watcher-driven DeleteFile.
+async fn dispatch_tantivy_delete(state: &VaultState, path: PathBuf) {
+    let tx = {
+        let Ok(guard) = state.index_coordinator.lock() else { return };
+        match guard.as_ref() {
+            Some(c) => c.tx.clone(),
+            None => return,
+        }
+    };
+    let _ = tx.send(IndexCmd::DeleteFile { path }).await;
+    let _ = tx.send(IndexCmd::Commit).await;
 }
 
 // ─── delete_file ─────────────────────────────────────────────────────────────
@@ -512,6 +592,11 @@ pub fn move_file_impl(state: &VaultState, from: String, to_folder: String) -> Re
 
     std::fs::rename(&canonical_from, &dest).map_err(VaultError::Io)?;
 
+    // #277: same staleness fix as rename_file_impl. Watcher's rename event is
+    // suppressed by write_ignore, so update the in-memory FileIndex directly.
+    let vault_root = get_vault_root(state)?;
+    sync_file_index_rename(state, &canonical_from, &dest, &vault_root);
+
     Ok(dest.to_string_lossy().into_owned())
 }
 
@@ -526,8 +611,14 @@ pub async fn move_file(
     // watcher's Remove event.
     #[cfg(feature = "embeddings")]
     let old_canonical = std::fs::canonicalize(&from).ok();
+    let old_canonical_for_tantivy = std::fs::canonicalize(&from).ok();
 
     let result = move_file_impl(&state, from, to_folder)?;
+
+    // #277: same Tantivy parity as rename_file.
+    if let Some(old) = old_canonical_for_tantivy {
+        dispatch_tantivy_delete(&state, old).await;
+    }
 
     #[cfg(feature = "embeddings")]
     if let Some(p) = old_canonical {

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -179,7 +179,14 @@ pub async fn open_vault(
         let mut guard = state.index_coordinator.lock().map_err(|_| VaultError::LockPoisoned)?;
         *guard = None;
     }
-    let coordinator = crate::indexer::IndexCoordinator::new(&canonical).await.map_err(|e| {
+    // #277: hand the coordinator the state-owned FileIndex so user-initiated
+    // rename/move updates land in the same map the coordinator reads from.
+    let coordinator = crate::indexer::IndexCoordinator::new_with_file_index(
+        &canonical,
+        std::sync::Arc::clone(&state.file_index),
+    )
+    .await
+    .map_err(|e| {
         log::error!("Failed to create IndexCoordinator: {e:?}");
         e
     })?;

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -159,7 +159,27 @@ impl IndexCoordinator {
     /// task is spawned. This is what surfaces `IndexLocked` / `IndexCorrupt`
     /// errors back to the caller instead of letting the writer task die
     /// silently after `new` already returned `Ok` (issue #108).
+    ///
+    /// Test-only convenience: creates a fresh FileIndex. Production callers go
+    /// through `new_with_file_index` so the coordinator shares the state-owned
+    /// `Arc<RwLock<FileIndex>>` and user-initiated rename/move updates (#277)
+    /// are observable both here and in state-scoped lookups.
     pub async fn new(vault_path: &Path) -> Result<Self, VaultError> {
+        Self::new_with_file_index(vault_path, Arc::new(RwLock::new(FileIndex::new()))).await
+    }
+
+    /// Like `new`, but uses `file_index` as the shared in-memory FileIndex.
+    /// See the rationale in `VaultState::file_index` (#277).
+    pub async fn new_with_file_index(
+        vault_path: &Path,
+        file_index: Arc<RwLock<FileIndex>>,
+    ) -> Result<Self, VaultError> {
+        // Start from a clean in-memory map on every open_vault — a previous
+        // session's FileIndex may have stale entries that the upcoming
+        // `index_vault` walk wouldn't otherwise evict.
+        if let Ok(mut guard) = file_index.write() {
+            guard.clear();
+        }
         let (schema, path_field, title_field, body_field) = tantivy_index::build_schema();
 
         let vaultcore_dir = vault_path.join(".vaultcore");
@@ -189,7 +209,6 @@ impl IndexCoordinator {
 
         let index = Arc::new(index);
         let reader = Arc::new(reader);
-        let file_index = Arc::new(RwLock::new(FileIndex::new()));
         let matcher = Arc::new(Mutex::new(nucleo_matcher::Matcher::new(
             nucleo_matcher::Config::DEFAULT,
         )));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,12 +11,14 @@ pub mod embeddings;
 #[cfg(test)]
 mod tests;
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
 use notify_debouncer_full::{Debouncer, RecommendedCache};
 use notify_debouncer_full::notify::RecommendedWatcher;
+
+use indexer::memory::FileIndex;
 
 /// Write-ignore-list: records own-write events so the file watcher can
 /// suppress spurious self-triggered events (D-12).
@@ -65,6 +67,13 @@ pub struct VaultState {
     pub watcher_handle: Arc<Mutex<Option<Debouncer<RecommendedWatcher, RecommendedCache>>>>,
     /// Tantivy IndexCoordinator — created lazily on first open_vault call.
     pub index_coordinator: Arc<Mutex<Option<indexer::IndexCoordinator>>>,
+    /// Shared in-memory FileIndex. Owned by `VaultState` so user-initiated
+    /// rename/move commands can update it directly — without this, the
+    /// watcher's rename event is suppressed by `write_ignore` and the index
+    /// never learns about the new rel_path (issue #277). The IndexCoordinator
+    /// receives a clone of this Arc on construction so both sides observe
+    /// the same map.
+    pub file_index: Arc<RwLock<FileIndex>>,
     /// Embed-on-save coordinator (#196). `None` when the embeddings
     /// feature is off, the model isn't bundled, or ORT init failed.
     /// `write_file` skips the embed dispatch silently in that case.
@@ -92,6 +101,7 @@ impl Default for VaultState {
             vault_reachable: Arc::new(Mutex::new(false)),
             watcher_handle: Arc::new(Mutex::new(None)),
             index_coordinator: Arc::new(Mutex::new(None)),
+            file_index: Arc::new(RwLock::new(FileIndex::new())),
             #[cfg(feature = "embeddings")]
             embed_coordinator: Arc::new(Mutex::new(None)),
             #[cfg(feature = "embeddings")]

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod aliases;
 mod snippets;
 mod file_index_contention;
 mod vault_walk;
+mod rename_link_resolution;
 #[cfg(feature = "embeddings")]
 mod embeddings;
 #[cfg(feature = "embeddings")]

--- a/src-tauri/src/tests/rename_link_resolution.rs
+++ b/src-tauri/src/tests/rename_link_resolution.rs
@@ -26,9 +26,9 @@
 // If this ever passes on current main, the bug is elsewhere (e.g. the
 // frontend's `resolvedLinks` cache).
 
-use crate::commands::files::rename_file_impl;
+use crate::commands::files::{move_file_impl, rename_file_impl};
 use crate::indexer::link_graph::resolve_link;
-use crate::indexer::memory::{FileIndex, FileMeta};
+use crate::indexer::memory::FileMeta;
 use crate::VaultState;
 
 use std::fs;
@@ -42,11 +42,15 @@ fn state_with_vault(root: &std::path::Path) -> VaultState {
     s
 }
 
-/// Seed the FileIndex the same way `IndexCoordinator::index_vault` does: one
-/// entry per .md file, keyed by canonical absolute path, with a vault-relative
-/// forward-slash string in `FileMeta.relative_path`.
-fn seed_file_index(fi: &mut FileIndex, vault_root: &std::path::Path, rel_paths: &[&str]) {
+/// Seed the state-owned FileIndex the same way `IndexCoordinator::index_vault`
+/// does: one entry per .md file, keyed by canonical absolute path, with a
+/// vault-relative forward-slash string in `FileMeta.relative_path`.
+///
+/// #277: writes into `state.file_index` (the same Arc consumed by
+/// `rename_file_impl` / `move_file_impl`) so assertions observe the updates.
+fn seed_file_index(state: &VaultState, vault_root: &std::path::Path, rel_paths: &[&str]) {
     let canonical = fs::canonicalize(vault_root).unwrap();
+    let mut fi = state.file_index.write().unwrap();
     for rel in rel_paths {
         let abs = canonical.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
         fi.insert(
@@ -82,12 +86,11 @@ fn rename_keeps_in_folder_wiki_link_resolvable() {
     // Mirror what `IndexCoordinator::index_vault` does on vault open: build a
     // populated FileIndex so the click-time resolver (`get_resolved_links` →
     // `resolve_link` over FileIndex::all_relative_paths) has realistic input.
-    let mut fi = FileIndex::new();
-    seed_file_index(&mut fi, vault_root, &["folder/A.md", "folder/B.md"]);
+    seed_file_index(&state, vault_root, &["folder/A.md", "folder/B.md"]);
 
     // Pre-rename sanity: the click-time resolver finds `folder/B.md` from
     // inside `folder/`. If this fails, the test fixture is wrong.
-    let all_pre: Vec<String> = fi.all_relative_paths();
+    let all_pre: Vec<String> = state.file_index.read().unwrap().all_relative_paths();
     assert_eq!(
         resolve_link("B", "folder/", &all_pre).as_deref(),
         Some("folder/B.md"),
@@ -116,7 +119,7 @@ fn rename_keeps_in_folder_wiki_link_resolvable() {
     // After the rename we require the NEW path to be resolvable. This is
     // exactly what the failing UAT step expects; the current implementation
     // returns `None`, so the frontend falls into the create-at-root branch.
-    let all_post: Vec<String> = fi.all_relative_paths();
+    let all_post: Vec<String> = state.file_index.read().unwrap().all_relative_paths();
     let resolved = resolve_link("B-new", "folder/", &all_post);
     assert_eq!(
         resolved.as_deref(),
@@ -129,11 +132,110 @@ fn rename_keeps_in_folder_wiki_link_resolvable() {
     // Tightening guard: the stale OLD rel_path must NOT linger in FileIndex
     // either — otherwise a stem collision (`B`) with a pre-existing root-level
     // `B.md` could re-route backlinks to the dead entry.
-    let has_stale_old = fi.contains_rel("folder/B.md");
+    let has_stale_old = state.file_index.read().unwrap().contains_rel("folder/B.md");
     assert!(
         !has_stale_old,
         "FileIndex must not retain the renamed-away rel_path folder/B.md",
     );
+}
+
+/// Parity guard for `move_file_impl` — the same staleness hole exists when a
+/// note moves between folders. After `move_file_impl(folder/B.md -> other/)`,
+/// the new rel_path `other/B.md` must be in the FileIndex and the old one
+/// must be gone (#277).
+#[test]
+fn move_keeps_wiki_link_resolvable_in_new_folder() {
+    let dir = tempdir().unwrap();
+    let vault_root = dir.path();
+
+    let folder = vault_root.join("folder");
+    let other = vault_root.join("other");
+    fs::create_dir(&folder).unwrap();
+    fs::create_dir(&other).unwrap();
+    fs::write(folder.join("B.md"), "# B\n").unwrap();
+
+    let state = state_with_vault(vault_root);
+    seed_file_index(&state, vault_root, &["folder/B.md"]);
+
+    let from_abs = folder.join("B.md");
+    let canonical_other = fs::canonicalize(&other).unwrap();
+    move_file_impl(
+        &state,
+        from_abs.to_string_lossy().into_owned(),
+        canonical_other.to_string_lossy().into_owned(),
+    )
+    .expect("move_file_impl must succeed");
+
+    assert!(other.join("B.md").exists(), "disk move must succeed");
+    assert!(!from_abs.exists(), "old path must be gone on disk");
+
+    let all_post: Vec<String> = state.file_index.read().unwrap().all_relative_paths();
+    let resolved = resolve_link("B", "", &all_post);
+    assert_eq!(
+        resolved.as_deref(),
+        Some("other/B.md"),
+        "after move, [[B]] must resolve to other/B.md. FileIndex: {:?}",
+        all_post,
+    );
+    assert!(
+        !state.file_index.read().unwrap().contains_rel("folder/B.md"),
+        "FileIndex must not retain the moved-away rel_path folder/B.md",
+    );
+}
+
+/// Case-only rename on a case-insensitive FS surfaces as `fs::rename` where
+/// `canonical_old == canonical_new`. The FileIndex entry must stay present
+/// with the new `relative_path` string (so UI shows the new casing); hash /
+/// aliases from the prior entry must be preserved (#277).
+#[test]
+fn case_only_rename_preserves_file_index_entry() {
+    let dir = tempdir().unwrap();
+    let vault_root = dir.path();
+
+    fs::write(vault_root.join("Note.md"), "# Note\n").unwrap();
+
+    let state = state_with_vault(vault_root);
+    // Seed with non-trivial aliases + hash so we can assert preservation.
+    let canonical = fs::canonicalize(vault_root).unwrap();
+    state.file_index.write().unwrap().insert(
+        canonical.join("Note.md"),
+        FileMeta {
+            relative_path: "Note.md".into(),
+            hash: "original-hash".into(),
+            title: "Note".into(),
+            aliases: vec!["nota".into()],
+        },
+    );
+
+    // Simulate a case-only rename. On case-sensitive FS this creates a
+    // distinct file; either way the FileIndex invariant we assert (new rel
+    // present, metadata preserved) must hold.
+    rename_file_impl(
+        &state,
+        canonical.join("Note.md").to_string_lossy().into_owned(),
+        "note.md".into(),
+    )
+    .expect("rename must succeed");
+
+    let fi = state.file_index.read().unwrap();
+    let rels: Vec<String> = fi.all_relative_paths();
+    assert!(
+        rels.iter().any(|r| r == "note.md"),
+        "new rel_path note.md must be in FileIndex after case-only rename. rels: {:?}",
+        rels,
+    );
+    // The old rel_path string must not linger as a separate entry —
+    // otherwise a lookup of the (new) rel_path could miss.
+    assert!(
+        !fi.contains_rel("Note.md"),
+        "old rel_path Note.md must not linger after rename. rels: {:?}",
+        rels,
+    );
+    // Preservation: hash + aliases must carry over to the new entry. This is
+    // what blocks a silent re-embed-everything on a cosmetic rename.
+    let entry = fi.entry_for_rel("note.md").expect("new entry");
+    assert_eq!(entry.hash, "original-hash");
+    assert_eq!(entry.aliases, vec!["nota".to_string()]);
 }
 
 // Silence unused import warnings in the rare case PathBuf isn't needed — keep

--- a/src-tauri/src/tests/rename_link_resolution.rs
+++ b/src-tauri/src/tests/rename_link_resolution.rs
@@ -1,0 +1,144 @@
+// Regression test for: in-folder wiki-link clicks create a root-level note
+// instead of opening the renamed target.
+//
+// Scenario (from UAT, paraphrased):
+//   - `folder/A.md` contains `[[B]]`
+//   - `folder/B.md` exists
+//   - The user renames `folder/B.md` → `folder/B-new.md`
+//   - The link text in `folder/A.md` is rewritten to `[[B-new]]` (good)
+//   - But clicking `[[B-new]]` creates `B-new.md` at the vault root instead of
+//     opening `folder/B-new.md` (bug)
+//
+// Root-cause hypothesis this test pins down:
+//   - The frontend click handler consults `get_resolved_links`, which is
+//     derived from `FileIndex::all_relative_paths()`.
+//   - `rename_file_impl` (src/commands/files.rs) renames on disk and records
+//     both paths in `write_ignore`, suppressing the watcher's rename event.
+//   - Because the watcher is suppressed, no `IndexCmd::{AddFile, DeleteFile}`
+//     ever fires for the rename. The `FileIndex` keeps the stale OLD rel_path
+//     (`folder/B.md`) and never learns about the NEW rel_path
+//     (`folder/B-new.md`).
+//   - `resolve_link("B-new", "folder/", &fi.all_relative_paths())` therefore
+//     returns `None`, which the frontend interprets as "create at root".
+//
+// The test asserts the backend-resolver invariant: after a rename, the NEW
+// rel_path must be resolvable from the perspective of an in-folder source.
+// If this ever passes on current main, the bug is elsewhere (e.g. the
+// frontend's `resolvedLinks` cache).
+
+use crate::commands::files::rename_file_impl;
+use crate::indexer::link_graph::resolve_link;
+use crate::indexer::memory::{FileIndex, FileMeta};
+use crate::VaultState;
+
+use std::fs;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn state_with_vault(root: &std::path::Path) -> VaultState {
+    let canonical = fs::canonicalize(root).unwrap();
+    let s = VaultState::default();
+    *s.current_vault.lock().unwrap() = Some(canonical);
+    s
+}
+
+/// Seed the FileIndex the same way `IndexCoordinator::index_vault` does: one
+/// entry per .md file, keyed by canonical absolute path, with a vault-relative
+/// forward-slash string in `FileMeta.relative_path`.
+fn seed_file_index(fi: &mut FileIndex, vault_root: &std::path::Path, rel_paths: &[&str]) {
+    let canonical = fs::canonicalize(vault_root).unwrap();
+    for rel in rel_paths {
+        let abs = canonical.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+        fi.insert(
+            abs,
+            FileMeta {
+                relative_path: (*rel).to_string(),
+                hash: "seed".to_string(),
+                title: rel.to_string(),
+                aliases: Vec::new(),
+            },
+        );
+    }
+}
+
+/// Regression guard: `[[B-new]]` clicked from `folder/A.md` must resolve to
+/// `folder/B-new.md`, not fall through to the frontend's create-at-root
+/// fallback. Fails today because `rename_file_impl` does not update the
+/// in-memory `FileIndex` — the rel_path map the click handler consults keeps
+/// the stale OLD path.
+#[test]
+fn rename_keeps_in_folder_wiki_link_resolvable() {
+    let dir = tempdir().unwrap();
+    let vault_root = dir.path();
+
+    // Build vault on disk: folder/A.md → [[B]], folder/B.md
+    let folder = vault_root.join("folder");
+    fs::create_dir(&folder).unwrap();
+    fs::write(folder.join("A.md"), "See [[B]] for context.\n").unwrap();
+    fs::write(folder.join("B.md"), "# B\n").unwrap();
+
+    let state = state_with_vault(vault_root);
+
+    // Mirror what `IndexCoordinator::index_vault` does on vault open: build a
+    // populated FileIndex so the click-time resolver (`get_resolved_links` →
+    // `resolve_link` over FileIndex::all_relative_paths) has realistic input.
+    let mut fi = FileIndex::new();
+    seed_file_index(&mut fi, vault_root, &["folder/A.md", "folder/B.md"]);
+
+    // Pre-rename sanity: the click-time resolver finds `folder/B.md` from
+    // inside `folder/`. If this fails, the test fixture is wrong.
+    let all_pre: Vec<String> = fi.all_relative_paths();
+    assert_eq!(
+        resolve_link("B", "folder/", &all_pre).as_deref(),
+        Some("folder/B.md"),
+        "pre-rename fixture broken — resolver should find folder/B.md from folder/",
+    );
+
+    // Perform the rename through the production code path.
+    let old_abs = folder.join("B.md");
+    let rename_result = rename_file_impl(
+        &state,
+        old_abs.to_string_lossy().into_owned(),
+        "B-new.md".into(),
+    )
+    .expect("rename_file_impl must succeed");
+
+    // Disk is renamed (sanity — not the assertion under test).
+    assert!(folder.join("B-new.md").exists(), "disk rename must succeed");
+    assert!(!old_abs.exists(), "old path must be gone on disk");
+    assert!(rename_result.new_path.ends_with("B-new.md"));
+
+    // === REGRESSION ASSERTION ===
+    //
+    // A user clicking `[[B-new]]` from inside `folder/A.md` triggers the
+    // click handler, which looks up `get_resolved_links()`. That command is
+    // built from `FileIndex::all_relative_paths()` via `resolve_link`.
+    // After the rename we require the NEW path to be resolvable. This is
+    // exactly what the failing UAT step expects; the current implementation
+    // returns `None`, so the frontend falls into the create-at-root branch.
+    let all_post: Vec<String> = fi.all_relative_paths();
+    let resolved = resolve_link("B-new", "folder/", &all_post);
+    assert_eq!(
+        resolved.as_deref(),
+        Some("folder/B-new.md"),
+        "clicking [[B-new]] from folder/A.md must resolve to folder/B-new.md, \
+         not fall through to a root-level create. FileIndex after rename: {:?}",
+        all_post,
+    );
+
+    // Tightening guard: the stale OLD rel_path must NOT linger in FileIndex
+    // either — otherwise a stem collision (`B`) with a pre-existing root-level
+    // `B.md` could re-route backlinks to the dead entry.
+    let has_stale_old = fi.contains_rel("folder/B.md");
+    assert!(
+        !has_stale_old,
+        "FileIndex must not retain the renamed-away rel_path folder/B.md",
+    );
+}
+
+// Silence unused import warnings in the rare case PathBuf isn't needed — keep
+// the import so future assertions can reach for it without re-threading.
+#[allow(dead_code)]
+fn _keep_pathbuf_in_scope() -> PathBuf {
+    PathBuf::new()
+}

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -27,6 +27,7 @@
   import { scrollToMatch } from "./flashHighlight";
   import { scrollStore } from "../../store/scrollStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
+  import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { tagsStore } from "../../store/tagsStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { setResolvedLinks, resolveTarget, refreshWikiLinks } from "./wikiLink";
@@ -248,6 +249,19 @@
       if (state.currentPath) {
         void reloadResolvedLinks();
       }
+    }
+  });
+
+  // #277: user-initiated rename/move bypass the watcher (write_ignore), so the
+  // module-level `resolvedLinks` map in wikiLink.ts keeps the stale OLD
+  // rel_path until a manual reload. TreeNode fires `resolvedLinksStore.requestReload()`
+  // after every rename/move so we refresh here and the click handler stops
+  // routing [[new-name]] into the create-at-root fallback.
+  let prevResolvedLinksToken: string | null = null;
+  const unsubResolvedLinks = resolvedLinksStore.subscribe((state) => {
+    if (state.token && state.token !== prevResolvedLinksToken) {
+      prevResolvedLinksToken = state.token;
+      void reloadResolvedLinks();
     }
   });
 
@@ -735,6 +749,7 @@
     unsubScroll();
     unsubTabReload();
     unsubVaultPath();
+    unsubResolvedLinks();
     unsubEditorHash();
     unlistenFileChange?.();
     unlistenVaultStatus?.();

--- a/src/components/Sidebar/TreeNode.svelte
+++ b/src/components/Sidebar/TreeNode.svelte
@@ -13,6 +13,7 @@
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { tabStore } from "../../store/tabStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
+  import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { bookmarksStore } from "../../store/bookmarksStore";
   import { sortEntries, type SortBy } from "../../lib/treeState";
   import { onMount, onDestroy, untrack } from "svelte";
@@ -284,6 +285,9 @@
     } else {
       onPathChanged(entry.path, newPath);
       onRefreshParent();
+      // #277: tell EditorPane to re-fetch the stem->relPath map so clicks on
+      // [[new-name]] resolve to the renamed file instead of creating at root.
+      resolvedLinksStore.requestReload();
     }
   }
 
@@ -297,6 +301,8 @@
     pendingRename = null;
     onPathChanged(entry.path, newPath);
     onRefreshParent();
+    // #277: same rationale as handleRenameConfirm's no-link branch.
+    resolvedLinksStore.requestReload();
     try {
       const result = await updateLinksAfterRename(oldRelPath, newRelPath);
       // Reload any open tabs whose content was rewritten — the cascade writes
@@ -480,6 +486,9 @@
       }
       await loadChildren();
       onRefreshParent();
+      // #277: refresh the wiki-link resolution map so clicks on links to the
+      // moved file open the new location instead of creating at root.
+      resolvedLinksStore.requestReload();
     } catch (err) {
       const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
@@ -499,6 +508,8 @@
       }
       await loadChildren();
       onRefreshParent();
+      // #277: same rationale as the no-backlink branch above.
+      resolvedLinksStore.requestReload();
       const result = await updateLinksAfterRename(sourceRelPath, newRelPath);
       // Reload open tabs for rewritten source files (see confirmRenameWithLinks).
       if (result.updatedPaths.length > 0) {

--- a/src/store/resolvedLinksStore.ts
+++ b/src/store/resolvedLinksStore.ts
@@ -1,0 +1,33 @@
+// resolvedLinksStore — one-shot signal that the wiki-link resolution map in
+// `components/Editor/wikiLink.ts` is stale and must be re-fetched.
+//
+// The module-level `resolvedLinks: Map<stem, relPath>` is populated once per
+// vault open via EditorPane and refreshed on click-to-create. It does NOT
+// update on user-initiated rename/move, because those paths bypass the
+// watcher (write_ignore / D-12) and therefore never reach the pane's
+// listenFileChange handler — leaving the map pointing at the OLD rel_path.
+// Sidebar call sites that rename or move files dispatch `requestReload()`
+// so EditorPane re-runs `getResolvedLinks` + `getResolvedAttachments` and
+// nudges every mounted view to rebuild decorations (#277).
+//
+// Pattern mirrors treeRefreshStore / scrollStore: monotonic token signals a
+// new request; consumer (EditorPane) watches for changes and calls
+// reloadResolvedLinks().
+
+import { writable } from "svelte/store";
+
+interface ResolvedLinksReloadState {
+  /** Opaque token — changes on every request. */
+  token: string | null;
+}
+
+const _store = writable<ResolvedLinksReloadState>({ token: null });
+
+export const resolvedLinksStore = {
+  subscribe: _store.subscribe,
+
+  /** Signal that the stem->relPath map is stale and should be re-fetched. */
+  requestReload(): void {
+    _store.set({ token: crypto.randomUUID() });
+  },
+};


### PR DESCRIPTION
## Summary

Closes #277. Rename/move bypass the watcher via `write_ignore` (D-12), so the in-memory `FileIndex` and the frontend `resolvedLinks: Map<stem, relPath>` both kept the stale OLD rel_path after a user-initiated rename. `resolve_link` then returned `None` for the NEW rel_path and the click handler fell into its create-at-root fallback — the UAT bug.

- **Backend**: move `Arc<RwLock<FileIndex>>` onto `VaultState`, share it with `IndexCoordinator::new_with_file_index`, and have `rename_file_impl` / `move_file_impl` update the index (remove old, insert new with preserved hash/title/aliases) on disk-rename success. The async `rename_file` / `move_file` wrappers also dispatch `IndexCmd::DeleteFile{old}` + `Commit` so Tantivy drops the stale doc.
- **Frontend**: new `resolvedLinksStore` one-shot signal. `EditorPane` subscribes and re-runs `reloadResolvedLinks()`; `TreeNode` fires on every rename/move branch.

## Why

The bug is pre-existing — regression test fails at `23872e7`, the last pre-perf merge on main. Tonight's perf work didn't introduce it. The in-memory `FileIndex` has never been touched by the user-initiated rename path; the watcher is the only writer, and `write_ignore` suppresses its events for self-mutations.

## Before / after

Repro from #277:
1. `folder/A.md` contains `[[B]]`; `folder/B.md` exists.
2. Sidebar rename `folder/B.md` -> `folder/B-new.md`, confirm cascade.
3. Open `folder/A.md`, click `[[B-new]]`.

- **Before**: `B-new.md` created at vault root; `folder/B-new.md` ignored.
- **After**: `folder/B-new.md` opens directly.

## Test plan

- [x] `cargo test --no-default-features --lib rename_link_resolution` — 3 tests pass (existing regression `rename_keeps_in_folder_wiki_link_resolvable`, new `move_keeps_wiki_link_resolvable_in_new_folder`, new `case_only_rename_preserves_file_index_entry`).
- [x] `cargo test --no-default-features --lib -- tests::files tests::files_ops tests::link_graph tests::aliases tests::indexer` — 69 tests pass, no regressions.
- [x] `cargo check --lib --features embeddings` clean.
- [x] `tsc --noEmit` clean.
- [x] Vitest: `wikiLink` (5 passed), `TreeNode` (8 passed), `EditorPane` (3 passed).
- [x] Unresolved-link create flow preserved: `resolveTarget` still returns `null` for genuine non-existent stems; `handleWikiLinkClick`'s `!detail.resolved` branch is untouched and still creates at vault root for those.

## Risk spotted + mitigated

- **Disk-rename failure**: `sync_file_index_rename` runs *after* `fs::rename` returns `Ok`, so a failed disk op leaves `FileIndex` untouched.
- **Case-only rename on case-insensitive FS** (`canonical_old == canonical_new`): pinned by `case_only_rename_preserves_file_index_entry` — the entry is preserved with updated `relative_path` and prior hash/aliases intact.
- **Watcher race**: if `write_ignore` lapses before the debounced rename event fires, the watcher's existing `UpdateLinks{new}` refreshes aliases on the already-correct entry — no duplicate inserts, no fight with the IPC path.
- **Deadlocks**: `sync_file_index_rename` holds only the `file_index` write lock; `dispatch_tantivy_delete` takes `index_coordinator` then drops it before awaiting on the channel, so no nested-lock await.