### PR TITLE
feat(home): per-vault home.canvas opened via sidebar vault name click (#279)

### DIFF
--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -294,6 +294,12 @@ impl IndexCoordinator {
     ) -> Result<VaultInfo, VaultError> {
         let vaultcore_dir = vault_path.join(".vaultcore");
 
+        // Issue #279: self-healing bootstrap of the per-vault home canvas.
+        // Runs every open so filesystem-level deletion recreates the file.
+        if let Err(e) = ensure_home_canvas(vault_path) {
+            log::warn!("ensure_home_canvas failed: {e:?}");
+        }
+
         // Collect all .md paths (skip dot-dirs and .vaultcore).
         let md_paths = collect_md_paths(vault_path);
         let total = md_paths.len();
@@ -651,6 +657,58 @@ pub(crate) fn walk_md_files(vault_path: &Path) -> impl Iterator<Item = PathBuf> 
 /// front for progress throttling.
 fn collect_md_paths(vault_path: &Path) -> Vec<PathBuf> {
     walk_md_files(vault_path).collect()
+}
+
+/// Ensure `<vault>/.vaultcore/home.canvas` exists.
+///
+/// Writes a minimal welcome canvas the first time a vault is opened so the
+/// sidebar vault-name click always has something to open. Living under
+/// `.vaultcore/` keeps it out of the tree walker, link graph, backlinks, and
+/// search — but wiki-links inside it still resolve outward because resolution
+/// is target-based.
+///
+/// Existing files are left untouched — never overwrite user edits.
+/// If the user deletes the file via the filesystem, the next vault open
+/// recreates this template.
+pub fn ensure_home_canvas(vault_path: &Path) -> Result<(), VaultError> {
+    let home_path = vault_path.join(".vaultcore").join("home.canvas");
+    if home_path.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = home_path.parent() {
+        std::fs::create_dir_all(parent).map_err(VaultError::Io)?;
+    }
+
+    let vault_name = vault_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("Vault");
+    let welcome_text = format!(
+        "# {}\n\nEdit this canvas — it's your personal home.",
+        vault_name
+    );
+
+    let doc = serde_json::json!({
+        "nodes": [{
+            "id": "welcome",
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "width": 400,
+            "height": 120,
+            "text": welcome_text,
+        }],
+        "edges": [],
+    });
+
+    let mut buf = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"\t");
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    serde::Serialize::serialize(&doc, &mut ser).map_err(|e| {
+        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+    })?;
+    std::fs::write(&home_path, &buf).map_err(VaultError::Io)?;
+    Ok(())
 }
 
 /// Collect all `.canvas` relative paths (forward-slash, vault-relative) under

--- a/src-tauri/src/tests/home_canvas.rs
+++ b/src-tauri/src/tests/home_canvas.rs
@@ -1,0 +1,57 @@
+// Tests for the per-vault home canvas bootstrap (#279).
+
+use crate::indexer::ensure_home_canvas;
+use tempfile::TempDir;
+
+#[test]
+fn ensure_home_canvas_creates_file_when_missing() {
+    let tmp = TempDir::new().unwrap();
+    let vault = tmp.path();
+
+    ensure_home_canvas(vault).expect("bootstrap should succeed");
+
+    let home = vault.join(".vaultcore").join("home.canvas");
+    assert!(home.exists(), "home.canvas should be created");
+
+    let body = std::fs::read_to_string(&home).unwrap();
+    // Must be valid JSON with the Obsidian canvas shape.
+    let doc: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+    assert!(doc.get("nodes").and_then(|v| v.as_array()).is_some_and(|a| !a.is_empty()));
+    assert!(doc.get("edges").and_then(|v| v.as_array()).is_some());
+
+    // Vault name should appear in the welcome text.
+    let vault_name = vault.file_name().unwrap().to_str().unwrap();
+    assert!(
+        body.contains(vault_name),
+        "welcome node should reference the vault name",
+    );
+}
+
+#[test]
+fn ensure_home_canvas_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let vault = tmp.path();
+
+    ensure_home_canvas(vault).unwrap();
+    let home = vault.join(".vaultcore").join("home.canvas");
+    std::fs::write(&home, "user edits").unwrap();
+
+    ensure_home_canvas(vault).unwrap();
+
+    // Existing content must NOT be overwritten.
+    assert_eq!(std::fs::read_to_string(&home).unwrap(), "user edits");
+}
+
+#[test]
+fn ensure_home_canvas_self_heals_after_delete() {
+    let tmp = TempDir::new().unwrap();
+    let vault = tmp.path();
+
+    ensure_home_canvas(vault).unwrap();
+    let home = vault.join(".vaultcore").join("home.canvas");
+    std::fs::remove_file(&home).unwrap();
+    assert!(!home.exists());
+
+    ensure_home_canvas(vault).unwrap();
+    assert!(home.exists(), "home.canvas should be recreated after deletion");
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod snippets;
 mod file_index_contention;
 mod vault_walk;
 mod rename_link_resolution;
+mod home_canvas;
 #[cfg(feature = "embeddings")]
 mod embeddings;
 #[cfg(feature = "embeddings")]

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -34,6 +34,7 @@
   import { treeRefreshStore } from "../../store/treeRefreshStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
   import { openFileAsTab } from "../../lib/openFileAsTab";
+  import { openHomeCanvas } from "../../lib/homeCanvas";
   import { resolveRevealRelPath } from "../../lib/activeTabReveal";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import { settingsStore } from "../../store/settingsStore";
@@ -544,6 +545,7 @@
       createNewCanvas: () => { void createNewCanvas(); },
       createNewFolder: () => { void createNewFolder(); },
       openGraph: () => { tabStore.openGraphTab(); },
+      openHome: () => { void openHomeCanvas(); },
       openCommandPalette: () => { commandPaletteOpen = true; },
       toggleBookmark: () => { void toggleActiveBookmark(); },
       openTodayNote: () => { void openTodayNote(); },

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -28,6 +28,7 @@
   } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import { tabStore } from "../../store/tabStore";
+  import { openHomeCanvas } from "../../lib/homeCanvas";
   import { searchStore } from "../../store/searchStore";
   import { treeRefreshStore } from "../../store/treeRefreshStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
@@ -364,9 +365,15 @@
         <span class="vc-sidebar-bulk-count">{bulkCount.toLocaleString()} files</span>
       </div>
     {:else}
-      <span class="vc-sidebar-vaultname" title={$vaultStore.currentPath ?? ""}>
+      <button
+        type="button"
+        class="vc-sidebar-vaultname"
+        title={`Open home (${$vaultStore.currentPath ?? ""})`}
+        onclick={() => { void openHomeCanvas(); }}
+        data-testid="sidebar-vaultname-home"
+      >
         {vaultName}
-      </span>
+      </button>
       <div class="vc-sidebar-actions" style="position: relative;">
         <!-- #145: split/dropdown "+ New ▾". Primary click = new note (parity
              with the previous lone FilePlus button); chevron toggles a menu
@@ -512,6 +519,23 @@
     flex: 1;
     min-width: 0;
     margin-right: 8px;
+    background: none;
+    border: none;
+    padding: 4px 6px;
+    margin-left: -6px;
+    text-align: left;
+    cursor: pointer;
+    border-radius: 4px;
+    font-family: inherit;
+  }
+
+  .vc-sidebar-vaultname:hover {
+    background: var(--color-bg);
+  }
+
+  .vc-sidebar-vaultname:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
   }
 
   .vc-sidebar-actions {

--- a/src/components/Tabs/Tab.svelte
+++ b/src/components/Tabs/Tab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { X } from "lucide-svelte";
+  import { X, Home } from "lucide-svelte";
   import type { Tab } from "../../store/tabStore";
+  import { isHomeCanvasPath, homeTabLabel } from "../../lib/homeCanvas";
 
   let {
     tab,
@@ -14,12 +15,16 @@
     onclose: () => void;
   } = $props();
 
+  const isHome = $derived(isHomeCanvasPath(tab.filePath));
+
   // Derive the display filename from the full path. Graph tabs use a
-  // friendly label instead of the sentinel filePath.
+  // friendly label; the home canvas shows the vault name (#279).
   const filename = $derived(
     tab.type === "graph"
       ? "Graph"
-      : (tab.filePath.split("/").pop() ?? tab.filePath),
+      : isHome
+        ? homeTabLabel(tab.filePath)
+        : (tab.filePath.split("/").pop() ?? tab.filePath),
   );
 
   function handleClick(e: MouseEvent) {
@@ -67,6 +72,11 @@
   aria-selected={isActive}
   tabindex={isActive ? 0 : -1}
 >
+  {#if isHome}
+    <span class="vc-tab-home-icon" aria-hidden="true">
+      <Home size={14} strokeWidth={1.75} />
+    </span>
+  {/if}
   <span class="vc-tab-label">{filename}</span>
 
   {#if tab.isDirty}
@@ -134,6 +144,17 @@
     border-radius: 50%;
     background: var(--color-accent);
     flex-shrink: 0;
+  }
+
+  .vc-tab-home-icon {
+    display: flex;
+    align-items: center;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+  }
+
+  .vc-tab--active .vc-tab-home-icon {
+    color: var(--color-text);
   }
 
   .vc-tab-close {

--- a/src/lib/__tests__/homeCanvas.test.ts
+++ b/src/lib/__tests__/homeCanvas.test.ts
@@ -1,0 +1,51 @@
+// Unit tests for the home-canvas path helpers (#279).
+
+import { describe, it, expect } from "vitest";
+import {
+  HOME_CANVAS_REL,
+  homeCanvasPath,
+  isHomeCanvasPath,
+  homeTabLabel,
+} from "../homeCanvas";
+
+describe("homeCanvas helpers", () => {
+  it("HOME_CANVAS_REL sits inside .vaultcore/", () => {
+    expect(HOME_CANVAS_REL).toBe(".vaultcore/home.canvas");
+  });
+
+  it("homeCanvasPath joins vault + relative with forward slash", () => {
+    expect(homeCanvasPath("/Users/x/MyVault")).toBe(
+      "/Users/x/MyVault/.vaultcore/home.canvas",
+    );
+  });
+
+  it("homeCanvasPath normalises Windows-style backslashes", () => {
+    expect(homeCanvasPath("C:\\vaults\\Notes")).toBe(
+      "C:/vaults/Notes/.vaultcore/home.canvas",
+    );
+  });
+
+  it("isHomeCanvasPath matches the exact suffix", () => {
+    expect(isHomeCanvasPath("/v/My/.vaultcore/home.canvas")).toBe(true);
+    expect(isHomeCanvasPath("C:\\v\\My\\.vaultcore\\home.canvas")).toBe(true);
+  });
+
+  it("isHomeCanvasPath rejects unrelated paths", () => {
+    expect(isHomeCanvasPath("/v/My/home.canvas")).toBe(false);
+    expect(isHomeCanvasPath("/v/My/.vaultcore/other.canvas")).toBe(false);
+    expect(isHomeCanvasPath("/v/My/note.md")).toBe(false);
+  });
+
+  it("homeTabLabel returns the vault directory name", () => {
+    expect(homeTabLabel("/Users/x/MyVault/.vaultcore/home.canvas")).toBe(
+      "MyVault",
+    );
+    expect(homeTabLabel("C:\\vaults\\Notes\\.vaultcore\\home.canvas")).toBe(
+      "Notes",
+    );
+  });
+
+  it("homeTabLabel falls back to 'Home' for malformed input", () => {
+    expect(homeTabLabel("nonsense")).toBe("Home");
+  });
+});

--- a/src/lib/commands/__tests__/defaultCommands.test.ts
+++ b/src/lib/commands/__tests__/defaultCommands.test.ts
@@ -40,6 +40,7 @@ function makeCtx(overrides: Partial<DefaultCommandContext> = {}): DefaultCommand
     exportActiveNotePdf: noop,
     toggleReadingMode: noop,
     insertTemplate: noop,
+    openHome: noop,
     ...overrides,
   };
 }

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -22,6 +22,7 @@ export interface DefaultCommandContext {
   exportActiveNotePdf: () => void;
   toggleReadingMode: () => void;
   insertTemplate: () => void;
+  openHome: () => void;
 }
 
 /** Id constants — consumed by tests and anyone dispatching by id. */
@@ -41,6 +42,7 @@ export const CMD_IDS = {
   NEXT_TAB: "tabs:next",
   CLOSE_TAB: "tabs:close",
   OPEN_GRAPH: "vault:open-graph",
+  OPEN_HOME: "vault:open-home",
   COMMAND_PALETTE: "app:command-palette",
   TOGGLE_BOOKMARK: "vault:toggle-bookmark",
   OPEN_TODAY: "vault:open-today",
@@ -70,6 +72,7 @@ export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
   { id: CMD_IDS.NEXT_TAB, name: "Nächster Tab", hotkey: { meta: true, key: "Tab" } },
   { id: CMD_IDS.CLOSE_TAB, name: "Tab schließen", hotkey: { meta: true, key: "w" } },
   { id: CMD_IDS.OPEN_GRAPH, name: "Graph-Ansicht öffnen", hotkey: { meta: true, shift: true, key: "g" } },
+  { id: CMD_IDS.OPEN_HOME, name: "Vault-Startseite öffnen", hotkey: { meta: true, shift: true, key: "h" } },
   { id: CMD_IDS.COMMAND_PALETTE, name: "Befehlspalette", hotkey: { meta: true, key: "p" } },
   { id: CMD_IDS.TOGGLE_BOOKMARK, name: "Lesezeichen umschalten", hotkey: { meta: true, key: "d" } },
   { id: CMD_IDS.OPEN_TODAY, name: "Tagesnotiz öffnen", hotkey: { meta: true, shift: true, key: "d" } },
@@ -98,6 +101,7 @@ export function registerDefaultCommands(ctx: DefaultCommandContext): void {
     [CMD_IDS.NEXT_TAB]: ctx.cycleTabNext,
     [CMD_IDS.CLOSE_TAB]: ctx.closeActiveTab,
     [CMD_IDS.OPEN_GRAPH]: ctx.openGraph,
+    [CMD_IDS.OPEN_HOME]: ctx.openHome,
     [CMD_IDS.COMMAND_PALETTE]: ctx.openCommandPalette,
     [CMD_IDS.TOGGLE_BOOKMARK]: ctx.toggleBookmark,
     [CMD_IDS.OPEN_TODAY]: ctx.openTodayNote,

--- a/src/lib/homeCanvas.ts
+++ b/src/lib/homeCanvas.ts
@@ -1,0 +1,48 @@
+// Per-vault home canvas helpers (#279).
+// The home canvas lives at `<vault>/.vaultcore/home.canvas` — a regular
+// canvas file, but stored inside the `.vaultcore/` state dir so the file
+// walker, link graph, backlinks, and search all skip it via the existing
+// dot-prefix rule. The Rust side (`ensure_home_canvas`) bootstraps the
+// template on every vault open.
+
+import { get } from "svelte/store";
+import { vaultStore } from "../store/vaultStore";
+import { openFileAsTab } from "./openFileAsTab";
+
+/** Vault-relative path of the home canvas. */
+export const HOME_CANVAS_REL = ".vaultcore/home.canvas";
+
+/** Normalise path separators so comparisons work on Windows paths too. */
+function norm(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/** Absolute path of the home canvas inside the given vault. */
+export function homeCanvasPath(vaultPath: string): string {
+  return `${norm(vaultPath)}/${HOME_CANVAS_REL}`;
+}
+
+/** True when `absPath` points at a vault's home canvas. */
+export function isHomeCanvasPath(absPath: string): boolean {
+  return norm(absPath).endsWith(`/${HOME_CANVAS_REL}`);
+}
+
+/** Derive the vault name to show on the home tab from its absolute path. */
+export function homeTabLabel(absPath: string): string {
+  const n = norm(absPath);
+  const idx = n.lastIndexOf(`/${HOME_CANVAS_REL}`);
+  if (idx <= 0) return "Home";
+  const vaultSegment = n.slice(0, idx).split("/").pop();
+  return vaultSegment && vaultSegment.length > 0 ? vaultSegment : "Home";
+}
+
+/**
+ * Open (or focus) the current vault's home canvas. Singleton by path —
+ * `openFileAsTab` routes to `tabStore.openFileTab` which dedupes on filePath.
+ * No-op when no vault is open.
+ */
+export async function openHomeCanvas(): Promise<void> {
+  const vaultPath = get(vaultStore).currentPath;
+  if (!vaultPath) return;
+  await openFileAsTab(homeCanvasPath(vaultPath));
+}


### PR DESCRIPTION
Closes #279.

## Summary
- Bootstraps `<vault>/.vaultcore/home.canvas` on every vault open — minimal welcome text node, self-healing if the user deletes it.
- Clicking the vault name in the sidebar opens (or focuses) the home canvas as a singleton tab; `Cmd+Shift+H` / `Ctrl+Shift+H` does the same from anywhere.
- The home tab label is the vault name, with a house icon instead of the default canvas icon.
- Living under `.vaultcore/` the file is automatically excluded from the tree walker, link graph, backlinks, and search (existing dot-prefix rule). Outward wiki-links still resolve because resolution is target-based.

## Non-goals
No widgets, no dashboard UI, no custom renderer — it's just a regular canvas, placed where nothing else can see it.

## Test plan
- [x] `cargo test --lib home_canvas` — 3/3 pass (create, idempotency, self-heal)
- [x] `cargo check` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 825/825 pass (7 new frontend tests for the path helpers)
- [ ] Manual UAT: open a fresh vault → `.vaultcore/home.canvas` exists, sidebar vault-name opens it, `Cmd+Shift+H` focuses it, tab label = vault name with house icon, home canvas does not appear in tree/graph/backlinks/OmniSearch, deleting the file and reopening the vault recreates it, wiki-links inside home.canvas resolve to real vault notes.