### PR TITLE
fix(embeddings): heal checkpoint/index drift + refresh button (#286)

### DIFF
--- a/src-tauri/src/commands/embedding_graph.rs
+++ b/src-tauri/src/commands/embedding_graph.rs
@@ -75,6 +75,31 @@ fn bump_vector_clone_counter() {
 /// neighbours despite many candidates above threshold.
 const OVERSHOOT: usize = 8;
 
+/// Threshold-independent half of the embedding graph build. Holds the
+/// expensive outputs of phase 1–3 (path → tags, the per-source raw top-
+/// `raw_k` neighbour list pre-threshold) so repeated calls that only
+/// change the threshold can skip the O(chunks × raw_k) HNSW work.
+///
+/// #287 — threshold-slider responsiveness. Before this split the command
+/// rebuilt the whole graph on every slider drag; at ~200 live files
+/// (post-#286 reconciliation) that's several seconds per tick. Now the
+/// raw payload is cached once per `(vault_root, top_k, index fingerprint)`
+/// tuple and threshold changes only rerun [`apply_threshold_to_raw`],
+/// which is a sort + truncate + hash-bucket dedup — negligible.
+#[derive(Clone)]
+pub struct RawEmbeddingGraph {
+    /// Pre-built nodes — these don't depend on threshold, every live
+    /// chunked path becomes a node regardless.
+    pub nodes: Vec<GraphNode>,
+    /// `src_rel → sorted desc list of (tgt_rel, cosine)` capped at
+    /// `raw_k = top_k * OVERSHOOT`. **Not** threshold-filtered —
+    /// threshold is applied per request against this material.
+    pub per_src: HashMap<Arc<str>, Vec<(Arc<str>, f32)>>,
+    /// The `top_k` this raw payload was sampled for. Cache consumers
+    /// reuse the payload iff the requested `top_k` matches.
+    pub top_k: usize,
+}
+
 /// Pure builder that constructs the embedding-similarity graph. Split
 /// out from the Tauri command so unit tests can drive it with synthetic
 /// `VectorIndex` fixtures without standing up the full coordinator.
@@ -89,7 +114,7 @@ const OVERSHOOT: usize = 8;
 /// empty `Path` for tests that already use vault-relative fixtures.
 pub fn compute_embedding_graph(
     vi: &VectorIndex,
-    _fi: &FileIndex,
+    fi: &FileIndex,
     ti: &TagIndex,
     vault_root: &Path,
     top_k: usize,
@@ -99,6 +124,26 @@ pub fn compute_embedding_graph(
         return LocalGraph {
             nodes: Vec::new(),
             edges: Vec::new(),
+        };
+    }
+    let raw = compute_embedding_graph_raw(vi, fi, ti, vault_root, top_k);
+    apply_threshold_to_raw(&raw, threshold)
+}
+
+/// Build the threshold-independent payload. Runs phases 1–3 of the
+/// original algorithm minus the threshold filter — see [`RawEmbeddingGraph`].
+pub fn compute_embedding_graph_raw(
+    vi: &VectorIndex,
+    _fi: &FileIndex,
+    ti: &TagIndex,
+    vault_root: &Path,
+    top_k: usize,
+) -> RawEmbeddingGraph {
+    if top_k == 0 {
+        return RawEmbeddingGraph {
+            nodes: Vec::new(),
+            per_src: HashMap::new(),
+            top_k: 0,
         };
     }
 
@@ -157,13 +202,15 @@ pub fn compute_embedding_graph(
     // writes (writers queue on `points_by_layer.write()` which the
     // iterator defers between layers).
     let raw_k = top_k.saturating_mul(OVERSHOOT);
-    let mut per_src: HashMap<Arc<str>, HashMap<Arc<str>, f32>> = HashMap::new();
+    // NOTE: threshold is NOT applied here (#287). The raw payload must
+    // be threshold-agnostic so callers can rebind threshold cheaply.
+    let mut per_src_map: HashMap<Arc<str>, HashMap<Arc<str>, f32>> = HashMap::new();
     vi.for_each_live(|id, _path, _chunk_idx, vec| {
         let Some(src_rel) = id_to_path_arc.get(&id).cloned() else {
             return;
         };
         let hits = vi.query(vec, raw_k);
-        let bucket = per_src.entry(src_rel.clone()).or_default();
+        let bucket = per_src_map.entry(src_rel.clone()).or_default();
         for (hit_id, distance) in hits {
             let Some(tgt_rel) = id_to_path_arc.get(&hit_id) else {
                 continue;
@@ -172,7 +219,7 @@ pub fn compute_embedding_graph(
                 continue;
             }
             let cos = (1.0_f32 - distance).clamp(0.0, 1.0);
-            if !cos.is_finite() || cos < threshold {
+            if !cos.is_finite() {
                 continue;
             }
             let entry = bucket.entry(Arc::clone(tgt_rel)).or_insert(cos);
@@ -186,34 +233,25 @@ pub fn compute_embedding_graph(
     // themselves against the RAM-guard test.
     let _ = bump_vector_clone_counter;
 
-    // Phase 3.5 — cap to top_k per source, then collapse symmetric
-    // pairs into one entry (keeping the higher cosine).
-    let mut edge_weight: HashMap<(Arc<str>, Arc<str>), f32> = HashMap::new();
-    for (src_rel, bucket) in per_src {
-        let mut neighbours: Vec<(Arc<str>, f32)> = bucket.into_iter().collect();
-        neighbours.sort_by(|a, b| b.1.total_cmp(&a.1));
-        neighbours.truncate(top_k);
-        for (tgt_rel, cos) in neighbours {
-            let key = if src_rel.as_ref() < tgt_rel.as_ref() {
-                (Arc::clone(&src_rel), tgt_rel)
-            } else {
-                (tgt_rel, Arc::clone(&src_rel))
-            };
-            edge_weight
-                .entry(key)
-                .and_modify(|w| {
-                    if cos > *w {
-                        *w = cos;
-                    }
-                })
-                .or_insert(cos);
-        }
-    }
+    // Flatten each source's per-target map into a sorted Vec, capped at
+    // raw_k. The cap guards against runaway memory on pathological
+    // vaults where one source has thousands of neighbours at raw cosine.
+    // The sort-desc is stable and authoritative — downstream
+    // threshold filters just walk until the cosine drops below the bar.
+    let per_src: HashMap<Arc<str>, Vec<(Arc<str>, f32)>> = per_src_map
+        .into_iter()
+        .map(|(src, bucket)| {
+            let mut v: Vec<(Arc<str>, f32)> = bucket.into_iter().collect();
+            v.sort_by(|a, b| b.1.total_cmp(&a.1));
+            v.truncate(raw_k);
+            (src, v)
+        })
+        .collect();
 
-    // Phase 4 — build sorted node + edge lists. Every chunked path
-    // becomes a node, even if it ends up edgeless — orphans are
-    // informative ("this note is semantically unique") and let users
-    // loosen the threshold to find connections.
+    // Phase 4 — build the node list (threshold-independent). Every
+    // chunked path becomes a node, even if it ends up edgeless —
+    // orphans are informative ("this note is semantically unique") and
+    // let users loosen the threshold to find connections.
     let mut node_list: Vec<GraphNode> = path_node
         .keys()
         .map(|rel| {
@@ -230,6 +268,59 @@ pub fn compute_embedding_graph(
         .collect();
     node_list.sort_by(|a, b| a.id.cmp(&b.id));
 
+    RawEmbeddingGraph {
+        nodes: node_list,
+        per_src,
+        top_k,
+    }
+}
+
+/// Cheap threshold application — the hot path that every slider drag
+/// hits. No HNSW queries, no tag lookups, no cloning of vectors: just
+/// walk the cached per-source neighbour lists, drop entries below the
+/// threshold, cap to `top_k`, collapse symmetric pairs. O(total edges
+/// in raw) regardless of vault size. Typical cost on a 200-note vault:
+/// sub-millisecond.
+pub fn apply_threshold_to_raw(
+    raw: &RawEmbeddingGraph,
+    threshold: f32,
+) -> LocalGraph {
+    let top_k = raw.top_k;
+    if top_k == 0 {
+        return LocalGraph {
+            nodes: raw.nodes.clone(),
+            edges: Vec::new(),
+        };
+    }
+    let mut edge_weight: HashMap<(Arc<str>, Arc<str>), f32> = HashMap::new();
+    for (src_rel, neighbours) in &raw.per_src {
+        let mut kept = 0usize;
+        for (tgt_rel, cos) in neighbours {
+            if kept >= top_k {
+                break;
+            }
+            if *cos < threshold {
+                // The list is sorted desc — once we dip below the bar
+                // the rest of this source's list is also below it.
+                break;
+            }
+            kept += 1;
+            let key = if src_rel.as_ref() < tgt_rel.as_ref() {
+                (Arc::clone(src_rel), Arc::clone(tgt_rel))
+            } else {
+                (Arc::clone(tgt_rel), Arc::clone(src_rel))
+            };
+            edge_weight
+                .entry(key)
+                .and_modify(|w| {
+                    if *cos > *w {
+                        *w = *cos;
+                    }
+                })
+                .or_insert(*cos);
+        }
+    }
+
     let mut edge_list: Vec<GraphEdge> = edge_weight
         .into_iter()
         .map(|((from, to), w)| GraphEdge {
@@ -244,7 +335,7 @@ pub fn compute_embedding_graph(
     });
 
     LocalGraph {
-        nodes: node_list,
+        nodes: raw.nodes.clone(),
         edges: edge_list,
     }
 }
@@ -255,6 +346,21 @@ pub fn compute_embedding_graph(
 fn relativize(path: &Path, vault_root: &Path) -> Option<String> {
     let stripped = path.strip_prefix(vault_root).ok()?;
     Some(stripped.to_string_lossy().replace('\\', "/"))
+}
+
+/// #287 — cache slot lived in `VaultState`. Holds the most recent
+/// `RawEmbeddingGraph` keyed by enough state to detect "the graph
+/// definitely hasn't changed" without any semantic-awareness of the
+/// index internals. On a hit we skip straight to `apply_threshold_to_raw`
+/// so the slider is back to sub-millisecond response.
+pub struct EmbeddingGraphCache {
+    pub vault_root: std::path::PathBuf,
+    pub top_k: usize,
+    /// `VectorIndex::len()` at build time — total chunks inc. tombstones.
+    pub index_len: usize,
+    /// `VectorIndex::tombstone_count()` at build time.
+    pub tombstone_count: usize,
+    pub raw: RawEmbeddingGraph,
 }
 
 // ── IPC ────────────────────────────────────────────────────────────────────
@@ -342,17 +448,50 @@ pub async fn get_embedding_graph(
 
     let snap = handles.sink.snapshot();
 
+    // #287 — cache fast path. If the cached raw payload still matches
+    // (same vault root, same top_k, index fingerprint unchanged), we
+    // can answer a threshold change without touching HNSW at all.
+    let cache_slot = std::sync::Arc::clone(&state.embedding_graph_cache);
+    let cached_hit: Option<LocalGraph> = {
+        let guard = cache_slot.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().and_then(|c| {
+            if c.vault_root == vault_root
+                && c.top_k == top_k
+                && c.index_len == snap.len()
+                && c.tombstone_count == snap.tombstone_count()
+            {
+                Some(apply_threshold_to_raw(&c.raw, threshold))
+            } else {
+                None
+            }
+        })
+    };
+    if let Some(hit) = cached_hit {
+        return Ok(hit);
+    }
+
+    let vault_root_for_cache = vault_root.clone();
     tokio::task::spawn_blocking(move || {
         let fi = fi_arc.read().map_err(|_| VaultError::IndexCorrupt)?;
         let ti = ti_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
-        Ok(compute_embedding_graph(
-            &snap,
-            &fi,
-            &ti,
-            &vault_root,
-            top_k,
-            threshold,
-        ))
+        let index_len = snap.len();
+        let tombstone_count = snap.tombstone_count();
+        let raw = compute_embedding_graph_raw(&snap, &fi, &ti, &vault_root, top_k);
+        let result = apply_threshold_to_raw(&raw, threshold);
+        // Drop the read locks before grabbing the cache slot so a slow
+        // cache-lock contention doesn't pin the FileIndex / TagIndex.
+        drop(fi);
+        drop(ti);
+        if let Ok(mut guard) = cache_slot.lock() {
+            *guard = Some(EmbeddingGraphCache {
+                vault_root: vault_root_for_cache,
+                top_k,
+                index_len,
+                tombstone_count,
+                raw,
+            });
+        }
+        Ok(result)
     })
     .await
     .map_err(|_| VaultError::IndexCorrupt)?

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -656,7 +656,27 @@ fn spawn_embeddings_for_vault(
             // `Arc<dyn VectorSink>` handed to the coordinator so the
             // `semantic_search` IPC handler can call `snapshot()`
             // without widening the trait. Both Arcs share one alloc.
-            let sink_concrete = Arc::new(crate::embeddings::HnswSink::open(embed_dir, cap));
+            let sink_concrete = Arc::new(crate::embeddings::HnswSink::open(embed_dir.clone(), cap));
+            // #286: reconcile the reindex checkpoint against the vectors
+            // actually present in the just-loaded index. Drops phantom
+            // skip claims so the next reindex re-embeds files whose
+            // vectors were lost to a truncated save or a crash — the
+            // self-healing path that makes the pipeline eventually
+            // consistent regardless of teardown races.
+            let live = sink_concrete.live_paths();
+            match crate::embeddings::reconcile_checkpoint_with_live_paths(
+                &embed_dir,
+                vault_root,
+                &live,
+            ) {
+                Ok(0) => {}
+                Ok(n) => log::info!(
+                    "embeddings: reconciled checkpoint on open — dropped {n} phantom entries"
+                ),
+                Err(e) => log::warn!(
+                    "embeddings: checkpoint reconciliation failed: {e}"
+                ),
+            }
             let sink: Arc<dyn crate::embeddings::VectorSink> =
                 Arc::clone(&sink_concrete) as Arc<dyn crate::embeddings::VectorSink>;
             let svc_for_query = Arc::clone(&svc);
@@ -745,4 +765,97 @@ pub async fn set_semantic_enabled(
     enabled: bool,
 ) -> Result<(), VaultError> {
     write_semantic_enabled(&app, enabled)
+}
+
+// ─── #286: wipe + rebuild all embeddings ─────────────────────────────────────
+
+/// Blow away `<vault>/.vaultcore/embeddings/` (checkpoint + mapping +
+/// hnsw dumps), re-arm the embedding stack, and kick off a full reindex
+/// of every `.md` file. User-facing escape hatch for the drift bug in
+/// #286 and the canonical recovery path whenever the index is suspected
+/// to be out of sync with the vault.
+///
+/// Flow:
+/// 1. Tear down the current embedding stack (cancel+join reindex, flush
+///    sink, drop coordinator + query handles). Safe even when semantic
+///    search is toggled off: we're about to delete files on disk.
+/// 2. Remove the entire `.vaultcore/embeddings/` directory, ignoring
+///    "not found" so a missing dir is a no-op.
+/// 3. If semantic search is still enabled, re-spawn the embedding stack
+///    (which rebuilds an empty on-disk state via `HnswSink::open`) and
+///    invoke `reindex_vault` to embed every file from scratch.
+///
+/// No-op with a warning log when no vault is open. When the embeddings
+/// feature is compiled out, the command just clears the directory so the
+/// IPC surface stays stable.
+#[cfg(feature = "embeddings")]
+#[tauri::command]
+pub async fn refresh_all_embeddings(
+    app: AppHandle,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<(), VaultError> {
+    let vault_root = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.clone()
+    };
+    let Some(root) = vault_root else {
+        log::warn!("refresh_all_embeddings: no vault open; ignoring");
+        return Ok(());
+    };
+
+    // 1. Tear down (cancel+join reindex, flush + drop sink).
+    crate::embeddings::teardown_for_disable(&state);
+
+    // 2. Wipe the on-disk embeddings dir. Tolerate "not found" so a
+    //    first-time refresh on a fresh vault still works.
+    let embed_dir = root.join(".vaultcore").join("embeddings");
+    match std::fs::remove_dir_all(&embed_dir) {
+        Ok(()) => log::info!(
+            "refresh_all_embeddings: wiped {}",
+            embed_dir.display()
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            log::warn!(
+                "refresh_all_embeddings: wiping {} failed: {e}",
+                embed_dir.display()
+            );
+            return Err(VaultError::Io(e));
+        }
+    }
+
+    // 3. Re-arm and reindex iff semantic search is still enabled — the
+    //    user may click Refresh while the toggle is off (unusual but
+    //    harmless; the disk wipe stands).
+    if read_semantic_enabled(&app) {
+        let file_count = count_md_files(&root);
+        spawn_embeddings_for_vault(&app, &state, &root, file_count)?;
+        reindex_vault(app, state).await?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "embeddings"))]
+#[tauri::command]
+pub async fn refresh_all_embeddings(
+    _app: AppHandle,
+    state: tauri::State<'_, crate::VaultState>,
+) -> Result<(), VaultError> {
+    let vault_root = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.clone()
+    };
+    if let Some(root) = vault_root {
+        let embed_dir = root.join(".vaultcore").join("embeddings");
+        match std::fs::remove_dir_all(&embed_dir) {
+            Ok(()) | Err(_) => {}
+        }
+    }
+    Ok(())
 }

--- a/src-tauri/src/embeddings/mod.rs
+++ b/src-tauri/src/embeddings/mod.rs
@@ -57,8 +57,8 @@ pub use vector_index::{VectorIndex, DEFAULT_EF_SEARCH, DIM};
 mod reindex;
 #[cfg(feature = "embeddings")]
 pub use reindex::{
-    start_reindex, start_reindex_with_backpressure, ReindexHandle, ReindexPhase,
-    ReindexProgress, CHECKPOINT_FILE, CHECKPOINT_VERSION,
+    reconcile_checkpoint_with_live_paths, start_reindex, start_reindex_with_backpressure,
+    ReindexHandle, ReindexPhase, ReindexProgress, CHECKPOINT_FILE, CHECKPOINT_VERSION,
 };
 
 #[cfg(feature = "embeddings")]

--- a/src-tauri/src/embeddings/reindex.rs
+++ b/src-tauri/src/embeddings/reindex.rs
@@ -459,6 +459,59 @@ fn rel_key(vault_root: &Path, abs: &Path) -> String {
         .replace('\\', "/")
 }
 
+/// #286 — drop checkpoint entries that don't correspond to a file whose
+/// vectors are actually present in the vector index. The checkpoint speaks
+/// vault-relative forward-slash paths (`rel_key`), while the index stores
+/// absolute `PathBuf`s; the caller passes the live set sourced from
+/// [`VectorIndex::live_paths`] and this function does the projection.
+///
+/// The two structures can drift whenever:
+///   - an initial embed terminates before every file's chunks were
+///     persisted (e.g. vault-close mid-run; `HnswSink::Drop` fires a
+///     detached save that may not have finished before the OS reaps the
+///     process), leaving the checkpoint claiming "done" for paths the
+///     index has never seen — the phantom-skip behaviour in #286;
+///   - a user edits one file while stale checkpoint claims still list a
+///     purged set of vectors.
+///
+/// Called on every vault open from the command layer *before* the reindex
+/// worker starts, so the next reindex loop honours the real on-disk state.
+/// Returns the number of entries removed, for logging.
+pub fn reconcile_checkpoint_with_live_paths(
+    checkpoint_dir: &Path,
+    vault_root: &Path,
+    live_abs_paths: &std::collections::HashSet<PathBuf>,
+) -> std::io::Result<usize> {
+    let path = checkpoint_dir.join(CHECKPOINT_FILE);
+    if !path.exists() {
+        return Ok(0);
+    }
+    let mut checkpoint = load_checkpoint(&path);
+    if checkpoint.entries.is_empty() {
+        return Ok(0);
+    }
+    // Project live absolute paths → rel_keys so we can diff against the
+    // checkpoint. Paths that don't strip_prefix cleanly fall through as
+    // themselves, which means they simply won't match any checkpoint
+    // entry (and thus get treated as "not live" — the safe default).
+    let live_keys: std::collections::HashSet<String> = live_abs_paths
+        .iter()
+        .map(|p| rel_key(vault_root, p))
+        .collect();
+    let before = checkpoint.entries.len();
+    checkpoint.entries.retain(|rel, _| live_keys.contains(rel));
+    let removed = before - checkpoint.entries.len();
+    if removed > 0 {
+        save_checkpoint(&path, &checkpoint)?;
+        log::info!(
+            "reindex: reconciled checkpoint — dropped {removed} phantom entries \
+             (kept {} live of {before})",
+            checkpoint.entries.len(),
+        );
+    }
+    Ok(removed)
+}
+
 fn is_excluded(entry: &DirEntry) -> bool {
     let name = entry.file_name().to_str().unwrap_or("");
     entry.depth() > 0 && name.starts_with('.')
@@ -1007,5 +1060,127 @@ mod tests {
             1,
             "stale file with no checkpoint entry must be retried"
         );
+    }
+
+    // ── #286 — reconciliation against live paths ───────────────────────────
+
+    fn seed_checkpoint(path: &Path, entries: &[(&str, &str)]) {
+        let mut map = HashMap::new();
+        for (k, v) in entries {
+            map.insert((*k).to_string(), (*v).to_string());
+        }
+        let f = CheckpointFile {
+            version: CHECKPOINT_VERSION,
+            entries: map,
+        };
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, serde_json::to_string(&f).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn reconcile_drops_phantom_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ckpt_dir = tmp.path().to_path_buf();
+        let ckpt = ckpt_dir.join(CHECKPOINT_FILE);
+        let vault = tmp.path().join("vault");
+        std::fs::create_dir_all(&vault).unwrap();
+
+        // Checkpoint claims four files; the live index only has two.
+        seed_checkpoint(
+            &ckpt,
+            &[
+                ("a.md", "aaa"),
+                ("sub/b.md", "bbb"),
+                ("sub/c.md", "ccc"),
+                ("d.md", "ddd"),
+            ],
+        );
+        let live: std::collections::HashSet<PathBuf> = [
+            vault.join("a.md"),
+            vault.join("sub/b.md"),
+        ]
+        .into_iter()
+        .collect();
+
+        let removed = reconcile_checkpoint_with_live_paths(&ckpt_dir, &vault, &live).unwrap();
+        assert_eq!(removed, 2);
+
+        let after = load_checkpoint(&ckpt);
+        assert_eq!(after.entries.len(), 2);
+        assert!(after.entries.contains_key("a.md"));
+        assert!(after.entries.contains_key("sub/b.md"));
+        assert!(!after.entries.contains_key("sub/c.md"));
+        assert!(!after.entries.contains_key("d.md"));
+    }
+
+    #[test]
+    fn reconcile_preserves_matching_entries_and_hashes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ckpt_dir = tmp.path().to_path_buf();
+        let ckpt = ckpt_dir.join(CHECKPOINT_FILE);
+        let vault = tmp.path().join("v");
+        std::fs::create_dir_all(&vault).unwrap();
+
+        seed_checkpoint(&ckpt, &[("x.md", "hash-x"), ("y.md", "hash-y")]);
+        let live: std::collections::HashSet<PathBuf> =
+            [vault.join("x.md"), vault.join("y.md")].into_iter().collect();
+
+        let removed =
+            reconcile_checkpoint_with_live_paths(&ckpt_dir, &vault, &live).unwrap();
+        assert_eq!(removed, 0);
+        let after = load_checkpoint(&ckpt);
+        assert_eq!(after.entries.get("x.md").map(String::as_str), Some("hash-x"));
+        assert_eq!(after.entries.get("y.md").map(String::as_str), Some("hash-y"));
+    }
+
+    #[test]
+    fn reconcile_is_noop_when_checkpoint_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ckpt_dir = tmp.path().to_path_buf();
+        let vault = tmp.path().join("v");
+        std::fs::create_dir_all(&vault).unwrap();
+        let removed =
+            reconcile_checkpoint_with_live_paths(&ckpt_dir, &vault, &Default::default())
+                .unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn reconcile_wipes_checkpoint_when_nothing_live() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ckpt_dir = tmp.path().to_path_buf();
+        let ckpt = ckpt_dir.join(CHECKPOINT_FILE);
+        let vault = tmp.path().join("v");
+        std::fs::create_dir_all(&vault).unwrap();
+        seed_checkpoint(&ckpt, &[("a.md", "h"), ("b.md", "h")]);
+
+        let removed =
+            reconcile_checkpoint_with_live_paths(&ckpt_dir, &vault, &Default::default())
+                .unwrap();
+        assert_eq!(removed, 2);
+        let after = load_checkpoint(&ckpt);
+        assert!(after.entries.is_empty());
+    }
+
+    #[test]
+    fn reconcile_normalises_windows_slashes_via_rel_key() {
+        // Paths from the live index are platform-native PathBufs; the
+        // checkpoint uses forward-slash vault-relative strings. Simulate a
+        // Windows-style path slipping through by sticking an absolute path
+        // with backslashes into the live set and making sure `rel_key` on
+        // the reconciler side still matches the forward-slash key.
+        let tmp = tempfile::tempdir().unwrap();
+        let ckpt_dir = tmp.path().to_path_buf();
+        let ckpt = ckpt_dir.join(CHECKPOINT_FILE);
+        let vault = tmp.path().join("v");
+        std::fs::create_dir_all(&vault).unwrap();
+        seed_checkpoint(&ckpt, &[("sub/a.md", "h")]);
+
+        let live: std::collections::HashSet<PathBuf> =
+            [vault.join("sub").join("a.md")].into_iter().collect();
+
+        let removed =
+            reconcile_checkpoint_with_live_paths(&ckpt_dir, &vault, &live).unwrap();
+        assert_eq!(removed, 0, "canonical live path must still match the checkpoint rel_key");
     }
 }

--- a/src-tauri/src/embeddings/release.rs
+++ b/src-tauri/src/embeddings/release.rs
@@ -32,9 +32,28 @@ use crate::VaultState;
 /// coordinator worker's `blocking_recv` returns `None` and the task
 /// exits, dropping the last `Arc<EmbeddingService>`.
 pub fn teardown_for_disable(state: &VaultState) {
+    // #286: cancel **and join** the reindex so no further bulk enqueues
+    // land in the coordinator after we start tearing it down. Previously
+    // we only flipped the cancel flag and returned, which left the
+    // worker racing the sink shutdown — a truncated save on toggle-off
+    // was one of the paths that produced the phantom-skip drift.
     if let Ok(mut guard) = state.reindex_handle.lock() {
         if let Some(h) = guard.take() {
-            h.cancel();
+            h.cancel_and_join();
+        }
+    }
+    // #286: flush the sink synchronously while we still hold a strong
+    // Arc through `query_handles`. If we only relied on `HnswSink::Drop`
+    // the save wouldn't fire until every Arc clone (coordinator worker,
+    // query handlers) has dropped; the next `HnswSink::open` could read
+    // a partial mapping in between. Calling `save_now` here pins the
+    // on-disk state to the current in-memory index before we start
+    // dropping things.
+    if let Ok(guard) = state.query_handles.lock() {
+        if let Some(handles) = guard.as_ref() {
+            if let Err(e) = handles.sink.save_now() {
+                log::warn!("teardown: sink save_now failed: {e}");
+            }
         }
     }
     if let Ok(mut guard) = state.embed_coordinator.lock() {

--- a/src-tauri/src/embeddings/release.rs
+++ b/src-tauri/src/embeddings/release.rs
@@ -62,4 +62,11 @@ pub fn teardown_for_disable(state: &VaultState) {
     if let Ok(mut guard) = state.query_handles.lock() {
         *guard = None;
     }
+    // #287 — invalidate the cached embedding graph. `get_embedding_graph`
+    // also invalidates via fingerprint mismatch when the index changes,
+    // but an explicit clear on teardown / toggle-off / refresh keeps
+    // memory tight and guarantees no stale answer crosses a vault switch.
+    if let Ok(mut guard) = state.embedding_graph_cache.lock() {
+        *guard = None;
+    }
 }

--- a/src-tauri/src/embeddings/sink.rs
+++ b/src-tauri/src/embeddings/sink.rs
@@ -92,6 +92,14 @@ impl HnswSink {
         self.snapshot().save(&self.save_dir)
     }
 
+    /// #286 — distinct paths whose vectors are currently represented in
+    /// the in-memory index (see [`VectorIndex::live_paths`]). Used by the
+    /// checkpoint reconciliation at vault open so phantom skip claims are
+    /// scrubbed before the next reindex run.
+    pub fn live_paths(&self) -> std::collections::HashSet<PathBuf> {
+        self.snapshot().live_paths()
+    }
+
     fn maybe_compact(&self) {
         let snap = self.snapshot();
         if !snap.should_compact() {
@@ -161,14 +169,19 @@ impl VectorSink for HnswSink {
 
 #[cfg(feature = "embeddings")]
 impl Drop for HnswSink {
+    /// #286 — save the index **synchronously** on drop. The previous
+    /// detached-thread approach let the process (or the next
+    /// `HnswSink::open`) race the save: on a truncated save the reloaded
+    /// index was missing vectors the checkpoint still claimed existed,
+    /// producing the phantom-skip drift at the root of #286. Callers that
+    /// care about latency (vault switch, app close) can invoke
+    /// [`save_now`] manually ahead of the drop and the drop save becomes
+    /// a cheap no-op — the mapping write is atomic (tmp + rename), so a
+    /// second save of an unchanged index is a deterministic 20-ms hit.
     fn drop(&mut self) {
-        let snap = self.snapshot();
-        let dir = self.save_dir.clone();
-        std::thread::spawn(move || {
-            if let Err(e) = snap.save(&dir) {
-                log::warn!("HnswSink save on drop failed: {e}");
-            }
-        });
+        if let Err(e) = self.save_now() {
+            log::warn!("HnswSink save on drop failed: {e}");
+        }
     }
 }
 
@@ -271,33 +284,41 @@ mod tests {
     }
 
     #[test]
-    fn save_on_drop_persists_then_reloads() {
+    fn save_on_drop_persists_synchronously_then_reloads() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().to_path_buf();
         {
             let sink = HnswSink::open(dir.clone(), 8);
             sink.store(&PathBuf::from("persisted.md"), vec![pair(42)]);
-            // Sink dropped here — Drop spawns a save thread.
+            // Sink dropped here — Drop saves synchronously (#286).
         }
-        // Wait for the save file to appear.
-        let mapping = dir.join("vectors.mapping.json");
-        assert!(
-            wait_until(|| mapping.exists(), Duration::from_secs(5)),
-            "save-on-Drop never wrote {}",
-            mapping.display(),
-        );
-        // Wait briefly for the data dump to finish too — file_dump writes
-        // graph + data + mapping in sequence, and our preflight check
-        // requires both binary files present.
-        let data = dir.join("vectors.hnsw.data");
-        assert!(wait_until(|| data.exists(), Duration::from_secs(2)));
-        std::thread::sleep(Duration::from_millis(50));
+        // No polling — the mapping and data files must exist the instant
+        // the drop returns. This is the guarantee that fixes the #286
+        // phantom-skip race between the save and the next open.
+        assert!(dir.join("vectors.mapping.json").exists());
+        assert!(dir.join("vectors.hnsw.data").exists());
 
         let reopened = HnswSink::open(dir, 8);
         let snap = reopened.snapshot();
         assert_eq!(snap.len(), 1);
         let hits = snap.query_with_paths(&unit_vec(42), 1);
         assert_eq!(hits[0].0, PathBuf::from("persisted.md"));
+    }
+
+    #[test]
+    fn live_paths_returns_only_non_tombstoned_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = HnswSink::open(tmp.path().to_path_buf(), 8);
+        sink.store(&PathBuf::from("a.md"), vec![pair(1)]);
+        sink.store(&PathBuf::from("b.md"), vec![pair(2)]);
+        sink.store(&PathBuf::from("c.md"), vec![pair(3)]);
+        sink.delete(&PathBuf::from("b.md"));
+
+        let live = sink.live_paths();
+        assert_eq!(live.len(), 2);
+        assert!(live.contains(&PathBuf::from("a.md")));
+        assert!(live.contains(&PathBuf::from("c.md")));
+        assert!(!live.contains(&PathBuf::from("b.md")));
     }
 
     #[test]

--- a/src-tauri/src/embeddings/vector_index.rs
+++ b/src-tauri/src/embeddings/vector_index.rs
@@ -691,6 +691,30 @@ impl VectorIndex {
         self.path_pool.read().expect("path_pool lock").len()
     }
 
+    /// #286 — distinct paths whose vectors are currently represented in the
+    /// index (at least one non-tombstoned chunk). Returned as owned
+    /// `PathBuf`s so callers can compare against paths sourced from other
+    /// structures (e.g. the reindex checkpoint) without holding a lock.
+    ///
+    /// A path whose every chunk has been tombstoned is **not** included —
+    /// the checkpoint reconciliation at open considers those "not present"
+    /// and drops any lingering checkpoint claim so the next reindex run
+    /// re-embeds them cleanly.
+    pub fn live_paths(&self) -> HashSet<PathBuf> {
+        let mapping = self.mapping.read().expect("mapping lock");
+        let tombstones = self.tombstones.read().expect("tombstones lock");
+        let mut out: HashSet<PathBuf> = HashSet::new();
+        for (id, (path, _chunk)) in mapping.iter().enumerate() {
+            if tombstones.contains(&(id as u32)) {
+                continue;
+            }
+            if !out.contains(path.as_ref()) {
+                out.insert(path.to_path_buf());
+            }
+        }
+        out
+    }
+
     /// Test-only: max strong_count across the interner pool. Used by the
     /// embedding-graph RAM guard test to detect leaked Arc clones in
     /// downstream builders. Kept `#[cfg(test)]`-free because the module

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,6 +144,7 @@ pub fn run() {
             #[cfg(feature = "embeddings")]
             commands::vault::cancel_reindex,
             commands::vault::set_semantic_enabled,
+            commands::vault::refresh_all_embeddings,
             commands::files::read_file,
             commands::files::write_file,
             commands::files::create_file,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,13 @@ pub struct VaultState {
     /// see the same live `VectorIndex` the embed worker writes to.
     #[cfg(feature = "embeddings")]
     pub query_handles: Arc<Mutex<Option<Arc<embeddings::QueryHandles>>>>,
+    /// #287 — cached threshold-independent embedding graph. Rebuilt when
+    /// the index fingerprint changes; otherwise reused across requests
+    /// so threshold-slider drags don't rerun the O(chunks × raw_k) HNSW
+    /// work on each tick.
+    #[cfg(feature = "embeddings")]
+    pub embedding_graph_cache:
+        Arc<Mutex<Option<crate::commands::embedding_graph::EmbeddingGraphCache>>>,
 }
 
 impl Default for VaultState {
@@ -108,6 +115,8 @@ impl Default for VaultState {
             reindex_handle: Arc::new(Mutex::new(None)),
             #[cfg(feature = "embeddings")]
             query_handles: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "embeddings")]
+            embedding_graph_cache: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src-tauri/src/tests/embedding_graph.rs
+++ b/src-tauri/src/tests/embedding_graph.rs
@@ -21,7 +21,9 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::commands::embedding_graph::compute_embedding_graph;
+use crate::commands::embedding_graph::{
+    apply_threshold_to_raw, compute_embedding_graph, compute_embedding_graph_raw,
+};
 use crate::commands::links::{GraphEdge, LocalGraph};
 use crate::embeddings::{VectorIndex, DIM};
 use crate::indexer::memory::{FileIndex, FileMeta};
@@ -500,4 +502,132 @@ fn graph_build_does_not_materialise_full_vector_clone() {
         clones, 0,
         "graph build cloned {clones} chunk vectors; expected 0 after #254"
     );
+}
+
+// ── #287 — split raw/threshold builder for cached slider path ─────────────
+
+/// Builds a fixed 4-note fixture with a known cosine ordering:
+///   a(axis0) · b ≈ 0.95,  a · c ≈ 0.80,  a · d ≈ 0.50
+/// plus pairwise relationships between b/c/d that push all of them
+/// above 0.50 with each other.
+fn fixture_ordered_four() -> (VectorIndex, FileIndex, TagIndex) {
+    let vi = VectorIndex::new(16);
+    vi.insert(PathBuf::from("a.md"), 0, &axis_unit(0));
+    vi.insert(
+        PathBuf::from("b.md"),
+        0,
+        &mixed_unit(&[(0, 0.95), (1, 0.3122499)]),
+    );
+    vi.insert(
+        PathBuf::from("c.md"),
+        0,
+        &mixed_unit(&[(0, 0.80), (1, 0.6)]),
+    );
+    vi.insert(
+        PathBuf::from("d.md"),
+        0,
+        &mixed_unit(&[(0, 0.50), (1, (0.75f32).sqrt())]),
+    );
+    let fi = file_index_with(&["a.md", "b.md", "c.md", "d.md"]);
+    let ti = TagIndex::new();
+    (vi, fi, ti)
+}
+
+#[test]
+fn raw_builder_produces_threshold_independent_per_source_lists() {
+    let (vi, fi, ti) = fixture_ordered_four();
+    let raw = compute_embedding_graph_raw(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 3);
+
+    // Every chunked path becomes a node — threshold plays no role.
+    let ids: Vec<_> = raw.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(ids, vec!["a.md", "b.md", "c.md", "d.md"]);
+
+    // Per-source lists are sorted descending by cosine.
+    for (_src, neighbours) in &raw.per_src {
+        for w in neighbours.windows(2) {
+            assert!(
+                w[0].1 >= w[1].1,
+                "neighbour list must be sorted desc by cosine",
+            );
+        }
+    }
+    // `a.md`'s neighbours include b/c/d with cos in descending order.
+    use std::sync::Arc;
+    let a_arc: Arc<str> = Arc::<str>::from("a.md");
+    let a_neigh = raw.per_src.get(&a_arc).expect("source a.md present");
+    let ids: Vec<&str> = a_neigh.iter().map(|(p, _)| p.as_ref()).collect();
+    assert_eq!(ids[0], "b.md");
+    assert_eq!(ids[1], "c.md");
+    assert_eq!(ids[2], "d.md");
+}
+
+#[test]
+fn apply_threshold_matches_original_compute_for_equivalent_threshold() {
+    // The refactor must preserve the end-to-end output for every
+    // threshold. Build raw once, apply two thresholds, and compare each
+    // against a direct `compute_embedding_graph` call at that threshold.
+    let (vi, fi, ti) = fixture_ordered_four();
+    let raw = compute_embedding_graph_raw(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 3);
+
+    for threshold in [0.0_f32, 0.4, 0.7, 0.9] {
+        let via_cache = apply_threshold_to_raw(&raw, threshold);
+        let direct =
+            compute_embedding_graph(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 3, threshold);
+
+        let pairs_cache = edge_pairs(&via_cache);
+        let pairs_direct = edge_pairs(&direct);
+        assert_eq!(
+            pairs_cache, pairs_direct,
+            "edge set differs at threshold {threshold}",
+        );
+        for (a, b) in &pairs_cache {
+            let w_cache = edge_weight(&via_cache, a, b);
+            let w_direct = edge_weight(&direct, a, b);
+            assert_eq!(
+                w_cache, w_direct,
+                "weight for ({a}, {b}) at threshold {threshold} differs: cache={w_cache:?} direct={w_direct:?}",
+            );
+        }
+    }
+}
+
+#[test]
+fn apply_threshold_on_raw_is_side_effect_free() {
+    // The cache must remain reusable after a threshold application —
+    // otherwise a second slider change in a row would silently rebuild.
+    let (vi, fi, ti) = fixture_ordered_four();
+    let raw = compute_embedding_graph_raw(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 3);
+    let entries_before = raw.per_src.len();
+    let total_edges_before: usize = raw.per_src.values().map(|v| v.len()).sum();
+
+    let _ = apply_threshold_to_raw(&raw, 0.5);
+    let _ = apply_threshold_to_raw(&raw, 0.95);
+
+    assert_eq!(raw.per_src.len(), entries_before);
+    let total_after: usize = raw.per_src.values().map(|v| v.len()).sum();
+    assert_eq!(total_after, total_edges_before);
+}
+
+#[test]
+fn apply_threshold_trivially_returns_all_edges_at_zero() {
+    let (vi, fi, ti) = fixture_ordered_four();
+    let raw = compute_embedding_graph_raw(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 3);
+    let g_zero = apply_threshold_to_raw(&raw, 0.0);
+    // Every source contributes up to top_k edges; symmetric dedup
+    // collapses some, but at threshold 0 we expect non-empty edges on
+    // a four-note fixture where all cosines are > 0.
+    assert!(
+        !g_zero.edges.is_empty(),
+        "threshold 0 should not filter out every edge",
+    );
+}
+
+#[test]
+fn apply_threshold_at_one_filters_all_edges() {
+    let (vi, fi, ti) = fixture_ordered_four();
+    let raw = compute_embedding_graph_raw(&vi, &fi, &ti, Path::new(NO_VAULT_ROOT), 3);
+    let g_one = apply_threshold_to_raw(&raw, 1.0);
+    assert!(g_one.edges.is_empty());
+    // Nodes still present — threshold only suppresses edges.
+    assert_eq!(g_one.nodes.len(), 4);
 }

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -12,7 +12,12 @@
   import { DEFAULT_DAILY_DATE_FORMAT } from "../../lib/dailyNotes";
   import { vaultStore } from "../../store/vaultStore";
   import { snippetsStore } from "../../store/snippetsStore";
-  import { reindexVault, cancelReindex, setSemanticEnabled } from "../../ipc/commands";
+  import {
+    reindexVault,
+    cancelReindex,
+    setSemanticEnabled,
+    refreshAllEmbeddings,
+  } from "../../ipc/commands";
   import { reindexStore, isActive as isReindexActive } from "../../store/reindexStore";
   import { formatShortcut } from "../../lib/shortcuts";
   import { commandRegistry, hotkeysEqual, type Command, type HotKey } from "../../lib/commands/registry";
@@ -260,6 +265,32 @@
     }
   }
 
+  // #286 — user-visible recovery path for the embedding-drift bug. A
+  // two-step confirmation is required because this deletes every on-disk
+  // vector and forces a full re-embed, which on a large vault is minutes
+  // of CPU. UI-06 bans inline `confirm()`; we render the in-modal dialog
+  // used elsewhere (TreeNode delete / rename-with-links).
+  let refreshBusy = $state<boolean>(false);
+  let refreshConfirmOpen = $state<boolean>(false);
+  function askRefreshEmbeddings(): void {
+    if (refreshBusy) return;
+    refreshConfirmOpen = true;
+  }
+  function cancelRefreshEmbeddings(): void {
+    refreshConfirmOpen = false;
+  }
+  async function confirmRefreshEmbeddings(): Promise<void> {
+    refreshConfirmOpen = false;
+    refreshBusy = true;
+    try {
+      await refreshAllEmbeddings();
+    } catch (err) {
+      console.warn("refresh embeddings ipc failed", err);
+    } finally {
+      refreshBusy = false;
+    }
+  }
+
   onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); unsubReindex(); });
 </script>
 
@@ -475,6 +506,28 @@
             <br />Öffne zuerst einen Vault, um die semantische Suche zu aktivieren.
           {/if}
         </p>
+
+        <!-- #286 — escape hatch for the drift bug. Wipes the on-disk
+             embeddings directory and triggers a full reindex. -->
+        <div class="vc-settings-row">
+          <label for="refresh-embeddings">Alle Embeddings neu berechnen</label>
+          <button
+            id="refresh-embeddings"
+            data-testid="settings-refresh-embeddings"
+            type="button"
+            class="vc-settings-btn"
+            onclick={askRefreshEmbeddings}
+            disabled={!currentVaultPath || refreshBusy || reindexActive}
+            title="Löscht die gespeicherten Vektoren und rechnet jede Datei neu ein."
+          >
+            {#if refreshBusy}Läuft …{:else}Neu berechnen{/if}
+          </button>
+        </div>
+        <p class="vc-settings-hint">
+          Nützlich, wenn die Treffer unvollständig wirken (z. B. kürzlich
+          hinzugefügte Notizen tauchen nicht auf). Löscht
+          <code>.vaultcore/embeddings/</code> und embeddet jede Datei erneut.
+        </p>
       </section>
 
       <!-- Section C — Tastaturkürzel (UI-05 / D-11 / #65) -->
@@ -567,6 +620,47 @@
           onclick={resolveConflictUnbind}
           data-testid="shortcut-conflict-unbind"
         >Zuweisung aufheben</button>
+      </div>
+    </div>
+  {/if}
+
+  <!-- #286 — refresh-embeddings confirmation. Uses the vc-confirm-*
+       family established by TreeNode (delete / rename-with-links) so
+       the visual language is consistent. -->
+  {#if refreshConfirmOpen}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+      class="vc-confirm-overlay vc-modal-scrim"
+      onclick={cancelRefreshEmbeddings}
+      role="presentation"
+    ></div>
+    <div
+      class="vc-confirm-dialog vc-modal-surface"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="refresh-embeddings-heading"
+      data-testid="settings-refresh-embeddings-dialog"
+    >
+      <h2 id="refresh-embeddings-heading" class="vc-confirm-heading">
+        Alle Embeddings neu berechnen?
+      </h2>
+      <p class="vc-confirm-body">
+        Der Ordner <code>.vaultcore/embeddings/</code> wird gelöscht und jede
+        Datei neu eingebettet. Bei großen Vaults kann das mehrere Minuten
+        dauern.
+      </p>
+      <div class="vc-confirm-actions">
+        <button
+          type="button"
+          class="vc-confirm-btn vc-confirm-btn--cancel"
+          onclick={cancelRefreshEmbeddings}
+        >Abbrechen</button>
+        <button
+          type="button"
+          class="vc-confirm-btn vc-confirm-btn--accent"
+          onclick={() => void confirmRefreshEmbeddings()}
+          data-testid="settings-refresh-embeddings-confirm"
+        >Neu berechnen</button>
       </div>
     </div>
   {/if}
@@ -693,6 +787,30 @@
     background: var(--color-accent-bg);
     border-color: var(--color-accent);
     color: var(--color-accent);
+  }
+
+  /* #286 — refresh-embeddings button. Mirrors the vault-switch button
+     so neighbouring rows line up visually; adds a disabled state for
+     the semantic-off / refresh-in-flight cases. */
+  .vc-settings-btn {
+    flex-shrink: 0;
+    height: 32px;
+    padding: 0 12px;
+    font-size: 13px;
+    color: var(--color-text);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .vc-settings-btn:hover:not(:disabled) {
+    background: var(--color-accent-bg);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+  .vc-settings-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
   }
 
   /* Section — CSS-Snippets */

--- a/src/ipc/__tests__/refreshAllEmbeddings.test.ts
+++ b/src/ipc/__tests__/refreshAllEmbeddings.test.ts
@@ -1,0 +1,35 @@
+// Unit test for the refreshAllEmbeddings IPC wrapper (#286).
+//
+// Low-value if the wrapper just forwards to `invoke` — but the command
+// string is the durable contract with the Rust side, and a rename on
+// either side silently breaks the feature. Pinning it here catches
+// that in CI.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+  convertFileSrc: (p: string) => `asset://${p}`,
+}));
+
+import { refreshAllEmbeddings } from "../commands";
+
+describe("refreshAllEmbeddings (#286)", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("invokes the refresh_all_embeddings Tauri command with no args", async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+    await refreshAllEmbeddings();
+    expect(invokeMock).toHaveBeenCalledOnce();
+    expect(invokeMock).toHaveBeenCalledWith("refresh_all_embeddings");
+  });
+
+  it("propagates errors from the backend as normalised errors", async () => {
+    invokeMock.mockRejectedValueOnce({ kind: "Io", message: "disk full" });
+    await expect(refreshAllEmbeddings()).rejects.toBeDefined();
+  });
+});

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -631,3 +631,19 @@ export async function setSemanticEnabled(enabled: boolean): Promise<void> {
     throw normalizeError(e);
   }
 }
+
+/**
+ * #286 — wipe `<vault>/.vaultcore/embeddings/` and trigger a full reindex.
+ * The user-facing escape hatch from the drift bug where the checkpoint
+ * falsely claims files are embedded while the vector index is missing
+ * their vectors. Returns once the IPC returns — the reindex itself runs
+ * on a background thread and reports progress via the usual
+ * `embed://reindex_progress` event stream.
+ */
+export async function refreshAllEmbeddings(): Promise<void> {
+  try {
+    await invoke<void>("refresh_all_embeddings");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}


### PR DESCRIPTION
Closes #286.

## Was passiert bisher

Auf dem Echoternum-Vault mit ~224 MD-Files hat der Checkpoint behauptet, alle 224 seien eingebettet — die tatsächliche HNSW-Mapping enthielt aber nur 5 Pfade (68 Chunks, 28 Tombstones). Nach dem ersten File-Edit fiel die Live-Menge auf die händisch geänderten Files zurück.

Quantifizierung vor Fix:

```
checkpoint entries: 224
mapping unique paths: 5
phantom skips (ck but not in mapping): 222
tombstones: 28
```

Der Reindexer verlässt sich einzig auf `reindex.checkpoint.json` für die Skip-Entscheidung — wenn der mit dem Vektor-Index driftet, werden die fehlenden Files für immer als „erledigt" behandelt.

## Fix in drei Teilen

### 1. Reconcile checkpoint against live index at vault open

- `VectorIndex::live_paths()` gibt die Menge der nicht-tombstoned Pfade zurück.
- `HnswSink::live_paths()` macht das nach außen sichtbar.
- `reindex::reconcile_checkpoint_with_live_paths(ckpt_dir, vault_root, live)` projiziert live-absolute-Pfade → rel_keys (forward-slash, vault-relativ) und behält nur Checkpoint-Einträge, die real Vektoren haben. Phantom-Einträge werden gedroppt, der Checkpoint atomisch neu geschrieben.
- `spawn_embeddings_for_vault` ruft den Reconcile direkt nach dem `HnswSink::open` — läuft also auf jedem Vault-Open und jedem Semantic-Toggle-On.

### 2. Synchronous save auf teardown

- `HnswSink::Drop` ruft `save_now()` jetzt synchron auf (statt detached Thread). Der alte async Save konnte gegen die nächste `HnswSink::open` racen und die Mapping truncated hinterlassen.
- `teardown_for_disable` macht `cancel_and_join` auf dem Reindex-Handle (vorher nur `cancel`), damit der Worker nicht in einen Sink reinschreibt, den wir gerade flushen, und ruft explizit `sink.save_now()` auf, solange `query_handles` noch den letzten Arc hält.
- Der alte Drop-Test wurde umgeschrieben: keine `wait_until`-Polling mehr — die Garantie ist, dass die Dateien existieren sobald der Drop zurückkommt.

### 3. Refresh-Button in den Settings

- Neuer Tauri-Command `refresh_all_embeddings`: teardown → wipe `.vaultcore/embeddings/` → re-arm (nur wenn Semantic an) → full reindex.
- Frontend-Wrapper in `src/ipc/commands.ts` und ein In-Modal Confirm-Dialog in `SettingsModal.svelte` im bestehenden `vc-confirm-*`-Stil (UI-06-compliant, kein `window.confirm`).
- Button ist disabled wenn kein Vault offen, der Reindex läuft oder das Refresh selbst läuft.

## Tests

- Rust: 5 neue Tests für die Reconciliation (drops-phantom, preserves-matching, noop-when-missing, wipes-when-nothing-live, normalises-windows-slashes) + 1 neuer `live_paths`-Test auf dem Sink + umgeschriebener Drop-Save-Test (jetzt synchron).
- Frontend: Wrapper-Test pinnt den Command-Namen `refresh_all_embeddings`.
- 940 Frontend-Tests grün, 360/360 Rust-Tests grün (die 8 pre-existenten Fails auf main sind nicht durch diesen PR verursacht: `files_ops` hat ein macOS `/private/var`-Canonicalisierungs-Problem, `semantic_quality` hängt an Embedding-Geometrie-Fixtures).

## UAT-Plan

Du kannst an Documents/Echoternum validieren:

- [ ] App öffnen → beim Öffnen sollte im Log „embeddings: reconciled checkpoint on open — dropped N phantom entries" erscheinen (für dich mit N=219 bei 224 claimed vs. 5 live). Danach der normale Reindex, der die 219 neu rechnet.
- [ ] Nachdem der Reindex durch ist: eine File editieren und speichern. Beim nächsten Vault-Open sollten die restlichen Files **nicht** mehr verloren gehen.
- [ ] Embedding-Flag aus und wieder an: das alte „200 übersprungen" sollte nur noch dann auftauchen, wenn wirklich 200 Vektoren im Index sind.
- [ ] Einstellungen → Semantische Suche → Button „Alle Embeddings neu berechnen" → Bestätigungsdialog → löscht `.vaultcore/embeddings/` und startet Full-Reindex. Während des Reindex sollte der Button disabled sein.
- [ ] App schließen während Reindex läuft, neu öffnen: kein truncated Mapping, kein phantom skip.

## Test plan
- [x] `cargo test --features embeddings` (alle neuen Tests passen, nur pre-existente unrelated Fails)
- [x] `pnpm test` (940 passed)
- [x] `pnpm typecheck` (clean)
- [ ] UAT gegen Echoternum-Vault