### PR TITLE
feat(templates): clickable [[...]] in rendered widget (#297)

### DIFF
--- a/src/components/Editor/__tests__/templateLivePreview.test.ts
+++ b/src/components/Editor/__tests__/templateLivePreview.test.ts
@@ -60,6 +60,7 @@ vi.mock("../../../store/editorStore", () => {
 import { templateLivePlugin } from "../templateLivePreview";
 // Pull the store handles to flip their values between tests.
 import { vaultStore } from "../../../store/vaultStore";
+import { setResolvedLinks } from "../wikiLink";
 
 function mount(doc: string, cursor = 0): EditorView {
   const anchor = Math.min(Math.max(cursor, 0), doc.length);
@@ -136,6 +137,52 @@ describe("templateLivePlugin — rendering", () => {
     const doc = "xxx {{vault.nonsense}} hi";
     const view = mount(doc, doc.length);
     expect(widgets(view)).toHaveLength(0);
+  });
+
+  it("parses [[...]] in rendered output into clickable wiki-link spans (#297)", () => {
+    // Seed the resolver so the target is known to be resolved.
+    setResolvedLinks(new Map([["first", "first.md"]]));
+
+    // An expression whose rendered string value includes `[[first]]`.
+    const doc = 'x {{"[[first]]"}} y';
+    const view = mount(doc, 0);
+
+    // The widget's `value` (pre-render string) still matches as before.
+    const ws = widgets(view);
+    expect(ws).toHaveLength(1);
+    expect(ws[0]!.text).toBe("[[first]]");
+
+    // The actual rendered DOM should contain an anchor-style span with the
+    // wiki-link data attributes and the resolved class.
+    const anchor = view.dom.querySelector(".vc-template-rendered [data-wiki-target]");
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute("data-wiki-target")).toBe("first");
+    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("true");
+    expect(anchor!.classList.contains("cm-wikilink-resolved")).toBe(true);
+    expect(anchor!.textContent).toBe("first");
+  });
+
+  it("marks unresolved targets with the unresolved class (#297)", () => {
+    setResolvedLinks(new Map());
+    const doc = 'x {{"[[ghost]]"}} y';
+    const view = mount(doc, 0);
+
+    const anchor = view.dom.querySelector(".vc-template-rendered [data-wiki-target]");
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("false");
+    expect(anchor!.classList.contains("cm-wikilink-unresolved")).toBe(true);
+  });
+
+  it("aliased [[target|alias]] shows the alias text but targets the stem (#297)", () => {
+    setResolvedLinks(new Map([["real", "real.md"]]));
+    const doc = 'x {{"[[real|Display]]"}} y';
+    const view = mount(doc, 0);
+
+    const anchor = view.dom.querySelector(".vc-template-rendered [data-wiki-target]");
+    expect(anchor).not.toBeNull();
+    expect(anchor!.textContent).toBe("Display");
+    expect(anchor!.getAttribute("data-wiki-target")).toBe("real");
+    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("true");
   });
 
   it("re-renders when the backing store changes", () => {

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -32,8 +32,14 @@ import { vaultStore } from "../../store/vaultStore";
 import { tagsStore } from "../../store/tagsStore";
 import { bookmarksStore } from "../../store/bookmarksStore";
 import { editorStore } from "../../store/editorStore";
+import { resolveTarget, stripKnownExt } from "./wikiLink";
 
 const refreshEffect = StateEffect.define<void>();
+
+// `[[target]]` or `[[target|alias]]`. Matches the shape wikiLink.ts uses for
+// real doc links — rendered expression output gets the same treatment so
+// `{{ ...select(n => "[[" + n.title + "]]")... }}` produces clickable links.
+const WIKI_LINK_IN_RENDER_RE = /\[\[([^\]|\n]+?)(?:\|([^\]\n]*))?\]\]/g;
 
 class RenderedValueWidget extends WidgetType {
   constructor(readonly value: string) { super(); }
@@ -47,10 +53,43 @@ class RenderedValueWidget extends WidgetType {
     // across lines inside the widget — default `normal` collapses \n to a
     // single space, which would flatten bulleted / tabular renders.
     el.style.whiteSpace = "pre-wrap";
-    el.textContent = this.value;
+    appendValueWithWikiLinks(el, this.value);
     return el;
   }
   override ignoreEvent(): boolean { return false; }
+}
+
+// Walks the rendered string and appends text nodes for plain runs and
+// anchor-style `<span>` elements for every `[[target(|alias)?]]` match.
+//
+// The anchor carries the same `data-wiki-target` / `data-wiki-resolved`
+// attributes the wikiLinkPlugin produces on real doc links, so its mousedown
+// handler (registered on the EditorView) picks up clicks inside this widget
+// and dispatches the shared `wiki-link-click` CustomEvent — EditorPane's
+// existing listener then navigates. Zero new plumbing.
+function appendValueWithWikiLinks(parent: HTMLElement, value: string): void {
+  let cursor = 0;
+  WIKI_LINK_IN_RENDER_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WIKI_LINK_IN_RENDER_RE.exec(value)) !== null) {
+    if (m.index > cursor) {
+      parent.appendChild(document.createTextNode(value.slice(cursor, m.index)));
+    }
+    const rawTarget = m[1]!;
+    const alias = m[2];
+    const stem = stripKnownExt(rawTarget);
+    const resolved = resolveTarget(rawTarget) !== null;
+    const link = document.createElement("span");
+    link.className = resolved ? "cm-wikilink-resolved" : "cm-wikilink-unresolved";
+    link.setAttribute("data-wiki-target", stem);
+    link.setAttribute("data-wiki-resolved", resolved ? "true" : "false");
+    link.textContent = alias !== undefined ? alias : rawTarget;
+    parent.appendChild(link);
+    cursor = m.index + m[0].length;
+  }
+  if (cursor < value.length) {
+    parent.appendChild(document.createTextNode(value.slice(cursor)));
+  }
 }
 
 const EXPR_RE = /\{\{([^{}]+?)\}\}/g;

--- a/src/components/Editor/wikiLink.ts
+++ b/src/components/Editor/wikiLink.ts
@@ -59,7 +59,7 @@ export function resolveTarget(target: string): string | null {
   return resolvedLinks.get(stem) ?? null;
 }
 
-function stripKnownExt(target: string): string {
+export function stripKnownExt(target: string): string {
   if (target.endsWith(".md")) return target.slice(0, -3);
   if (target.endsWith(".canvas")) return target.slice(0, -7);
   return target;


### PR DESCRIPTION
Closes #297.

## Summary

Makes wiki-links inside a template expression's rendered output actually clickable. Before this, `{{vault.folders.first().notes.select(n => "- [[" + n.title + "]]").join("\n")}}` rendered as plain text — the `[[name]]` pieces looked like links but weren't.

Now the widget's DOM contains spans with the same `data-wiki-target` / `data-wiki-resolved` attributes the `wikiLinkPlugin` puts on real doc links. Since that plugin's mousedown handler uses `target.closest("[data-wiki-target]")`, it picks up clicks anywhere in the view — including inside widgets — and dispatches the shared `wiki-link-click` CustomEvent. `EditorPane.handleWikiLinkClick` navigates. Zero new plumbing.

## Changes

- `src/components/Editor/wikiLink.ts` — promote `stripKnownExt` to a public export so the widget path produces stem-identical targets.
- `src/components/Editor/templateLivePreview.ts` — `RenderedValueWidget.toDOM()` now walks the rendered string for `[[target(|alias)?]]` and emits text nodes + styled wiki-link spans (`cm-wikilink-resolved` / `cm-wikilink-unresolved`). Existing widget contract (`eq`, `value`) unchanged.
- `src/components/Editor/__tests__/templateLivePreview.test.ts` — 3 new tests: resolved link styling + attributes, unresolved styling, aliased form.

## Out of scope

- Markdown-style `[text](url)` links inside rendered output.
- `![[...]]` embeds (note/image content in a widget).
- Stale resolution when a hardcoded `[[Name]]` template later matches a newly-created file (`widget.eq` compares by value only; rare for dynamic templates).

## Test plan

- [x] `pnpm test` — 955/955 passing (was 952, +3 new)
- [x] `pnpm typecheck` — clean
- [ ] Manual: paste the Done-folder expression on its own line in a note, leave the cursor. Expect a bulleted list of clickable links styled in the accent color; click one → opens that note in a tab.