### PR TITLE
feat(template): add string methods (contains/startsWith/endsWith/trim/case) (#317)

### DIFF
--- a/src/lib/__tests__/templateExpression.test.ts
+++ b/src/lib/__tests__/templateExpression.test.ts
@@ -184,3 +184,65 @@ describe("renderValue — serialization", () => {
     expect(renderValue(["a", "b", "c"])).toBe("a, b, c");
   });
 });
+
+describe("evaluate — string methods (#317)", () => {
+  it("contains returns true when the substring is present", () => {
+    expect(evaluate("'Hallo Welt'.contains('Welt')", {})).toBe(true);
+    expect(evaluate("'Hallo Welt'.contains('Mond')", {})).toBe(false);
+  });
+
+  it("contains is case-sensitive", () => {
+    expect(evaluate("'Heute'.contains('heute')", {})).toBe(false);
+  });
+
+  it("contains composes with toLowerCase for case-insensitive search", () => {
+    expect(
+      evaluate("'Heute ist Montag'.toLowerCase().contains('heute')", {}),
+    ).toBe(true);
+  });
+
+  it("startsWith / endsWith match the boundary", () => {
+    expect(evaluate("'foo.md'.endsWith('.md')", {})).toBe(true);
+    expect(evaluate("'foo.md'.startsWith('foo')", {})).toBe(true);
+    expect(evaluate("'foo.md'.endsWith('.txt')", {})).toBe(false);
+  });
+
+  it("toLowerCase / toUpperCase / trim are exposed", () => {
+    expect(evaluate("'ABC'.toLowerCase()", {})).toBe("abc");
+    expect(evaluate("'abc'.toUpperCase()", {})).toBe("ABC");
+    expect(evaluate("'  x  '.trim()", {})).toBe("x");
+  });
+
+  it("string methods coerce their arguments to string", () => {
+    expect(evaluate("'abc123'.contains(123)", {})).toBe(true);
+  });
+
+  it("length still works alongside the methods", () => {
+    expect(evaluate("'abc'.length", {})).toBe(3);
+  });
+
+  it("unknown string members still throw", () => {
+    expect(() => evaluate("'abc'.nope", {})).toThrow(/Unknown member/);
+    expect(() => evaluate("'abc'.replaceAll('a','b')", {})).toThrow(
+      /Unknown member/,
+    );
+  });
+
+  it("does not expose dangerous String.prototype members", () => {
+    expect(() => evaluate("'abc'.constructor", {})).toThrow(/not allowed/);
+    expect(() => evaluate("'abc'.__proto__", {})).toThrow(/not allowed/);
+  });
+
+  it("filters a Collection by substring via contains", () => {
+    const coll = new Collection([
+      { title: "Heute ist Montag" },
+      { title: "Gestern war Sonntag" },
+      { title: "Heute lernen wir" },
+    ]);
+    const out = evaluate(
+      "c.where(n => n.title.contains('Heute')).select(n => n.title).toArray()",
+      { c: coll },
+    );
+    expect(out).toEqual(["Heute ist Montag", "Heute lernen wir"]);
+  });
+});

--- a/src/lib/templateExpression.ts
+++ b/src/lib/templateExpression.ts
@@ -438,6 +438,19 @@ function evalMember(
   return readProperty(obj, key);
 }
 
+// Whitelisted string methods exposed to expressions. Each entry builds a
+// bound function over the receiver so `"abc".contains("b")` parses as a
+// normal member-call through `readProperty` + `evalCall`. Argument coercion
+// uses `String(...)` to mirror template-land's loose typing.
+const STRING_METHODS: Record<string, (s: string) => (...args: unknown[]) => unknown> = {
+  contains: (s) => (needle) => s.includes(String(needle)),
+  startsWith: (s) => (prefix) => s.startsWith(String(prefix)),
+  endsWith: (s) => (suffix) => s.endsWith(String(suffix)),
+  toLowerCase: (s) => () => s.toLowerCase(),
+  toUpperCase: (s) => () => s.toUpperCase(),
+  trim: (s) => () => s.trim(),
+};
+
 // Reads a property while preventing prototype-pollution / Object.prototype
 // method access. Own properties are always allowed. Prototype properties
 // are allowed only when the prototype belongs to one of our own classes
@@ -452,7 +465,12 @@ function readProperty(obj: unknown, key: string): unknown {
   if (BANNED_PROPS.has(key)) {
     throw new ExprError(`Access to '${key}' is not allowed`);
   }
-  if (typeof obj === "string" && key === "length") return obj.length;
+  if (typeof obj === "string") {
+    if (key === "length") return obj.length;
+    const m = STRING_METHODS[key];
+    if (m) return m(obj);
+    throw new ExprError(`Unknown member '${key}'`);
+  }
   if (typeof obj !== "object" || obj === null) {
     throw new ExprError(`Cannot read '${key}' on ${typeof obj}`);
   }

--- a/src/lib/vaultApiDescriptor.ts
+++ b/src/lib/vaultApiDescriptor.ts
@@ -92,6 +92,25 @@ const NOTE_PROPERTIES: TypeDescriptor = {
   dynamic: true,
 };
 
+const STRING: TypeDescriptor = {
+  name: "string",
+  members: [
+    { kind: "property", name: "length", returns: "number", doc: "Character count" },
+    { kind: "method", name: "contains", returns: "boolean",
+      doc: "True if the string contains the given substring" },
+    { kind: "method", name: "startsWith", returns: "boolean",
+      doc: "True if the string starts with the given prefix" },
+    { kind: "method", name: "endsWith", returns: "boolean",
+      doc: "True if the string ends with the given suffix" },
+    { kind: "method", name: "toLowerCase", returns: "string",
+      doc: "Lowercased copy of the string" },
+    { kind: "method", name: "toUpperCase", returns: "string",
+      doc: "Uppercased copy of the string" },
+    { kind: "method", name: "trim", returns: "string",
+      doc: "String with leading and trailing whitespace removed" },
+  ],
+};
+
 // Collection<T> — `T` is substituted by the completion engine.
 const COLLECTION: TypeDescriptor = {
   name: "Collection<T>",
@@ -133,6 +152,7 @@ export const TYPES: Record<string, TypeDescriptor> = {
   VaultStats: VAULT_STATS,
   NoteProperties: NOTE_PROPERTIES,
   "Collection<T>": COLLECTION,
+  string: STRING,
 };
 
 /** The set of identifiers visible at the root of a `{{ ... }}` expression. */


### PR DESCRIPTION
Closes #317.

## Summary
- Adds whitelisted string methods to the `{{ ... }}` expression language: `contains`, `startsWith`, `endsWith`, `toLowerCase`, `toUpperCase`, `trim`
- Exposed via the same `readProperty` special-case that already handled `.length`, so prototype-access protections stay in place
- Registers a `string` type descriptor so completion surfaces the new members

Now works: `vault.notes.where(n => n.content.contains(\"Heute\"))`.

## Test plan
- [x] `pnpm test` — 1080 tests passing, incl. new `evaluate — string methods (#317)` block
- [x] `pnpm typecheck` clean
- [ ] Smoke-test in editor: type `{{vault.notes.where(n => n.title.contains(\"...\")).count()}}` and confirm it evaluates