### PR TITLE
feat(settings): show build version (commit count + sha + date) (#313)

### DIFF
--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -582,6 +582,19 @@
           <p class="vc-shortcut-error" role="alert" data-testid="shortcut-error">{recordError}</p>
         {/if}
       </section>
+
+      <!-- Section — Build (#313) -->
+      <section class="vc-settings-section" data-testid="settings-build">
+        <h3 class="vc-settings-section-title">BUILD</h3>
+        <div class="vc-settings-row">
+          <label for="build-version">Version</label>
+          <code id="build-version" class="vc-build-version" data-testid="settings-build-version">{__VC_BUILD_VERSION__}</code>
+        </div>
+        <p class="vc-settings-hint">
+          Format: <code>&lt;commits-auf-main&gt;-g&lt;short-sha&gt; · &lt;commit-datum&gt;</code>.
+          Höhere Commit-Zahl = neuer.
+        </p>
+      </section>
     </div>
   </div>
 
@@ -969,6 +982,18 @@
     margin: 8px 16px 0;
     font-size: 12px;
     color: var(--color-danger, #c62828);
+  }
+
+  /* Build version (#313) */
+  .vc-build-version {
+    font-family: var(--vc-font-mono);
+    font-size: 12px;
+    color: var(--color-text-muted);
+    padding: 2px 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    user-select: text;
   }
 
   /* Conflict modal (#65) */

--- a/src/types/build.d.ts
+++ b/src/types/build.d.ts
@@ -1,0 +1,1 @@
+declare const __VC_BUILD_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,27 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
+import { execSync } from 'node:child_process';
 
-// https://vite.dev/config/
+function git(cmd: string): string | null {
+  try {
+    return execSync(`git ${cmd}`, { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+const count = git('rev-list --count HEAD');
+const sha = git('rev-parse --short HEAD');
+const date = git('log -1 --format=%cI');
+const buildVersion =
+  count && sha && date ? `${count}-g${sha} · ${date.slice(0, 10)}` : 'dev';
+
 export default defineConfig({
   plugins: [svelte(), tailwindcss()],
+  define: {
+    __VC_BUILD_VERSION__: JSON.stringify(buildVersion),
+  },
 });


### PR DESCRIPTION
Closes #313.

## Summary
- Inject `__VC_BUILD_VERSION__` at build time from `git` (commit count on main, short SHA, commit date) via Vite `define`, with a `dev` fallback if `git` isn't available.
- Surface the value in a new `BUILD` section at the bottom of the Settings modal as `<count>-g<sha> · <date>` — copyable, monospace.

Makes it trivial to tell whether a local build is behind `main`: higher commit count = newer.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm exec svelte-check` clean (no new errors)
- [x] `pnpm exec vite build` — verified injected version string in `dist/assets/index-*.js`
- [ ] Open Settings in the running app and confirm the `BUILD` row shows the expected `<count>-g<sha> · <date>` format