### PR TITLE
fix(editor): stop reporting phantom external edits after watcher modify events

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -36,6 +36,7 @@
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { setResolvedLinks, resolveTarget, refreshWikiLinks } from "./wikiLink";
   import { setResolvedAttachments } from "./embeds";
+  import { decideExternalModifyAction, sha256Hex } from "./externalChangeHandler";
   import { listenFileChange, listenVaultStatus, type FileChangePayload } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
 
@@ -793,19 +794,35 @@
       const filename = path.split("/").pop() ?? path;
 
       try {
-        const result = await mergeExternalChange(path, editorContent, lastSavedContent);
+        const action = await decideExternalModifyAction(
+          { getFileHash, mergeExternalChange, sha256Hex },
+          { path, editorContent, lastSavedContent },
+        );
 
-        if (result.outcome === "clean") {
+        if (action.kind === "sync-hash") {
+          // Disk bytes match the editor — either our own write slipped past
+          // the WriteIgnoreList TTL or an external tool touched the file
+          // without changing content. Refresh the hash tracker so the next
+          // autosave doesn't re-detect a phantom mismatch.
+          tabStore.setLastSavedHash(tabWithPath.id, action.diskHash);
+          tabStore.setLastSavedContent(tabWithPath.id, editorContent);
+          tabStore.setDirty(tabWithPath.id, false);
+          editorStore.setLastSavedHash(action.diskHash);
+        } else if (action.kind === "clean-merge") {
           view.dispatch({
-            changes: { from: 0, to: view.state.doc.length, insert: result.merged_content },
+            changes: { from: 0, to: view.state.doc.length, insert: action.mergedContent },
           });
-          tabStore.setLastSavedContent(tabWithPath.id, result.merged_content);
+          tabStore.setLastSavedContent(tabWithPath.id, action.mergedContent);
+          tabStore.setLastSavedHash(tabWithPath.id, action.diskHash);
+          editorStore.setLastSavedHash(action.diskHash);
           toastStore.push({
             variant: "clean-merge",
             message: `Externe Änderungen wurden in ${filename} eingebunden.`,
           });
         } else {
           tabStore.setLastSavedContent(tabWithPath.id, editorContent);
+          tabStore.setLastSavedHash(tabWithPath.id, action.diskHash);
+          editorStore.setLastSavedHash(action.diskHash);
           toastStore.push({
             variant: "conflict",
             message: `Konflikt in ${filename} – lokale Version behalten.`,

--- a/src/components/Editor/__tests__/externalChangeHandler.test.ts
+++ b/src/components/Editor/__tests__/externalChangeHandler.test.ts
@@ -1,0 +1,155 @@
+// Regression coverage for the "falsely reports external edit" bug.
+//
+// Two causes conspire to make the autosave merge-branch fire when the user
+// hasn't actually edited in another tool:
+//   1. Our own write slipping past the 500ms WriteIgnoreList TTL on slow
+//      saves, producing a self-triggered modify event with byte-identical
+//      disk content.
+//   2. The previous handler never refreshed `lastSavedHash` after a merge,
+//      so the next autosave compared a stale expected-hash against the
+//      fresh disk hash and re-entered the merge path.
+//
+// decideExternalModifyAction owns both fixes: the byte-identical shortcut
+// (kind: "sync-hash") and the always-return-diskHash contract so callers
+// can refresh the tracker in every branch.
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  decideExternalModifyAction,
+  sha256Hex,
+} from "../externalChangeHandler";
+
+function makeDeps(overrides: {
+  diskHash: string;
+  editorHash: string;
+  mergeOutcome?: "clean" | "conflict";
+  mergedContent?: string;
+}) {
+  const getFileHash = vi.fn().mockResolvedValue(overrides.diskHash);
+  const sha256 = vi.fn().mockResolvedValue(overrides.editorHash);
+  const mergeExternalChange = vi.fn().mockResolvedValue({
+    outcome: overrides.mergeOutcome ?? "clean",
+    merged_content: overrides.mergedContent ?? "",
+  });
+  return {
+    getFileHash,
+    sha256Hex: sha256,
+    mergeExternalChange,
+    _mocks: { getFileHash, sha256, mergeExternalChange },
+  };
+}
+
+describe("decideExternalModifyAction", () => {
+  it("returns sync-hash and skips merge when disk is byte-identical to the editor", async () => {
+    // Self-write that slipped past WriteIgnoreList OR external tool touched
+    // the file without changing content (git checkout same commit, Spotlight
+    // metadata write). Must NOT trigger the merge RPC or a toast.
+    const deps = makeDeps({ diskHash: "aa", editorHash: "aa" });
+
+    const action = await decideExternalModifyAction(deps, {
+      path: "/v/a.md",
+      editorContent: "hello",
+      lastSavedContent: "hello",
+    });
+
+    expect(action).toEqual({ kind: "sync-hash", diskHash: "aa" });
+    expect(deps._mocks.mergeExternalChange).not.toHaveBeenCalled();
+  });
+
+  it("returns clean-merge with the fresh disk hash so lastSavedHash can be refreshed", async () => {
+    const deps = makeDeps({
+      diskHash: "bb",
+      editorHash: "aa",
+      mergeOutcome: "clean",
+      mergedContent: "merged!",
+    });
+
+    const action = await decideExternalModifyAction(deps, {
+      path: "/v/a.md",
+      editorContent: "local",
+      lastSavedContent: "base",
+    });
+
+    expect(action).toEqual({
+      kind: "clean-merge",
+      mergedContent: "merged!",
+      diskHash: "bb",
+    });
+    expect(deps._mocks.mergeExternalChange).toHaveBeenCalledWith(
+      "/v/a.md",
+      "local",
+      "base",
+    );
+  });
+
+  it("returns conflict with the fresh disk hash so the next autosave is unambiguous", async () => {
+    // Contract: on conflict the editor keeps local content but the caller
+    // MUST record diskHash — otherwise the next autosave will re-enter the
+    // merge branch against a stale expected hash and surface the phantom
+    // "external edit" toast again.
+    const deps = makeDeps({
+      diskHash: "cc",
+      editorHash: "aa",
+      mergeOutcome: "conflict",
+      mergedContent: "ignored",
+    });
+
+    const action = await decideExternalModifyAction(deps, {
+      path: "/v/a.md",
+      editorContent: "local",
+      lastSavedContent: "base",
+    });
+
+    expect(action).toEqual({ kind: "conflict", diskHash: "cc" });
+  });
+
+  it("does not read disk twice — getFileHash and sha256Hex run in parallel", async () => {
+    // Guard against a regression that would serialize the two hashes and
+    // double end-to-end latency of every modify event.
+    const order: string[] = [];
+    const getFileHash = vi.fn().mockImplementation(async () => {
+      order.push("getFileHash:start");
+      await new Promise((r) => setTimeout(r, 5));
+      order.push("getFileHash:end");
+      return "aa";
+    });
+    const sha256 = vi.fn().mockImplementation(async () => {
+      order.push("sha256:start");
+      await new Promise((r) => setTimeout(r, 5));
+      order.push("sha256:end");
+      return "aa";
+    });
+
+    await decideExternalModifyAction(
+      {
+        getFileHash,
+        sha256Hex: sha256,
+        mergeExternalChange: vi.fn(),
+      },
+      { path: "/v/a.md", editorContent: "x", lastSavedContent: "x" },
+    );
+
+    // Both starts happen before either end → parallel.
+    expect(order.slice(0, 2).sort()).toEqual([
+      "getFileHash:start",
+      "sha256:start",
+    ]);
+  });
+});
+
+describe("sha256Hex", () => {
+  // The backend uses `hash_bytes` = lowercase hex of Sha256::digest(bytes).
+  // The frontend equality shortcut depends on producing the exact same
+  // string. NIST known-answer vectors:
+  it("matches the NIST empty-input vector", async () => {
+    expect(await sha256Hex("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("matches the known 'hello' vector used in the Rust hash tests", async () => {
+    expect(await sha256Hex("hello")).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    );
+  });
+});

--- a/src/components/Editor/externalChangeHandler.ts
+++ b/src/components/Editor/externalChangeHandler.ts
@@ -1,0 +1,93 @@
+// Pure decision logic for watcher-driven "modify" events on open tabs.
+//
+// Split out of EditorPane.svelte so the branches (byte-identical skip / clean
+// merge / conflict) can be unit-tested without a Svelte harness.
+//
+// Why this exists: the previous inline handler never refreshed
+// `lastSavedHash` after a merge, so the next autosave compared a stale
+// expected-hash against the freshly-written disk hash and re-entered the
+// merge path — surfacing "Externe Änderungen wurden eingebunden" even when
+// the user hadn't touched the file in another tool. A second source of
+// spurious mismatches is our own write slipping past the 500ms
+// `WriteIgnoreList` TTL on slow saves; the byte-identical shortcut collapses
+// that case to a hash-sync with no user-visible toast.
+
+export interface ExternalModifyDeps {
+  getFileHash: (path: string) => Promise<string>;
+  mergeExternalChange: (
+    path: string,
+    local: string,
+    base: string,
+  ) => Promise<{ outcome: "clean" | "conflict"; merged_content: string }>;
+  /** SHA-256 hex of the given UTF-8 string. Injected so tests can stub it. */
+  sha256Hex: (s: string) => Promise<string>;
+}
+
+export type ExternalModifyAction =
+  | { kind: "sync-hash"; diskHash: string }
+  | { kind: "clean-merge"; mergedContent: string; diskHash: string }
+  | { kind: "conflict"; diskHash: string };
+
+export interface ExternalModifyInput {
+  path: string;
+  editorContent: string;
+  lastSavedContent: string;
+}
+
+/**
+ * Decide what to do when the watcher reports an external "modify" for an
+ * open tab.
+ *
+ * Contract:
+ * - `sync-hash`: disk content is byte-identical to the editor buffer. The
+ *   caller must only refresh `lastSavedHash` (and drop `isDirty`); no merge,
+ *   no toast. Fires for self-writes that slipped past `WriteIgnoreList` and
+ *   for external touches that produced identical bytes (git checkout same
+ *   commit, Time Machine, Spotlight metadata writes).
+ * - `clean-merge`: disk diverged from our base snapshot; the three-way merge
+ *   resolved cleanly. The caller must replace the CM6 doc with
+ *   `mergedContent` and record `diskHash` as the new `lastSavedHash`.
+ * - `conflict`: merge failed; the caller keeps the editor's local content
+ *   but still records `diskHash` so the next autosave writes through
+ *   deliberately (the documented "lokale Version behalten" behaviour).
+ */
+export async function decideExternalModifyAction(
+  deps: ExternalModifyDeps,
+  input: ExternalModifyInput,
+): Promise<ExternalModifyAction> {
+  const [diskHash, editorHash] = await Promise.all([
+    deps.getFileHash(input.path),
+    deps.sha256Hex(input.editorContent),
+  ]);
+
+  if (diskHash === editorHash) {
+    return { kind: "sync-hash", diskHash };
+  }
+
+  const result = await deps.mergeExternalChange(
+    input.path,
+    input.editorContent,
+    input.lastSavedContent,
+  );
+
+  if (result.outcome === "clean") {
+    return {
+      kind: "clean-merge",
+      mergedContent: result.merged_content,
+      diskHash,
+    };
+  }
+  return { kind: "conflict", diskHash };
+}
+
+/**
+ * SHA-256 hex of a UTF-8 string via Web Crypto. Matches the backend
+ * `hash_bytes` output (lowercase hex of `Sha256::digest(bytes)`).
+ */
+export async function sha256Hex(s: string): Promise<string> {
+  const buf = new TextEncoder().encode(s);
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}


### PR DESCRIPTION
## Summary
- Watcher-driven modify handler now refreshes `lastSavedHash` in every branch (clean-merge, conflict, and the new byte-identical shortcut) so the next autosave doesn't re-detect a phantom mismatch
- Byte-identical shortcut collapses self-writes that slip past the 500ms WriteIgnoreList TTL — no merge RPC, no toast
- Merge decision extracted to `externalChangeHandler.ts` so the three branches are unit-testable without a Svelte harness

## Root cause
Before the fix, `handleExternalFileChange` updated `lastSavedContent` on every outcome but never touched `lastSavedHash`. The next autosave compared `tab.lastSavedHash` (pre-event) against the current disk hash (post-event) and re-entered the merge path, surfacing "Externe Änderungen wurden eingebunden" even when the user hadn't touched the file in another tool. The most common trigger was our own write arriving at the watcher after the 500ms ignore window expired on a slow save.

## Test plan
- [x] `pnpm exec vitest run src/components/Editor/__tests__/externalChangeHandler.test.ts` — 6/6 green
- [x] `pnpm test` — 1070/1070 green
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `cargo test --lib hash` — 11/11 green (parity check: frontend `sha256Hex` matches Rust `hash_bytes` on NIST vectors)
- [ ] Manual: edit a file, let autosave fire, confirm no phantom "external edit" toast
- [ ] Manual: `git checkout` a branch that leaves the current file byte-identical, confirm sync-hash path runs silently