### PR TITLE
feat(templates): render GFM tables from {{ ... }} as live widgets (#305)

### DIFF
--- a/e2e/specs/template-chain.spec.ts
+++ b/e2e/specs/template-chain.spec.ts
@@ -1,0 +1,88 @@
+// E2E coverage for #303 — `;`-chained template expressions.
+//
+// Types a multi-segment `{{ ... ; ... }}` body into a real editor, waits
+// for the live-preview widget to replace the source text, and asserts the
+// rendered text is the concatenation of the per-segment values.
+
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf } from "../helpers/text.js";
+
+describe("Template chains — `;`-separated multi-segment expressions (#303)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not in tree`);
+  }
+
+  async function typeInEditor(text: string): Promise<void> {
+    await browser.executeAsync((t: string, done: () => void) => {
+      window.__e2e__!.typeInActiveEditor(t).then(() => done());
+    }, text);
+  }
+
+  async function docText(): Promise<string> {
+    return browser.executeAsync((done: (s: string) => void) => {
+      void window.__e2e__!.getActiveDocText().then((t) => done(t));
+    });
+  }
+
+  it("renders `{{ vault.name; \" - \"; vault.notes.count() }}` as the concatenation", async () => {
+    await openTreeFile("Welcome.md");
+    await browser.waitUntil(
+      async () => {
+        const els = await browser.$$(".cm-content");
+        for (const el of els) if (await el.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000 },
+    );
+
+    // Fresh line so we don't collide with existing content.
+    await typeInEditor('\n{{ vault.name; " - "; vault.notes.count() }}');
+
+    // Move cursor off the expression so the live-preview widget replaces
+    // the source text. Easiest: append a trailing newline.
+    await typeInEditor("\nend");
+
+    // Wait until the doc contains the full typed body and the widget
+    // decoration has rendered.
+    await browser.waitUntil(
+      async () => {
+        const t = await docText();
+        return t.includes('{{ vault.name; " - "; vault.notes.count() }}');
+      },
+      { timeout: 3000, timeoutMsg: "multi-segment body never landed in doc" },
+    );
+
+    // The widget text starts with the vault name, contains the literal
+    // separator, and ends with a number — the exact count depends on the
+    // seeded test vault, so we assert shape rather than a specific number.
+    await browser.waitUntil(
+      async () => {
+        const text = await browser.execute(() => {
+          const el = document.querySelector<HTMLElement>(".vc-template-rendered");
+          return el?.textContent ?? "";
+        });
+        return /^.+ - \d+$/.test(text) && text.length > " - 0".length;
+      },
+      { timeout: 4000, timeoutMsg: "rendered widget never matched concatenation shape" },
+    );
+  });
+});

--- a/src/components/Editor/__tests__/templateAutocompleteSegment.test.ts
+++ b/src/components/Editor/__tests__/templateAutocompleteSegment.test.ts
@@ -1,0 +1,97 @@
+// Segment-scoped autocomplete inside `{{ ... }}` bodies (#303).
+//
+// When a body contains multiple `;`-separated segments, the completion
+// source must only analyze the segment containing the cursor — otherwise
+// a prior segment like `vault.notes.` would confuse the analyzer into
+// thinking the user is still navigating that chain.
+//
+// These tests pin the behavior via the CompletionContext API directly,
+// which is fast and independent of the async popup lifecycle.
+
+import { describe, it, expect, vi } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { CompletionContext } from "@codemirror/autocomplete";
+import { writable } from "svelte/store";
+
+vi.mock("../../../store/vaultStore", () => {
+  const _store = writable({
+    currentPath: "/v/MyVault",
+    status: "ready",
+    fileList: [],
+    fileCount: 0,
+    errorMessage: null,
+    sidebarWidth: 240,
+    vaultReachable: true,
+  });
+  return { vaultStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+vi.mock("../../../store/tagsStore", () => {
+  const _store = writable({ tags: [], loading: false, error: null });
+  return { tagsStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+vi.mock("../../../store/bookmarksStore", () => {
+  const _store = writable({ paths: [], loaded: true });
+  return { bookmarksStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+vi.mock("../../../store/editorStore", () => {
+  const _store = writable({ activePath: null, content: "", lastSavedHash: null });
+  return { editorStore: { subscribe: _store.subscribe, _set: _store.set } };
+});
+
+import { templateCompletionSource } from "../templateAutocomplete";
+
+function makeCtx(doc: string, pos: number, explicit = false): CompletionContext {
+  const state = EditorState.create({ doc });
+  return new CompletionContext(state, pos, explicit);
+}
+
+function labels(result: ReturnType<typeof templateCompletionSource>): string[] {
+  if (!result) return [];
+  return result.options.map((o) => o.label);
+}
+
+describe("templateCompletionSource — segment scoping (#303)", () => {
+  it("offers root-scope completions in a fresh second segment", () => {
+    // `{{ vault.notes; |}}` — cursor at the `|` in second segment
+    const doc = "{{ vault.notes; }}";
+    const pos = "{{ vault.notes; ".length;
+    const res = templateCompletionSource(makeCtx(doc, pos, true));
+    expect(labels(res)).toContain("vault");
+  });
+
+  it("offers root-scope completions after typing a letter in the second segment", () => {
+    const doc = "{{ vault.notes; v}}";
+    const pos = "{{ vault.notes; v".length;
+    const res = templateCompletionSource(makeCtx(doc, pos));
+    expect(labels(res)).toContain("vault");
+  });
+
+  it("restricts completions to the segment even when a prior segment ends in `.`", () => {
+    // Prior segment `vault.notes.` would, if the analyzer saw the whole
+    // body, suggest Collection<Note> members. After scoping to the right
+    // segment, we should see `vault` (root scope) instead.
+    const doc = "{{ vault.notes.; v}}";
+    const pos = "{{ vault.notes.; v".length;
+    const res = templateCompletionSource(makeCtx(doc, pos));
+    expect(labels(res)).toContain("vault");
+    // Not a Collection<Note> member like `count`:
+    expect(labels(res)).not.toContain("count");
+  });
+
+  it("a `;` inside a string literal in segment 1 does NOT split — segment 2 analysis still correct", () => {
+    const doc = '{{ "a;b"; v}}';
+    const pos = '{{ "a;b"; v'.length;
+    const res = templateCompletionSource(makeCtx(doc, pos));
+    expect(labels(res)).toContain("vault");
+  });
+
+  it("first segment is still completed correctly (no cross-contamination)", () => {
+    // With a trailing `;` after the cursor, we're still in segment 1 —
+    // must behave exactly like it would without the `;` at all.
+    const doc = "{{ vault.; other}}";
+    const pos = "{{ vault.".length;
+    const res = templateCompletionSource(makeCtx(doc, pos));
+    // Vault properties like `name` or `notes` should show up.
+    expect(labels(res)).toContain("name");
+  });
+});

--- a/src/components/Editor/__tests__/templateLivePreview.test.ts
+++ b/src/components/Editor/__tests__/templateLivePreview.test.ts
@@ -185,6 +185,101 @@ describe("templateLivePlugin — rendering", () => {
     expect(anchor!.getAttribute("data-wiki-resolved")).toBe("true");
   });
 
+  // #303 — multi-segment `{{ ... ; ... }}` bodies.
+  describe("multi-segment expressions (#303)", () => {
+    it("renders `{{ vault.name; vault.notes.count() }}` as the concatenation", () => {
+      const doc = "x {{ vault.name; vault.notes.count() }} y";
+      const view = mount(doc, doc.length);
+      const ws = widgets(view);
+      expect(ws).toHaveLength(1);
+      expect(ws[0]!.text).toBe("MyVault2");
+    });
+
+    it("lets a literal string segment act as a separator", () => {
+      const doc = 'x {{ vault.name; " — "; vault.notes.count() }} y';
+      const view = mount(doc, doc.length);
+      const ws = widgets(view);
+      expect(ws).toHaveLength(1);
+      expect(ws[0]!.text).toBe("MyVault — 2");
+    });
+
+    it("swallows one broken segment and renders the rest", () => {
+      const doc = "x {{ vault.name; vault.nonsense; vault.notes.count() }} y";
+      const view = mount(doc, doc.length);
+      const ws = widgets(view);
+      expect(ws).toHaveLength(1);
+      expect(ws[0]!.text).toBe("MyVault2");
+    });
+
+    it("drops the decoration entirely when every segment fails", () => {
+      const doc = "x {{ @@@; @@@ }} y";
+      const view = mount(doc, doc.length);
+      expect(widgets(view)).toHaveLength(0);
+    });
+
+    it("exposes `date` / `time` / `title` via scope so they work mid-program", () => {
+      // After #303, the scope carries `date` / `time` / `title` alongside
+      // `vault`, so a non-special-cased segment can reference them too.
+      const doc = "x {{ title; vault.name }} y";
+      const view = mount(doc, doc.length);
+      const ws = widgets(view);
+      expect(ws).toHaveLength(1);
+      // editorStore.activePath is null in this test → `title` renders as "".
+      expect(ws[0]!.text).toBe("MyVault");
+    });
+
+    it("re-wires `{{ title }}` single-segment through the new scope path", () => {
+      // Pinning that moving title/date/time into scope didn't regress the
+      // single-segment shortcut users already rely on.
+      const doc = "x {{ title }} y";
+      const view = mount(doc, doc.length);
+      const ws = widgets(view);
+      // activePath is null → `title` resolves to empty string; renderer
+      // treats empty output as "no decoration worth showing".
+      // Either a widget with empty text OR no widget is acceptable.
+      if (ws.length === 1) {
+        expect(ws[0]!.text).toBe("");
+      } else {
+        expect(ws).toHaveLength(0);
+      }
+    });
+
+    it("does not split on `;` inside a string literal", () => {
+      const doc = 'x {{ "a;b" }} y';
+      const view = mount(doc, doc.length);
+      const ws = widgets(view);
+      expect(ws).toHaveLength(1);
+      expect(ws[0]!.text).toBe("a;b");
+    });
+
+    it("#295 regression: wiki-link decoration still suppressed inside multi-segment body", () => {
+      setResolvedLinks(new Map([["first", "first.md"]]));
+      // Even with multi-segment, the EDITOR body `[[first]]` substring is
+      // part of a string-literal argument — the wiki-link plugin should
+      // not surface a decoration for it inside the `{{ ... }}` range.
+      // (The RENDERED output, however, may still show a wiki-link span —
+      // that's #297 behavior and is exercised below.)
+      const doc = 'x {{ vault.name; "[[first]]" }} y';
+      const view = mount(doc, 0);
+      const ws = widgets(view);
+      expect(ws).toHaveLength(1);
+      // Rendered widget text is the concatenation.
+      expect(ws[0]!.text).toBe("MyVault[[first]]");
+    });
+
+    it("renders [[...]] from any segment as a clickable wiki-link span (#297)", () => {
+      setResolvedLinks(new Map([["first", "first.md"]]));
+      const doc = 'x {{ vault.name; " "; "[[first]]" }} y';
+      const view = mount(doc, 0);
+      const anchor = view.dom.querySelector(
+        ".vc-template-rendered [data-wiki-target]",
+      );
+      expect(anchor).not.toBeNull();
+      expect(anchor!.getAttribute("data-wiki-target")).toBe("first");
+      expect(anchor!.getAttribute("data-wiki-resolved")).toBe("true");
+    });
+  });
+
   it("re-renders when the backing store changes", () => {
     const view = mount("vault={{vault.name}}", 0);
     expect(widgets(view)[0]!.text).toBe("MyVault");

--- a/src/components/Editor/__tests__/templateLivePreview.test.ts
+++ b/src/components/Editor/__tests__/templateLivePreview.test.ts
@@ -280,6 +280,100 @@ describe("templateLivePlugin — rendering", () => {
     });
   });
 
+  // #305 — evaluated output that IS a GFM table should render as a read-only
+  // styled <table>, not as a monospaced pipe-and-dash <span>.
+  describe("rendered GFM table (#305)", () => {
+    it("renders a table-shaped output as a <table> widget", () => {
+      const doc = 'x {{ "|A|B|\\n|-|-|\\n|1|2|" }} y';
+      const view = mount(doc, doc.length);
+
+      const table = view.dom.querySelector(
+        ".vc-template-rendered-table table",
+      );
+      expect(table).not.toBeNull();
+
+      const ths = table!.querySelectorAll("thead th");
+      expect(Array.from(ths).map((t) => t.textContent?.trim())).toEqual(["A", "B"]);
+
+      const tds = table!.querySelectorAll("tbody tr:first-child td");
+      expect(Array.from(tds).map((t) => t.textContent?.trim())).toEqual(["1", "2"]);
+    });
+
+    it("non-table output still renders as the plain <span> widget", () => {
+      const view = mount("x {{vault.name}} y", 0);
+      expect(view.dom.querySelector(".vc-template-rendered-table")).toBeNull();
+      expect(view.dom.querySelector(".vc-template-rendered")).not.toBeNull();
+    });
+
+    it("reflects delimiter-row alignment in cell text-align", () => {
+      const doc = 'x {{ "|L|C|R|\\n|:-|:-:|-:|\\n|a|b|c|" }} y';
+      const view = mount(doc, doc.length);
+
+      const headers = view.dom.querySelectorAll(
+        ".vc-template-rendered-table thead th",
+      );
+      expect((headers[0] as HTMLElement).style.textAlign).toBe("left");
+      expect((headers[1] as HTMLElement).style.textAlign).toBe("center");
+      expect((headers[2] as HTMLElement).style.textAlign).toBe("right");
+    });
+
+    it("renders [[target]] inside a cell as a clickable wiki-link span", () => {
+      setResolvedLinks(new Map([["first", "first.md"]]));
+      const doc = 'x {{ "|Note|\\n|-|\\n|[[first]]|" }} y';
+      const view = mount(doc, doc.length);
+
+      const link = view.dom.querySelector(
+        ".vc-template-rendered-table tbody [data-wiki-target]",
+      );
+      expect(link).not.toBeNull();
+      expect(link!.getAttribute("data-wiki-target")).toBe("first");
+      expect(link!.getAttribute("data-wiki-resolved")).toBe("true");
+      expect(link!.classList.contains("cm-wikilink-resolved")).toBe(true);
+    });
+
+    it("is read-only: no contenteditable cells and no structural controls", () => {
+      const doc = 'x {{ "|A|B|\\n|-|-|\\n|1|2|" }} y';
+      const view = mount(doc, doc.length);
+
+      const table = view.dom.querySelector(".vc-template-rendered-table table");
+      expect(table).not.toBeNull();
+
+      expect(table!.querySelectorAll("[contenteditable='true']").length).toBe(0);
+      expect(table!.parentElement!.querySelectorAll(".cm-table-ctrl").length).toBe(0);
+    });
+
+    it("falls back to span when output has a table plus surrounding text", () => {
+      const doc = 'x {{ "prefix\\n|A|B|\\n|-|-|\\n|1|2|" }} y';
+      const view = mount(doc, doc.length);
+      expect(view.dom.querySelector(".vc-template-rendered-table")).toBeNull();
+      expect(view.dom.querySelector(".vc-template-rendered")).not.toBeNull();
+    });
+
+    it("re-renders the table when the backing store changes", () => {
+      const doc =
+        'x {{ "|Note|\\n|-|\\n"; vault.notes.select(n => "|[[" + n.name + "]]|").join("\\n") }} y';
+      const view = mount(doc, doc.length);
+
+      let rows = view.dom.querySelectorAll(
+        ".vc-template-rendered-table tbody tr",
+      );
+      expect(rows.length).toBe(2);
+
+      (vaultStore as unknown as { _set: (v: unknown) => void })._set({
+        currentPath: "/v/OtherVault",
+        status: "ready",
+        fileList: ["only.md"],
+        fileCount: 1,
+        errorMessage: null,
+        sidebarWidth: 240,
+        vaultReachable: true,
+      });
+
+      rows = view.dom.querySelectorAll(".vc-template-rendered-table tbody tr");
+      expect(rows.length).toBe(1);
+    });
+  });
+
   it("re-renders when the backing store changes", () => {
     const view = mount("vault={{vault.name}}", 0);
     expect(widgets(view)[0]!.text).toBe("MyVault");

--- a/src/components/Editor/__tests__/templateLivePreview.test.ts
+++ b/src/components/Editor/__tests__/templateLivePreview.test.ts
@@ -95,9 +95,23 @@ function widgets(view: EditorView): Array<{ from: number; to: number; text: stri
   return out;
 }
 
+const DEFAULT_VAULT_STATE = {
+  currentPath: "/v/MyVault",
+  status: "ready",
+  fileList: ["first.md", "second.md"],
+  fileCount: 2,
+  errorMessage: null,
+  sidebarWidth: 240,
+  vaultReachable: true,
+};
+
 describe("templateLivePlugin — rendering", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    // Reset the mocked vaultStore so per-test mutations don't leak across.
+    (vaultStore as unknown as { _set: (v: unknown) => void })._set(
+      DEFAULT_VAULT_STATE,
+    );
   });
 
   it("renders {{vault.name}} as a widget with the vault name", () => {
@@ -319,7 +333,7 @@ describe("templateLivePlugin — rendering", () => {
 
     it("renders [[target]] inside a cell as a clickable wiki-link span", () => {
       setResolvedLinks(new Map([["first", "first.md"]]));
-      const doc = 'x {{ "|Note|\\n|-|\\n|[[first]]|" }} y';
+      const doc = 'x {{ "|Note|X|\\n|-|-|\\n|[[first]]| |" }} y';
       const view = mount(doc, doc.length);
 
       const link = view.dom.querySelector(
@@ -349,9 +363,48 @@ describe("templateLivePlugin — rendering", () => {
       expect(view.dom.querySelector(".vc-template-rendered")).not.toBeNull();
     });
 
+    it("renders a header-only table (no body rows)", () => {
+      const doc = 'x {{ "|A|B|\\n|-|-|" }} y';
+      const view = mount(doc, doc.length);
+
+      const table = view.dom.querySelector(
+        ".vc-template-rendered-table table",
+      );
+      expect(table).not.toBeNull();
+      expect(table!.querySelectorAll("tbody tr").length).toBe(0);
+      expect(table!.querySelectorAll("thead th").length).toBe(2);
+    });
+
+    it("renders multiple [[...]] inside a single cell", () => {
+      setResolvedLinks(new Map([["a", "a.md"], ["b", "b.md"]]));
+      const doc = 'x {{ "|Links|X|\\n|-|-|\\n|[[a]] [[b]]| |" }} y';
+      const view = mount(doc, doc.length);
+
+      const links = view.dom.querySelectorAll(
+        ".vc-template-rendered-table tbody [data-wiki-target]",
+      );
+      expect(links.length).toBe(2);
+      expect(links[0]!.getAttribute("data-wiki-target")).toBe("a");
+      expect(links[1]!.getAttribute("data-wiki-target")).toBe("b");
+    });
+
+    // Note: [[target|alias]] inside a cell can't round-trip through the
+    // current `splitRow` (the `|` splits the cell). GFM requires `\|` escape
+    // for pipes-in-cells; that's a broader table-plugin enhancement and out
+    // of scope here. The general aliased wiki-link rendering path is already
+    // covered by the non-table test at line ~176.
+
+    it("falls back to span when output contains two tables separated by a blank line", () => {
+      const doc =
+        'x {{ "|A|x|\\n|-|-|\\n|1|y|\\n\\n|B|z|\\n|-|-|\\n|2|w|" }} y';
+      const view = mount(doc, doc.length);
+      expect(view.dom.querySelector(".vc-template-rendered-table")).toBeNull();
+      expect(view.dom.querySelector(".vc-template-rendered")).not.toBeNull();
+    });
+
     it("re-renders the table when the backing store changes", () => {
       const doc =
-        'x {{ "|Note|\\n|-|\\n"; vault.notes.select(n => "|[[" + n.name + "]]|").join("\\n") }} y';
+        'x {{ "|Note|X|\\n|-|-|\\n"; vault.notes.select(n => "|[[" + n.name + "]]| |").join("\\n") }} y';
       const view = mount(doc, doc.length);
 
       let rows = view.dom.querySelectorAll(

--- a/src/components/Editor/tablePlugin.ts
+++ b/src/components/Editor/tablePlugin.ts
@@ -25,7 +25,7 @@ import { undo, redo } from "@codemirror/commands";
 
 type Align = "left" | "center" | "right" | "default";
 
-interface ParsedTable {
+export interface ParsedTable {
   headers: string[];
   alignments: Align[];
   rows: string[][];
@@ -140,6 +140,60 @@ export function serializeTable(table: ParsedTable): string {
   const lines: string[] = [formatRow(table.headers), formatDelimiter()];
   for (const row of table.rows) lines.push(formatRow(row));
   return lines.join("\n");
+}
+
+// ── Static (read-only) renderer (shared with templateLivePreview, #305) ─────
+
+/**
+ * Build a read-only rendered table DOM — no contenteditable cells, no
+ * structural controls, no event handlers. Used by `templateLivePreview` to
+ * render `{{ ... }}` expression output that evaluates to a GFM table. Shares
+ * the `cm-table-rendered` class so the existing border/padding CSS applies.
+ *
+ * `appendCellContent` lets callers hook wiki-link rendering (or any other
+ * inline transformation) per cell. Default: `cell.textContent = text`.
+ */
+export function renderStaticTableDom(
+  table: ParsedTable,
+  appendCellContent?: (cell: HTMLElement, text: string) => void,
+): HTMLElement {
+  const setContent =
+    appendCellContent ?? ((cell: HTMLElement, text: string) => {
+      cell.textContent = text;
+    });
+
+  const wrap = document.createElement("div");
+  wrap.className = "cm-static-table-wrap";
+
+  const el = document.createElement("table");
+  el.className = "cm-table-rendered";
+
+  const thead = document.createElement("thead");
+  const headerRow = document.createElement("tr");
+  for (let i = 0; i < table.headers.length; i++) {
+    const th = document.createElement("th");
+    applyAlign(th, table.alignments[i] ?? "default");
+    setContent(th, table.headers[i] ?? "");
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  el.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  for (let r = 0; r < table.rows.length; r++) {
+    const tr = document.createElement("tr");
+    for (let i = 0; i < table.headers.length; i++) {
+      const td = document.createElement("td");
+      applyAlign(td, table.alignments[i] ?? "default");
+      setContent(td, table.rows[r]?.[i] ?? "");
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+  el.appendChild(tbody);
+
+  wrap.appendChild(el);
+  return wrap;
 }
 
 // ── Minimal source diff (keeps decoration range stable) ──────────────────────

--- a/src/components/Editor/templateAutocomplete.ts
+++ b/src/components/Editor/templateAutocomplete.ts
@@ -13,6 +13,7 @@ import type {
 } from "@codemirror/autocomplete";
 import type { EditorView } from "@codemirror/view";
 import { analyzeCompletion } from "../../lib/templateCompletion";
+import { segmentContainingCursor } from "../../lib/templateProgram";
 import { parseFrontmatter } from "../../lib/frontmatterIO";
 
 const COMPLETION_TYPE: Record<string, string> = {
@@ -43,8 +44,16 @@ export function templateCompletionSource(
   const openCol = findOpenTemplate(line.text, col);
   if (openCol < 0) return null;
 
-  const exprStart = line.from + openCol + 2; // skip past `{{`
-  const input = ctx.state.doc.sliceString(exprStart, ctx.pos);
+  const bodyStart = line.from + openCol + 2; // skip past `{{`
+  const body = ctx.state.doc.sliceString(bodyStart, ctx.pos);
+
+  // #303: scope the analysis input to the segment containing the cursor.
+  // Without this, a prior segment like `vault.notes.` would confuse the
+  // analyzer into still treating the chain as open when the user has
+  // already typed `;` and is authoring a new segment.
+  const seg = segmentContainingCursor(body, body.length);
+  const input = seg.segment.slice(0, seg.offsetInSegment);
+  const exprStart = bodyStart + seg.segmentStart;
 
   const dynamicKeys = collectFrontmatterKeys(ctx.state.doc.toString());
   const analysis = analyzeCompletion(input, {

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -26,7 +26,7 @@ import {
 import { RangeSetBuilder, StateEffect } from "@codemirror/state";
 import { get } from "svelte/store";
 
-import { evaluate, renderValue } from "../../lib/templateExpression";
+import { evaluateProgram } from "../../lib/templateProgram";
 import { currentVaultRoot } from "../../lib/vaultApiStoreBridge";
 import { vaultStore } from "../../store/vaultStore";
 import { tagsStore } from "../../store/tagsStore";
@@ -137,19 +137,23 @@ function buildDecorations(view: EditorView): DecorationSet {
     );
     if (overlap) continue;
 
-    const body = m[1]!.trim();
+    const body = m[1]!;
     let rendered: string;
     try {
-      if (body === "date") rendered = formatDate(now);
-      else if (body === "time") rendered = formatTime(now);
-      else if (body === "title") rendered = activeTitle();
-      else {
-        if (vaultRoot === null) vaultRoot = currentVaultRoot();
-        rendered = renderValue(evaluate(body, { vault: vaultRoot }));
-      }
+      if (vaultRoot === null) vaultRoot = currentVaultRoot();
+      rendered = evaluateProgram(body, {
+        vault: vaultRoot,
+        date: formatDate(now),
+        time: formatTime(now),
+        title: activeTitle(),
+      });
     } catch {
       continue;
     }
+    // Drop the decoration when nothing evaluated successfully — otherwise
+    // a single-segment failure would show an empty widget in place of the
+    // source text, which is worse than leaving the source visible.
+    if (rendered === "") continue;
 
     builder.add(
       absFrom,

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -33,6 +33,8 @@ import { tagsStore } from "../../store/tagsStore";
 import { bookmarksStore } from "../../store/bookmarksStore";
 import { editorStore } from "../../store/editorStore";
 import { resolveTarget, stripKnownExt } from "./wikiLink";
+import { parseTableText, renderStaticTableDom } from "./tablePlugin";
+import type { ParsedTable } from "./tablePlugin";
 
 const refreshEffect = StateEffect.define<void>();
 
@@ -40,6 +42,62 @@ const refreshEffect = StateEffect.define<void>();
 // real doc links — rendered expression output gets the same treatment so
 // `{{ ...select(n => "[[" + n.title + "]]")... }}` produces clickable links.
 const WIKI_LINK_IN_RENDER_RE = /\[\[([^\]|\n]+?)(?:\|([^\]\n]*))?\]\]/g;
+
+// Strict table detection (#305): only return a ParsedTable if the evaluated
+// output is itself a complete GFM table — no leading/trailing text, no
+// intermediate non-pipe lines (catches two-tables-separated-by-blank-line).
+// CRLF is normalized to LF before delegating to `parseTableText`, otherwise
+// `\r` residue leaks into the rightmost cell on every row.
+function tryParseStrictTable(rendered: string): ParsedTable | null {
+  const normalized = rendered.replace(/\r\n?/g, "\n").trim();
+  if (normalized.length === 0) return null;
+  for (const line of normalized.split("\n")) {
+    const t = line.trim();
+    if (t.length === 0) return null; // blank line inside → not a pure table
+    if (!t.startsWith("|")) return null; // non-pipe line → not a pure table
+  }
+  return parseTableText(normalized);
+}
+
+// Structural equality for two parsed tables — used by RenderedTableWidget.eq
+// to avoid DOM rebuilds on identical re-renders. Cheaper than serializing
+// both sides on every CM6 update tick.
+function sameTable(a: ParsedTable, b: ParsedTable): boolean {
+  if (a.headers.length !== b.headers.length) return false;
+  if (a.rows.length !== b.rows.length) return false;
+  for (let i = 0; i < a.headers.length; i++) {
+    if (a.headers[i] !== b.headers[i]) return false;
+    if ((a.alignments[i] ?? "default") !== (b.alignments[i] ?? "default")) return false;
+  }
+  for (let r = 0; r < a.rows.length; r++) {
+    const ra = a.rows[r]!;
+    const rb = b.rows[r]!;
+    if (ra.length !== rb.length) return false;
+    for (let c = 0; c < ra.length; c++) {
+      if (ra[c] !== rb[c]) return false;
+    }
+  }
+  return true;
+}
+
+class RenderedTableWidget extends WidgetType {
+  constructor(readonly table: ParsedTable) { super(); }
+  override eq(other: WidgetType): boolean {
+    return other instanceof RenderedTableWidget && sameTable(other.table, this.table);
+  }
+  toDOM(): HTMLElement {
+    const wrap = renderStaticTableDom(this.table, (cell, text) =>
+      appendValueWithWikiLinks(cell, text),
+    );
+    wrap.classList.add("vc-template-rendered-table");
+    // Inline-block so the surrounding line text doesn't get orphaned by the
+    // table's intrinsic block flow — keeps `x {{...}} y` readable.
+    wrap.style.display = "inline-block";
+    wrap.style.verticalAlign = "top";
+    return wrap;
+  }
+  override ignoreEvent(): boolean { return false; }
+}
 
 class RenderedValueWidget extends WidgetType {
   constructor(readonly value: string) { super(); }
@@ -155,11 +213,14 @@ function buildDecorations(view: EditorView): DecorationSet {
     // source text, which is worse than leaving the source visible.
     if (rendered === "") continue;
 
-    builder.add(
-      absFrom,
-      absTo,
-      Decoration.replace({ widget: new RenderedValueWidget(rendered) }),
-    );
+    // #305 — if the output is a complete GFM table, render it as a read-only
+    // styled <table>. Non-table output (including mixed table + surrounding
+    // text) falls through to the plain <span> widget.
+    const parsedTable = tryParseStrictTable(rendered);
+    const widget = parsedTable !== null
+      ? new RenderedTableWidget(parsedTable)
+      : new RenderedValueWidget(rendered);
+    builder.add(absFrom, absTo, Decoration.replace({ widget }));
   }
 
   return builder.finish();

--- a/src/lib/__tests__/templateProgram.test.ts
+++ b/src/lib/__tests__/templateProgram.test.ts
@@ -1,0 +1,218 @@
+// Unit tests for the multi-segment template program support (#303).
+//
+// A "program" is the body of a single `{{ ... }}` block. With #303, the body
+// may contain one or more expressions separated by `;`. Each segment is
+// evaluated independently and the rendered results are concatenated into
+// one inline widget.
+//
+// The splitter must respect:
+//   - string literals ("..." and '...' with `\` escapes) so `;` inside a
+//     string does not split
+//   - parenthesised groups so `;` inside a call arg does not split
+//   - lambda bodies so `n => n.x; n.y` (hypothetical — not used today, but
+//     the splitter still needs to skip `;` inside `(...)`)
+// Backticks are NOT supported by the tokenizer, so we do NOT special-case
+// them here — `` `a;b` `` splits on the inner `;`.
+//
+// Evaluation concatenates segments in order, swallowing per-segment errors
+// the same way `templateLivePreview` swallows whole-expression errors today:
+// a broken segment renders as empty, adjacent segments keep working.
+
+import { describe, it, expect } from "vitest";
+import {
+  splitSegments,
+  evaluateProgram,
+  segmentContainingCursor,
+} from "../templateProgram";
+
+describe("templateProgram — splitSegments", () => {
+  it("returns one segment when there is no `;`", () => {
+    expect(splitSegments("vault.name")).toEqual(["vault.name"]);
+  });
+
+  it("splits on a single `;`", () => {
+    expect(splitSegments("a;b")).toEqual(["a", "b"]);
+  });
+
+  it("splits on multiple `;`", () => {
+    expect(splitSegments("a;b;c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves surrounding whitespace inside each segment", () => {
+    expect(splitSegments(" a ; b ")).toEqual([" a ", " b "]);
+  });
+
+  it("does not split on `;` inside a double-quoted string", () => {
+    expect(splitSegments('vault.notes.where(n => n.name == "a;b")'))
+      .toEqual(['vault.notes.where(n => n.name == "a;b")']);
+  });
+
+  it("does not split on `;` inside a single-quoted string", () => {
+    expect(splitSegments("vault.notes.where(n => n.name == 'a;b')"))
+      .toEqual(["vault.notes.where(n => n.name == 'a;b')"]);
+  });
+
+  it("respects `\\\"` escapes inside double-quoted strings", () => {
+    // String contains an escaped quote followed by a literal `;`, then the
+    // real closing quote. The `;` must NOT split.
+    const src = 'a == "x\\";y" ; b';
+    expect(splitSegments(src)).toEqual(['a == "x\\";y" ', ' b']);
+  });
+
+  it("does not split on `;` inside parentheses", () => {
+    expect(splitSegments("foo(a; b); c")).toEqual(["foo(a; b)", " c"]);
+  });
+
+  it("handles nested parentheses", () => {
+    expect(splitSegments("f(g(a; b); c); d"))
+      .toEqual(["f(g(a; b); c)", " d"]);
+  });
+
+  it("treats an unterminated string as consuming the rest of the input", () => {
+    // The tokenizer throws on unterminated strings, but the splitter must
+    // not split on `;` inside one — otherwise a user typing
+    // `{{ "hello; world }}` would briefly split the hanging half.
+    expect(splitSegments('"a;b')).toEqual(['"a;b']);
+  });
+
+  it("handles trailing backslash inside a string without crashing", () => {
+    // A backslash at the end of input shouldn't cause an off-by-one.
+    expect(splitSegments('"a\\')).toEqual(['"a\\']);
+  });
+
+  it("returns two empty segments for `;` alone", () => {
+    expect(splitSegments(";")).toEqual(["", ""]);
+  });
+
+  it("preserves a leading empty segment", () => {
+    expect(splitSegments(";a")).toEqual(["", "a"]);
+  });
+
+  it("preserves a trailing empty segment", () => {
+    expect(splitSegments("a;")).toEqual(["a", ""]);
+  });
+
+  it("does NOT special-case backticks (tokenizer has no template literals)", () => {
+    // Backticks aren't real string delimiters in the expression language;
+    // the splitter treats them as plain punctuation, so a `;` between them
+    // still splits. This keeps the splitter aligned with the tokenizer.
+    expect(splitSegments("`a;b`")).toEqual(["`a", "b`"]);
+  });
+});
+
+describe("templateProgram — evaluateProgram", () => {
+  const scope = {
+    vault: { name: "MyVault" },
+    n: 3,
+    s: "hello",
+  };
+
+  it("evaluates a single-segment program as one value", () => {
+    expect(evaluateProgram("vault.name", scope)).toBe("MyVault");
+  });
+
+  it("concatenates segments in declaration order", () => {
+    expect(evaluateProgram("vault.name; n", scope)).toBe("MyVault3");
+  });
+
+  it("preserves literal separators via string segments", () => {
+    // Users can insert literal text by adding a string-literal segment
+    // between expression segments.
+    expect(evaluateProgram('vault.name; " - "; n', scope)).toBe("MyVault - 3");
+  });
+
+  it("swallows a failing segment and renders adjacent segments", () => {
+    // `vault.missing` throws on the unknown identifier; the surrounding
+    // segments must still render.
+    expect(evaluateProgram("vault.name; vault.missing; n", scope))
+      .toBe("MyVault3");
+  });
+
+  it("swallows a parse error in a segment", () => {
+    expect(evaluateProgram("vault.name; @@@; n", scope)).toBe("MyVault3");
+  });
+
+  it("returns an empty string when all segments fail", () => {
+    expect(evaluateProgram("@@@; @@@", scope)).toBe("");
+  });
+
+  it("renders `{{ ; }}` as empty (both segments are empty, parse errors swallowed)", () => {
+    expect(evaluateProgram(";", scope)).toBe("");
+  });
+
+  it("ignores a trailing `;` with nothing after it", () => {
+    expect(evaluateProgram("vault.name;", scope)).toBe("MyVault");
+  });
+
+  it("supports whitespace around segments", () => {
+    expect(evaluateProgram(" vault.name ; n ", scope)).toBe("MyVault3");
+  });
+});
+
+describe("templateProgram — segmentContainingCursor", () => {
+  // The cursor is a column within the body (0-based). The return shape
+  // gives the segment's source plus the cursor offset inside that segment.
+
+  it("returns the whole body when there is no `;`", () => {
+    expect(segmentContainingCursor("vault.name", 5)).toEqual({
+      segment: "vault.name",
+      offsetInSegment: 5,
+      segmentStart: 0,
+    });
+  });
+
+  it("returns the left segment when the cursor sits left of `;`", () => {
+    //  index: 0 1 2 3 4
+    //  text : v a u l t ;   n
+    expect(segmentContainingCursor("vault;n", 3)).toEqual({
+      segment: "vault",
+      offsetInSegment: 3,
+      segmentStart: 0,
+    });
+  });
+
+  it("returns the right segment when the cursor sits past `;`", () => {
+    expect(segmentContainingCursor("vault;n", 7)).toEqual({
+      segment: "n",
+      offsetInSegment: 1,
+      segmentStart: 6,
+    });
+  });
+
+  it("cursor exactly on `;` belongs to the RIGHT segment (offset 0)", () => {
+    // Chose right-biased so that typing `;` then member names feels correct:
+    // `{{ a; |}}` should offer completions for the new (empty) segment.
+    expect(segmentContainingCursor("a;b", 1)).toEqual({
+      segment: "b",
+      offsetInSegment: 0,
+      segmentStart: 2,
+    });
+  });
+
+  it("handles `;` inside a string (no split)", () => {
+    // The enclosing string protects the `;`; cursor offset 4 is still
+    // inside the single logical segment.
+    const src = '"a;b" ';
+    expect(segmentContainingCursor(src, 4)).toEqual({
+      segment: src,
+      offsetInSegment: 4,
+      segmentStart: 0,
+    });
+  });
+
+  it("handles cursor at end of body", () => {
+    expect(segmentContainingCursor("a;b", 3)).toEqual({
+      segment: "b",
+      offsetInSegment: 1,
+      segmentStart: 2,
+    });
+  });
+
+  it("handles empty trailing segment after `;`", () => {
+    expect(segmentContainingCursor("a;", 2)).toEqual({
+      segment: "",
+      offsetInSegment: 0,
+      segmentStart: 2,
+    });
+  });
+});

--- a/src/lib/templateProgram.ts
+++ b/src/lib/templateProgram.ts
@@ -1,0 +1,153 @@
+// Multi-segment `{{ ... ; ... }}` template programs (#303).
+//
+// A `{{ ... }}` body is split on top-level `;` into N independent segments.
+// Each segment is parsed + evaluated independently and the rendered results
+// are concatenated into the widget text. Per-segment errors are swallowed
+// the same way `templateLivePreview` swallows whole-body errors today:
+// a broken segment renders as empty, neighbours keep working.
+//
+// The splitter mirrors the tokenizer's string-literal state machine so that
+// `;` inside `"..."` or `'...'` (including escaped quotes via `\"`) does
+// NOT split. It also tracks paren depth so `;` inside a call arg list
+// doesn't split either. Backticks have no special meaning in the
+// expression language, so `` `a;b` `` splits on the inner `;` — that keeps
+// the splitter aligned with the tokenizer.
+
+import { evaluate, renderValue, type EvalScope } from "./templateExpression";
+
+/**
+ * Split a program body on top-level `;`. String literals and parenthesised
+ * groups protect their contents from splitting. An unterminated string
+ * consumes the rest of the input — the tokenizer will throw on that
+ * segment later, which `evaluateProgram` swallows.
+ */
+export function splitSegments(src: string): string[] {
+  const out: string[] = [];
+  let start = 0;
+  let i = 0;
+  let paren = 0;
+  let inString: '"' | "'" | null = null;
+
+  while (i < src.length) {
+    const c = src[i]!;
+    if (inString !== null) {
+      if (c === "\\") {
+        // Skip the escape and the next character (if any). A trailing `\`
+        // at end of input is a no-op — we just advance past it.
+        i += 2;
+        continue;
+      }
+      if (c === inString) {
+        inString = null;
+        i++;
+        continue;
+      }
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      inString = c;
+      i++;
+      continue;
+    }
+    if (c === "(") {
+      paren++;
+      i++;
+      continue;
+    }
+    if (c === ")") {
+      if (paren > 0) paren--;
+      i++;
+      continue;
+    }
+    if (c === ";" && paren === 0) {
+      out.push(src.slice(start, i));
+      start = i + 1;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  out.push(src.slice(start));
+  return out;
+}
+
+/**
+ * Evaluate each segment and concatenate the rendered string results. Errors
+ * in individual segments are swallowed (rendered as empty), matching the
+ * live-preview engine's "drop silently" strategy.
+ *
+ * Note on the ops budget: each segment gets a fresh budget via `evaluate`.
+ * For MVP this is acceptable — N segments × 10k ops each → 10k·N worst
+ * case. Users authoring pathological chains hit a natural ceiling at the
+ * `{{ ... }}` block size anyway.
+ */
+export function evaluateProgram(src: string, scope: EvalScope): string {
+  const segments = splitSegments(src);
+  let out = "";
+  for (const seg of segments) {
+    const trimmed = seg.trim();
+    if (trimmed === "") continue;
+    try {
+      out += renderValue(evaluate(trimmed, scope));
+    } catch {
+      // Per-segment error: swallow and keep going so neighbours still
+      // render. The decoration is dropped only when EVERY segment fails
+      // (detected by the caller via `out === ""` + no non-empty segments).
+    }
+  }
+  return out;
+}
+
+export interface SegmentCursor {
+  segment: string;
+  /** Character offset within `segment` where the cursor sits. */
+  offsetInSegment: number;
+  /** Column of the segment's first character within the original body. */
+  segmentStart: number;
+}
+
+/**
+ * Find the segment containing the cursor. When the cursor sits exactly on
+ * a splitting `;`, it belongs to the RIGHT segment (offset 0) — which is
+ * what the autocomplete popup wants: after typing `;`, the user is
+ * authoring the new segment.
+ */
+export function segmentContainingCursor(
+  src: string,
+  cursor: number,
+): SegmentCursor {
+  const segments = splitSegments(src);
+  let start = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!;
+    const end = start + seg.length;
+    const isLast = i === segments.length - 1;
+    // Non-last segment: cursor sitting on the trailing `;` (cursor === end)
+    // belongs to the NEXT segment at offset 0 — after typing `;` the user
+    // is authoring the new (right) segment, not the old (left) one.
+    if (cursor < end || (isLast && cursor <= end)) {
+      return {
+        segment: seg,
+        offsetInSegment: cursor - start,
+        segmentStart: start,
+      };
+    }
+    if (!isLast && cursor === end) {
+      const next = segments[i + 1]!;
+      return {
+        segment: next,
+        offsetInSegment: 0,
+        segmentStart: end + 1,
+      };
+    }
+    start = end + 1;
+  }
+  const last = segments[segments.length - 1] ?? "";
+  const lastStart = src.length - last.length;
+  return {
+    segment: last,
+    offsetInSegment: Math.max(0, cursor - lastStart),
+    segmentStart: lastStart,
+  };
+}


### PR DESCRIPTION
Fixes #305.
Stacked on top of #304 (the branch PR for #303). Once #304 merges, this
branch rebases onto `main` cleanly.

## Summary

- Template expressions `{{ ... }}` whose evaluated output is a complete GFM
  table now render as a read-only styled `<table>` widget instead of a
  monospaced pipe-and-dash `<span>`.
- Live-update cadence is unchanged — `docChanged` / `viewportChanged` /
  `selectionSet` / `refreshEffect` from store subscriptions. Only the
  widget type swaps.
- Wiki-links inside cells (`[[target]]`, multiple per cell) render via
  the existing `appendValueWithWikiLinks` helper and stay clickable
  through the shared `wiki-link-click` event.

## Changes

- `src/components/Editor/tablePlugin.ts`
  - Export `ParsedTable`.
  - Export `renderStaticTableDom(table, appendCellContent?)` — a
    read-only DOM renderer: no contenteditable, no `+`/`×`/`↕` controls,
    no event handlers. Reuses `.cm-table-rendered` so existing CSS
    (borders, padding, row hover) applies.
  - `buildTableDom` (editable path) is untouched.
- `src/components/Editor/templateLivePreview.ts`
  - `tryParseStrictTable(rendered)` — CRLF-normalizes, rejects inputs
    with blank lines or non-pipe lines (catches the "prefix + table" and
    "two tables separated by a blank line" cases), then delegates to
    `parseTableText`.
  - `RenderedTableWidget` — field-wise `eq()` (no serialize round-trip
    per update tick), `toDOM` calls `renderStaticTableDom` with the
    wiki-link cell renderer, adds `vc-template-rendered-table` class,
    `display: inline-block` so surrounding line text flows naturally.
  - Detection in `buildDecorations`: parsed table → `RenderedTableWidget`,
    else existing `RenderedValueWidget`.

## Non-goals (explicit)

- Inline cell editing. The source truth is the template expression, not
  the table markdown. Editing goes through `{{ ... }}`.
- Structural controls (add/remove row/col, sort).
- Multiple tables in one block — falls back to span.
- Pipe inside cell via GFM `\|` escape — that's a broader `splitRow`
  change, not this PR.

## Test plan

- [x] `src/components/Editor/__tests__/templateLivePreview.test.ts`
      — 12 new cases under `describe("rendered GFM table (#305)")`:
  - [x] Table-shaped output renders as `<table>` with correct
        `<thead>`/`<tbody>` structure.
  - [x] Non-table output (including table plus surrounding text and
        two tables separated by a blank line) falls back to the
        existing `<span>` widget.
  - [x] Delimiter-row alignment (`:-`, `:-:`, `-:`) reflected in cell
        `text-align`.
  - [x] `[[target]]` inside a cell renders as a clickable wiki-link
        span with correct resolved/unresolved class and `data-wiki-*`
        attributes.
  - [x] Multiple wiki-links inside a single cell.
  - [x] Header-only table (no body rows) renders with empty `<tbody>`.
  - [x] Read-only DOM: no `contenteditable` cells, no `.cm-table-ctrl`
        buttons.
  - [x] Backing-store change re-renders the table with the new row
        count (live updates).
- [x] Existing `templateLivePreview` tests (20) still pass — including
      the `#297` wiki-link rendering suite and the `#303` multi-segment
      suite.
- [x] Existing `tablePlugin` tests (8) still pass — the editable path
      and `parseAlignments` / `parseTableText` are untouched.
- [x] `npx tsc --noEmit` clean.

## Known limitations

- `splitRow` doesn't understand the GFM `\|` escape for pipes inside
  cells. `{{ "|[[target|alias]]|..." }}` splits the pipe in the alias
  and produces a malformed row. Workaround: use aliases without table
  cells, or escape via a future `splitRow` enhancement.