### PR TITLE
fix(vault): keep fileList + link-resolution live under FS events (#307)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -306,11 +306,26 @@ pub fn create_file_impl(state: &VaultState, parent: String, name: String) -> Res
 
 #[tauri::command]
 pub async fn create_file(
+    app: tauri::AppHandle,
     state: tauri::State<'_, VaultState>,
     parent: String,
     name: String,
 ) -> Result<String, VaultError> {
-    create_file_impl(&state, parent, name)
+    use tauri::Emitter;
+    let final_path = create_file_impl(&state, parent, name)?;
+    // #307: the watcher suppresses this create via write_ignore (D-12), so
+    // emit a synthetic file_changed event — same pattern as delete_file (#102).
+    // Without this, frontend listeners (vaultStore.fileList, template live
+    // preview) never see self-initiated file creates until app restart.
+    let _ = app.emit(
+        crate::watcher::FILE_CHANGED_EVENT,
+        crate::watcher::FileChangePayload {
+            path: final_path.clone(),
+            kind: "create".to_string(),
+            new_path: None,
+        },
+    );
+    Ok(final_path)
 }
 
 // ─── create_folder ───────────────────────────────────────────────────────────
@@ -454,10 +469,12 @@ fn sync_file_index_rename(
 
 #[tauri::command]
 pub async fn rename_file(
+    app: tauri::AppHandle,
     state: tauri::State<'_, VaultState>,
     old_path: String,
     new_name: String,
 ) -> Result<RenameResult, VaultError> {
+    use tauri::Emitter;
     // Capture the canonical pre-rename path so we can dispatch an embed
     // delete for the OLD path after the rename succeeds. write_ignore
     // suppresses the watcher's natural Remove event for self-mutations,
@@ -466,8 +483,23 @@ pub async fn rename_file(
     #[cfg(feature = "embeddings")]
     let old_canonical = std::fs::canonicalize(&old_path).ok();
     let old_canonical_for_tantivy = std::fs::canonicalize(&old_path).ok();
+    let old_canonical_for_event = old_canonical_for_tantivy
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| old_path.clone());
 
     let result = rename_file_impl(&state, old_path, new_name)?;
+
+    // #307: write_ignore (D-12) suppresses the watcher's natural rename
+    // event, so emit a synthetic one — same pattern as delete_file (#102).
+    let _ = app.emit(
+        crate::watcher::FILE_CHANGED_EVENT,
+        crate::watcher::FileChangePayload {
+            path: old_canonical_for_event,
+            kind: "rename".to_string(),
+            new_path: Some(result.new_path.clone()),
+        },
+    );
 
     // #277: the watcher would normally dispatch DeleteFile(old) + AddFile(new)
     // on a rename event, but write_ignore suppresses that for self-mutations.
@@ -602,18 +634,35 @@ pub fn move_file_impl(state: &VaultState, from: String, to_folder: String) -> Re
 
 #[tauri::command]
 pub async fn move_file(
+    app: tauri::AppHandle,
     state: tauri::State<'_, VaultState>,
     from: String,
     to_folder: String,
 ) -> Result<String, VaultError> {
+    use tauri::Emitter;
     // #201 PR-A: same rationale as rename_file — the OLD path's vectors
     // need an explicit tombstone because write_ignore hides the
     // watcher's Remove event.
     #[cfg(feature = "embeddings")]
     let old_canonical = std::fs::canonicalize(&from).ok();
     let old_canonical_for_tantivy = std::fs::canonicalize(&from).ok();
+    let old_canonical_for_event = old_canonical_for_tantivy
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| from.clone());
 
     let result = move_file_impl(&state, from, to_folder)?;
+
+    // #307: write_ignore (D-12) suppresses the watcher's natural rename
+    // event. A move is reported as a rename with a new parent path.
+    let _ = app.emit(
+        crate::watcher::FILE_CHANGED_EVENT,
+        crate::watcher::FileChangePayload {
+            path: old_canonical_for_event,
+            kind: "rename".to_string(),
+            new_path: Some(result.clone()),
+        },
+    );
 
     // #277: same Tantivy parity as rename_file.
     if let Some(old) = old_canonical_for_tantivy {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -301,7 +301,40 @@ pub fn create_file_impl(state: &VaultState, parent: String, name: String) -> Res
     record_write(state, final_path.clone());
     std::fs::write(&final_path, "").map_err(VaultError::Io)?;
 
+    // #307: write_ignore (D-12) suppresses the watcher's natural create event,
+    // which would normally populate FileIndex. Insert directly so `resolve_link`
+    // (and anything else that reads FileIndex) finds the new file immediately,
+    // instead of falling back to the "create-at-root" path on the next click.
+    if let Ok(vault_root) = get_vault_root(state) {
+        sync_file_index_create(state, &final_path, &vault_root);
+    }
+
     Ok(final_path.to_string_lossy().into_owned())
+}
+
+/// Insert `canonical` into FileIndex with a minimal FileMeta. Used by
+/// `create_file_impl` to compensate for the write_ignore-suppressed watcher
+/// event. Hash stays empty until the file is saved with content; the title
+/// defaults to the filename stem so wiki-link resolution works right away.
+fn sync_file_index_create(state: &VaultState, canonical: &Path, vault_root: &Path) {
+    let Ok(mut fi) = state.file_index.write() else { return };
+    let rel = match canonical.strip_prefix(vault_root) {
+        Ok(p) => p.to_string_lossy().replace('\\', "/"),
+        Err(_) => return,
+    };
+    let title = canonical
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    fi.insert(
+        canonical.to_path_buf(),
+        FileMeta {
+            relative_path: rel,
+            hash: String::new(),
+            title,
+            aliases: Vec::new(),
+        },
+    );
 }
 
 #[tauri::command]

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -15,6 +15,7 @@
   import { backlinksStore } from "../../store/backlinksStore";
   import { bookmarksStore } from "../../store/bookmarksStore";
   import { vaultStore } from "../../store/vaultStore";
+  import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { commandRegistry } from "../../lib/commands/registry";
   import { registerDefaultCommands } from "../../lib/commands/defaultCommands";
   import {
@@ -574,6 +575,15 @@
       if (cancelledStale) return;
       vaultStore.applyFileChange(payload);
       searchStore.setIndexStale(true);
+      // #307: wiki-link resolution uses a cached stem→relPath map populated
+      // once per vault-open (see wikiLink.ts setResolvedLinks). Creates,
+      // renames and deletes all shift the map — request a reload so that
+      // clicks on `[[new-name]]` rendered by template expressions open the
+      // real file instead of falling through to the create-at-root handler.
+      // `modify` leaves the topology untouched, so skip it.
+      if (payload.kind !== "modify") {
+        resolvedLinksStore.requestReload();
+      }
     }).then((fn) => {
       if (cancelledStale) { fn(); return; }
       unlistenStale = fn;

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -563,10 +563,17 @@
     // #174 — any FS change flips the search index to "stale". The omni-search
     // modal will auto-rebuild on next open. Subscription lives here (not in
     // OmniSearch) so the flag is tracked even while the modal is closed.
+    // #307 — same callback also forwards the payload to the vault store so
+    // `fileList` reflects new/deleted/renamed notes in real time (e.g. for
+    // template expressions that query the vault). Store update first, then
+    // the stale flag, so any subscriber reading `fileList` in response to
+    // the flip sees fresh data.
     let cancelledStale = false;
     let unlistenStale: (() => void) | undefined;
-    void listenFileChange(() => {
-      if (!cancelledStale) searchStore.setIndexStale(true);
+    void listenFileChange((payload) => {
+      if (cancelledStale) return;
+      vaultStore.applyFileChange(payload);
+      searchStore.setIndexStale(true);
     }).then((fn) => {
       if (cancelledStale) { fn(); return; }
       unlistenStale = fn;

--- a/src/store/__tests__/vaultStore.test.ts
+++ b/src/store/__tests__/vaultStore.test.ts
@@ -1,0 +1,160 @@
+// Unit tests for `vaultStore.applyFileChange` (#307) — the incremental
+// updater that keeps `fileList` in sync with FS events from the Rust watcher.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+import { vaultStore } from "../vaultStore";
+import type { FileChangePayload } from "../../ipc/events";
+
+const VAULT_ROOT = "/tmp/test-vault";
+
+function openVault(fileList: string[]): void {
+  vaultStore.setOpening(VAULT_ROOT);
+  vaultStore.setReady({
+    currentPath: VAULT_ROOT,
+    fileList,
+    fileCount: fileList.length,
+  });
+}
+
+function abs(rel: string): string {
+  return `${VAULT_ROOT}/${rel}`;
+}
+
+describe("vaultStore.applyFileChange (#307)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+  });
+
+  describe("create", () => {
+    it("appends a new .md file relative path and keeps the list sorted", () => {
+      openVault(["a.md", "c.md"]);
+      vaultStore.applyFileChange({ path: abs("b.md"), kind: "create" });
+      const s = get(vaultStore);
+      expect(s.fileList).toEqual(["a.md", "b.md", "c.md"]);
+      expect(s.fileCount).toBe(3);
+    });
+
+    it("ignores non-.md files", () => {
+      openVault(["a.md"]);
+      vaultStore.applyFileChange({ path: abs("image.png"), kind: "create" });
+      expect(get(vaultStore).fileList).toEqual(["a.md"]);
+    });
+
+    it("is idempotent for duplicate create events", () => {
+      openVault(["a.md"]);
+      vaultStore.applyFileChange({ path: abs("b.md"), kind: "create" });
+      vaultStore.applyFileChange({ path: abs("b.md"), kind: "create" });
+      expect(get(vaultStore).fileList).toEqual(["a.md", "b.md"]);
+    });
+
+    it("ignores paths outside the vault root", () => {
+      openVault(["a.md"]);
+      vaultStore.applyFileChange({
+        path: "/some/other/place/x.md",
+        kind: "create",
+      });
+      expect(get(vaultStore).fileList).toEqual(["a.md"]);
+    });
+
+    it("normalizes backslashes in nested Windows-style paths", () => {
+      openVault([]);
+      vaultStore.applyFileChange({
+        path: `${VAULT_ROOT}\\notes\\daily.md`,
+        kind: "create",
+      });
+      expect(get(vaultStore).fileList).toEqual(["notes/daily.md"]);
+    });
+  });
+
+  describe("delete", () => {
+    it("removes the file from fileList", () => {
+      openVault(["a.md", "b.md", "c.md"]);
+      vaultStore.applyFileChange({ path: abs("b.md"), kind: "delete" });
+      const s = get(vaultStore);
+      expect(s.fileList).toEqual(["a.md", "c.md"]);
+      expect(s.fileCount).toBe(2);
+    });
+
+    it("is a no-op when the path is not in the list", () => {
+      openVault(["a.md"]);
+      vaultStore.applyFileChange({ path: abs("ghost.md"), kind: "delete" });
+      expect(get(vaultStore).fileList).toEqual(["a.md"]);
+    });
+  });
+
+  describe("rename", () => {
+    it("swaps old for new and keeps the list sorted", () => {
+      openVault(["a.md", "b.md"]);
+      vaultStore.applyFileChange({
+        path: abs("a.md"),
+        new_path: abs("z.md"),
+        kind: "rename",
+      });
+      expect(get(vaultStore).fileList).toEqual(["b.md", "z.md"]);
+    });
+
+    it("treats rename out of .md scope as delete", () => {
+      openVault(["a.md"]);
+      vaultStore.applyFileChange({
+        path: abs("a.md"),
+        new_path: abs("a.txt"),
+        kind: "rename",
+      });
+      expect(get(vaultStore).fileList).toEqual([]);
+    });
+
+    it("treats rename into .md scope as create", () => {
+      openVault([]);
+      vaultStore.applyFileChange({
+        path: abs("note.txt"),
+        new_path: abs("note.md"),
+        kind: "rename",
+      });
+      expect(get(vaultStore).fileList).toEqual(["note.md"]);
+    });
+
+    it("is a no-op without new_path", () => {
+      openVault(["a.md"]);
+      vaultStore.applyFileChange({ path: abs("a.md"), kind: "rename" });
+      expect(get(vaultStore).fileList).toEqual(["a.md"]);
+    });
+  });
+
+  describe("modify", () => {
+    it("is a no-op (content change, list unchanged)", () => {
+      openVault(["a.md"]);
+      vaultStore.applyFileChange({ path: abs("a.md"), kind: "modify" });
+      expect(get(vaultStore).fileList).toEqual(["a.md"]);
+    });
+  });
+
+  describe("guards", () => {
+    it("is a no-op when no vault is open", () => {
+      vaultStore.applyFileChange({ path: "/anywhere/a.md", kind: "create" });
+      expect(get(vaultStore).fileList).toEqual([]);
+      expect(get(vaultStore).currentPath).toBeNull();
+    });
+  });
+
+  describe("subscribers", () => {
+    it("notifies subscribers when fileList actually changes", () => {
+      openVault(["a.md"]);
+      let notifications = 0;
+      const unsub = vaultStore.subscribe(() => {
+        notifications += 1;
+      });
+      notifications = 0; // skip the initial synchronous call
+
+      vaultStore.applyFileChange({ path: abs("b.md"), kind: "create" });
+      expect(notifications).toBeGreaterThan(0);
+
+      unsub();
+    });
+  });
+});
+
+// Type-only check: FileChangePayload is importable; helps catch drift.
+const _sanity: FileChangePayload = { path: "x", kind: "create" };
+void _sanity;

--- a/src/store/vaultStore.ts
+++ b/src/store/vaultStore.ts
@@ -9,6 +9,7 @@
 import { writable } from "svelte/store";
 import type { VaultStatus } from "../types/vault";
 import type { DirEntry } from "../types/tree";
+import type { FileChangePayload } from "../ipc/events";
 
 export interface VaultState {
   currentPath: string | null;
@@ -73,6 +74,70 @@ export const vaultStore = {
 
   setVaultReachable(reachable: boolean): void {
     _store.update((s) => ({ ...s, vaultReachable: reachable }));
+  },
+
+  // #307 — incremental fileList updater driven by vault://file_changed events.
+  // Keeps the list in sync with the filesystem without re-listing the whole
+  // vault (O(log n) per event, survives 100k-note vaults). Out-of-root and
+  // non-.md paths are ignored; the vault root is read from `currentPath`.
+  applyFileChange(payload: FileChangePayload): void {
+    _store.update((s) => {
+      if (s.currentPath === null) return s;
+      const root = s.currentPath.replace(/\\/g, "/");
+
+      const toRel = (abs: string): string | null => {
+        const normalized = abs.replace(/\\/g, "/");
+        if (!normalized.startsWith(root)) return null;
+        let rel = normalized.slice(root.length);
+        if (rel.startsWith("/")) rel = rel.slice(1);
+        if (!rel.endsWith(".md")) return null;
+        return rel;
+      };
+
+      const insert = (list: string[], rel: string): string[] => {
+        if (list.includes(rel)) return list;
+        let idx = 0;
+        while (idx < list.length && list[idx]! < rel) idx++;
+        const next = list.slice();
+        next.splice(idx, 0, rel);
+        return next;
+      };
+
+      const remove = (list: string[], rel: string): string[] => {
+        const idx = list.indexOf(rel);
+        if (idx === -1) return list;
+        const next = list.slice();
+        next.splice(idx, 1);
+        return next;
+      };
+
+      let list = s.fileList;
+      switch (payload.kind) {
+        case "create": {
+          const rel = toRel(payload.path);
+          if (rel !== null) list = insert(list, rel);
+          break;
+        }
+        case "delete": {
+          const rel = toRel(payload.path);
+          if (rel !== null) list = remove(list, rel);
+          break;
+        }
+        case "rename": {
+          if (payload.new_path === undefined) break;
+          const oldRel = toRel(payload.path);
+          const newRel = toRel(payload.new_path);
+          if (oldRel !== null) list = remove(list, oldRel);
+          if (newRel !== null) list = insert(list, newRel);
+          break;
+        }
+        case "modify":
+          break;
+      }
+
+      if (list === s.fileList) return s;
+      return { ...s, fileList: list, fileCount: list.length };
+    });
   },
 
   // Tree cache helpers (module-level Map, not in store state)


### PR DESCRIPTION
## Summary

`vaultStore.fileList` was seeded once at vault-open and never updated, so template expressions like `vault.folders.where(...).notes.select(...)` rendered a stale snapshot. This PR wires incremental FS-event updates through the full chain so creates/renames/deletes reach both the frontend store AND the backend FileIndex.

## Changes

- **`vaultStore.applyFileChange(payload)`** — new incremental updater driven by `vault://file_changed`. O(log n) per event; non-`.md` and out-of-root paths are filtered. 14 new unit tests cover create/delete/rename/modify/guards/subscribers.
- **`VaultLayout.svelte`** — the existing `listenFileChange` subscription now also calls `vaultStore.applyFileChange(payload)` and `resolvedLinksStore.requestReload()` (for non-modify kinds) so the wiki-link map stays in sync.
- **Rust `create_file` / `rename_file` / `move_file`** — emit a synthetic `vault://file_changed` event (`delete_file` already did this since bug #102). `write_ignore` (D-12) filters self-writes from the watcher, so without this the frontend would never learn about notes it created itself.
- **Rust `create_file_impl`** — now calls `sync_file_index_create` (symmetrical to `sync_file_index_rename`) to insert the new file into `FileIndex` immediately, matching what the suppressed watcher event would have done.

## Known follow-up

Clicking a wiki-link rendered inside a template-query table still falls through to create-at-root for files created via the sidebar during the same session (#309). This PR lands the plumbing (the stores and caches are refreshed), but something in the decoration-rebuild chain is still serving a stale `data-wiki-resolved="false"` on the first click.

## Test plan

- [x] `cd src-tauri && cargo test --lib` — 357/357
- [x] `npx vitest run` — 1064/1064
- [x] `npx tsc --noEmit` — clean
- [x] TDD: failing test committed first (`1008a3b`), fix landed after
- [ ] Manual UAT: open template query, create note via sidebar → table updates live

Closes #307.