### PR TITLE
feat(templates): Collection.join + multi-line widget (#293)

### DIFF
--- a/src-tauri/resources/DOCS.template.md
+++ b/src-tauri/resources/DOCS.template.md
@@ -218,6 +218,25 @@ Lazy where possible — `first()` and `any()` short-circuit without materializin
 | `all(pred)` | boolean | Every element matches |
 | `groupBy(n => key)` | any | Group by key |
 | `toArray()` | any[] | Materialize |
+| `join(sep)` | string | Materialize as a string with separator between elements |
+
+##### Multi-line output
+
+`.join("\n")` produces real line breaks in both the insert-template flow and the live editor preview. Combine with `.select(...)` to shape each item:
+
+```
+{{vault.folders.where(f => f.name == "Done").first().notes.select(n => "- [[" + n.title + "]]").join("\n")}}
+```
+
+Renders as:
+
+```
+- [[First note]]
+- [[Second note]]
+- [[Third note]]
+```
+
+For cleanest layout put the `{{ ... }}` on its own line — the multi-line block then occupies its own lines in the rendered output.
 
 #### Operators
 

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -43,6 +43,10 @@ class RenderedValueWidget extends WidgetType {
   toDOM(): HTMLElement {
     const el = document.createElement("span");
     el.className = "vc-template-rendered";
+    // `pre-wrap` so multi-line output from `.join("\n")` actually breaks
+    // across lines inside the widget — default `normal` collapses \n to a
+    // single space, which would flatten bulleted / tabular renders.
+    el.style.whiteSpace = "pre-wrap";
     el.textContent = this.value;
     return el;
   }

--- a/src/lib/__tests__/queryCollection.test.ts
+++ b/src/lib/__tests__/queryCollection.test.ts
@@ -32,6 +32,33 @@ describe("Collection — terminal ops", () => {
     expect(byKey[1]).toEqual([1, 3, 5]);
     expect(byKey[0]).toEqual([2, 4]);
   });
+
+  it("join concatenates string elements with the separator", () => {
+    expect(new Collection(["a", "b", "c"]).join(", ")).toBe("a, b, c");
+  });
+
+  it("join coerces non-string elements via String()", () => {
+    expect(new Collection([1, 2, 3]).join("-")).toBe("1-2-3");
+  });
+
+  it("join on an empty collection returns an empty string", () => {
+    expect(new Collection<string>([]).join(", ")).toBe("");
+  });
+
+  it("join with a newline separator preserves newlines verbatim", () => {
+    const out = new Collection([1, 2, 3])
+      .select((n) => "- " + n)
+      .join("\n");
+    expect(out).toBe("- 1\n- 2\n- 3");
+  });
+
+  it("join composes after where/select just like any other terminal op", () => {
+    const out = new Collection([1, 2, 3, 4])
+      .where((n) => n % 2 === 0)
+      .select((n) => "#" + n)
+      .join(" ");
+    expect(out).toBe("#2 #4");
+  });
 });
 
 describe("Collection — chaining", () => {

--- a/src/lib/queryCollection.ts
+++ b/src/lib/queryCollection.ts
@@ -106,6 +106,15 @@ export class Collection<T> {
     return true;
   }
 
+  // Materialise the pipeline into a single string, coercing each element via
+  // `String()` and inserting `separator` between them. Mirrors
+  // `Array.prototype.join`. Accepting arbitrary separators (including `"\n"`)
+  // is what makes multi-line expression output possible — downstream
+  // `renderValue()` passes strings through verbatim.
+  join(separator: string): string {
+    return this.materialize().map((v) => String(v)).join(separator);
+  }
+
   groupBy<K>(key: Selector<T, K>): { key: K; items: T[] }[] {
     const map = new Map<K, T[]>();
     for (const item of this.materialize()) {

--- a/src/lib/vaultApiDescriptor.ts
+++ b/src/lib/vaultApiDescriptor.ts
@@ -120,6 +120,8 @@ const COLLECTION: TypeDescriptor = {
       doc: "Group by a key selector" },
     { kind: "method", name: "toArray", returns: "any",
       doc: "Materialize as an array" },
+    { kind: "method", name: "join", returns: "string",
+      doc: "Materialize as a string, separator between elements" },
   ],
 };
 


### PR DESCRIPTION
Closes #293.

## Summary

Makes this work:

```
{{vault.folders.where(f => f.name=="Done").first().notes.select(n => "- [[" + n.title + "]]").join("\n")}}
```

Two independent pieces:

1. `Collection<T>.join(separator: string): string` — terminal op, mirrors `Array.prototype.join`, coerces elements with `String()`.
2. Live-preview widget gets `white-space: pre-wrap` so newlines in the rendered string actually break lines in the editor (default `normal` collapsed them to spaces).

Insert-template flow was already correct (`substituteTemplateVars` does a raw string replace), so that path needed no change.

## Changes

- `src/lib/queryCollection.ts` — `.join(sep)` terminal op.
- `src/lib/vaultApiDescriptor.ts` — descriptor entry; existing pin test covers alignment.
- `src/lib/__tests__/queryCollection.test.ts` — 5 new cases: strings, non-string coercion, empty, newline separator, chained after `where`/`select`.
- `src/components/Editor/templateLivePreview.ts` — inline `whiteSpace = "pre-wrap"` on the widget span.
- `src-tauri/resources/DOCS.template.md` — table row + worked example.

## Test plan

- [x] `pnpm test` — 937/937 passing (was 932, +5 join tests)
- [x] `pnpm typecheck` — clean
- [ ] Manual: open a note, paste `{{vault.folders.first().notes.select(n => "- " + n.title).join("\n")}}` on its own line, move cursor off it — expect a bulleted list spanning multiple visual lines inside the widget.