### PR TITLE
fix(build): stop dev-watcher rebuild loop from onnxruntime re-signing (#281)

### DIFF
--- a/src-tauri/.taurignore
+++ b/src-tauri/.taurignore
@@ -1,0 +1,13 @@
+# Tauri dev-watcher exclusions. Anything listed here is ignored by the file
+# watcher that restarts the app on change — not a Cargo or bundle exclusion.
+#
+# resources/ holds vendored binaries (onnxruntime dylib, ONNX model, tokenizer)
+# that build.rs fetches and — on macOS — re-signs via `codesign --force`.
+# `codesign --force` rewrites the file even when the signature is already
+# ad-hoc, so without this ignore every `cargo build` triggers a watcher
+# restart which triggers another build, which re-signs, which triggers
+# another restart — an infinite rebuild loop. build.rs makes the signing
+# step idempotent too, but keeping the watcher off vendored binaries is
+# defense-in-depth.
+resources/
+target/

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -121,16 +121,36 @@ fn ensure_onnxruntime(
     // Tauri's bundled host is linker-signed ad-hoc with no Team — the TeamID
     // mismatch makes AMFI refuse the dlopen at runtime, so embeddings fail
     // silently in installed builds. Strip the upstream signature back to
-    // ad-hoc so it matches the host's identity. Idempotent: re-running on an
-    // already-ad-hoc dylib is a no-op rewrite. Non-fatal on failure (e.g.
-    // cross-compiling from Linux where `codesign` doesn't exist) — the build
-    // continues and the runtime falls back to the existing signature.
-    if platform.starts_with("macos-") {
+    // ad-hoc so it matches the host's identity. Skipped when the dylib is
+    // already ad-hoc — `codesign --force` rewrites the file unconditionally
+    // and bumps mtime, which triggers the Tauri dev watcher into an endless
+    // rebuild loop (#281). Non-fatal on failure (e.g. cross-compiling from
+    // Linux where `codesign` doesn't exist) — the build continues and the
+    // runtime falls back to the existing signature.
+    if platform.starts_with("macos-") && !is_adhoc_signed(&dest) {
         if let Err(e) = adhoc_resign(&dest) {
             println!("cargo:warning=macos adhoc re-sign skipped: {e}");
         }
     }
     Ok(())
+}
+
+/// `codesign -dv` prints signing metadata to stderr. Ad-hoc signed binaries
+/// emit the literal line `Signature=adhoc`; every other status (unsigned,
+/// TeamID-signed, or codesign missing entirely) is reported as "not adhoc"
+/// so the caller falls through to the re-sign step.
+fn is_adhoc_signed(path: &Path) -> bool {
+    let Ok(out) = std::process::Command::new("codesign")
+        .args(["-dv"])
+        .arg(path)
+        .output()
+    else {
+        return false;
+    };
+    if !out.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&out.stderr).contains("Signature=adhoc")
 }
 
 fn adhoc_resign(path: &Path) -> Result<(), AssetError> {


### PR DESCRIPTION
Closes #281.

## Summary
`build.rs` ran `codesign --force --sign -` on the bundled onnxruntime dylib on every macOS build. `--force` rewrites the signature block even when the dylib is already ad-hoc, bumping mtime → Tauri dev watcher restarts the app → new build runs `codesign --force` again → mtime bumps → restart → **infinite rebuild loop**.

## Changes
- `adhoc_resign` now short-circuits when `codesign -dv` already reports `Signature=adhoc`, so the file only changes when the signature actually needs rewriting (e.g. fresh download from upstream where it carries the Microsoft TeamID).
- New `src-tauri/.taurignore` keeps vendored build artefacts (`resources/`, `target/`) out of the dev watcher — defense-in-depth against future resource-touching build steps.

Download logic is untouched (`if !dest.exists()` / `if dest.exists()` guards in `ensure_onnxruntime` / `fetch_one_file`) — it was already correctly cached and not involved in the loop.

## Test plan
- [x] `codesign -dv` on the local dylib reports `Signature=adhoc`
- [x] `touch build.rs && cargo build` — mtime of the dylib unchanged before vs. after (verified: `1776671583` both times)
- [x] Negative check: `codesign -dv` on an unsigned file exits non-zero → `is_adhoc_signed` returns `false` → re-sign step would run
- [ ] Manual UAT: `pnpm tauri dev` starts and stays started — no `"libonnxruntime... changed. Rebuilding application…"` restart loop
- [ ] UAT on a fresh checkout (first build downloads + signs the dylib, second build is a no-op on the dylib)