### PR TITLE
feat(editor): inline renderers skip content inside {{...}} ranges (#295)

### DIFF
--- a/src/components/Editor/__tests__/inlineGuardsInTemplate.test.ts
+++ b/src/components/Editor/__tests__/inlineGuardsInTemplate.test.ts
@@ -1,0 +1,90 @@
+// Integration test (#295): wikiLinkPlugin must not decorate `[[...]]` that
+// occurs inside a `{{ ... }}` template expression body.
+//
+// This is the user-reported regression — `{{ ... select(n => "- [[" + n.title
+// + "]]").join("\n") }}` was triggering the wiki-link live preview on the
+// literal brackets inside the expression source.
+//
+// We mount a real CodeMirror EditorView with only `wikiLinkPlugin` and read
+// the decoration set directly. No markdown language extension is installed,
+// so `isInsideCodeBlock` sees only a trivial syntax tree (always returns
+// false) — exactly the case we want the new guard to catch.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView, Decoration } from "@codemirror/view";
+
+import { wikiLinkPlugin, setResolvedLinks } from "../wikiLink";
+
+function mount(doc: string, cursor: number): EditorView {
+  const state = EditorState.create({
+    doc,
+    selection: { anchor: cursor },
+    extensions: [wikiLinkPlugin],
+  });
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  return new EditorView({ state, parent });
+}
+
+// Count decoration spans the plugin installed in `[from, to)`.
+function decoCountInRange(view: EditorView, from: number, to: number): number {
+  let count = 0;
+  for (const plugin of (view as unknown as {
+    plugins: Array<{ value?: { decorations?: unknown } }>;
+  }).plugins) {
+    const deco = plugin.value?.decorations;
+    if (!deco) continue;
+    const set = deco as ReturnType<typeof Decoration.none.update>;
+    const iter = set.iter();
+    while (iter.value) {
+      if (iter.from >= from && iter.to <= to) count++;
+      iter.next();
+    }
+  }
+  return count;
+}
+
+describe("wikiLinkPlugin — respects {{ ... }} template ranges (#295)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    // Seed a single resolvable target so wiki-link decorations WOULD normally
+    // fire on `[[Alpha]]`; this is how we prove the guard is what's
+    // suppressing them inside the expression body.
+    setResolvedLinks(new Map([["alpha", "Alpha.md"]]));
+  });
+
+  it("decorates a plain [[Alpha]] outside any template expression", () => {
+    const doc = "See [[Alpha]] for details.";
+    const view = mount(doc, 0);
+    // Cursor away from the link range → the plugin emits HIDE + mark spans.
+    const linkFrom = doc.indexOf("[[Alpha]]");
+    const linkTo = linkFrom + "[[Alpha]]".length;
+    expect(decoCountInRange(view, linkFrom, linkTo)).toBeGreaterThan(0);
+  });
+
+  it("does NOT decorate [[Alpha]] that appears inside a {{ ... }} body", () => {
+    const doc = 'pre {{vault.notes.select(n => "[[Alpha]]").join("\\n")}} post';
+    const view = mount(doc, 0);
+
+    const exprFrom = doc.indexOf("{{");
+    const exprTo = doc.indexOf("}}") + 2;
+    // No wiki-link decoration may appear anywhere inside the expression span.
+    expect(decoCountInRange(view, exprFrom, exprTo)).toBe(0);
+  });
+
+  it("still decorates [[Alpha]] outside the expression even when another [[...]] sits inside", () => {
+    // Same literal-in-expression case, but an independent real wiki-link
+    // exists after it. The guard must only suppress the in-expression one.
+    const doc = 'x {{select(n => "[[Alpha]]")}} and then [[Alpha]] for real';
+    const view = mount(doc, 0);
+
+    const realLinkFrom = doc.lastIndexOf("[[Alpha]]");
+    const realLinkTo = realLinkFrom + "[[Alpha]]".length;
+    expect(decoCountInRange(view, realLinkFrom, realLinkTo)).toBeGreaterThan(0);
+
+    const exprFrom = doc.indexOf("{{");
+    const exprTo = doc.indexOf("}}") + 2;
+    expect(decoCountInRange(view, exprFrom, exprTo)).toBe(0);
+  });
+});

--- a/src/components/Editor/__tests__/templateExprRanges.test.ts
+++ b/src/components/Editor/__tests__/templateExprRanges.test.ts
@@ -1,0 +1,93 @@
+// Unit tests for the shared template-expression range helper (#295).
+
+import { describe, it, expect } from "vitest";
+import {
+  findTemplateExprRanges,
+  isInsideTemplateExpr,
+} from "../templateExprRanges";
+
+describe("findTemplateExprRanges", () => {
+  it("returns empty when the text contains no expression", () => {
+    expect(findTemplateExprRanges("just some prose")).toEqual([]);
+  });
+
+  it("finds a single-line expression", () => {
+    const text = "before {{vault.name}} after";
+    const [first] = findTemplateExprRanges(text);
+    expect(first).toBeDefined();
+    const [from, to] = first!;
+    expect(text.slice(from, to)).toBe("{{vault.name}}");
+  });
+
+  it("finds multiple expressions in document order", () => {
+    const text = "{{a}} then {{b}} then {{c}}";
+    const ranges = findTemplateExprRanges(text);
+    expect(ranges).toHaveLength(3);
+    expect(ranges[0]![0]).toBeLessThan(ranges[1]![0]);
+    expect(ranges[1]![0]).toBeLessThan(ranges[2]![0]);
+  });
+
+  it("supports multi-line expression bodies", () => {
+    const text = "prose\n{{vault.notes\n.count()}}\ntail";
+    const ranges = findTemplateExprRanges(text);
+    expect(ranges).toHaveLength(1);
+    const [from, to] = ranges[0]!;
+    expect(text.slice(from, to)).toBe("{{vault.notes\n.count()}}");
+  });
+
+  it("does not match unbalanced or nested braces", () => {
+    // `{{ { }}` — inner `{` is excluded by the `[^{}]` class, so the regex
+    // finds no complete match.
+    expect(findTemplateExprRanges("{{ { }}")).toEqual([]);
+    // Lone braces round-trip fine.
+    expect(findTemplateExprRanges("just { and }")).toEqual([]);
+  });
+
+  it("offsets positions by baseOffset so callers can pass viewport slices", () => {
+    const full = "lorem ipsum {{vault.name}} dolor";
+    const sliceFrom = 6;
+    const slice = full.slice(sliceFrom); // "ipsum {{vault.name}} dolor"
+    const ranges = findTemplateExprRanges(slice, sliceFrom);
+    expect(ranges).toHaveLength(1);
+    const [from, to] = ranges[0]!;
+    // Coordinates are in the *original* document frame.
+    expect(full.slice(from, to)).toBe("{{vault.name}}");
+  });
+});
+
+describe("isInsideTemplateExpr", () => {
+  const ranges = findTemplateExprRanges("aa {{X}} bb {{YY}} cc");
+  // Ranges are roughly [3,8) and [12,18) — computed dynamically so the test
+  // does not encode magic offsets.
+
+  it("returns true for a zero-length probe inside an expression", () => {
+    const [a] = ranges[0]!;
+    expect(isInsideTemplateExpr(ranges, a + 1)).toBe(true);
+  });
+
+  it("returns false outside any expression range", () => {
+    expect(isInsideTemplateExpr(ranges, 0)).toBe(false);
+    expect(isInsideTemplateExpr(ranges, 20)).toBe(false);
+  });
+
+  it("returns true when a match range overlaps the start of an expression", () => {
+    const [from] = ranges[0]!;
+    // Match span [from-1, from+2) straddles the opening `{{`.
+    expect(isInsideTemplateExpr(ranges, from - 1, from + 2)).toBe(true);
+  });
+
+  it("returns false for a match that ends exactly at the expression's start", () => {
+    // Half-open semantics: [x, from) does NOT overlap [from, to).
+    const [from] = ranges[0]!;
+    expect(isInsideTemplateExpr(ranges, 0, from)).toBe(false);
+  });
+
+  it("returns false for an empty range list", () => {
+    expect(isInsideTemplateExpr([], 5, 10)).toBe(false);
+  });
+
+  it("returns true when probe spans multiple expressions", () => {
+    // A match that straddles the whole doc obviously overlaps both.
+    expect(isInsideTemplateExpr(ranges, 0, 100)).toBe(true);
+  });
+});

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -28,6 +28,10 @@ import { mount, unmount } from "svelte";
 
 import { resolveAttachment } from "./embeds";
 import { resolveTarget } from "./wikiLink";
+import {
+  findTemplateExprRanges,
+  isInsideTemplateExpr,
+} from "./templateExprRanges";
 import { vaultStore } from "../../store/vaultStore";
 import { tabStore } from "../../store/tabStore";
 import { readFile } from "../../ipc/commands";
@@ -569,6 +573,7 @@ function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
   const text = view.state.doc.toString();
   const head = view.state.selection.main.head;
+  const exprRanges = findTemplateExprRanges(text);
 
   const matches: EmbedMatch[] = [];
 
@@ -583,6 +588,7 @@ function buildDecorations(view: EditorView): DecorationSet {
 
     // Skip code blocks / inline code.
     if (isInsideCodeBlock(view.state, from)) continue;
+    if (isInsideTemplateExpr(exprRanges, from, to)) continue;
 
     // Cursor inside → show raw syntax, do not replace.
     if (head >= from && head <= to) continue;
@@ -643,6 +649,7 @@ function buildDecorations(view: EditorView): DecorationSet {
     const to = from + m[0].length;
 
     if (isInsideCodeBlock(view.state, from)) continue;
+    if (isInsideTemplateExpr(exprRanges, from, to)) continue;
     if (head >= from && head <= to) continue;
 
     // Skip remote URLs — out of scope for this PR; the browser will fail the

--- a/src/components/Editor/inlineHtml.ts
+++ b/src/components/Editor/inlineHtml.ts
@@ -39,6 +39,11 @@ import { syntaxTree } from "@codemirror/language";
 import DOMPurify from "dompurify";
 import type { Extension } from "@codemirror/state";
 
+import {
+  findTemplateExprRanges,
+  isInsideTemplateExpr,
+} from "./templateExprRanges";
+
 // ── Sanitizer config ─────────────────────────────────────────────────────────
 
 const PURIFY_CONFIG = {
@@ -244,6 +249,18 @@ function buildDecorations(state: EditorState): InlineHtmlValue {
   const doc = state.doc;
 
   const viewport = state.field(viewportField, false) ?? UNKNOWN_VIEWPORT;
+
+  // `{{ ... }}` bodies are template source, not Markdown. Anything an
+  // HTML-looking substring there represents is literal text of the user's
+  // expression — do not sanitize/render it as HTML (#295). We scan the same
+  // slice we're about to iterate so coordinates align.
+  const exprScanFrom = viewport.from === -1 ? 0 : viewport.from;
+  const exprScanTo = viewport.to === -1 ? doc.length : viewport.to;
+  const exprRanges = findTemplateExprRanges(
+    doc.sliceString(exprScanFrom, exprScanTo),
+    exprScanFrom,
+  );
+
   const iterateArgs: {
     from?: number;
     to?: number;
@@ -254,6 +271,8 @@ function buildDecorations(state: EditorState): InlineHtmlValue {
 
       const from = node.from;
       const to = node.to;
+
+      if (isInsideTemplateExpr(exprRanges, from, to)) return;
 
       nodeRanges.push({ from, to });
 

--- a/src/components/Editor/livePreview.ts
+++ b/src/components/Editor/livePreview.ts
@@ -2,6 +2,10 @@ import { ViewPlugin, Decoration, type EditorView, type DecorationSet, type ViewU
 import { RangeSetBuilder } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import { detectFrontmatterInDoc } from "./frontmatterPlugin";
+import {
+  findTemplateExprRanges,
+  isInsideTemplateExpr,
+} from "./templateExprRanges";
 
 const HIDE = Decoration.replace({});
 
@@ -29,11 +33,19 @@ function buildDecorations(view: EditorView): DecorationSet {
   // transaction paid a full-doc `toString()` allocation here.
   const frontmatter = detectFrontmatterInDoc(doc);
 
+  // Scan the viewport slice once up-front so we can short-circuit any markup-
+  // hiding node that sits inside a `{{ ... }}` range — template expression
+  // bodies are source code, not Markdown (#295).
+  const viewportText = doc.sliceString(view.viewport.from, view.viewport.to);
+  const exprRanges = findTemplateExprRanges(viewportText, view.viewport.from);
+
   syntaxTree(view.state).iterate({
     from: view.viewport.from,
     to: view.viewport.to,
     enter(node) {
       const name = node.name;
+
+      if (isInsideTemplateExpr(exprRanges, node.from, node.to)) return;
 
       if (name === "HeaderMark") {
         if (frontmatter && node.from >= frontmatter.from && node.to <= frontmatter.to) {

--- a/src/components/Editor/templateExprRanges.ts
+++ b/src/components/Editor/templateExprRanges.ts
@@ -1,0 +1,57 @@
+// Shared helper for locating `{{ ... }}` template expression ranges in editor
+// text, plus an overlap check consulted by every inline decoration plugin
+// (wikiLink, embedPlugin, livePreview, inlineHtml).
+//
+// Rule (#295): content inside a `{{ ... }}` range is template source code, not
+// Markdown — no inline renderer other than the template live-preview itself
+// and the autocomplete provider should decorate it.
+//
+// The regex mirrors the one used by `templateSubstitution.ts` and
+// `templateLivePreview.ts`: single-line OR multi-line bodies are fine so long
+// as they contain no `{` or `}` characters. If all three call-sites ever need
+// to diverge, promote the regex into a shared constant — until then, keeping
+// them textually identical is the simplest guarantee.
+
+const EXPR_RE = /\{\{([^{}]+?)\}\}/g;
+
+export type TemplateExprRange = readonly [number, number];
+
+/**
+ * Scan `text` for `{{ ... }}` ranges.
+ *
+ * `baseOffset` is added to every returned position, so callers that pass a
+ * viewport slice (e.g. `doc.sliceString(viewport.from, viewport.to)`) can
+ * pass `viewport.from` and receive absolute document coordinates back.
+ * Defaults to 0 for full-document scans.
+ */
+export function findTemplateExprRanges(
+  text: string,
+  baseOffset: number = 0,
+): TemplateExprRange[] {
+  const out: TemplateExprRange[] = [];
+  EXPR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = EXPR_RE.exec(text)) !== null) {
+    out.push([baseOffset + m.index, baseOffset + m.index + m[0].length]);
+  }
+  return out;
+}
+
+/**
+ * Returns true iff the half-open interval `[from, to)` overlaps any of
+ * `ranges`. Call with only `from` to probe a single position.
+ *
+ * Linear scan — fine in practice (a note with even a few hundred expressions
+ * is an edge case). If this ever shows up in a profile, swap to a sorted
+ * binary-search walk; ranges are already emitted in document order.
+ */
+export function isInsideTemplateExpr(
+  ranges: readonly TemplateExprRange[],
+  from: number,
+  to: number = from,
+): boolean {
+  for (const [a, b] of ranges) {
+    if (to > a && from < b) return true;
+  }
+  return false;
+}

--- a/src/components/Editor/wikiLink.ts
+++ b/src/components/Editor/wikiLink.ts
@@ -15,6 +15,11 @@ import { RangeSetBuilder } from "@codemirror/state";
 import type { EditorState } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 
+import {
+  findTemplateExprRanges,
+  isInsideTemplateExpr,
+} from "./templateExprRanges";
+
 const HIDE = Decoration.replace({});
 
 // ── Wiki-link regex ────────────────────────────────────────────────────────────
@@ -109,6 +114,7 @@ function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
   const text = view.state.doc.toString();
   const head = view.state.selection.main.head;
+  const exprRanges = findTemplateExprRanges(text);
 
   const matches: WikiMatch[] = [];
 
@@ -122,6 +128,7 @@ function buildDecorations(view: EditorView): DecorationSet {
     const to = from + m[0].length;
 
     if (isInsideCodeBlock(view.state, from)) continue;
+    if (isInsideTemplateExpr(exprRanges, from, to)) continue;
 
     const stem: string = stripKnownExt(rawTarget);
     const resolved = resolvedLinks.has(stem.toLowerCase());


### PR DESCRIPTION
Closes #295.

## Summary

Fixes the user-reported regression where `{{vault.notes.select(n => "- [[" + n.title + "]]").join("\n")}}` was being mangled by the wiki-link live preview — the literal `[[` / `]]` inside the expression source got styled as a wiki-link before the expression even rendered.

**New rule**: content inside a `{{ ... }}` range is template source code, not Markdown. No inline renderer (wiki-link, embed, emphasis/code/strike markup, inline HTML) may decorate it. The autocomplete / completion subsystem is unaffected and continues to work inside expressions — that's the explicit exception.

## Changes

- New helper `src/components/Editor/templateExprRanges.ts` — `findTemplateExprRanges(text, baseOffset?)` and `isInsideTemplateExpr(ranges, from, to?)`. Small, pure, unit-tested.
- 4× inline plugins guarded:
  - `wikiLink.ts`, `embedPlugin.ts` — full-doc scan (they already ran one for regex matching).
  - `livePreview.ts`, `inlineHtml.ts` — viewport-slice scan with `baseOffset = viewport.from` so returned coordinates stay in the absolute document frame.
- Block-level plugins (frontmatter, callouts, taskList, tablePlugin) deliberately out of scope — they match grammar that can't overlap an inline `{{ ... }}` body. Helper is available if a collision surfaces later.

## Tests

- Unit tests (`templateExprRanges.test.ts`): empty input, multi-line bodies, multiple matches, unbalanced-brace rejection, `baseOffset` correctness, overlap semantics at range boundaries, zero-length probe, empty-list edge, multi-range span.
- Integration test (`inlineGuardsInTemplate.test.ts`): mounts `wikiLinkPlugin` in a real `EditorView`, asserts `[[Alpha]]` IS decorated outside any expression, IS NOT decorated inside a `{{ ... }}` body, and a document with both produces decorations only on the real link.

## Test plan

- [x] `pnpm test` — 952/952 passing (was 937, +15 new)
- [x] `pnpm typecheck` — clean
- [ ] Manual: open a note, type the user's reported expression, verify no wiki-link styling fires on the literal brackets inside the body.