### PR TITLE
feat(graph): non-linear weight curves + semantic-mode force defaults (#288)

### DIFF
--- a/src/components/Graph/GraphView.svelte
+++ b/src/components/Graph/GraphView.svelte
@@ -4,7 +4,11 @@
   import GraphCanvas from "./GraphCanvas.svelte";
   import GraphFilters, { type GraphFilterState } from "./GraphFilters.svelte";
   import GraphForces from "./GraphForces.svelte";
-  import { DEFAULT_FORCE_SETTINGS, type ForceSettings } from "./graphRender";
+  import {
+    DEFAULT_FORCE_SETTINGS,
+    DEFAULT_EMBEDDING_FORCE_SETTINGS,
+    type ForceSettings,
+  } from "./graphRender";
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore, type Tab, GRAPH_TAB_PATH } from "../../store/tabStore";
   import { getEmbeddingGraph, getLinkGraph } from "../../ipc/commands";
@@ -17,7 +21,12 @@
   // ── Persistence ─────────────────────────────────────────────────────────────
   const CAMERA_KEY_PREFIX = "vaultcore-graph-camera-";
   const FILTER_KEY_PREFIX = "vaultcore-graph-filters-";
+  // #288 — force settings persist per (vault, mode). The link-mode key
+  // stays under the original prefix for backward compatibility with
+  // previously-saved settings; embedding mode lives under its own slot
+  // with its own defaults tuned for dense graphs.
   const FORCES_KEY_PREFIX = "vaultcore-graph-forces-";
+  const FORCES_EMBEDDING_KEY_PREFIX = "vaultcore-graph-forces-embedding-";
   const FROZEN_KEY_PREFIX = "vaultcore-graph-frozen-";
   // #235 — embedding-mode persistence keys.
   const MODE_KEY_PREFIX = "vaultcore-graph-mode-";
@@ -122,20 +131,33 @@
     }
   }
 
-  function loadForces(vaultPath: string): ForceSettings {
+  /** #288 — resolve the correct (storage key, default) pair for a mode. */
+  function forcesSlotFor(mode: GraphMode, vaultPath: string): {
+    key: string;
+    defaults: ForceSettings;
+  } {
+    const hash = hashVaultPath(vaultPath);
+    return mode === "embedding"
+      ? { key: FORCES_EMBEDDING_KEY_PREFIX + hash, defaults: DEFAULT_EMBEDDING_FORCE_SETTINGS }
+      : { key: FORCES_KEY_PREFIX + hash, defaults: DEFAULT_FORCE_SETTINGS };
+  }
+
+  function loadForces(vaultPath: string, mode: GraphMode): ForceSettings {
+    const { key, defaults } = forcesSlotFor(mode, vaultPath);
     try {
-      const raw = localStorage.getItem(FORCES_KEY_PREFIX + hashVaultPath(vaultPath));
-      if (!raw) return { ...DEFAULT_FORCE_SETTINGS };
+      const raw = localStorage.getItem(key);
+      if (!raw) return { ...defaults };
       const parsed = JSON.parse(raw) as Partial<ForceSettings>;
-      return { ...DEFAULT_FORCE_SETTINGS, ...parsed };
+      return { ...defaults, ...parsed };
     } catch {
-      return { ...DEFAULT_FORCE_SETTINGS };
+      return { ...defaults };
     }
   }
 
-  function saveForces(vaultPath: string, s: ForceSettings): void {
+  function saveForces(vaultPath: string, mode: GraphMode, s: ForceSettings): void {
     try {
-      localStorage.setItem(FORCES_KEY_PREFIX + hashVaultPath(vaultPath), JSON.stringify(s));
+      const { key } = forcesSlotFor(mode, vaultPath);
+      localStorage.setItem(key, JSON.stringify(s));
     } catch {
       /* ignore */
     }
@@ -279,9 +301,11 @@
       vaultPath = s.currentPath;
       if (vaultPath) {
         filters = loadFilters(vaultPath);
-        forces = loadForces(vaultPath);
         frozen = loadFrozen(vaultPath);
+        // #288 — load mode first so force defaults can match the active
+        // graph type (link vs embedding have very different tunings).
         mode = loadMode(vaultPath);
+        forces = loadForces(vaultPath, mode);
         embeddingThreshold = loadThreshold(vaultPath);
         const loadedCluster = loadClusterThreshold(vaultPath);
         embeddingClusterThreshold = loadedCluster;
@@ -487,8 +511,16 @@
 
   function onModeChange(next: GraphMode): void {
     if (next === mode) return;
+    // #288 — forces persist per mode. Flush the current mode's settings
+    // before switching so user tweaks on the link graph don't get
+    // clobbered by loading the embedding slot, then load the new mode's
+    // slot (falling back to its mode-appropriate defaults).
+    if (vaultPath) saveForces(vaultPath, mode, forces);
     mode = next;
-    if (vaultPath) saveMode(vaultPath, next);
+    if (vaultPath) {
+      saveMode(vaultPath, next);
+      forces = loadForces(vaultPath, next);
+    }
     // Full dataset swap — force a layout re-seed so nodes don't animate
     // from link-graph positions into embedding-graph positions.
     datasetVersion += 1;
@@ -542,7 +574,7 @@
 
   function onForcesChange(next: ForceSettings): void {
     forces = next;
-    if (vaultPath) saveForces(vaultPath, next);
+    if (vaultPath) saveForces(vaultPath, mode, next);
   }
 
   function onFrozenChange(next: boolean): void {

--- a/src/components/Graph/__tests__/graphRender.test.ts
+++ b/src/components/Graph/__tests__/graphRender.test.ts
@@ -56,8 +56,13 @@ vi.mock("sigma", () => {
 
 import {
   applyAlpha,
+  DEFAULT_EMBEDDING_FORCE_SETTINGS,
   DEFAULT_FORCE_SETTINGS,
   destroyGraph,
+  edgeAlphaForWeight,
+  edgeDistanceForWeight,
+  edgeSizeForWeight,
+  edgeStrengthScaleForWeight,
   mountGraph,
   setForceSettings,
   setLayoutFrozen,
@@ -240,5 +245,120 @@ describe("d3-force integration", () => {
     expect(handle.simulation).toBe(before);
     expect(handle.options.forceSettings?.scalingRatio).toBe(20);
     destroyGraph(handle);
+  });
+});
+
+// #288 — weight-driven layout & visual curves.
+//
+// These are pure numeric helpers driving the embedding-mode force sim and
+// edge rendering. The link-mode contract is "weight=null means no change
+// from historical behaviour"; the embedding contract is "non-linear curve
+// that makes strong edges dominate layout and weak edges fade into the
+// background". Both ends and the monotonicity are pinned here so a
+// future tweak to the curve shape can't accidentally invert the
+// relationship or regress link-mode visuals.
+
+describe("edgeDistanceForWeight (#288)", () => {
+  it("returns the historical link-mode distance when weight is null", () => {
+    expect(edgeDistanceForWeight(null)).toBe(80);
+  });
+
+  it("strong edges (w→1) collapse to the minimum rest length", () => {
+    const atOne = edgeDistanceForWeight(1);
+    expect(atOne).toBe(30);
+  });
+
+  it("weak edges (w→0) stretch to the maximum rest length", () => {
+    const atZero = edgeDistanceForWeight(0);
+    expect(atZero).toBe(260);
+  });
+
+  it("is strictly monotone decreasing in weight (stronger similarity → shorter edge)", () => {
+    const values = [0.1, 0.3, 0.5, 0.7, 0.9].map(edgeDistanceForWeight);
+    for (let i = 0; i < values.length - 1; i += 1) {
+      expect(values[i]).toBeGreaterThan(values[i + 1]!);
+    }
+  });
+
+  it("has a wider high-weight → low-weight spread than the previous linear curve", () => {
+    // Previous curve was 120 - 80*w → spread at (0.55 vs 0.95) = 32 units.
+    // New curve widens that so clusters actually pull apart visually.
+    const gap = edgeDistanceForWeight(0.55) - edgeDistanceForWeight(0.95);
+    expect(gap).toBeGreaterThan(40);
+  });
+});
+
+describe("edgeStrengthScaleForWeight (#288)", () => {
+  it("passes through unchanged for link-mode edges (weight=null → 1)", () => {
+    expect(edgeStrengthScaleForWeight(null)).toBe(1);
+  });
+
+  it("weak edges contribute near-zero pull so they don't homogenise the layout", () => {
+    // At w=0.1 the old curve gave 0.325; the new w² curve gives 0.01 —
+    // a 30× reduction so hundreds of weak neighbours can't collectively
+    // dominate real cluster edges.
+    expect(edgeStrengthScaleForWeight(0.1)).toBeLessThan(0.05);
+  });
+
+  it("strong edges pull hard enough to drive cluster shape", () => {
+    expect(edgeStrengthScaleForWeight(0.95)).toBeGreaterThan(0.8);
+  });
+
+  it("is strictly monotone increasing in weight", () => {
+    const values = [0.1, 0.3, 0.5, 0.7, 0.9].map(edgeStrengthScaleForWeight);
+    for (let i = 0; i < values.length - 1; i += 1) {
+      expect(values[i]).toBeLessThan(values[i + 1]!);
+    }
+  });
+});
+
+describe("edgeAlphaForWeight (#288)", () => {
+  it("link-mode edges stay fully opaque", () => {
+    expect(edgeAlphaForWeight(null)).toBe(1);
+  });
+
+  it("near-zero weight sits at the alpha floor, not a legacy 0.45 baseline", () => {
+    // The previous linear curve left w=0 at 0.45 alpha — hundreds of
+    // such edges painted a grey fog. Floor at 0.05 keeps them visible
+    // only on direct inspection.
+    expect(edgeAlphaForWeight(0)).toBeCloseTo(0.05, 5);
+    expect(edgeAlphaForWeight(0.1)).toBeLessThan(0.1);
+  });
+
+  it("strong edges dominate visually with alpha ≥ 0.8", () => {
+    expect(edgeAlphaForWeight(0.95)).toBeGreaterThan(0.8);
+    expect(edgeAlphaForWeight(1)).toBeCloseTo(1, 5);
+  });
+});
+
+describe("edgeSizeForWeight (#288)", () => {
+  it("link-mode edges keep the historical size=1 default", () => {
+    expect(edgeSizeForWeight(null)).toBe(1);
+  });
+
+  it("weak edges render near string-thin", () => {
+    expect(edgeSizeForWeight(0.1)).toBeLessThan(0.6);
+  });
+
+  it("strong edges render visibly thicker", () => {
+    expect(edgeSizeForWeight(0.95)).toBeGreaterThan(2.5);
+  });
+});
+
+describe("DEFAULT_EMBEDDING_FORCE_SETTINGS (#288)", () => {
+  it("is stronger on repulsion than link mode so dense graphs spread apart", () => {
+    expect(DEFAULT_EMBEDDING_FORCE_SETTINGS.scalingRatio).toBeGreaterThan(
+      DEFAULT_FORCE_SETTINGS.scalingRatio,
+    );
+  });
+
+  it("is softer on centering so clusters can breathe apart", () => {
+    expect(DEFAULT_EMBEDDING_FORCE_SETTINGS.gravity).toBeLessThan(
+      DEFAULT_FORCE_SETTINGS.gravity,
+    );
+  });
+
+  it("uses full edge-weight influence so the w² per-edge curve can dominate", () => {
+    expect(DEFAULT_EMBEDDING_FORCE_SETTINGS.edgeWeightInfluence).toBe(1);
   });
 });

--- a/src/components/Graph/graphRender.ts
+++ b/src/components/Graph/graphRender.ts
@@ -57,6 +57,38 @@ export const DEFAULT_FORCE_SETTINGS: ForceSettings = {
   slowDown: 10,
 };
 
+/**
+ * #288 — force defaults tuned for the embedding-similarity graph.
+ *
+ * The link graph is sparse (mostly 1–3 edges per node) so the link-mode
+ * defaults above are fine: a bit of repulsion, a moderate link pull, and
+ * the graph finds equilibrium as a loose constellation.
+ *
+ * The embedding graph is **dense** — every node has top_k neighbours (10)
+ * and at a moderate threshold a 200-note vault emits hundreds of edges.
+ * With the link-mode defaults the forces from unrelated neighbours cancel
+ * each other out and the whole thing collapses into a uniform hairball
+ * (see issue #288 screenshot). These defaults counter that:
+ *
+ * - `scalingRatio: 90` — far stronger per-node repulsion (translates to
+ *   `charge.strength = -1350` vs link mode's -600). Pushes unconnected
+ *   nodes hard enough to escape the crowd.
+ * - `edgeWeightInfluence: 1.0` — full strength on top of the per-edge
+ *   `w²` non-linearity (see `edgeStrengthScaleForWeight`), so strong
+ *   cosine ties dominate layout while weak ties barely tug.
+ * - `slowDown: 13` — slightly heavier damping so the denser graph
+ *   settles before the user starts interacting. Over-damping (>15)
+ *   freezes clusters mid-formation.
+ * - `gravity: 0.6` — softer centering so clusters can breathe apart
+ *   instead of being squeezed toward a common centroid.
+ */
+export const DEFAULT_EMBEDDING_FORCE_SETTINGS: ForceSettings = {
+  gravity: 0.6,
+  scalingRatio: 90,
+  edgeWeightInfluence: 1.0,
+  slowDown: 13,
+};
+
 /** Node datum handed to d3-force — references the underlying graphology id
  *  so `forceLink` can resolve source/target by string. */
 interface SimNode extends SimulationNodeDatum {
@@ -229,18 +261,60 @@ function normalizeWeight(weight: number | undefined): number | null {
   return weight;
 }
 
-/** Edge rest length scales inversely with weight — stronger similarity pulls
- *  nodes closer. Link-mode (weight=null) keeps the historical 80-unit default. */
-function edgeDistanceForWeight(weight: number | null): number {
-  if (weight === null) return 80;
-  return 120 - 80 * weight;
+/** Minimum rest length for a weighted edge — the pair of most-similar
+ *  notes in the vault still want a bit of breathing room so overlapping
+ *  labels stay legible. */
+const EDGE_MIN_DISTANCE = 30;
+/** Maximum rest length for a weighted edge. Set wide so weak edges stretch
+ *  long ropes across the canvas, creating visible gaps between clusters. */
+const EDGE_MAX_DISTANCE = 260;
+/** Link-mode edges (no weight) keep the historical 80-unit default so the
+ *  link graph's layout is visually unchanged by #288. */
+const LINK_MODE_DISTANCE = 80;
+
+/** Edge rest length scales inversely with weight on a quadratic curve.
+ *  #288: the earlier linear `120 − 80·w` was too narrow (a 0.55 edge and
+ *  a 0.95 edge differed by only 32 units) so edges from weak-but-plentiful
+ *  neighbours pulled every cluster apart. `(1 − w)²` widens the high-weight
+ *  band (0.95 ⇒ 30.6, 0.75 ⇒ 44.4) and stretches weak edges far out
+ *  (0.35 ⇒ 127.3, 0.10 ⇒ 216.3), so clusters collapse tight and weak
+ *  connections visually become long ropes. */
+export function edgeDistanceForWeight(weight: number | null): number {
+  if (weight === null) return LINK_MODE_DISTANCE;
+  const inv = 1 - weight;
+  return EDGE_MIN_DISTANCE + (EDGE_MAX_DISTANCE - EDGE_MIN_DISTANCE) * inv * inv;
 }
 
-/** Edge pull strength multiplier. Link-mode passes through unchanged (1);
- *  embedding-mode scales with weight so weak edges barely tug. */
-function edgeStrengthScaleForWeight(weight: number | null): number {
+/** Edge pull strength multiplier on a quadratic weight curve. #288:
+ *  the earlier `0.25 + 0.75·w` still gave weak edges a baseline pull
+ *  which, multiplied over hundreds of weak neighbours, homogenised the
+ *  layout into a single blob. `w²` near-zeroes weak edges (0.35² = 0.12,
+ *  0.10² = 0.01) so they contribute almost nothing while strong edges
+ *  (0.95² = 0.90) pull hard and enforce cluster shape. Link-mode
+ *  passes through unchanged. */
+export function edgeStrengthScaleForWeight(weight: number | null): number {
   if (weight === null) return 1;
-  return 0.25 + 0.75 * weight;
+  return weight * weight;
+}
+
+/** Edge alpha on an aggressive cubic curve. #288: the earlier
+ *  `0.45 + 0.55·w` left weak edges at ~0.64 alpha which, with hundreds of
+ *  them overlapping, painted a grey fog across the whole canvas. A
+ *  cubic with a 0.05 floor (0.05 + 0.95·w³) pushes weak edges near-invisible
+ *  (0.35 ⇒ 0.09, 0.10 ⇒ 0.05) while strong edges stand out (0.95 ⇒ 0.86,
+ *  0.80 ⇒ 0.54). Link-mode (weight=null) stays fully opaque. */
+export function edgeAlphaForWeight(weight: number | null): number {
+  if (weight === null) return 1;
+  return 0.05 + 0.95 * weight * weight * weight;
+}
+
+/** Edge thickness grows quadratically with weight so the cluster backbone
+ *  visually emerges. #288: the earlier linear `1 + 2.5·w` made every edge
+ *  look similar weight; `0.5 + 2.5·w²` gives weak edges near-string width
+ *  (0.10 ⇒ 0.53) and strong edges visible line weight (0.95 ⇒ 2.76). */
+export function edgeSizeForWeight(weight: number | null): number {
+  if (weight === null) return 1;
+  return 0.5 + 2.5 * weight * weight;
 }
 
 /** Build the d3-force node/link datum arrays from the current graphology
@@ -536,17 +610,15 @@ export function mountGraph(
 
   // Edge reducer — hover dim + weight-driven thickness/alpha.
   //
-  // In embedding mode each edge carries a `weight` attr (cosine similarity
-  // in 0..1). Map it to:
-  //   size  : 1  → 3.5  (thicker line for stronger relations)
-  //   alpha : 0.45 → 1.0 (fade weak edges into the background)
-  //
-  // Link-mode edges have no weight — they render with the historical
-  // size=1 / full-opacity color, so the link graph is visually unchanged.
+  // #288 — weight curves retuned to surface cluster structure in dense
+  // embedding graphs. Weak edges (low cosine) fade near-invisible and
+  // visually string-thin; strong edges stand out in thickness and
+  // opacity. Link-mode edges (no weight) keep full-opacity size=1 so
+  // the link graph is visually unchanged.
   renderer.setSetting("edgeReducer", (e, attrs) => {
     const weight = normalizeWeight(attrs.weight as number | undefined);
-    const baseSize = weight === null ? 1 : 1 + weight * 2.5;
-    const baseAlpha = weight === null ? 1 : 0.45 + weight * 0.55;
+    const baseSize = edgeSizeForWeight(weight);
+    const baseAlpha = edgeAlphaForWeight(weight);
     const weightedEdgeColor = baseAlpha < 1 ? applyAlpha(edge, baseAlpha) : edge;
 
     if (!handle.hoveredNode) {


### PR DESCRIPTION
Closes #288.

## Was das fixt

Der Embedding-Graph ist aktuell ein gleichmäßiger Knäuel — alle Nodes liegen ungefähr gleich weit voneinander entfernt, Cluster sind optisch nicht erkennbar. Ursache: (a) die linearen Weight-Curves haben schwache Kanten ähnlich stark gezogen wie starke, so dass hunderte schwacher Nachbarn jede Cluster-Struktur neutralisiert haben, und (b) die Force-Defaults vom Link-Graph (sparse) sind für den Embedding-Graph (dense, ~10 Edges pro Node) zu schwach auf Repulsion.

## Was der PR ändert

**Weight-Curves** (in `graphRender.ts`, wirken nur auf embedding edges — `weight===null` Branch lässt link-mode unverändert):

| Curve | Vorher (linear) | Nachher | Effekt |
|---|---|---|---|
| `edgeDistanceForWeight` | `120 − 80·w` (40–120) | `30 + 230·(1−w)²` (30–260) | Starke Paare ziehen tight, schwache stretchen weit → Cluster-Gaps |
| `edgeStrengthScaleForWeight` | `0.25 + 0.75·w` | `w²` | Schwache Edges (w=0.1) 30× schwächerer Pull → kein Homogenisierungs-Rauschen |
| `edgeAlphaForWeight` | `0.45 + 0.55·w` | `0.05 + 0.95·w³` | Weaker Edges visuell fast unsichtbar → grau-Fog weg |
| `edgeSizeForWeight` | `1 + 2.5·w` | `0.5 + 2.5·w²` | Cluster-Backbone visuell dicker als Filler |

**Force-Defaults** (neue `DEFAULT_EMBEDDING_FORCE_SETTINGS`, `GraphView.svelte` persistiert Forces jetzt pro `(vault, mode)`):

- `scalingRatio: 90` (vs 40) — stärkere Repulsion, passt zu dense graphs
- `edgeWeightInfluence: 1.0` (vs 0.7) — volle Edge-Influence, kombiniert mit `w²` Non-Linearität
- `slowDown: 13` (vs 10) — mehr Damping, dense Graph stabilisiert schneller
- `gravity: 0.6` (vs 1.0) — softer Centering, Cluster dürfen sich trennen

Link-Mode: **`DEFAULT_FORCE_SETTINGS` unverändert**. Link-Graph rendert identisch.

## Persistenz

Die Forces-Persistenz war bisher ein Key pro Vault. Jetzt ein Key pro `(vault, mode)`:
- `vaultcore-graph-forces-<hash>` → link-mode (bestehender Key, rückwärtskompatibel)
- `vaultcore-graph-forces-embedding-<hash>` → embedding-mode (neu)

Beim Mode-Switch: aktuelle Forces in den alten Slot gespeichert, dann neuer Slot geladen (oder Mode-Defaults wenn noch leer). User-Tweaks auf dem Link-Graph werden also nicht vom Embedding-Defaults überschrieben.

## Tests

18 neue Tests in `graphRender.test.ts`:
- Boundary-Werte für alle 4 Weight-Helpers (null → legacy, 0 → floor, 1 → ceiling)
- Strikte Monotonie
- Spread-Vergleich gegen die alte lineare Kurve
- Semantic-Defaults strikt stärker auf Repulsion / softer auf Centering

958 Frontend-Tests grün (+18), `tsc --noEmit` sauber.

## UAT-Plan

Auf dem Echoternum-Vault:
- [ ] Embedding-Mode öffnen → nach ein paar Sekunden sollten Cluster visuell getrennt sein, statt uniform blob
- [ ] Mehrere Cluster (3+) sollten durch Lücken trennbar sein
- [ ] Schwache Edges (grau) kaum noch sichtbar, starke Edges deutlich
- [ ] Threshold-Slider bleibt Echtzeit (der Cache von #287 bleibt unberührt — dieser PR fasst nur Render/Force-Parameter an)
- [ ] Link-Mode (toggle oben links) sieht **identisch** aus wie vorher
- [ ] Force-Sliders in den Settings-Panel (falls aufgeklappt): Einstellungen bleiben pro Mode persistent

## Test plan

- [x] `pnpm test` — 958 green
- [x] `pnpm typecheck` — clean
- [x] `cargo check` — clean (nur Frontend-Änderungen)
- [ ] UAT gegen Echoternum — Cluster visuell trennbar?

Falls nach dem Merge irgendein Parameter noch zu drastisch / zu mild ist, sind die vier Kurven-Konstanten (`EDGE_MIN_DISTANCE`, `EDGE_MAX_DISTANCE`, die Exponenten, `DEFAULT_EMBEDDING_FORCE_SETTINGS`) alle isolierte Drehknöpfe für einen Follow-up.