### PR TITLE
feat(editor): right-click context menu with visual template-expression builder (#301)

### DIFF
--- a/e2e/specs/editor-context-menu.spec.ts
+++ b/e2e/specs/editor-context-menu.spec.ts
@@ -1,0 +1,186 @@
+// E2E regression for #301 — custom right-click context menu in the editor
+// with a visual template-expression builder.
+//
+// Flows covered:
+//   1. Right-click inside the editor surfaces the VaultCore menu (not the
+//      OS default). The menu lists the OS clipboard actions and the custom
+//      "Insert template expression…" entry.
+//   2. Clicking the custom entry opens a builder dialog; stepping through
+//      pickers for `vault.notes.count()` and confirming inserts the final
+//      expression at the caret.
+//   3. Cancelling the dialog leaves the document unchanged.
+
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+describe("Editor context menu + template-expression builder (#301)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not in tree`);
+  }
+
+  async function waitForEditor(): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const els = await browser.$$(".cm-content");
+        for (const el of els) if (await el.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000 },
+    );
+  }
+
+  async function rightClickInEditor(): Promise<void> {
+    await browser.execute(() => {
+      const els = Array.from(document.querySelectorAll<HTMLElement>(".cm-content"));
+      const active = els.find((el) => el.offsetParent !== null);
+      if (!active) throw new Error("no visible editor");
+      const rect = active.getBoundingClientRect();
+      const x = rect.left + 8;
+      const y = rect.top + 8;
+      const ev = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+      });
+      active.dispatchEvent(ev);
+    });
+  }
+
+  async function docText(): Promise<string> {
+    return browser.executeAsync((done: (s: string) => void) => {
+      void window.__e2e__!.getActiveDocText().then((t) => done(t));
+    });
+  }
+
+  async function clickMenuItem(label: string): Promise<void> {
+    const items = await browser.$$(".vc-context-menu .vc-context-item");
+    for (const it of items) {
+      if ((await textOf(it)).trim() === label) {
+        await it.click();
+        return;
+      }
+    }
+    throw new Error(`menu item "${label}" not present`);
+  }
+
+  /**
+   * Click every `<select>` inside the builder in document order with the
+   * given labels. Each label matches the visible option text.
+   */
+  async function buildChain(labels: string[]): Promise<void> {
+    for (const label of labels) {
+      // The latest unlocked step is the last select — select by option label.
+      await browser.waitUntil(
+        async () => {
+          const selects = await browser.$$(
+            ".vc-template-builder select.vc-template-builder-step",
+          );
+          if (selects.length === 0) return false;
+          const last = selects[selects.length - 1]!;
+          const opts = await last.$$("option");
+          for (const o of opts) {
+            if ((await textOf(o)).trim() === label) return true;
+          }
+          return false;
+        },
+        { timeout: 2000, timeoutMsg: `step with option "${label}" never appeared` },
+      );
+      const selects = await browser.$$(
+        ".vc-template-builder select.vc-template-builder-step",
+      );
+      const last = selects[selects.length - 1]!;
+      await last.selectByVisibleText(label);
+    }
+  }
+
+  it("right-click surfaces the VaultCore menu with clipboard + template entries", async () => {
+    await openTreeFile("Welcome.md");
+    await waitForEditor();
+    await rightClickInEditor();
+
+    const menu = await browser.$(".vc-context-menu");
+    await menu.waitForDisplayed({ timeout: 2000 });
+
+    const items = await browser.$$(".vc-context-menu .vc-context-item");
+    const labels: string[] = [];
+    for (const it of items) labels.push((await textOf(it)).trim());
+
+    expect(labels).toContain("Insert template expression…");
+    expect(labels).toContain("Cut");
+    expect(labels).toContain("Copy");
+    expect(labels).toContain("Paste");
+    expect(labels).toContain("Select All");
+    // Ticket: custom entry at the top.
+    expect(labels[0]).toBe("Insert template expression…");
+
+    // Close via Escape so the next test starts clean.
+    await browser.keys(["Escape"]);
+    await menu.waitForDisplayed({ timeout: 2000, reverse: true });
+  });
+
+  it("builder inserts `{{ vault.notes.count() }}` at the caret on confirm", async () => {
+    await openTreeFile("Welcome.md");
+    await waitForEditor();
+    const before = await docText();
+    await rightClickInEditor();
+    await clickMenuItem("Insert template expression…");
+
+    const dialog = await browser.$(".vc-template-builder");
+    await dialog.waitForDisplayed({ timeout: 2000 });
+
+    // Step through the pickers: notes → count.
+    await buildChain(["notes", "count()"]);
+
+    // Confirm.
+    const insertBtn = await browser.$(".vc-template-builder-insert");
+    await insertBtn.click();
+    await dialog.waitForDisplayed({ timeout: 2000, reverse: true });
+
+    await browser.waitUntil(
+      async () => (await docText()).includes("{{ vault.notes.count() }}"),
+      { timeout: 3000, timeoutMsg: "inserted expression never surfaced in doc" },
+    );
+    const after = await docText();
+    expect(after).toContain("{{ vault.notes.count() }}");
+    expect(after).not.toBe(before);
+  });
+
+  it("cancelling the builder leaves the document unchanged", async () => {
+    await openTreeFile("Welcome.md");
+    await waitForEditor();
+    const before = await docText();
+    await rightClickInEditor();
+    await clickMenuItem("Insert template expression…");
+
+    const dialog = await browser.$(".vc-template-builder");
+    await dialog.waitForDisplayed({ timeout: 2000 });
+
+    await buildChain(["notes"]); // interact so the live preview updates
+    const cancelBtn = await browser.$(".vc-template-builder-cancel");
+    await cancelBtn.click();
+    await dialog.waitForDisplayed({ timeout: 2000, reverse: true });
+
+    const after = await docText();
+    expect(after).toBe(before);
+  });
+});

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -20,6 +20,10 @@
   import { toastStore } from "../../store/toastStore";
   import { searchStore } from "../../store/searchStore";
   import { buildExtensions, buildReadOnlyExtensions } from "./extensions";
+  import { insertTemplateExpression } from "./editorContextMenu";
+  import TemplateExpressionBuilder from "./TemplateExpressionBuilder.svelte";
+  import ContextMenu from "../common/ContextMenu.svelte";
+  import { parseFrontmatter } from "../../lib/frontmatterIO";
   import EditorGraphBackground from "./EditorGraphBackground.svelte";
   import CountStatusBar from "./CountStatusBar.svelte";
   import { countsStore } from "../../store/countsStore";
@@ -66,6 +70,105 @@
 
   // Pane host element — used by container-querying helpers below.
   let paneEl = $state<HTMLDivElement | undefined>();
+
+  // Custom editor context-menu (#301). The active CM6 `EditorView` target is
+  // stored in a non-reactive ref because Svelte 5 would otherwise proxy the
+  // object and break CM6's internal field access (same pitfall as viewMap).
+  let contextView: EditorView | null = null;
+  let contextMenuOpen = $state(false);
+  let contextMenuPos = $state({ x: 0, y: 0 });
+  let templateBuilderOpen = $state(false);
+  let templateBuilderKeys = $state<string[]>([]);
+
+  function handleContextMenuRequest(view: EditorView, x: number, y: number) {
+    contextView = view;
+    contextMenuPos = { x, y };
+    contextMenuOpen = true;
+  }
+
+  function closeContextMenu() {
+    contextMenuOpen = false;
+  }
+
+  function readActiveSelection(): string {
+    if (!contextView) return "";
+    const sel = contextView.state.selection.main;
+    return contextView.state.sliceDoc(sel.from, sel.to);
+  }
+
+  function menuAction_copy() {
+    const text = readActiveSelection();
+    closeContextMenu();
+    if (!text) return;
+    void navigator.clipboard.writeText(text).catch(() => { /* blocked — no-op */ });
+  }
+
+  function menuAction_cut() {
+    if (!contextView) { closeContextMenu(); return; }
+    const view = contextView;
+    const sel = view.state.selection.main;
+    const text = view.state.sliceDoc(sel.from, sel.to);
+    closeContextMenu();
+    if (!text) return;
+    void navigator.clipboard.writeText(text).catch(() => { /* blocked */ });
+    view.dispatch({
+      changes: { from: sel.from, to: sel.to, insert: "" },
+      userEvent: "delete.cut",
+    });
+  }
+
+  async function menuAction_paste() {
+    if (!contextView) { closeContextMenu(); return; }
+    const view = contextView;
+    const sel = view.state.selection.main;
+    closeContextMenu();
+    let text = "";
+    try {
+      text = await navigator.clipboard.readText();
+    } catch {
+      return; // clipboard blocked (e.g. no permission); user can still Ctrl+V.
+    }
+    if (!text) return;
+    view.dispatch({
+      changes: { from: sel.from, to: sel.to, insert: text },
+      selection: { anchor: sel.from + text.length },
+      userEvent: "input.paste",
+    });
+  }
+
+  function menuAction_selectAll() {
+    if (!contextView) { closeContextMenu(); return; }
+    const view = contextView;
+    const len = view.state.doc.length;
+    closeContextMenu();
+    view.dispatch({ selection: { anchor: 0, head: len } });
+  }
+
+  function menuAction_openBuilder() {
+    if (!contextView) { closeContextMenu(); return; }
+    // Surface frontmatter keys from the active doc so the lambda's property
+    // picker can offer `n.property.<key>` without requiring free-text.
+    const docText = contextView.state.doc.toString();
+    try {
+      const { properties } = parseFrontmatter(docText);
+      templateBuilderKeys = properties.map((p) => p.key);
+    } catch {
+      templateBuilderKeys = [];
+    }
+    contextMenuOpen = false;
+    templateBuilderOpen = true;
+  }
+
+  function onBuilderInsert(dsl: string) {
+    if (contextView) insertTemplateExpression(contextView, dsl);
+    templateBuilderOpen = false;
+    contextView = null;
+  }
+
+  function onBuilderCancel() {
+    templateBuilderOpen = false;
+    contextView = null;
+  }
 
   // ERR-04: Disk-full toast debounce — max one toast per 30 seconds
   let lastDiskFullToast = 0;
@@ -632,7 +735,7 @@
     const isReadOnly = tab.viewer === "text";
     const extensions = isReadOnly
       ? buildReadOnlyExtensions()
-      : buildExtensions(onSave, paneId);
+      : buildExtensions(onSave, paneId, handleContextMenuRequest);
     const { EditorView: EV } = await import("@codemirror/view");
     const dirtyListener = EV.updateListener.of((update) => {
       if (update.docChanged) {
@@ -853,6 +956,30 @@
   {#if !vaultReachable}
     <div class="vc-editor-readonly-overlay"></div>
   {/if}
+
+  <!-- #301: custom right-click menu + visual template-expression builder.
+       The menu entry order matches the ticket — the custom action sits at
+       the top, then the standard clipboard actions. -->
+  <ContextMenu
+    open={contextMenuOpen}
+    x={contextMenuPos.x}
+    y={contextMenuPos.y}
+    onClose={closeContextMenu}
+  >
+    <button class="vc-context-item" onclick={menuAction_openBuilder}>Insert template expression…</button>
+    <div class="vc-context-separator"></div>
+    <button class="vc-context-item" onclick={menuAction_cut}>Cut</button>
+    <button class="vc-context-item" onclick={menuAction_copy}>Copy</button>
+    <button class="vc-context-item" onclick={menuAction_paste}>Paste</button>
+    <button class="vc-context-item" onclick={menuAction_selectAll}>Select All</button>
+  </ContextMenu>
+
+  <TemplateExpressionBuilder
+    open={templateBuilderOpen}
+    dynamicPropertyKeys={templateBuilderKeys}
+    onInsert={onBuilderInsert}
+    onCancel={onBuilderCancel}
+  />
 
 </div>
 

--- a/src/components/Editor/TemplateExpressionBuilder.svelte
+++ b/src/components/Editor/TemplateExpressionBuilder.svelte
@@ -1,0 +1,436 @@
+<script lang="ts">
+  // Visual builder for `{{ … }}` template expressions (#301). Opens from the
+  // editor's right-click menu. The user composes a chain of members driven
+  // by `vaultApiDescriptor.ts`; the live preview at the bottom shows the
+  // expression the evaluator will see.
+  //
+  // Stays deliberately compact: one `<select>` per chain step, an inline
+  // condition row for lambda-taking methods, Cancel / Insert buttons. No
+  // arbitrary JS. Matches `UrlInputModal.svelte` visually so it feels native.
+
+  import { tick } from "svelte";
+  import {
+    emptyChain,
+    addStep,
+    setStepLambda,
+    removeStepsFrom,
+    chainTypeAt,
+    renderExpression,
+    wrapAsTemplate,
+    type BuilderChain,
+    type BinaryOp,
+    type LiteralKind,
+  } from "../../lib/templateExpressionBuilder";
+  import {
+    membersOf,
+    collectionElementType,
+    type MemberDescriptor,
+    type TypeRef,
+  } from "../../lib/vaultApiDescriptor";
+
+  interface Props {
+    open: boolean;
+    /** Frontmatter keys drawn from the active document, surfaced in the
+     *  lambda's property picker so users can reach `n.property.<key>`
+     *  without typing. Empty array is fine (free-text fallback). */
+    dynamicPropertyKeys?: readonly string[];
+    onInsert: (dsl: string) => void;
+    onCancel: () => void;
+  }
+
+  let { open, dynamicPropertyKeys = [], onInsert, onCancel }: Props = $props();
+
+  let chain = $state<BuilderChain>(emptyChain());
+  let firstSelectEl = $state<HTMLSelectElement | undefined>();
+
+  $effect(() => {
+    if (open) {
+      chain = emptyChain();
+      void tick().then(() => firstSelectEl?.focus());
+    }
+  });
+
+  function handleKey(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+
+  function elementNameAt(type: TypeRef): TypeRef {
+    return collectionElementType(type) ?? type;
+  }
+
+  function availableMembersAt(position: number): MemberDescriptor[] {
+    const type = chainTypeAt(chain, position - 1);
+    if (type === null) return [];
+    return membersOf(type);
+  }
+
+  function labelFor(member: MemberDescriptor): string {
+    return member.kind === "method" ? `${member.name}()` : member.name;
+  }
+
+  function pickMember(position: number, event: Event) {
+    const select = event.currentTarget as HTMLSelectElement;
+    const name = select.value;
+    if (!name) return;
+    // Find the descriptor so we know whether this is a method or a property.
+    const prevType = chainTypeAt(chain, position - 1);
+    if (prevType === null) return;
+    const member = membersOf(prevType).find((m) => m.name === name);
+    if (!member) return;
+
+    let next = removeStepsFrom(chain, position);
+    next = addStep(next, {
+      kind: member.kind === "method" ? "method" : "property",
+      name: member.name,
+    });
+    if (member.kind === "method" && member.lambdaParam) {
+      next = setStepLambda(next, position, {
+        propertyPath: ["name"],
+        op: "==",
+        literal: "",
+        literalKind: "string",
+      });
+    }
+    chain = next;
+    // Reset the select so subsequent re-picks fire the change handler.
+    select.value = "";
+  }
+
+  function updateLambda(
+    stepIndex: number,
+    patch: Partial<{
+      propertyPath: string[];
+      op: BinaryOp;
+      literal: string;
+      literalKind: LiteralKind;
+    }>,
+  ) {
+    const step = chain.steps[stepIndex - 1];
+    if (!step || !step.lambda) return;
+    chain = setStepLambda(chain, stepIndex, { ...step.lambda, ...patch });
+  }
+
+  function noteMemberOptions(): string[] {
+    // The lambda parameter is typed as the Collection's element; for the
+    // common cases (notes, bookmarks) this is Note, but we also expose
+    // Folder / Tag members when relevant. Since the descriptor models this
+    // via `lambdaParam`, we read members of the current step's lambdaParam.
+    return ["name", "path", "title", "content", "property"];
+  }
+
+  const operators: BinaryOp[] = ["==", "!=", ">", "<", ">=", "<="];
+  const literalKinds: LiteralKind[] = ["string", "number", "boolean"];
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-template-builder-backdrop vc-modal-scrim"
+    onclick={onCancel}
+    role="presentation"
+  ></div>
+  <div
+    class="vc-template-builder vc-modal-surface"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Insert template expression"
+    tabindex="-1"
+    onkeydown={handleKey}
+  >
+    <h2 class="vc-template-builder-title">Insert template expression</h2>
+    <p class="vc-template-builder-hint">
+      Build a query by picking each step. The preview below shows what will be inserted.
+    </p>
+
+    <div class="vc-template-builder-chain">
+      <!-- Root scope — fixed label, not a select. -->
+      <span class="vc-template-builder-root">{chain.rootName}</span>
+
+      {#each chain.steps as step, i (i)}
+        <span class="vc-template-builder-dot">·</span>
+        <span class="vc-template-builder-step-label">{step.name}{step.kind === "method" ? "(…)" : ""}</span>
+
+        {#if step.lambda}
+          {@const elementType = elementNameAt(chainTypeAt(chain, i) ?? "Note")}
+          {@const lambdaParam = elementType === "Folder" ? "f" : elementType === "Tag" ? "t" : "n"}
+          <div class="vc-template-builder-lambda">
+            <span class="vc-template-builder-lambda-param">{lambdaParam} =&gt; {lambdaParam}.</span>
+            <select
+              class="vc-template-builder-lambda-field"
+              value={step.lambda.propertyPath[0] ?? "name"}
+              onchange={(e) => {
+                const v = (e.currentTarget as HTMLSelectElement).value;
+                updateLambda(i + 1, { propertyPath: v === "property" ? ["property", ""] : [v] });
+              }}
+            >
+              {#each noteMemberOptions() as opt (opt)}
+                <option value={opt}>{opt}</option>
+              {/each}
+            </select>
+
+            {#if step.lambda.propertyPath[0] === "property"}
+              {#if dynamicPropertyKeys.length > 0}
+                <select
+                  class="vc-template-builder-lambda-key"
+                  value={step.lambda.propertyPath[1] ?? ""}
+                  onchange={(e) => {
+                    const k = (e.currentTarget as HTMLSelectElement).value;
+                    updateLambda(i + 1, { propertyPath: ["property", k] });
+                  }}
+                >
+                  <option value="" disabled>key…</option>
+                  {#each dynamicPropertyKeys as k (k)}
+                    <option value={k}>{k}</option>
+                  {/each}
+                </select>
+              {:else}
+                <input
+                  class="vc-template-builder-lambda-key"
+                  type="text"
+                  placeholder="key"
+                  value={step.lambda.propertyPath[1] ?? ""}
+                  oninput={(e) => {
+                    const k = (e.currentTarget as HTMLInputElement).value;
+                    updateLambda(i + 1, { propertyPath: ["property", k] });
+                  }}
+                />
+              {/if}
+            {/if}
+
+            <select
+              class="vc-template-builder-lambda-op"
+              value={step.lambda.op}
+              onchange={(e) => {
+                updateLambda(i + 1, { op: (e.currentTarget as HTMLSelectElement).value as BinaryOp });
+              }}
+            >
+              {#each operators as op (op)}
+                <option value={op}>{op}</option>
+              {/each}
+            </select>
+
+            <select
+              class="vc-template-builder-lambda-kind"
+              value={step.lambda.literalKind}
+              onchange={(e) => {
+                updateLambda(i + 1, {
+                  literalKind: (e.currentTarget as HTMLSelectElement).value as LiteralKind,
+                });
+              }}
+            >
+              {#each literalKinds as k (k)}
+                <option value={k}>{k}</option>
+              {/each}
+            </select>
+
+            {#if step.lambda.literalKind === "boolean"}
+              <select
+                class="vc-template-builder-lambda-literal"
+                value={step.lambda.literal === "true" ? "true" : "false"}
+                onchange={(e) => {
+                  updateLambda(i + 1, { literal: (e.currentTarget as HTMLSelectElement).value });
+                }}
+              >
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+            {:else}
+              <input
+                class="vc-template-builder-lambda-literal"
+                type={step.lambda.literalKind === "number" ? "number" : "text"}
+                placeholder={step.lambda.literalKind === "string" ? "value" : "0"}
+                value={step.lambda.literal}
+                oninput={(e) => {
+                  updateLambda(i + 1, { literal: (e.currentTarget as HTMLInputElement).value });
+                }}
+              />
+            {/if}
+          </div>
+        {/if}
+      {/each}
+
+      {#if availableMembersAt(chain.steps.length + 1).length > 0}
+        <span class="vc-template-builder-dot">·</span>
+        <select
+          class="vc-template-builder-step"
+          bind:this={firstSelectEl}
+          value=""
+          onchange={(e) => pickMember(chain.steps.length + 1, e)}
+        >
+          <option value="" disabled>add step…</option>
+          {#each availableMembersAt(chain.steps.length + 1) as m (m.name)}
+            <option value={m.name}>{labelFor(m)}</option>
+          {/each}
+        </select>
+      {:else}
+        <span class="vc-template-builder-dead-end">(no further members)</span>
+      {/if}
+    </div>
+
+    <div class="vc-template-builder-preview">
+      {wrapAsTemplate(chain)}
+    </div>
+
+    <div class="vc-template-builder-actions">
+      <button
+        type="button"
+        class="vc-template-builder-cancel"
+        onclick={onCancel}
+      >Cancel</button>
+      <button
+        type="button"
+        class="vc-template-builder-insert"
+        onclick={() => onInsert(renderExpression(chain))}
+      >Insert</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-template-builder-backdrop {
+    z-index: 200;
+  }
+
+  .vc-template-builder {
+    position: fixed;
+    top: 15%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 560px;
+    max-width: calc(100vw - 32px);
+    max-height: 70vh;
+    z-index: 201;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    overflow: auto;
+  }
+
+  .vc-template-builder-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .vc-template-builder-hint {
+    margin: 0;
+    font-size: 12px;
+    color: var(--color-text-muted);
+  }
+
+  .vc-template-builder-chain {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 10px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+  }
+
+  .vc-template-builder-root {
+    color: var(--color-accent);
+    font-weight: 600;
+  }
+
+  .vc-template-builder-dot {
+    color: var(--color-text-muted);
+    user-select: none;
+  }
+
+  .vc-template-builder-step-label {
+    color: var(--color-text);
+  }
+
+  .vc-template-builder-step,
+  .vc-template-builder-lambda-field,
+  .vc-template-builder-lambda-key,
+  .vc-template-builder-lambda-op,
+  .vc-template-builder-lambda-kind,
+  .vc-template-builder-lambda-literal {
+    height: 26px;
+    padding: 0 6px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    font: inherit;
+    outline: none;
+  }
+
+  .vc-template-builder-step:focus,
+  .vc-template-builder-lambda-field:focus,
+  .vc-template-builder-lambda-key:focus,
+  .vc-template-builder-lambda-op:focus,
+  .vc-template-builder-lambda-kind:focus,
+  .vc-template-builder-lambda-literal:focus {
+    border-color: var(--color-accent);
+  }
+
+  .vc-template-builder-lambda {
+    display: flex;
+    flex-basis: 100%;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    margin-left: 20px;
+    padding: 6px 8px;
+    background: var(--color-accent-bg);
+    border-radius: 4px;
+  }
+
+  .vc-template-builder-lambda-param {
+    color: var(--color-text-muted);
+    user-select: none;
+  }
+
+  .vc-template-builder-dead-end {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .vc-template-builder-preview {
+    padding: 10px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    color: var(--color-text);
+    word-break: break-all;
+  }
+
+  .vc-template-builder-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .vc-template-builder-cancel,
+  .vc-template-builder-insert {
+    font-size: 13px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .vc-template-builder-insert {
+    background: var(--color-accent);
+    color: var(--color-accent-contrast, #fff);
+    border-color: var(--color-accent);
+  }
+</style>

--- a/src/components/Editor/__tests__/editorContextMenu.test.ts
+++ b/src/components/Editor/__tests__/editorContextMenu.test.ts
@@ -1,0 +1,137 @@
+// Unit tests for the CM6 extension that bridges right-clicks in the editor
+// to the VaultCore custom context menu (#301). The extension:
+//   1. Intercepts `contextmenu` events on `view.dom`, prevents the default
+//      OS menu, and invokes the `onOpen` callback with the CM6 view and the
+//      viewport-fixed coordinates.
+//   2. When the click lands outside the current selection, moves the caret
+//      to the clicked position first — so a subsequent Cut/Copy operates on
+//      the word the user right-clicked on, not a stale selection.
+//   3. Inserts a template expression at the current selection, replacing it,
+//      leaving the caret after `}}`.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import {
+  editorContextMenuExtension,
+  insertTemplateExpression,
+} from "../editorContextMenu";
+
+let view: EditorView | null = null;
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+function mount(doc: string, onOpen: (view: EditorView, x: number, y: number) => void): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const state = EditorState.create({
+    doc,
+    extensions: [editorContextMenuExtension(onOpen)],
+  });
+  view = new EditorView({ state, parent });
+  return view;
+}
+
+function fireContextMenu(v: EditorView, x: number, y: number): MouseEvent {
+  const ev = new MouseEvent("contextmenu", {
+    bubbles: true,
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+  });
+  // CM6's domEventHandlers attach to the contentDOM (the editable child).
+  // Dispatching on the outer `.cm-editor` wouldn't reach it because events
+  // only bubble upward.
+  v.contentDOM.dispatchEvent(ev);
+  return ev;
+}
+
+describe("editorContextMenu extension", () => {
+  it("fires onOpen with viewport coords and prevents the native menu", () => {
+    const onOpen = vi.fn();
+    const v = mount("hello world", onOpen);
+    const ev = fireContextMenu(v, 42, 88);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    const [calledView, x, y] = onOpen.mock.calls[0]!;
+    expect(calledView).toBe(v);
+    expect(x).toBe(42);
+    expect(y).toBe(88);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("leaves the existing selection intact when the click is inside it", () => {
+    const onOpen = vi.fn();
+    const v = mount("hello world", onOpen);
+    // Select "hello" (0..5).
+    v.dispatch({ selection: { anchor: 0, head: 5 } });
+    // Mock posAtCoords to return a position inside the selection.
+    const posSpy = vi.spyOn(v, "posAtCoords").mockImplementation(() => 2);
+    fireContextMenu(v, 10, 10);
+    expect(v.state.selection.main.from).toBe(0);
+    expect(v.state.selection.main.to).toBe(5);
+    posSpy.mockRestore();
+  });
+
+  it("moves the caret to the click position when the click is outside the selection", () => {
+    const onOpen = vi.fn();
+    const v = mount("hello world", onOpen);
+    v.dispatch({ selection: { anchor: 0, head: 5 } }); // "hello"
+    const posSpy = vi.spyOn(v, "posAtCoords").mockImplementation(() => 9); // inside "world"
+    fireContextMenu(v, 100, 10);
+    expect(v.state.selection.main.from).toBe(9);
+    expect(v.state.selection.main.to).toBe(9);
+    posSpy.mockRestore();
+  });
+
+  it("leaves an empty-collapsed selection alone when posAtCoords returns null", () => {
+    const onOpen = vi.fn();
+    const v = mount("hello world", onOpen);
+    v.dispatch({ selection: { anchor: 3, head: 3 } });
+    const posSpy = vi.spyOn(v, "posAtCoords").mockImplementation(() => null);
+    fireContextMenu(v, -50, -50);
+    expect(v.state.selection.main.head).toBe(3);
+    posSpy.mockRestore();
+  });
+});
+
+describe("insertTemplateExpression helper", () => {
+  it("inserts `{{ expr }}` at a collapsed caret and leaves the caret after `}}`", () => {
+    const v = mount("prefix suffix", vi.fn());
+    v.dispatch({ selection: { anchor: 7, head: 7 } }); // between "prefix " and "suffix"
+    insertTemplateExpression(v, "vault.name");
+    expect(v.state.doc.toString()).toBe("prefix {{ vault.name }}suffix");
+    expect(v.state.selection.main.head).toBe("prefix {{ vault.name }}".length);
+  });
+
+  it("replaces an existing selection with the template expression", () => {
+    const v = mount("hello world", vi.fn());
+    v.dispatch({ selection: { anchor: 0, head: 5 } }); // select "hello"
+    insertTemplateExpression(v, "vault.name");
+    expect(v.state.doc.toString()).toBe("{{ vault.name }} world");
+    expect(v.state.selection.main.head).toBe("{{ vault.name }}".length);
+  });
+
+  it("tags the insert with userEvent `input.template` so undo groups correctly", () => {
+    const seen: string[] = [];
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    view = new EditorView({
+      state: EditorState.create({
+        doc: "",
+        extensions: [
+          EditorView.updateListener.of((update) => {
+            for (const tr of update.transactions) {
+              if (tr.isUserEvent("input.template")) seen.push("input.template");
+            }
+          }),
+        ],
+      }),
+      parent,
+    });
+    insertTemplateExpression(view, "vault.name");
+    expect(seen).toEqual(["input.template"]);
+  });
+});

--- a/src/components/Editor/editorContextMenu.ts
+++ b/src/components/Editor/editorContextMenu.ts
@@ -1,0 +1,61 @@
+// CodeMirror 6 bridge between right-clicks in the editor and the VaultCore
+// custom context menu (#301). The extension:
+//
+//   1. Listens for `contextmenu` events on `view.dom` and forwards them to
+//      a Svelte-side callback with viewport-fixed coordinates. The native
+//      browser menu is suppressed via `preventDefault`.
+//
+//   2. If the click position lies outside the current CM6 selection, moves
+//      the caret to the clicked position before the menu opens. Without
+//      this, right-clicking on a different word and picking `Cut` would
+//      act on the stale selection — surprising.
+//
+// The extension stays a pure CM6 module so it can be unit-tested with a
+// minimal EditorView and carries no dependency on Svelte stores.
+//
+// `insertTemplateExpression` is the commit helper the modal calls with the
+// generated DSL string. It replaces the current selection with `{{ expr }}`
+// and leaves the caret after the closing `}}` — tagged with
+// `userEvent: "input.template"` so undo groups the insert correctly.
+
+import { EditorView } from "@codemirror/view";
+import type { Extension } from "@codemirror/state";
+
+export type ContextMenuOpen = (
+  view: EditorView,
+  x: number,
+  y: number,
+) => void;
+
+export function editorContextMenuExtension(onOpen: ContextMenuOpen): Extension {
+  return EditorView.domEventHandlers({
+    contextmenu: (event, view) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const clickPos = view.posAtCoords(
+        { x: event.clientX, y: event.clientY },
+        false,
+      );
+      if (clickPos !== null) {
+        const sel = view.state.selection.main;
+        const inside = clickPos >= sel.from && clickPos <= sel.to;
+        if (!inside) {
+          view.dispatch({ selection: { anchor: clickPos } });
+        }
+      }
+      onOpen(view, event.clientX, event.clientY);
+      return true;
+    },
+  });
+}
+
+export function insertTemplateExpression(view: EditorView, dsl: string): void {
+  const sel = view.state.selection.main;
+  const insert = `{{ ${dsl} }}`;
+  view.dispatch({
+    changes: { from: sel.from, to: sel.to, insert },
+    selection: { anchor: sel.from + insert.length },
+    userEvent: "input.template",
+  });
+}

--- a/src/components/Editor/extensions.ts
+++ b/src/components/Editor/extensions.ts
@@ -39,6 +39,7 @@ import { activeViewStore } from "../../store/activeViewStore";
 import { imageAttachmentExtension } from "./imageAttachment";
 import { inlineHtmlPlugin } from "./inlineHtml";
 import { tablePlugin } from "./tablePlugin";
+import { editorContextMenuExtension, type ContextMenuOpen } from "./editorContextMenu";
 
 // Debounce sidebar panel re-renders during typing: rapid docChanged updates
 // otherwise flood PropertiesPanel and OutgoingLinksPanel with re-parses on
@@ -58,6 +59,7 @@ const docVersionBumpListener = EditorView.updateListener.of((update) => {
 export function buildExtensions(
   onSave: (text: string) => void,
   paneId?: PaneId,
+  onContextMenu?: ContextMenuOpen,
 ): Extension[] {
   const extensions: Extension[] = [
     history(),
@@ -104,6 +106,10 @@ export function buildExtensions(
 
   if (paneId !== undefined) {
     extensions.push(countsPlugin(paneId));
+  }
+
+  if (onContextMenu) {
+    extensions.push(editorContextMenuExtension(onContextMenu));
   }
 
   return extensions;

--- a/src/lib/__tests__/templateExpressionBuilder.test.ts
+++ b/src/lib/__tests__/templateExpressionBuilder.test.ts
@@ -1,0 +1,234 @@
+// Unit tests for the pure expression-builder library used by the visual
+// query builder (#301). The builder produces DSL strings like
+// `vault.notes.where(n => n.property.tags == "x").count()` from a structured
+// chain of steps. Tests pin both the rendered output and round-trip through
+// the existing `parse()` evaluator so the builder can never emit a string
+// that the live-preview engine can't parse.
+
+import { describe, it, expect } from "vitest";
+import {
+  emptyChain,
+  addStep,
+  setStepLambda,
+  removeStepsFrom,
+  chainTypeAt,
+  renderExpression,
+  wrapAsTemplate,
+} from "../templateExpressionBuilder";
+import { parse } from "../templateExpression";
+
+function assertParses(src: string): void {
+  expect(() => parse(src)).not.toThrow();
+}
+
+describe("templateExpressionBuilder — empty / root", () => {
+  it("empty chain renders as just the root scope name", () => {
+    const c = emptyChain();
+    expect(renderExpression(c)).toBe("vault");
+  });
+
+  it("wraps as `{{ vault }}`", () => {
+    expect(wrapAsTemplate(emptyChain())).toBe("{{ vault }}");
+  });
+
+  it("root type is Vault", () => {
+    expect(chainTypeAt(emptyChain(), 0)).toBe("Vault");
+  });
+});
+
+describe("templateExpressionBuilder — property chains", () => {
+  it("vault.name", () => {
+    const c = addStep(emptyChain(), { kind: "property", name: "name" });
+    expect(renderExpression(c)).toBe("vault.name");
+    assertParses(renderExpression(c));
+    expect(chainTypeAt(c, 1)).toBe("string");
+  });
+
+  it("vault.notes is a Collection<Note>", () => {
+    const c = addStep(emptyChain(), { kind: "property", name: "notes" });
+    expect(chainTypeAt(c, 1)).toBe("Collection<Note>");
+  });
+
+  it("vault.stats.noteCount", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "stats" });
+    c = addStep(c, { kind: "property", name: "noteCount" });
+    expect(renderExpression(c)).toBe("vault.stats.noteCount");
+    assertParses(renderExpression(c));
+  });
+});
+
+describe("templateExpressionBuilder — method chains without lambda", () => {
+  it("vault.notes.count()", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "count" });
+    expect(renderExpression(c)).toBe("vault.notes.count()");
+    assertParses(renderExpression(c));
+  });
+
+  it("vault.notes.first()", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "first" });
+    expect(renderExpression(c)).toBe("vault.notes.first()");
+    assertParses(renderExpression(c));
+    // first() on Collection<Note> yields Note — user can keep chaining
+    expect(chainTypeAt(c, 2)).toBe("Note");
+  });
+
+  it("allows further chaining after first()", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "first" });
+    c = addStep(c, { kind: "property", name: "title" });
+    expect(renderExpression(c)).toBe("vault.notes.first().title");
+    assertParses(renderExpression(c));
+  });
+});
+
+describe("templateExpressionBuilder — method chains with lambda", () => {
+  it("vault.notes.where(n => n.name == \"todo\")", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "where" });
+    c = setStepLambda(c, 2, {
+      propertyPath: ["name"],
+      op: "==",
+      literal: "todo",
+      literalKind: "string",
+    });
+    expect(renderExpression(c)).toBe('vault.notes.where(n => n.name == "todo")');
+    assertParses(renderExpression(c));
+  });
+
+  it("chains another method after a lambda-taking method", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "where" });
+    c = setStepLambda(c, 2, {
+      propertyPath: ["name"],
+      op: "==",
+      literal: "todo",
+      literalKind: "string",
+    });
+    c = addStep(c, { kind: "method", name: "count" });
+    expect(renderExpression(c)).toBe(
+      'vault.notes.where(n => n.name == "todo").count()',
+    );
+    assertParses(renderExpression(c));
+  });
+
+  it("supports numeric literals without quotes", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "tags" });
+    c = addStep(c, { kind: "method", name: "where" });
+    c = setStepLambda(c, 2, {
+      propertyPath: ["count"],
+      op: ">",
+      literal: "5",
+      literalKind: "number",
+    });
+    expect(renderExpression(c)).toBe("vault.tags.where(t => t.count > 5)");
+    assertParses(renderExpression(c));
+  });
+
+  it("supports boolean literals", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "where" });
+    c = setStepLambda(c, 2, {
+      propertyPath: ["property", "published"],
+      op: "==",
+      literal: "true",
+      literalKind: "boolean",
+    });
+    expect(renderExpression(c)).toBe(
+      "vault.notes.where(n => n.property.published == true)",
+    );
+    assertParses(renderExpression(c));
+  });
+
+  it("reaches nested frontmatter via property.<key>", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "where" });
+    c = setStepLambda(c, 2, {
+      propertyPath: ["property", "tags"],
+      op: "==",
+      literal: "x",
+      literalKind: "string",
+    });
+    expect(renderExpression(c)).toBe(
+      'vault.notes.where(n => n.property.tags == "x")',
+    );
+    assertParses(renderExpression(c));
+  });
+});
+
+describe("templateExpressionBuilder — string escaping", () => {
+  it("escapes double quotes and backslashes in string literals", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "where" });
+    c = setStepLambda(c, 2, {
+      propertyPath: ["name"],
+      op: "==",
+      literal: 'has "quotes" and \\ slashes',
+      literalKind: "string",
+    });
+    const out = renderExpression(c);
+    expect(out).toBe(
+      'vault.notes.where(n => n.name == "has \\"quotes\\" and \\\\ slashes")',
+    );
+    // Must still parse — round-trip through the evaluator.
+    assertParses(out);
+  });
+});
+
+describe("templateExpressionBuilder — mutations", () => {
+  it("removeStepsFrom truncates the chain at the given index", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "where" });
+    c = addStep(c, { kind: "method", name: "count" });
+    const truncated = removeStepsFrom(c, 2);
+    expect(renderExpression(truncated)).toBe("vault.notes");
+  });
+
+  it("removeStepsFrom(0) collapses to bare root", () => {
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    const bare = removeStepsFrom(c, 1);
+    expect(renderExpression(bare)).toBe("vault");
+  });
+
+  it("chainTypeAt returns null when walking past a known type", () => {
+    // toArray returns `any`, which is an untyped dead-end — the builder
+    // should expose this so the UI can show "no further members".
+    let c = emptyChain();
+    c = addStep(c, { kind: "property", name: "notes" });
+    c = addStep(c, { kind: "method", name: "toArray" });
+    expect(chainTypeAt(c, 2)).toBe("any");
+  });
+});
+
+describe("templateExpressionBuilder — operator surface", () => {
+  const ops = ["==", "!=", ">", "<", ">=", "<="] as const;
+  for (const op of ops) {
+    it(`renders the ${op} operator`, () => {
+      let c = emptyChain();
+      c = addStep(c, { kind: "property", name: "notes" });
+      c = addStep(c, { kind: "method", name: "where" });
+      c = setStepLambda(c, 2, {
+        propertyPath: ["name"],
+        op,
+        literal: "x",
+        literalKind: "string",
+      });
+      const expected = `vault.notes.where(n => n.name ${op} "x")`;
+      expect(renderExpression(c)).toBe(expected);
+      assertParses(expected);
+    });
+  }
+});

--- a/src/lib/templateExpressionBuilder.ts
+++ b/src/lib/templateExpressionBuilder.ts
@@ -1,0 +1,166 @@
+// Pure, DOM-free library that powers the visual template-expression builder
+// (#301). A `BuilderChain` is a root scope followed by an ordered list of
+// steps; each step references a member name from `vaultApiDescriptor.ts`.
+// Method steps that take a lambda carry an additional `lambda` condition
+// which renders as `x => x.<propertyPath> <op> <literal>`.
+//
+// `renderExpression` produces a string that the existing
+// `templateExpression.parse()` evaluator accepts — the round-trip is pinned
+// by the test suite so the builder can never emit a shape the live-preview
+// engine rejects.
+
+import {
+  ROOT_SCOPE,
+  membersOf,
+  collectionElementType,
+  type TypeRef,
+} from "./vaultApiDescriptor";
+
+export type BinaryOp = "==" | "!=" | ">" | "<" | ">=" | "<=";
+export type LiteralKind = "string" | "number" | "boolean";
+
+export interface BuilderLambda {
+  /** Path traversed from the lambda parameter — e.g. `["property", "tags"]` for `n.property.tags`. */
+  propertyPath: string[];
+  op: BinaryOp;
+  /** Raw literal value as typed by the user; `renderExpression` quotes it based on `literalKind`. */
+  literal: string;
+  literalKind: LiteralKind;
+}
+
+export interface BuilderStep {
+  kind: "property" | "method";
+  name: string;
+  lambda?: BuilderLambda;
+}
+
+export interface BuilderChain {
+  rootName: string;
+  rootType: TypeRef;
+  steps: BuilderStep[];
+}
+
+function rootScope(): { name: string; type: TypeRef } {
+  const root = ROOT_SCOPE[0];
+  if (!root) {
+    throw new Error("vaultApiDescriptor.ROOT_SCOPE is empty");
+  }
+  return { name: root.name, type: root.returns };
+}
+
+export function emptyChain(): BuilderChain {
+  const root = rootScope();
+  return { rootName: root.name, rootType: root.type, steps: [] };
+}
+
+export function addStep(chain: BuilderChain, step: BuilderStep): BuilderChain {
+  return { ...chain, steps: [...chain.steps, step] };
+}
+
+export function setStepLambda(
+  chain: BuilderChain,
+  stepIndex: number,
+  lambda: BuilderLambda,
+): BuilderChain {
+  // stepIndex is 1-based (index 0 is the root); steps[] is 0-based, so we
+  // translate here to match the test-facing API.
+  const internal = stepIndex - 1;
+  const next = chain.steps.slice();
+  const existing = next[internal];
+  if (!existing) throw new Error(`setStepLambda: no step at ${stepIndex}`);
+  next[internal] = { ...existing, lambda };
+  return { ...chain, steps: next };
+}
+
+/**
+ * Truncate the chain at the given index in the *full* chain. Index 0 is the
+ * root, 1 is the first step, etc. — so `removeStepsFrom(chain, 1)` collapses
+ * to the bare root, and `removeStepsFrom(chain, 2)` keeps the root plus one
+ * step.
+ */
+export function removeStepsFrom(
+  chain: BuilderChain,
+  stepIndex: number,
+): BuilderChain {
+  const keep = Math.max(0, stepIndex - 1);
+  return { ...chain, steps: chain.steps.slice(0, keep) };
+}
+
+/**
+ * Returns the current type at position `stepIndex`, where 0 is the root and
+ * subsequent indices walk member types through the descriptor. Collection
+ * methods with return type `T` expand via `collectionElementType`. Returns
+ * `null` if the chain references an unknown member.
+ */
+export function chainTypeAt(chain: BuilderChain, stepIndex: number): TypeRef | null {
+  let current: TypeRef = chain.rootType;
+  for (let i = 0; i < stepIndex; i++) {
+    const step = chain.steps[i];
+    if (!step) return current;
+    const members = membersOf(current);
+    const match = members.find((m) => m.name === step.name);
+    if (!match) return null;
+    current = match.returns;
+    // Lambda-taking methods that return `Collection<T>` — `membersOf`
+    // already substitutes T when the receiver is a Collection, so `current`
+    // is already the concrete element type for e.g. `first()` on `Collection<Note>`.
+    void collectionElementType;
+  }
+  return current;
+}
+
+function quoteString(s: string): string {
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function renderLiteral(lit: BuilderLambda): string {
+  switch (lit.literalKind) {
+    case "string":
+      return quoteString(lit.literal);
+    case "number":
+      return lit.literal;
+    case "boolean":
+      return lit.literal === "true" ? "true" : "false";
+  }
+}
+
+/**
+ * The parameter name used for the lambda in the rendered DSL. Varies by the
+ * element type so the output matches conventional naming (`n` for notes,
+ * `f` for folders, `t` for tags). Falls back to `x` for anything else.
+ */
+function lambdaParamName(elementType: TypeRef): string {
+  if (elementType === "Note") return "n";
+  if (elementType === "Folder") return "f";
+  if (elementType === "Tag") return "t";
+  return "x";
+}
+
+function renderStep(step: BuilderStep, elementType: TypeRef): string {
+  if (step.kind === "property") return step.name;
+  // method
+  if (!step.lambda) return `${step.name}()`;
+  const param = lambdaParamName(elementType);
+  const path = step.lambda.propertyPath.length > 0
+    ? `.${step.lambda.propertyPath.join(".")}`
+    : "";
+  return `${step.name}(${param} => ${param}${path} ${step.lambda.op} ${renderLiteral(step.lambda)})`;
+}
+
+export function renderExpression(chain: BuilderChain): string {
+  let out = chain.rootName;
+  let current: TypeRef = chain.rootType;
+  for (const step of chain.steps) {
+    // Element type of the *current* receiver, used to name the lambda param.
+    const element = collectionElementType(current) ?? current;
+    out += `.${renderStep(step, element)}`;
+    const members = membersOf(current);
+    const match = members.find((m) => m.name === step.name);
+    current = match ? match.returns : current;
+  }
+  return out;
+}
+
+export function wrapAsTemplate(chain: BuilderChain): string {
+  return `{{ ${renderExpression(chain)} }}`;
+}


### PR DESCRIPTION
Closes #301.

## Summary

The editor now owns its right-click menu instead of surfacing the OS default. The menu keeps the standard clipboard actions (Cut / Copy / Paste / Select All) and adds a top entry "Insert template expression…" that opens a no-code builder for the `{{ … }}` DSL. Users pick a root scope, drill into members (driven entirely by `vaultApiDescriptor.ts`), configure lambda conditions, and the live preview shows the expression the evaluator will receive. Confirming inserts `{{ expr }}` at the caret; cancelling leaves the document untouched.

## Design

- **No new primitives.** Menu reuses the shared `ContextMenu.svelte` (same component the file tree and bookmarks panel use). Modal mirrors `UrlInputModal.svelte` — fixed-position `vc-modal-surface` on a `vc-modal-scrim`, Escape cancels. CSS is CSS-vars only (`--color-surface`, `--color-border`, `--color-accent`, …), no new theme tokens.
- **Pure CM6 bridge.** `editorContextMenu.ts` is a small `domEventHandlers` extension that intercepts `contextmenu`, moves the caret if the click is outside the current selection (otherwise Cut/Copy would act on a stale range), and forwards the event to a Svelte-side callback. It also exports `insertTemplateExpression` which commits `{{ expr }}` tagged with `userEvent: "input.template"` so undo groups correctly.
- **Pure builder library.** `templateExpressionBuilder.ts` is DOM-free and fully unit-tested. It models the builder state (root + ordered steps + optional lambda condition) and renders it to a DSL string. The test suite pins round-trip parseability through the existing `templateExpression.parse()` evaluator so the builder can never emit a shape the live-preview engine rejects.
- **Svelte 5 pitfall respected.** The active `EditorView` is stored in a plain `let` inside `EditorPane.svelte` — not `$state` — because Svelte's reactive proxy would break CM6's internal field access (same rule that already applies to `viewMap`).
- **Interaction with global suppression.** `VaultLayout.svelte`'s capture-phase `contextmenu` handler already allows the native menu through on contenteditable elements. The new CM6 extension runs on the bubble phase and then calls `preventDefault`/`stopPropagation`, so the native menu never surfaces inside the editor and the rest of the app is unaffected.

## Scope

Only the builder surface explicitly asked for by the ticket:
- Root scope = `ROOT_SCOPE` from the descriptor (currently `vault`).
- Chain of property / method steps with `Collection<T>` method chaining and `T` substitution handled by the existing descriptor helpers.
- Lambda conditions: single `x => x.<path> <op> <literal>` with `== / != / > / < / >= / <=` and `string / number / boolean` literal kinds. Frontmatter keys from the active doc feed `n.property.<key>`.

Out of scope per the ticket: editing existing expressions in-place, arbitrary JS lambda bodies, method-call lambdas like `.contains(...)` (can be a follow-up ticket), keyboard shortcut for the menu entry, multi-selection.

## Test plan

- [x] `src/lib/__tests__/templateExpressionBuilder.test.ts` — 24 tests covering empty/root chain, property chains, method chains without lambda, chained lambdas, operator surface (6 ops), string-literal escaping, chain mutations, dead-end type traversal. Every rendered string is also round-tripped through `parse()` so no shape can bypass the evaluator.
- [x] `src/components/Editor/__tests__/editorContextMenu.test.ts` — 7 tests mounting a real `EditorView` with the extension: asserts `onOpen` fires with viewport coords + `preventDefault`, selection is preserved when the click lands inside it, caret moves on outside clicks, `insertTemplateExpression` inserts `{{ expr }}` at collapsed carets and over existing selections, and tags the change with `userEvent: "input.template"`.
- [x] `e2e/specs/editor-context-menu.spec.ts` — WDIO spec that opens a vault, right-clicks in the editor, verifies the custom menu's items and order (custom entry at the top), walks the builder for `vault.notes.count()`, confirms, and asserts the insertion; a second flow covers Cancel leaving the doc unchanged.
- [x] `svelte-check` — 0 errors, 3 pre-existing warnings (unrelated).
- [x] `vite build` — clean.
- [ ] `pnpm test:e2e:build` — needs a release binary build; run in CI / before merge.

## Process notes

Followed the ticket's own workflow:
1. Plan drafted against the concrete repo layout (existing `ContextMenu` primitive, `VaultLayout` suppression, `UrlInputModal` modal pattern, descriptor helpers).
2. Plan reviewed by the `Plan` subagent — blind-spot list addressed before writing code (right-click caret-move, string-literal quoting, non-reactive `EditorView` ref, read-only tabs left untouched, menu order per ticket, round-trip test through the evaluator). Deferred items (accessibility focus-trap, i18n, disabled Cut/Copy/Paste states) match existing-primitive parity and can be their own ticket.
3. TDD: failing unit + e2e tests committed alongside the implementation.