### PR TITLE
fix(editor): template autocomplete caret lands at end of inserted text (#299)

### DIFF
--- a/e2e/specs/template-autocomplete.spec.ts
+++ b/e2e/specs/template-autocomplete.spec.ts
@@ -1,0 +1,144 @@
+// E2E regression for #299 — chained template autocomplete caret position.
+//
+// Drives the full `{{ ` → accept `vault` → type `.` → accept member flow
+// through real keyboard selection of popup entries (via Enter) and asserts
+// that the final document text and the CodeMirror selection head land where
+// the user expects: immediately after the inserted member name.
+
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+describe("Template autocomplete — caret after chained selection (#299)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not in tree`);
+  }
+
+  async function typeInEditor(text: string): Promise<void> {
+    await browser.executeAsync((t: string, done: () => void) => {
+      window.__e2e__!.typeInActiveEditor(t).then(() => done());
+    }, text);
+  }
+
+  /** Read `view.state.doc.toString()` on the visible editor. */
+  async function docText(): Promise<string> {
+    return browser.executeAsync((done: (s: string) => void) => {
+      void window.__e2e__!.getActiveDocText().then((t) => done(t));
+    });
+  }
+
+  /** Read `view.state.selection.main.head` on the visible editor. */
+  async function selectionHead(): Promise<number> {
+    return browser.executeAsync((done: (n: number) => void) => {
+      void window.__e2e__!.getActiveSelectionHead().then((n) => done(n));
+    });
+  }
+
+  /** Read the label of the currently-selected popup option. */
+  async function waitForPopupWithOption(label: string): Promise<void> {
+    const tooltip = await browser.$(".cm-tooltip-autocomplete");
+    await tooltip.waitForDisplayed({ timeout: 3000 });
+    await browser.waitUntil(
+      async () => {
+        const opts = await browser.$$(".cm-tooltip-autocomplete li");
+        for (const li of opts) if ((await textOf(li)).startsWith(label)) return true;
+        return false;
+      },
+      { timeout: 3000, timeoutMsg: `popup never surfaced option ${label}` },
+    );
+  }
+
+  /** Arrow-down until the highlighted option's label starts with `label`, then Enter. */
+  async function selectOption(label: string): Promise<void> {
+    // The popup auto-highlights the first option. Walk the list until we
+    // land on the one we want — keeps the spec independent of insertion
+    // order changes in the vault API descriptor.
+    for (let i = 0; i < 50; i++) {
+      const selectedText = await browser.execute(() => {
+        const el = document.querySelector<HTMLElement>(
+          ".cm-tooltip-autocomplete li[aria-selected='true']",
+        );
+        return el?.textContent ?? "";
+      });
+      if (selectedText.startsWith(label)) {
+        await browser.keys(["Enter"]);
+        return;
+      }
+      await browser.keys(["ArrowDown"]);
+      await browser.pause(30);
+    }
+    throw new Error(`could not select option ${label}`);
+  }
+
+  it("accepts vault, then `.`, then a member — caret lands at end of member name", async () => {
+    await openTreeFile("Welcome.md");
+    await browser.waitUntil(
+      async () => {
+        const els = await browser.$$(".cm-content");
+        for (const el of els) if (await el.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000 },
+    );
+
+    // Start on a fresh line so we don't collide with existing doc content.
+    await typeInEditor("\n{{ ");
+
+    await waitForPopupWithOption("vault");
+    await selectOption("vault");
+    await browser
+      .$(".cm-tooltip-autocomplete")
+      .waitForDisplayed({ timeout: 2000, reverse: true });
+
+    // Baseline: after accepting vault, the doc must end with `{{ vault`
+    // and the caret must sit at the end of that text.
+    await browser.waitUntil(
+      async () => {
+        const t = await docText();
+        return t.endsWith("{{ vault");
+      },
+      { timeout: 3000, timeoutMsg: "accepting `vault` never produced `{{ vault` at end of doc" },
+    );
+    const afterVaultDoc = await docText();
+    const afterVaultHead = await selectionHead();
+    expect(afterVaultHead).toBe(afterVaultDoc.length);
+
+    // Now the regression: `.` then pick a member — caret must end AFTER the
+    // member name, not snap back to the `v` of `vault`.
+    await typeInEditor(".");
+    await waitForPopupWithOption("name");
+    await selectOption("name");
+    await browser
+      .$(".cm-tooltip-autocomplete")
+      .waitForDisplayed({ timeout: 2000, reverse: true });
+
+    await browser.waitUntil(
+      async () => {
+        const t = await docText();
+        return t.endsWith("{{ vault.name");
+      },
+      { timeout: 3000, timeoutMsg: "accepting member never produced `{{ vault.name`" },
+    );
+    const finalDoc = await docText();
+    const finalHead = await selectionHead();
+    expect(finalHead).toBe(finalDoc.length);
+  });
+});

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -247,6 +247,15 @@
         if (!view) return "";
         return view.state.doc.toString();
       };
+      const getActiveSelectionHead = async (): Promise<number> => {
+        const { EditorView } = await import("@codemirror/view");
+        const els = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+        const active = els.find((el) => el.offsetParent !== null);
+        if (!active) return -1;
+        const view = EditorView.findFromDOM(active);
+        if (!view) return -1;
+        return view.state.selection.main.head;
+      };
       // #204: subscribe once to the reindex-done signal so E2E specs can
       // wait for embeddings to be queryable before running a semantic-only
       // search. We keep a single listener for the lifetime of the window
@@ -277,6 +286,7 @@
         finishProgress,
         typeInActiveEditor,
         getActiveDocText,
+        getActiveSelectionHead,
         reindexAndWaitDone,
       };
     }

--- a/src/components/Editor/__tests__/templateAutocompleteCursor.test.ts
+++ b/src/components/Editor/__tests__/templateAutocompleteCursor.test.ts
@@ -1,0 +1,268 @@
+// Regression test for the template autocomplete cursor bug (#299):
+// Typing `{{ `, accepting `vault` from the popup, then typing `.` and accepting
+// a member must leave the caret AFTER the inserted member name — not at the
+// start of `vault`. The first version of templateAutocomplete.ts returned a
+// CompletionResult without a `to` field, so CodeMirror used the initial
+// cursor snapshot taken *before* the `.` transaction settled; member selection
+// then replaced `{{ vault.` from the old `from` back to that stale snapshot,
+// collapsing the caret to the leading `v`.
+//
+// We mount a real EditorView (with autocompletion + our source), drive it with
+// real `input.type` transactions, wait for the popup to appear, and call the
+// acceptCompletion command to commit the selection.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import {
+  autocompletion,
+  closeBrackets,
+  closeBracketsKeymap,
+  acceptCompletion,
+  currentCompletions,
+  completionStatus,
+  moveCompletionSelection,
+  startCompletion,
+} from "@codemirror/autocomplete";
+import { keymap } from "@codemirror/view";
+import { defaultKeymap } from "@codemirror/commands";
+import { writable } from "svelte/store";
+
+vi.mock("../../../store/vaultStore", () => {
+  const _store = writable({
+    currentPath: "/v/MyVault",
+    status: "ready",
+    fileList: [],
+    fileCount: 0,
+    errorMessage: null,
+    sidebarWidth: 240,
+    vaultReachable: true,
+  });
+  return { vaultStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+vi.mock("../../../store/tagsStore", () => {
+  const _store = writable({ tags: [], loading: false, error: null });
+  return { tagsStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+vi.mock("../../../store/bookmarksStore", () => {
+  const _store = writable({ paths: [], loaded: true });
+  return { bookmarksStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+vi.mock("../../../store/editorStore", () => {
+  const _store = writable({ activePath: null, content: "", lastSavedHash: null });
+  return { editorStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+
+import { templateCompletionSource } from "../templateAutocomplete";
+import { templateLivePlugin } from "../templateLivePreview";
+
+let view: EditorView | null = null;
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+function mount(doc = ""): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const state = EditorState.create({
+    doc,
+    extensions: [
+      closeBrackets(),
+      autocompletion({
+        override: [templateCompletionSource],
+        activateOnTyping: true,
+        activateOnTypingDelay: 0,
+        interactionDelay: 0,
+      }),
+      keymap.of([...closeBracketsKeymap, ...defaultKeymap]),
+      templateLivePlugin,
+    ],
+  });
+  view = new EditorView({ state, parent });
+  return view;
+}
+
+async function typeChar(v: EditorView, text: string): Promise<void> {
+  const pos = v.state.selection.main.head;
+  v.dispatch({
+    changes: { from: pos, to: pos, insert: text },
+    selection: { anchor: pos + text.length },
+    userEvent: "input.type",
+  });
+  await waitForCompletions(v);
+}
+
+async function waitForCompletions(v: EditorView, timeout = 2000): Promise<void> {
+  const start = Date.now();
+  // Kick the popup explicitly — typing-driven activation is debounced via
+  // activateOnTypingDelay and the async source dispatch; jsdom can miss it.
+  startCompletion(v);
+  while (Date.now() - start < timeout) {
+    if (
+      currentCompletions(v.state).length > 0 &&
+      completionStatus(v.state) === "active"
+    ) return;
+    await new Promise((r) => setTimeout(r, 15));
+  }
+}
+
+function pickOption(v: EditorView, label: string): void {
+  const opts = currentCompletions(v.state);
+  const idx = opts.findIndex((o) => o.label === label);
+  if (idx < 0) {
+    throw new Error(
+      `Option ${label} not in [${opts.map((o) => o.label).join(",")}]`,
+    );
+  }
+  for (let i = 0; i < idx; i++) moveCompletionSelection(true)(v);
+  if (!acceptCompletion(v)) {
+    throw new Error(
+      `acceptCompletion returned false — status=${completionStatus(v.state)}, options=[${opts.map((o) => o.label).join(",")}], doc="${v.state.doc.toString()}", pos=${v.state.selection.main.head}`,
+    );
+  }
+}
+
+describe("template autocomplete — caret position after chained selection", () => {
+  it("leaves the caret after `vault` when `vault` is picked", async () => {
+    const v = mount();
+    await typeChar(v, "{");
+    await typeChar(v, "{");
+    await typeChar(v, " ");
+    pickOption(v, "vault");
+    expect(v.state.doc.toString()).toBe("{{ vault");
+    expect(v.state.selection.main.head).toBe("{{ vault".length);
+  });
+
+  it("leaves the caret AFTER the inserted member when `.` is typed then a member is picked", async () => {
+    const v = mount();
+    await typeChar(v, "{");
+    await typeChar(v, "{");
+    await typeChar(v, " ");
+    pickOption(v, "vault");
+    expect(v.state.doc.toString()).toBe("{{ vault");
+
+    // This is the bug: typing `.` and picking `name` used to land the caret
+    // at position 3 (before the `v`) rather than at end-of-`name`.
+    await typeChar(v, ".");
+    pickOption(v, "name");
+
+    expect(v.state.doc.toString()).toBe("{{ vault.name");
+    expect(v.state.selection.main.head).toBe("{{ vault.name".length);
+  });
+
+  it("preserves caret when a member is picked from a manually-typed chain", async () => {
+    const v = mount();
+    for (const c of "{{ vault.") await typeChar(v, c);
+    pickOption(v, "path");
+    expect(v.state.doc.toString()).toBe("{{ vault.path");
+    expect(v.state.selection.main.head).toBe("{{ vault.path".length);
+  });
+
+  it("method completion inserts `name(` and leaves caret after the `(`", async () => {
+    // Collection<Note> exposes `where`, `first`, etc. as methods whose
+    // insertText ends with `(` so the user lands inside the arg list.
+    const v = mount();
+    for (const c of "{{ vault.notes.") await typeChar(v, c);
+    pickOption(v, "where");
+    expect(v.state.doc.toString()).toBe("{{ vault.notes.where(");
+    expect(v.state.selection.main.head).toBe("{{ vault.notes.where(".length);
+  });
+
+  it("types `{{ vault.` without ever accepting the popup — cursor stays at end", async () => {
+    const v = mount();
+    for (const c of "{{ vault.") await typeChar(v, c);
+    // The popup is showing members of Vault. User has not accepted.
+    expect(v.state.doc.toString()).toBe("{{ vault.");
+    expect(v.state.selection.main.head).toBe(9);
+  });
+
+  it("types `{{ v`, accepts vault, types `.` — document is `{{ vault.` with caret at end", async () => {
+    const v = mount();
+    await typeChar(v, "{");
+    await typeChar(v, "{");
+    await typeChar(v, " ");
+    await typeChar(v, "v");
+    pickOption(v, "vault");
+    // After accepting: doc should be `{{ vault`, caret at end (8)
+    expect(v.state.doc.toString()).toBe("{{ vault");
+    expect(v.state.selection.main.head).toBe(8);
+    // Now type `.`
+    await typeChar(v, ".");
+    expect(v.state.doc.toString()).toBe("{{ vault.");
+    expect(v.state.selection.main.head).toBe(9);
+  });
+
+  it("simulates closeBrackets auto-closing `{{` to `{{}}`", async () => {
+    // When the real editor runs, typing `{` through closeBrackets produces
+    // `{|}` and a second `{` produces `{{|}}`. Dispatch that manually.
+    const v = mount();
+    v.dispatch({
+      changes: { from: 0, to: 0, insert: "{{}}" },
+      selection: { anchor: 2 },
+      userEvent: "input.type",
+    });
+    await waitForCompletions(v);
+    // popup should show vault — accept it.
+    pickOption(v, "vault");
+    expect(v.state.doc.toString()).toBe("{{vault}}");
+    expect(v.state.selection.main.head).toBe(7);
+    // Now type `.`
+    await typeChar(v, ".");
+    expect(v.state.doc.toString()).toBe("{{vault.}}");
+    expect(v.state.selection.main.head).toBe(8);
+    pickOption(v, "name");
+    expect(v.state.doc.toString()).toBe("{{vault.name}}");
+    expect(v.state.selection.main.head).toBe(12);
+  });
+
+  it("no space between `{{` and `vault` — pick vault, type `.`, pick member", async () => {
+    const v = mount();
+    await typeChar(v, "{");
+    await typeChar(v, "{");
+    // No space — user picks vault immediately
+    pickOption(v, "vault");
+    expect(v.state.doc.toString()).toBe("{{vault");
+    expect(v.state.selection.main.head).toBe(7);
+    await typeChar(v, ".");
+    expect(v.state.doc.toString()).toBe("{{vault.");
+    expect(v.state.selection.main.head).toBe(8);
+    pickOption(v, "name");
+    expect(v.state.doc.toString()).toBe("{{vault.name");
+    expect(v.state.selection.main.head).toBe(12);
+  });
+
+  it("simulates full typing flow including closeBrackets auto-close", async () => {
+    // Use keyboard events so closeBrackets actually fires. In jsdom we
+    // emulate that by invoking the insert transaction the way CM6 would.
+    const v = mount();
+    // The real app uses closeBrackets — typing `{` inserts `{}` with cursor
+    // between. We drive that by dispatching an `input` user event that the
+    // closeBrackets extension will intercept, approximating the typed input.
+    function simulateTyped(c: string): void {
+      const pos = v.state.selection.main.head;
+      // Call the input handler CM6 sets up via the closeBrackets ext.
+      // The straightforward path is to dispatch an input.type transaction
+      // and let any beforeinput listeners run; in our unit env that means
+      // dispatching like the typeChar helper does.
+      v.dispatch({
+        changes: { from: pos, to: pos, insert: c },
+        selection: { anchor: pos + c.length },
+        userEvent: "input.type",
+      });
+    }
+    simulateTyped("{");
+    simulateTyped("{");
+    simulateTyped(" ");
+    await waitForCompletions(v);
+    pickOption(v, "vault");
+    const afterVault = v.state.doc.toString();
+    const posAfterVault = v.state.selection.main.head;
+    simulateTyped(".");
+    await waitForCompletions(v);
+    pickOption(v, "path");
+    expect(v.state.doc.toString()).toBe(afterVault + ".path");
+    expect(v.state.selection.main.head).toBe(posAfterVault + 5); // `.path`
+  });
+});

--- a/src/components/Editor/templateAutocomplete.ts
+++ b/src/components/Editor/templateAutocomplete.ts
@@ -11,6 +11,7 @@ import type {
   CompletionContext,
   CompletionResult,
 } from "@codemirror/autocomplete";
+import type { EditorView } from "@codemirror/view";
 import { analyzeCompletion } from "../../lib/templateCompletion";
 import { parseFrontmatter } from "../../lib/frontmatterIO";
 
@@ -56,7 +57,19 @@ export function templateCompletionSource(
     const opt: Completion = {
       label: item.label,
       detail: item.detail,
-      apply: item.insertText,
+      // #299: function-form apply guarantees the caret lands at the end of
+      // the inserted text regardless of how CodeMirror resolves `to` under
+      // a chained-completion timing (e.g. picking `vault`, then `.`, then
+      // picking a member). The string-form fallback used to leave the caret
+      // anchored at `result.from` when `to` drifted across transactions.
+      apply: (view: EditorView, _completion, from: number, to: number) => {
+        const insert = item.insertText;
+        view.dispatch({
+          changes: { from, to, insert },
+          selection: { anchor: from + insert.length },
+          userEvent: "input.complete",
+        });
+      },
       type: COMPLETION_TYPE[item.kind] ?? "text",
     };
     if (item.doc !== undefined) opt.info = item.doc;
@@ -65,6 +78,7 @@ export function templateCompletionSource(
 
   return {
     from: exprStart + analysis.from,
+    to: ctx.pos,
     options,
     filter: true,
   };

--- a/src/types/e2e-hook.ts
+++ b/src/types/e2e-hook.ts
@@ -16,6 +16,10 @@ export interface E2eHook {
   finishProgress: () => void;
   typeInActiveEditor: (text: string) => Promise<void>;
   getActiveDocText: () => Promise<string>;
+  /** Current CodeMirror selection head on the visible editor, or -1 when
+   *  no editor is mounted. Used by #299 regression specs to assert that
+   *  chained autocomplete leaves the caret at the end of the inserted text. */
+  getActiveSelectionHead: () => Promise<number>;
   /** #204: trigger `reindex_vault` and resolve once the reindex worker
    *  emits a terminal `done` progress event. Used by the hybrid-search
    *  E2E spec to wait for embeddings to be queryable before running a


### PR DESCRIPTION
Fixes #299.

## Summary

- `templateCompletionSource` now returns `to: ctx.pos` and each option uses a function-form `apply` that dispatches the change with a pinned `selection` anchor — same shape as `wikiLinkAutocomplete`. The string-form previously let CodeMirror fall back to a stale `to`, so under chained completion timing (`{{ ` → pick `vault` → type `.` → pick member) the caret collapsed back to the leading `v` of `vault`.
- New CM6 integration unit spec mounts a real EditorView and drives the chained flow (`{{ ` → `vault` → `.` → member) plus method-completion cases (`where(`).
- New WDIO e2e spec drives the same flow via real keyboard selection of popup entries; a new `getActiveSelectionHead` e2e hook exposes `view.state.selection.main.head` so the spec can assert caret position.

## Test plan

- [x] `npx vitest run src/components/Editor/__tests__/templateAutocompleteCursor.test.ts` — 9 passing
- [x] `npx vitest run src/lib/__tests__/templateCompletion.test.ts` — 22 passing (no regression)
- [x] `npx vitest run src/components/Editor/__tests__/templateLivePreview.test.ts src/components/Editor/__tests__/templateExprRanges.test.ts` — 21 passing
- [x] `npx tsc --noEmit` — clean
- [ ] E2E `template-autocomplete.spec.ts` — added, not run locally (WDIO driver not installed on this box); will exercise in CI.