### PR TITLE
feat(templates): share note-content cache across embed + vault API (#319)

### DIFF
--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -36,6 +36,11 @@ import { vaultStore } from "../../store/vaultStore";
 import { tabStore } from "../../store/tabStore";
 import { readFile } from "../../ipc/commands";
 import { listenFileChange } from "../../ipc/events";
+import {
+  readCached as readCachedNote,
+  requestLoad as requestLoadNote,
+  onCacheChanged as onNoteCacheChanged,
+} from "../../lib/noteContentCache";
 import { parseCanvas } from "../../lib/canvas/parse";
 import type { CanvasNode } from "../../lib/canvas/types";
 import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from "../../lib/canvas/types";
@@ -57,23 +62,12 @@ const WIKI_EMBED_RE = /!\[\[([^\]|#]+?)(?:#([^\]|]+))?(?:\|([^\]]*))?\]\]/g;
 /** Matches `![alt](path)` — captures the path. */
 const MD_IMAGE_RE = /!\[[^\]]*\]\(([^)]+)\)/g;
 
-// ── Cache for note-embed content ──────────────────────────────────────────────
-
-/**
- * Vault-relative path → file content. Entries are invalidated selectively by
- * two module-level subscriptions installed at import time:
- *   - `listenFileChange` for external modifications the watcher sees
- *   - `tabStore.subscribe` for internal auto-saves (which suppress the watcher
- *     via write_ignore, so we'd otherwise miss them)
- * Previously the cache was cleared on every local `docChanged`, which caused
- * the `…` placeholder to flash on every keystroke — see #27.
- */
-const noteContentCache: Map<string, string> = new Map();
-/**
- * Paths whose `readFile` call is already in flight, used to suppress duplicate
- * IPC requests from back-to-back plugin rebuilds.
- */
-const noteFetchInFlight: Set<string> = new Set();
+// ── Cache for canvas-embed content ────────────────────────────────────────────
+//
+// Note-embed content moved to `src/lib/noteContentCache.ts` (#319) so the
+// template expression path (`n.content`) and the embed path share a single
+// source of truth. Canvas JSON keeps its own cache here — it's only consumed
+// by this plugin, not by the vault API.
 
 /**
  * Canvas embeds (#147) share the same caching contract as note embeds (#27):
@@ -128,12 +122,12 @@ function toVaultRel(absPath: string): string | null {
   return absFwd.slice(vaultFwd.length + 1);
 }
 
-// ── Cache invalidation: external file changes ─────────────────────────────────
+// ── Canvas-cache invalidation: external file changes ─────────────────────────
 //
-// The watcher only fires for modifications NOT initiated by our own IPC writes
-// (write_ignore suppresses self-writes). That means this catches edits made by
-// tools outside the app — Finder rename, shell `cp`, other editors. Internal
-// auto-saves are handled by the tabStore subscription below.
+// Note-content invalidation lives in `noteContentCache.ts` now. This handler
+// keeps the canvas-specific portion of the old behaviour in place: external
+// watcher events (Finder rename, shell `cp`, other editors) drop the cached
+// JSON for the affected path and kick mounted views.
 //
 // Guarded try/catch because the subscription is module-level and the test
 // environment has no Tauri IPC — a synchronous throw here would break imports.
@@ -141,19 +135,11 @@ try {
   void listenFileChange((payload) => {
     let changed = false;
     const rel = toVaultRel(payload.path);
-    if (rel !== null) {
-      if (noteContentCache.delete(rel)) changed = true;
-      if (canvasContentCache.delete(rel)) changed = true;
-    }
+    if (rel !== null && canvasContentCache.delete(rel)) changed = true;
     if (payload.new_path) {
       const newRel = toVaultRel(payload.new_path);
-      if (newRel !== null) {
-        if (noteContentCache.delete(newRel)) changed = true;
-        if (canvasContentCache.delete(newRel)) changed = true;
-      }
+      if (newRel !== null && canvasContentCache.delete(newRel)) changed = true;
     }
-    // #154: refresh inline canvas previews (and note embeds) in every open
-    // editor without waiting for the next keystroke.
     if (changed) kickAllEmbedViews();
   }).catch(() => {
     /* Tauri not initialized — tests run without the IPC backend. */
@@ -162,59 +148,33 @@ try {
   /* same reason — swallow so the module still loads under vitest. */
 }
 
-// ── Cache invalidation: internal auto-saves via other tabs ────────────────────
+// ── Canvas-cache invalidation: internal auto-saves via other tabs ────────────
 //
-// tabStore.setLastSavedContent fires after writeFile returns successfully. We
-// snapshot each tab's lastSavedContent the first time we see it and diff on
-// subsequent store emissions — when the snapshot changes, the file was just
-// saved (by any tab, including ones in other panes), so invalidate its cache
-// entry. This lets the next embed rebuild re-fetch the fresh content.
-const lastSavedByTabId: Map<string, string> = new Map();
+// Mirror of the original snapshot-diff pattern (#154). Note-content writes
+// fire the same snapshot change but are now handled in noteContentCache.ts;
+// this handler only touches the canvas-JSON side.
+const lastSavedCanvasByTabId: Map<string, string> = new Map();
 tabStore.subscribe((state) => {
   let changed = false;
   for (const tab of state.tabs) {
-    const prev = lastSavedByTabId.get(tab.id);
+    const prev = lastSavedCanvasByTabId.get(tab.id);
     if (prev !== tab.lastSavedContent) {
-      lastSavedByTabId.set(tab.id, tab.lastSavedContent);
+      lastSavedCanvasByTabId.set(tab.id, tab.lastSavedContent);
       const rel = toVaultRel(tab.filePath);
-      if (rel !== null) {
-        if (noteContentCache.delete(rel)) changed = true;
-        // #154: CanvasView calls setLastSavedContent after every autosave, so
-        // the same diff-on-snapshot path that catches note writes now catches
-        // canvas writes too — the watcher's write_ignore would otherwise hide
-        // our own saves from the file-change listener.
-        if (canvasContentCache.delete(rel)) changed = true;
-      }
+      if (rel !== null && canvasContentCache.delete(rel)) changed = true;
     }
   }
-  // Clean up snapshots for tabs that have closed so the map doesn't grow.
   const liveIds = new Set(state.tabs.map((t) => t.id));
-  for (const id of Array.from(lastSavedByTabId.keys())) {
-    if (!liveIds.has(id)) lastSavedByTabId.delete(id);
+  for (const id of Array.from(lastSavedCanvasByTabId.keys())) {
+    if (!liveIds.has(id)) lastSavedCanvasByTabId.delete(id);
   }
   if (changed) kickAllEmbedViews();
 });
 
-function scheduleNoteFetch(view: EditorView, relPath: string): void {
-  if (noteContentCache.has(relPath) || noteFetchInFlight.has(relPath)) return;
-  const vault = get(vaultStore).currentPath;
-  if (!vault) return;
-  const abs = `${vault}/${relPath}`;
-  noteFetchInFlight.add(relPath);
-  void readFile(abs)
-    .then((content) => {
-      noteContentCache.set(relPath, content);
-    })
-    .catch(() => {
-      noteContentCache.set(relPath, "");
-    })
-    .finally(() => {
-      noteFetchInFlight.delete(relPath);
-      // Kick the plugin to re-render now that we have content.
-      if (!view.dom.isConnected) return;
-      view.dispatch({ effects: [] });
-    });
-}
+// #319: the shared note-content cache lives in its own module. Subscribe to
+// its change signal so embed decorations refresh when a background fetch
+// lands — same UX as the legacy per-view dispatch had.
+onNoteCacheChanged(kickAllEmbedViews);
 
 /**
  * #154 — mirror of scheduleNoteFetch for `.canvas` embeds. Runs when
@@ -622,9 +582,10 @@ function buildDecorations(view: EditorView): DecorationSet {
             deco = Decoration.replace({ widget: new CanvasEmbedWidget(rel, sizePx, cachedCanvas) });
           }
         } else {
-          const cached = noteContentCache.get(rel);
-          if (cached === undefined) {
-            scheduleNoteFetch(view, rel);
+          // #319: note-content cache is shared with the vault API.
+          const cached = readCachedNote(rel);
+          if (cached === null) {
+            requestLoadNote(rel);
             // Show a muted placeholder while the fetch is in flight so the UI
             // doesn't flash with a stale version of the target note.
             deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, "…") });
@@ -701,9 +662,10 @@ export const embedPlugin = ViewPlugin.fromClass(
     private view: EditorView;
 
     constructor(view: EditorView) {
-      // Clear caches so stale content from a previous vault does not leak into
-      // the freshly-mounted view. Cheap because the caches are module-level.
-      noteContentCache.clear();
+      // Canvas cache clears on mount so stale JSON from a previous vault
+      // doesn't leak into the freshly-mounted view. The note-content cache
+      // is managed by `noteContentCache.ts` and already clears on vault
+      // switch via its own vaultStore subscription.
       canvasContentCache.clear();
       this.view = view;
       // #154: register so module-level invalidation hooks can kick a rebuild.
@@ -730,12 +692,12 @@ export const embedPlugin = ViewPlugin.fromClass(
 );
 
 /**
- * Test-only hook: clear both caches so unit tests start from a clean slate.
+ * Test-only hook: clear the canvas cache so unit tests start from a clean
+ * slate. The note-content cache lives in its own module now — tests that
+ * exercise that surface should reset it via `__cacheForTests.reset()`.
  * Not part of the public API.
  */
 export function __resetEmbedCachesForTests(): void {
-  noteContentCache.clear();
-  noteFetchInFlight.clear();
   canvasContentCache.clear();
 }
 

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -39,8 +39,9 @@ import { listenFileChange } from "../../ipc/events";
 import {
   readCached as readCachedNote,
   requestLoad as requestLoadNote,
-  onCacheChanged as onNoteCacheChanged,
+  noteContentCacheVersion,
 } from "../../lib/noteContentCache";
+import { toVaultRel as toVaultRelHelper, absFromRel as absFromRelHelper } from "../../lib/vaultPath";
 import { parseCanvas } from "../../lib/canvas/parse";
 import type { CanvasNode } from "../../lib/canvas/types";
 import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from "../../lib/canvas/types";
@@ -110,16 +111,11 @@ function kickAllEmbedViews(): void {
 
 /**
  * Convert an absolute path to a vault-relative forward-slash path, or return
- * null when the path is outside the vault (or no vault is open).
+ * null when the path is outside the vault (or no vault is open). Thin
+ * wrapper around the shared helper so all call-sites here stay terse.
  */
 function toVaultRel(absPath: string): string | null {
-  const vault = get(vaultStore).currentPath;
-  if (!vault) return null;
-  const absFwd = absPath.replace(/\\/g, "/");
-  const vaultFwd = vault.replace(/\\/g, "/").replace(/\/$/, "");
-  if (absFwd === vaultFwd) return "";
-  if (!absFwd.startsWith(vaultFwd + "/")) return null;
-  return absFwd.slice(vaultFwd.length + 1);
+  return toVaultRelHelper(absPath, get(vaultStore).currentPath ?? null);
 }
 
 // ── Canvas-cache invalidation: external file changes ─────────────────────────
@@ -172,9 +168,15 @@ tabStore.subscribe((state) => {
 });
 
 // #319: the shared note-content cache lives in its own module. Subscribe to
-// its change signal so embed decorations refresh when a background fetch
-// lands — same UX as the legacy per-view dispatch had.
-onNoteCacheChanged(kickAllEmbedViews);
+// its version store so embed decorations refresh when a background fetch
+// lands — same UX as the legacy per-view dispatch had. Svelte stores fire
+// synchronously with the current value on subscribe; a `ready` latch
+// swallows that initial call so we don't kick on module import.
+let noteCacheReady = false;
+noteContentCacheVersion.subscribe(() => {
+  if (noteCacheReady) kickAllEmbedViews();
+});
+noteCacheReady = true;
 
 /**
  * #154 — mirror of scheduleNoteFetch for `.canvas` embeds. Runs when
@@ -184,9 +186,8 @@ onNoteCacheChanged(kickAllEmbedViews);
  */
 function scheduleCanvasFetch(view: EditorView, relPath: string): void {
   if (canvasContentCache.has(relPath) || canvasFetchInFlight.has(relPath)) return;
-  const vault = get(vaultStore).currentPath;
-  if (!vault) return;
-  const abs = `${vault}/${relPath}`;
+  const abs = absFromRel(relPath);
+  if (abs === null) return;
   canvasFetchInFlight.add(relPath);
   void readFile(abs)
     .then((content) => {
@@ -218,10 +219,7 @@ function isImageFilename(name: string): boolean {
  * `convertFileSrc` tolerates either.
  */
 function absFromRel(relPath: string): string | null {
-  const vault = get(vaultStore).currentPath;
-  if (!vault) return null;
-  const v = vault.replace(/\\/g, "/").replace(/\/$/, "");
-  return `${v}/${relPath}`;
+  return absFromRelHelper(relPath, get(vaultStore).currentPath ?? null);
 }
 
 class ImageEmbedWidget extends WidgetType {

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -28,6 +28,7 @@ import { get } from "svelte/store";
 
 import { evaluateProgram } from "../../lib/templateProgram";
 import { currentVaultRoot } from "../../lib/vaultApiStoreBridge";
+import { noteContentCacheVersion } from "../../lib/noteContentCache";
 import { vaultStore } from "../../store/vaultStore";
 import { tagsStore } from "../../store/tagsStore";
 import { bookmarksStore } from "../../store/bookmarksStore";
@@ -246,6 +247,10 @@ export const templateLivePlugin = ViewPlugin.fromClass(
         vaultStore.subscribe(trigger),
         tagsStore.subscribe(trigger),
         bookmarksStore.subscribe(trigger),
+        // #319: trigger re-decoration when an async `requestLoad` lands so
+        // `{{vault.notes.where(n => n.content.contains("X"))}}` fills in
+        // once the backing note contents have been read from disk.
+        noteContentCacheVersion.subscribe(trigger),
       );
       ready = true;
     }

--- a/src/lib/__tests__/noteContentCache.test.ts
+++ b/src/lib/__tests__/noteContentCache.test.ts
@@ -1,0 +1,340 @@
+// Unit tests for the shared note-content cache (#319). Exercise the LRU,
+// invalidation, generation-token, concurrency, and version-bump-batching
+// surfaces — the pieces that went missing when the cache lived inline in
+// `embedPlugin.ts`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+const handlerSlot = vi.hoisted(() => {
+  const slot: { cb: ((p: { path: string; new_path?: string | null }) => void) | null } = {
+    cb: null,
+  };
+  return slot;
+});
+
+const readerSlot = vi.hoisted(() => ({
+  impl: (_path: string) => Promise.resolve(""),
+}));
+
+vi.mock("../../ipc/events", () => ({
+  listenFileChange: vi.fn(async (cb: (p: { path: string; new_path?: string | null }) => void) => {
+    handlerSlot.cb = cb;
+    return () => {
+      handlerSlot.cb = null;
+    };
+  }),
+}));
+vi.mock("../../ipc/commands", () => ({
+  readFile: vi.fn((path: string) => readerSlot.impl(path)),
+}));
+
+import {
+  readCached,
+  requestLoad,
+  invalidate,
+  clear,
+  onCacheChanged,
+  noteContentCacheVersion,
+  __cacheForTests,
+} from "../noteContentCache";
+import { vaultStore } from "../../store/vaultStore";
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe("noteContentCache — basic read/write", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+    readerSlot.impl = () => Promise.resolve("");
+  });
+
+  it("readCached returns null for an unknown key", () => {
+    expect(readCached("a.md")).toBeNull();
+  });
+
+  it("requestLoad populates the cache via the injected reader", async () => {
+    readerSlot.impl = (p) => Promise.resolve(`hello-${p}`);
+    requestLoad("a.md");
+    await flushMicrotasks();
+    expect(readCached("a.md")).toBe("hello-/vault/a.md");
+  });
+
+  it("requestLoad dedupes concurrent loads for the same path", async () => {
+    let calls = 0;
+    readerSlot.impl = (_p) => {
+      calls++;
+      return Promise.resolve("x");
+    };
+    requestLoad("a.md");
+    requestLoad("a.md");
+    requestLoad("a.md");
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+  });
+
+  it("invalidate drops an existing entry and returns true", () => {
+    __cacheForTests.set("a.md", "old");
+    expect(invalidate("a.md")).toBe(true);
+    expect(readCached("a.md")).toBeNull();
+  });
+
+  it("invalidate on an absent key returns false without side effects", () => {
+    expect(invalidate("never.md")).toBe(false);
+  });
+});
+
+describe("noteContentCache — LRU eviction", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("evicts the oldest entry when the cap is exceeded", () => {
+    const { LRU_MAX_ENTRIES } = __cacheForTests.limits();
+    for (let i = 0; i < LRU_MAX_ENTRIES; i++) {
+      __cacheForTests.set(`n${i}.md`, String(i));
+    }
+    expect(__cacheForTests.size()).toBe(LRU_MAX_ENTRIES);
+    __cacheForTests.set("overflow.md", "x");
+    expect(__cacheForTests.size()).toBe(LRU_MAX_ENTRIES);
+    // Oldest (`n0.md`) should be gone; newest is retained.
+    expect(readCached("n0.md")).toBeNull();
+    expect(readCached("overflow.md")).toBe("x");
+  });
+
+  it("touching an entry via readCached moves it to the newest slot", () => {
+    const { LRU_MAX_ENTRIES } = __cacheForTests.limits();
+    for (let i = 0; i < LRU_MAX_ENTRIES; i++) {
+      __cacheForTests.set(`n${i}.md`, String(i));
+    }
+    // Read the oldest — should promote it.
+    expect(readCached("n0.md")).toBe("0");
+    __cacheForTests.set("overflow.md", "x");
+    // n0 promoted, so n1 is the oldest and gets evicted instead.
+    expect(readCached("n0.md")).toBe("0");
+    expect(readCached("n1.md")).toBeNull();
+  });
+});
+
+describe("noteContentCache — per-file size cap", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("does not retain files larger than the per-file cap", async () => {
+    const { MAX_FILE_BYTES } = __cacheForTests.limits();
+    const big = "x".repeat(MAX_FILE_BYTES + 1);
+    readerSlot.impl = () => Promise.resolve(big);
+    requestLoad("huge.md");
+    await flushMicrotasks();
+    expect(__cacheForTests.has("huge.md")).toBe(false);
+  });
+
+  it("retains files at or below the per-file cap", async () => {
+    const { MAX_FILE_BYTES } = __cacheForTests.limits();
+    const ok = "x".repeat(MAX_FILE_BYTES);
+    readerSlot.impl = () => Promise.resolve(ok);
+    requestLoad("fits.md");
+    await flushMicrotasks();
+    expect(__cacheForTests.has("fits.md")).toBe(true);
+  });
+});
+
+describe("noteContentCache — generation tokens (race safety)", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("invalidate-during-load discards the stale resolve", async () => {
+    let resolve: (v: string) => void = () => {};
+    readerSlot.impl = () => new Promise<string>((r) => { resolve = r; });
+    requestLoad("a.md");
+    // Load is in flight. Invalidate bumps the generation.
+    invalidate("a.md");
+    resolve("stale-content");
+    await flushMicrotasks();
+    expect(readCached("a.md")).toBeNull();
+  });
+
+  it("clear-during-load discards the stale resolve", async () => {
+    let resolve: (v: string) => void = () => {};
+    readerSlot.impl = () => new Promise<string>((r) => { resolve = r; });
+    requestLoad("a.md");
+    clear();
+    resolve("stale-vault-a-content");
+    await flushMicrotasks();
+    expect(readCached("a.md")).toBeNull();
+  });
+
+  it("a successful resolve after a fresh requestLoad does populate", async () => {
+    let resolve: (v: string) => void = () => {};
+    readerSlot.impl = () => new Promise<string>((r) => { resolve = r; });
+    requestLoad("a.md");
+    resolve("fresh");
+    await flushMicrotasks();
+    expect(readCached("a.md")).toBe("fresh");
+  });
+});
+
+describe("noteContentCache — failure handling", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("caches an empty string on read failure (no retry storm)", async () => {
+    let calls = 0;
+    readerSlot.impl = () => {
+      calls++;
+      return Promise.reject(new Error("permission-denied"));
+    };
+    requestLoad("bad.md");
+    await flushMicrotasks();
+    expect(readCached("bad.md")).toBe("");
+    // Second requestLoad must not re-fetch.
+    requestLoad("bad.md");
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+  });
+});
+
+describe("noteContentCache — version-bump batching", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("coalesces concurrent completions inside one microtask into one bump", async () => {
+    readerSlot.impl = (p) => Promise.resolve(p);
+    const baseline = get(noteContentCacheVersion);
+    const { MAX_CONCURRENT } = __cacheForTests.limits();
+    // Load exactly one concurrency-batch worth so all completions land in
+    // the same microtask — across batches we'd legitimately get one bump
+    // per wave, which is still better than 1-per-resolve but not what this
+    // test asserts.
+    for (let i = 0; i < MAX_CONCURRENT; i++) requestLoad(`n${i}.md`);
+    await flushMicrotasks();
+    const bumped = get(noteContentCacheVersion);
+    expect(bumped - baseline).toBe(1);
+  });
+
+  it("keeps the bump count proportional to batches, not to completions", async () => {
+    readerSlot.impl = (p) => Promise.resolve(p);
+    const baseline = get(noteContentCacheVersion);
+    for (let i = 0; i < 50; i++) requestLoad(`n${i}.md`);
+    await flushMicrotasks();
+    const bumped = get(noteContentCacheVersion);
+    // 50 completions must NOT produce 50 bumps. Upper bound: one bump per
+    // concurrency wave (~50/8 = 7 waves) plus some slack for microtask
+    // timing. 50 would mean the batching is dead.
+    expect(bumped - baseline).toBeLessThan(15);
+    expect(bumped - baseline).toBeGreaterThan(0);
+  });
+});
+
+describe("noteContentCache — concurrency cap", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("never runs more than MAX_CONCURRENT fetches at once", async () => {
+    const { MAX_CONCURRENT } = __cacheForTests.limits();
+    let peak = 0;
+    let active = 0;
+    const resolvers: Array<() => void> = [];
+    readerSlot.impl = () =>
+      new Promise<string>((r) => {
+        active++;
+        if (active > peak) peak = active;
+        resolvers.push(() => {
+          active--;
+          r("x");
+        });
+      });
+    for (let i = 0; i < MAX_CONCURRENT * 3; i++) requestLoad(`n${i}.md`);
+    // Let the first batch fire but not yet resolve.
+    await flushMicrotasks();
+    expect(peak).toBeLessThanOrEqual(MAX_CONCURRENT);
+    // Drain.
+    while (resolvers.length > 0) {
+      resolvers.shift()!();
+      await flushMicrotasks();
+    }
+    expect(peak).toBeLessThanOrEqual(MAX_CONCURRENT);
+  });
+});
+
+describe("noteContentCache — subscriber notifications", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("onCacheChanged fires after a successful load", async () => {
+    let fired = 0;
+    const unsub = onCacheChanged(() => { fired++; });
+    readerSlot.impl = () => Promise.resolve("x");
+    requestLoad("a.md");
+    await flushMicrotasks();
+    expect(fired).toBeGreaterThan(0);
+    unsub();
+  });
+
+  it("onCacheChanged unsubscribe stops firing", async () => {
+    let fired = 0;
+    const unsub = onCacheChanged(() => { fired++; });
+    unsub();
+    readerSlot.impl = () => Promise.resolve("x");
+    requestLoad("a.md");
+    await flushMicrotasks();
+    expect(fired).toBe(0);
+  });
+
+  it("isolates errors thrown by one subscriber from the others", async () => {
+    let second = 0;
+    onCacheChanged(() => { throw new Error("boom"); });
+    onCacheChanged(() => { second++; });
+    readerSlot.impl = () => Promise.resolve("x");
+    requestLoad("a.md");
+    await flushMicrotasks();
+    expect(second).toBeGreaterThan(0);
+  });
+});
+
+describe("noteContentCache — external file-change invalidation", () => {
+  beforeEach(() => {
+    __cacheForTests.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("drops the cache entry when the watcher reports a modify", () => {
+    __cacheForTests.set("a.md", "old");
+    // Watcher payload carries absolute paths; the module's own toVaultRel
+    // handles the mapping. If the subscription never wired (no Tauri in the
+    // test env — our vi.mock returns a resolved promise that stashes the
+    // handler), `handlerSlot.cb` is set.
+    expect(handlerSlot.cb).not.toBeNull();
+    handlerSlot.cb!({ path: "/vault/a.md" });
+    expect(readCached("a.md")).toBeNull();
+  });
+
+  it("handles rename via new_path", () => {
+    __cacheForTests.set("old.md", "content");
+    __cacheForTests.set("new.md", "target");
+    handlerSlot.cb!({ path: "/vault/old.md", new_path: "/vault/new.md" });
+    expect(readCached("old.md")).toBeNull();
+    expect(readCached("new.md")).toBeNull();
+  });
+
+  it("ignores events for paths outside the vault", () => {
+    __cacheForTests.set("a.md", "content");
+    handlerSlot.cb!({ path: "/somewhere/else/a.md" });
+    expect(readCached("a.md")).toBe("content");
+  });
+});

--- a/src/lib/__tests__/noteContentCache.test.ts
+++ b/src/lib/__tests__/noteContentCache.test.ts
@@ -34,7 +34,6 @@ import {
   requestLoad,
   invalidate,
   clear,
-  onCacheChanged,
   noteContentCacheVersion,
   __cacheForTests,
 } from "../noteContentCache";
@@ -179,6 +178,52 @@ describe("noteContentCache — generation tokens (race safety)", () => {
     await flushMicrotasks();
     expect(readCached("a.md")).toBe("fresh");
   });
+
+  // Review B2: before the fix, invalidate() bumped generation but left the
+  // inFlight slot set, so the very next requestLoad(rel) was a silent no-op.
+  // The stale fetch resolved and got dropped as intended — but then no new
+  // fetch was scheduled, and the path stayed missing until the next outside
+  // invalidation. Pin the fix: after invalidate, requestLoad must enqueue
+  // a fresh fetch that actually lands.
+  it("invalidate mid-load releases the slot so requestLoad can re-enqueue", async () => {
+    const resolvers: Array<(v: string) => void> = [];
+    readerSlot.impl = () =>
+      new Promise<string>((r) => {
+        resolvers.push(r);
+      });
+    requestLoad("a.md");
+    expect(__cacheForTests.inFlightSize()).toBe(1);
+    invalidate("a.md");
+    expect(__cacheForTests.inFlightSize()).toBe(0);
+    requestLoad("a.md");
+    expect(__cacheForTests.inFlightSize()).toBe(1);
+    // Two fetches are now open; the first-bumped one drops, the second lands.
+    resolvers[0]!("stale");
+    resolvers[1]!("fresh");
+    await flushMicrotasks();
+    expect(readCached("a.md")).toBe("fresh");
+  });
+
+  // Review B1: same story for clear() — it used to leave inFlight populated,
+  // wedging the path until an external invalidation fired. The fix clears
+  // inFlight too and a fresh requestLoad after clear() must work.
+  it("clear mid-load releases the slot so requestLoad can re-enqueue", async () => {
+    const resolvers: Array<(v: string) => void> = [];
+    readerSlot.impl = () =>
+      new Promise<string>((r) => {
+        resolvers.push(r);
+      });
+    requestLoad("a.md");
+    expect(__cacheForTests.inFlightSize()).toBe(1);
+    clear();
+    expect(__cacheForTests.inFlightSize()).toBe(0);
+    requestLoad("a.md");
+    expect(__cacheForTests.inFlightSize()).toBe(1);
+    resolvers[0]!("stale-vault-a");
+    resolvers[1]!("fresh-vault-b");
+    await flushMicrotasks();
+    expect(readCached("a.md")).toBe("fresh-vault-b");
+  });
 });
 
 describe("noteContentCache — failure handling", () => {
@@ -200,6 +245,20 @@ describe("noteContentCache — failure handling", () => {
     requestLoad("bad.md");
     await flushMicrotasks();
     expect(calls).toBe(1);
+  });
+
+  // Pins the documented trade-off from the module header: failed reads
+  // cache as `""` so `.contains("X")` returns false for permanently
+  // unreadable files. The side effect — `.contains("")` returns `true` for
+  // both legit empty files and failed reads — is intentional; users who
+  // care can filter via `n.content.length > 0` first.
+  it("treats failed reads as indistinguishable from empty files by design", async () => {
+    readerSlot.impl = () => Promise.reject(new Error("permission-denied"));
+    requestLoad("failed.md");
+    await flushMicrotasks();
+    expect(readCached("failed.md")).toBe("");
+    expect(readCached("failed.md")?.includes("anything")).toBe(false);
+    expect(readCached("failed.md")?.includes("")).toBe(true);
   });
 });
 
@@ -270,40 +329,32 @@ describe("noteContentCache — concurrency cap", () => {
   });
 });
 
-describe("noteContentCache — subscriber notifications", () => {
+describe("noteContentCache — store-based change notifications", () => {
   beforeEach(() => {
     __cacheForTests.reset();
     vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
   });
 
-  it("onCacheChanged fires after a successful load", async () => {
-    let fired = 0;
-    const unsub = onCacheChanged(() => { fired++; });
+  it("bumps noteContentCacheVersion after a successful load", async () => {
+    const before = get(noteContentCacheVersion);
     readerSlot.impl = () => Promise.resolve("x");
     requestLoad("a.md");
     await flushMicrotasks();
-    expect(fired).toBeGreaterThan(0);
-    unsub();
+    expect(get(noteContentCacheVersion)).toBeGreaterThan(before);
   });
 
-  it("onCacheChanged unsubscribe stops firing", async () => {
+  it("subscriber unsubscribe stops firing", async () => {
     let fired = 0;
-    const unsub = onCacheChanged(() => { fired++; });
+    let ready = false;
+    const unsub = noteContentCacheVersion.subscribe(() => {
+      if (ready) fired++;
+    });
+    ready = true;
     unsub();
     readerSlot.impl = () => Promise.resolve("x");
     requestLoad("a.md");
     await flushMicrotasks();
     expect(fired).toBe(0);
-  });
-
-  it("isolates errors thrown by one subscriber from the others", async () => {
-    let second = 0;
-    onCacheChanged(() => { throw new Error("boom"); });
-    onCacheChanged(() => { second++; });
-    readerSlot.impl = () => Promise.resolve("x");
-    requestLoad("a.md");
-    await flushMicrotasks();
-    expect(second).toBeGreaterThan(0);
   });
 });
 

--- a/src/lib/__tests__/vaultApi.test.ts
+++ b/src/lib/__tests__/vaultApi.test.ts
@@ -202,3 +202,26 @@ describe("createVaultRoot — type tags for debug rendering", () => {
     expect(a.__id).toBe("a.md");
   });
 });
+
+// #319: Regression — the original bug was that `n.content.contains(...)` only
+// considered the active editor tab. A `readNoteContent` that returns content
+// for every note must let the filter match all of them.
+describe("createVaultRoot — content-based filtering across all notes (#319)", () => {
+  it("where(n => n.content.contains(...)) matches non-active notes", () => {
+    const bodies: Record<string, string> = {
+      "a.md": "nothing here",
+      "sub/b.md": "mentions Maestro somewhere",
+      "sub/c.md": "also Maestro in this one",
+    };
+    const v = createVaultRoot(
+      mkStores({
+        readNoteContent: (p) => bodies[p] ?? null,
+      }),
+    );
+    const hits = v.notes
+      .where((n) => n.content.includes("Maestro"))
+      .select((n) => n.path)
+      .toArray();
+    expect(hits).toEqual(["sub/b.md", "sub/c.md"]);
+  });
+});

--- a/src/lib/noteContentCache.ts
+++ b/src/lib/noteContentCache.ts
@@ -12,7 +12,13 @@
 //   - `readCached(rel)` is synchronous; returns the current string or `null`.
 //   - `requestLoad(rel)` enqueues an async `readFile` IPC if no entry exists
 //     and no fetch is already queued or in flight for that key. On
-//     completion the cache fills and subscribers are notified.
+//     completion the cache fills and subscribers are notified via the
+//     `noteContentCacheVersion` store.
+//   - `invalidate(rel)` + `clear()` drop the `inFlight` slot for the
+//     affected key so a subsequent `requestLoad` can immediately re-enqueue.
+//     The old in-flight fetch still resolves, but its `generation` token is
+//     stale at that point so its result is discarded — no stale write, no
+//     "silently wedged" key (PR #320 review B1/B2).
 //
 // Invalidation sources
 //   1. `listenFileChange` — external edits the watcher sees
@@ -35,9 +41,9 @@
 //   - `.first()` / `.any()` during warm-up may be non-deterministic across
 //     consecutive renders until every touched note has landed.
 //   - No eager bulk pre-fetch on vault open.
-//   - Unreadable files cache as `""` (mirrors the pre-existing embed
-//     behaviour). `.contains("X")` stays `false`; `.contains("")` stays
-//     `true`, identical to the old code path.
+//   - Unreadable files cache as `""` (cheap + keeps `.contains("X")` false).
+//     Side effect: `.contains("")` returns `true` for those notes — users
+//     who care can filter via `.where(n => n.content.length > 0)` first.
 
 import { writable, type Readable, get } from "svelte/store";
 
@@ -45,6 +51,7 @@ import { vaultStore } from "../store/vaultStore";
 import { tabStore } from "../store/tabStore";
 import { readFile } from "../ipc/commands";
 import { listenFileChange } from "../ipc/events";
+import { toVaultRel, absFromRel } from "./vaultPath";
 
 const LRU_MAX_ENTRIES = 1000;
 const MAX_FILE_BYTES = 256 * 1024;
@@ -52,7 +59,10 @@ const MAX_CONCURRENT = 8;
 
 const cache: Map<string, string> = new Map();
 const inFlight: Set<string> = new Set();
-const queue: string[] = [];
+// Map used as an ordered set — preserves FIFO order while giving O(1)
+// membership checks (the old `queue.indexOf` was O(n) per requestLoad and
+// mattered once a vault-wide `.where(n => n.content...)` enqueues thousands).
+const queue: Map<string, true> = new Map();
 let activeFetches = 0;
 
 // Per-key generation token. `invalidate()` / `clear()` bump it; a resolved
@@ -80,21 +90,8 @@ function scheduleBump(): void {
   });
 }
 
-function toVaultRel(absPath: string): string | null {
-  const vault = get(vaultStore).currentPath;
-  if (!vault) return null;
-  const absFwd = absPath.replace(/\\/g, "/");
-  const vaultFwd = vault.replace(/\\/g, "/").replace(/\/$/, "");
-  if (absFwd === vaultFwd) return "";
-  if (!absFwd.startsWith(vaultFwd + "/")) return null;
-  return absFwd.slice(vaultFwd.length + 1);
-}
-
-function absFromRel(rel: string): string | null {
-  const vault = get(vaultStore).currentPath;
-  if (!vault) return null;
-  const v = vault.replace(/\\/g, "/").replace(/\/$/, "");
-  return `${v}/${rel}`;
+function currentVaultPath(): string | null {
+  return get(vaultStore).currentPath ?? null;
 }
 
 // --- Public API ---------------------------------------------------------
@@ -109,69 +106,56 @@ export function readCached(rel: string): string | null {
 }
 
 export function requestLoad(rel: string): void {
-  if (cache.has(rel) || inFlight.has(rel)) return;
-  if (queue.indexOf(rel) !== -1) return;
-  queue.push(rel);
+  if (cache.has(rel) || inFlight.has(rel) || queue.has(rel)) return;
+  queue.set(rel, true);
   pump();
 }
 
 export function invalidate(rel: string): boolean {
   bumpGeneration(rel);
   const hadEntry = cache.delete(rel);
+  // B2 fix: drop the in-flight slot so the next `requestLoad` can re-enqueue
+  // immediately. The already-running fetch will still resolve but fail the
+  // generation check and discard its result.
+  inFlight.delete(rel);
+  queue.delete(rel);
   if (hadEntry) scheduleBump();
   return hadEntry;
 }
 
 export function clear(): void {
-  // Bump generation for every key the module knows about so any resolving
-  // in-flight fetches discard themselves instead of re-populating the fresh
-  // post-clear cache with stale content.
-  const seen = new Set<string>();
-  for (const k of cache.keys()) seen.add(k);
-  for (const k of inFlight) seen.add(k);
-  for (const k of queue) seen.add(k);
-  for (const k of seen) bumpGeneration(k);
+  // Bump generation for every in-flight key so their resolutions drop when
+  // they compare their captured token against the post-bump current value.
+  // Keys only in the queue never started a fetch, so their generation is
+  // meaningless; keys only in `cache` have nothing pending to drop.
+  for (const rel of inFlight) bumpGeneration(rel);
   cache.clear();
-  queue.length = 0;
-  // `inFlight` is intentionally not touched — the fetches themselves keep
-  // running, but their completion handlers check generation and no-op.
+  queue.clear();
+  // B1 fix: releasing in-flight slots lets a fresh `requestLoad(rel)` after
+  // the clear re-enqueue immediately instead of early-returning forever.
+  inFlight.clear();
+  // `generation` is intentionally not cleared — the bumped values are the
+  // sentinels that make stale resolves drop. Map growth is bounded by the
+  // count of unique keys that have ever been invalidated in this session;
+  // for a 10k-note vault under normal usage that is well under 1 MB.
   scheduleBump();
-  notifyImperative();
-}
-
-// Imperative subscriber list for consumers that can't use Svelte stores
-// (CM6 ViewPlugin instances that must dispatch a StateEffect per view).
-const subscribers: Set<() => void> = new Set();
-
-export function onCacheChanged(fn: () => void): () => void {
-  subscribers.add(fn);
-  return () => {
-    subscribers.delete(fn);
-  };
-}
-
-function notifyImperative(): void {
-  for (const fn of Array.from(subscribers)) {
-    try {
-      fn();
-    } catch {
-      // Isolate subscriber errors — one bad handler must not break others.
-    }
-  }
 }
 
 // --- Internals ----------------------------------------------------------
 
 function pump(): void {
-  while (activeFetches < MAX_CONCURRENT && queue.length > 0) {
-    const rel = queue.shift()!;
+  while (activeFetches < MAX_CONCURRENT && queue.size > 0) {
+    // Pull FIFO: iterator returns insertion order.
+    const rel = queue.keys().next().value as string;
+    queue.delete(rel);
     if (cache.has(rel) || inFlight.has(rel)) continue;
     void doFetch(rel);
   }
 }
 
 async function doFetch(rel: string): Promise<void> {
-  const abs = absFromRel(rel);
+  const vault = currentVaultPath();
+  const abs = absFromRel(rel, vault);
   if (abs === null) return;
   const gen = generation.get(rel) ?? 0;
   inFlight.add(rel);
@@ -179,19 +163,30 @@ async function doFetch(rel: string): Promise<void> {
   try {
     const content = await readFile(abs);
     if ((generation.get(rel) ?? 0) !== gen) return;
-    if (content.length > MAX_FILE_BYTES) return;
+    if (content.length > MAX_FILE_BYTES) {
+      if (import.meta.env?.DEV) {
+        // Surface the skip in dev so a user with a giant note doesn't silently
+        // wonder why `.contains(...)` never matches it.
+        console.debug(
+          `[noteContentCache] skipping cache for ${rel}: ${content.length} bytes exceeds cap ${MAX_FILE_BYTES}`,
+        );
+      }
+      return;
+    }
     setCache(rel, content);
   } catch {
     if ((generation.get(rel) ?? 0) === gen) {
-      // Mirror the pre-existing embed-plugin behaviour: failures cache as
-      // empty string so the UI doesn't retry on every render.
+      // Cache an empty string for unreadable files. Keeps `.contains("X")`
+      // returning false and prevents an every-render retry storm for a
+      // permanently broken path. Trade-off documented in the module header.
       setCache(rel, "");
     }
   } finally {
+    // `invalidate` / `clear` may have already released the slot — `Set.delete`
+    // on an absent key is a safe no-op, so the finally block is idempotent.
     inFlight.delete(rel);
     activeFetches--;
     scheduleBump();
-    notifyImperative();
     pump();
   }
 }
@@ -206,23 +201,39 @@ function setCache(rel: string, content: string): void {
 }
 
 // --- Wiring: invalidation sources ---------------------------------------
+//
+// State captured at module scope (not inside wireOnce) so the test-only
+// reset hook can wipe the `lastSaved*` and `lastVaultPath` snapshots too —
+// otherwise two tests that touch different vault paths would leak state
+// across cases.
 
+const lastSavedByTabId: Map<string, string> = new Map();
+let lastVaultPath: string | null | undefined = undefined;
 let wired = false;
+// Capture unlisten handles so HMR (Vite) can tear them down and avoid
+// stacking duplicate subscriptions across hot reloads.
+const teardown: Array<() => void> = [];
+
 function wireOnce(): void {
   if (wired) return;
   wired = true;
 
   try {
     void listenFileChange((payload) => {
-      const rel = toVaultRel(payload.path);
+      const vault = currentVaultPath();
+      const rel = toVaultRel(payload.path, vault);
       if (rel !== null) invalidate(rel);
       if (payload.new_path) {
-        const newRel = toVaultRel(payload.new_path);
+        const newRel = toVaultRel(payload.new_path, vault);
         if (newRel !== null) invalidate(newRel);
       }
-    }).catch(() => {
-      // Tauri backend missing — tests run without IPC.
-    });
+    })
+      .then((unlisten) => {
+        teardown.push(unlisten);
+      })
+      .catch(() => {
+        // Tauri backend missing — tests run without IPC.
+      });
   } catch {
     // Same reason — keep module importable under vitest.
   }
@@ -230,57 +241,100 @@ function wireOnce(): void {
   // Diff lastSavedContent per-tab to catch internal auto-saves that the
   // watcher suppresses via `write_ignore`. Mirror of the pattern in the
   // previous embedPlugin.ts implementation (issue #27).
-  const lastSavedByTabId: Map<string, string> = new Map();
-  tabStore.subscribe((state) => {
-    for (const tab of state.tabs) {
-      const prev = lastSavedByTabId.get(tab.id);
-      if (prev !== tab.lastSavedContent) {
-        lastSavedByTabId.set(tab.id, tab.lastSavedContent);
-        const rel = toVaultRel(tab.filePath);
-        if (rel !== null) invalidate(rel);
+  teardown.push(
+    tabStore.subscribe((state) => {
+      const vault = currentVaultPath();
+      for (const tab of state.tabs) {
+        const prev = lastSavedByTabId.get(tab.id);
+        if (prev !== tab.lastSavedContent) {
+          lastSavedByTabId.set(tab.id, tab.lastSavedContent);
+          const rel = toVaultRel(tab.filePath, vault);
+          if (rel !== null) invalidate(rel);
+        }
+      }
+      const live = new Set(state.tabs.map((t) => t.id));
+      for (const id of Array.from(lastSavedByTabId.keys())) {
+        if (!live.has(id)) lastSavedByTabId.delete(id);
+      }
+    }),
+  );
+
+  // Vault switch → full clear. First observation only records the baseline.
+  teardown.push(
+    vaultStore.subscribe((state) => {
+      if (lastVaultPath === undefined) {
+        lastVaultPath = state.currentPath;
+        return;
+      }
+      if (state.currentPath !== lastVaultPath) {
+        lastVaultPath = state.currentPath;
+        clear();
+        // A fresh vault means new tabs too; reset the per-tab snapshot map
+        // so the first auto-save on the new vault isn't suppressed by a
+        // stale match from the old vault's tab ids.
+        lastSavedByTabId.clear();
+      }
+    }),
+  );
+}
+
+// HMR teardown so Vite hot-reload doesn't stack duplicate subscriptions.
+// `import.meta.hot` is undefined in production bundles and in vitest, so the
+// guard keeps both paths silent.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    for (const fn of teardown.splice(0)) {
+      try {
+        fn();
+      } catch {
+        // A failed teardown must not prevent the next handler from running.
       }
     }
-    const live = new Set(state.tabs.map((t) => t.id));
-    for (const id of Array.from(lastSavedByTabId.keys())) {
-      if (!live.has(id)) lastSavedByTabId.delete(id);
-    }
-  });
-
-  // Vault switch → full clear. Initial subscription call doesn't clear
-  // because `lastVaultPath` starts at the initial value.
-  let lastVaultPath: string | null | undefined = undefined;
-  vaultStore.subscribe((state) => {
-    if (lastVaultPath === undefined) {
-      lastVaultPath = state.currentPath;
-      return;
-    }
-    if (state.currentPath !== lastVaultPath) {
-      lastVaultPath = state.currentPath;
-      clear();
-    }
+    wired = false;
   });
 }
 
 wireOnce();
 
 // --- Test hooks ---------------------------------------------------------
+//
+// Gated behind a dev/test check so a stray production caller can't silently
+// wipe the cache. The import itself still succeeds in production — only the
+// methods themselves throw.
+
+const IS_TEST_ENV =
+  (typeof import.meta !== "undefined" && import.meta.env?.MODE === "test") ||
+  (typeof process !== "undefined" && process.env?.NODE_ENV === "test") ||
+  (typeof globalThis !== "undefined" &&
+    (globalThis as { __vitest_worker__?: unknown }).__vitest_worker__ !== undefined);
+
+function assertTestEnv(): void {
+  if (!IS_TEST_ENV) {
+    throw new Error("__cacheForTests is only callable from test environments");
+  }
+}
 
 export const __cacheForTests = {
-  get: (rel: string) => cache.get(rel),
-  set: (rel: string, content: string) => setCache(rel, content),
-  has: (rel: string) => cache.has(rel),
-  size: () => cache.size,
-  inFlightSize: () => inFlight.size,
-  queueLength: () => queue.length,
-  activeFetches: () => activeFetches,
-  limits: () => ({ LRU_MAX_ENTRIES, MAX_FILE_BYTES, MAX_CONCURRENT }),
+  get: (rel: string) => (assertTestEnv(), cache.get(rel)),
+  set: (rel: string, content: string) => (assertTestEnv(), setCache(rel, content)),
+  has: (rel: string) => (assertTestEnv(), cache.has(rel)),
+  size: () => (assertTestEnv(), cache.size),
+  inFlightSize: () => (assertTestEnv(), inFlight.size),
+  queueLength: () => (assertTestEnv(), queue.size),
+  activeFetches: () => (assertTestEnv(), activeFetches),
+  limits: () => (assertTestEnv(), { LRU_MAX_ENTRIES, MAX_FILE_BYTES, MAX_CONCURRENT }),
   reset: () => {
+    assertTestEnv();
     cache.clear();
     inFlight.clear();
-    queue.length = 0;
+    queue.clear();
     activeFetches = 0;
     generation.clear();
     pendingBump = false;
     versionStore.set(0);
+    // Wiping the wiring-layer snapshots too — otherwise a test that flips
+    // vault paths inherits closure state from the previous test.
+    lastSavedByTabId.clear();
+    lastVaultPath = undefined;
   },
 };

--- a/src/lib/noteContentCache.ts
+++ b/src/lib/noteContentCache.ts
@@ -1,0 +1,286 @@
+// Shared module-level cache for reading note content from disk, keyed by
+// vault-relative path. Backs two consumers:
+//   - `embedPlugin.ts` (note-embed rendering `![[Foo]]`)
+//   - `vaultApiStoreBridge.ts` (template expressions like
+//     `{{vault.notes.where(n => n.content.contains("X"))}}`)
+//
+// Before extraction each consumer ran its own cache; invalidation drift
+// between the two was the bug #319 root-cause. One cache, one invalidation
+// surface.
+//
+// Invariants
+//   - `readCached(rel)` is synchronous; returns the current string or `null`.
+//   - `requestLoad(rel)` enqueues an async `readFile` IPC if no entry exists
+//     and no fetch is already queued or in flight for that key. On
+//     completion the cache fills and subscribers are notified.
+//
+// Invalidation sources
+//   1. `listenFileChange` — external edits the watcher sees
+//   2. `tabStore` diff-on-snapshot — internal auto-saves (suppressed from
+//      the watcher by `write_ignore`, so we diff lastSavedContent instead)
+//   3. `vaultStore.currentPath` change → `clear()`
+//
+// Limits
+//   - LRU: `LRU_MAX_ENTRIES` entries. Map-insertion-order drives eviction;
+//     each hit re-inserts to approximate LRU without a second data structure.
+//   - Per-file cap: files larger than `MAX_FILE_BYTES` are fetched but not
+//     retained, so a single huge file cannot blow the budget.
+//   - Concurrency: at most `MAX_CONCURRENT` reads in flight; overflow queues.
+//
+// Batching
+//   - Version bumps coalesce through a microtask so N parallel completions
+//     produce one re-render tick, not N.
+//
+// Known non-goals (deferred follow-ups)
+//   - `.first()` / `.any()` during warm-up may be non-deterministic across
+//     consecutive renders until every touched note has landed.
+//   - No eager bulk pre-fetch on vault open.
+//   - Unreadable files cache as `""` (mirrors the pre-existing embed
+//     behaviour). `.contains("X")` stays `false`; `.contains("")` stays
+//     `true`, identical to the old code path.
+
+import { writable, type Readable, get } from "svelte/store";
+
+import { vaultStore } from "../store/vaultStore";
+import { tabStore } from "../store/tabStore";
+import { readFile } from "../ipc/commands";
+import { listenFileChange } from "../ipc/events";
+
+const LRU_MAX_ENTRIES = 1000;
+const MAX_FILE_BYTES = 256 * 1024;
+const MAX_CONCURRENT = 8;
+
+const cache: Map<string, string> = new Map();
+const inFlight: Set<string> = new Set();
+const queue: string[] = [];
+let activeFetches = 0;
+
+// Per-key generation token. `invalidate()` / `clear()` bump it; a resolved
+// fetch whose generation no longer matches drops its result — defends against
+// (a) delete-during-load ghost resurrection and (b) vault-switch-during-load
+// races where content for vault A would otherwise land in the cache of
+// vault B.
+const generation: Map<string, number> = new Map();
+function bumpGeneration(rel: string): number {
+  const g = (generation.get(rel) ?? 0) + 1;
+  generation.set(rel, g);
+  return g;
+}
+
+const versionStore = writable(0);
+export const noteContentCacheVersion: Readable<number> = versionStore;
+
+let pendingBump = false;
+function scheduleBump(): void {
+  if (pendingBump) return;
+  pendingBump = true;
+  queueMicrotask(() => {
+    pendingBump = false;
+    versionStore.update((v) => v + 1);
+  });
+}
+
+function toVaultRel(absPath: string): string | null {
+  const vault = get(vaultStore).currentPath;
+  if (!vault) return null;
+  const absFwd = absPath.replace(/\\/g, "/");
+  const vaultFwd = vault.replace(/\\/g, "/").replace(/\/$/, "");
+  if (absFwd === vaultFwd) return "";
+  if (!absFwd.startsWith(vaultFwd + "/")) return null;
+  return absFwd.slice(vaultFwd.length + 1);
+}
+
+function absFromRel(rel: string): string | null {
+  const vault = get(vaultStore).currentPath;
+  if (!vault) return null;
+  const v = vault.replace(/\\/g, "/").replace(/\/$/, "");
+  return `${v}/${rel}`;
+}
+
+// --- Public API ---------------------------------------------------------
+
+export function readCached(rel: string): string | null {
+  const value = cache.get(rel);
+  if (value === undefined) return null;
+  // LRU touch.
+  cache.delete(rel);
+  cache.set(rel, value);
+  return value;
+}
+
+export function requestLoad(rel: string): void {
+  if (cache.has(rel) || inFlight.has(rel)) return;
+  if (queue.indexOf(rel) !== -1) return;
+  queue.push(rel);
+  pump();
+}
+
+export function invalidate(rel: string): boolean {
+  bumpGeneration(rel);
+  const hadEntry = cache.delete(rel);
+  if (hadEntry) scheduleBump();
+  return hadEntry;
+}
+
+export function clear(): void {
+  // Bump generation for every key the module knows about so any resolving
+  // in-flight fetches discard themselves instead of re-populating the fresh
+  // post-clear cache with stale content.
+  const seen = new Set<string>();
+  for (const k of cache.keys()) seen.add(k);
+  for (const k of inFlight) seen.add(k);
+  for (const k of queue) seen.add(k);
+  for (const k of seen) bumpGeneration(k);
+  cache.clear();
+  queue.length = 0;
+  // `inFlight` is intentionally not touched — the fetches themselves keep
+  // running, but their completion handlers check generation and no-op.
+  scheduleBump();
+  notifyImperative();
+}
+
+// Imperative subscriber list for consumers that can't use Svelte stores
+// (CM6 ViewPlugin instances that must dispatch a StateEffect per view).
+const subscribers: Set<() => void> = new Set();
+
+export function onCacheChanged(fn: () => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+function notifyImperative(): void {
+  for (const fn of Array.from(subscribers)) {
+    try {
+      fn();
+    } catch {
+      // Isolate subscriber errors — one bad handler must not break others.
+    }
+  }
+}
+
+// --- Internals ----------------------------------------------------------
+
+function pump(): void {
+  while (activeFetches < MAX_CONCURRENT && queue.length > 0) {
+    const rel = queue.shift()!;
+    if (cache.has(rel) || inFlight.has(rel)) continue;
+    void doFetch(rel);
+  }
+}
+
+async function doFetch(rel: string): Promise<void> {
+  const abs = absFromRel(rel);
+  if (abs === null) return;
+  const gen = generation.get(rel) ?? 0;
+  inFlight.add(rel);
+  activeFetches++;
+  try {
+    const content = await readFile(abs);
+    if ((generation.get(rel) ?? 0) !== gen) return;
+    if (content.length > MAX_FILE_BYTES) return;
+    setCache(rel, content);
+  } catch {
+    if ((generation.get(rel) ?? 0) === gen) {
+      // Mirror the pre-existing embed-plugin behaviour: failures cache as
+      // empty string so the UI doesn't retry on every render.
+      setCache(rel, "");
+    }
+  } finally {
+    inFlight.delete(rel);
+    activeFetches--;
+    scheduleBump();
+    notifyImperative();
+    pump();
+  }
+}
+
+function setCache(rel: string, content: string): void {
+  if (cache.has(rel)) cache.delete(rel);
+  cache.set(rel, content);
+  if (cache.size > LRU_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
+// --- Wiring: invalidation sources ---------------------------------------
+
+let wired = false;
+function wireOnce(): void {
+  if (wired) return;
+  wired = true;
+
+  try {
+    void listenFileChange((payload) => {
+      const rel = toVaultRel(payload.path);
+      if (rel !== null) invalidate(rel);
+      if (payload.new_path) {
+        const newRel = toVaultRel(payload.new_path);
+        if (newRel !== null) invalidate(newRel);
+      }
+    }).catch(() => {
+      // Tauri backend missing — tests run without IPC.
+    });
+  } catch {
+    // Same reason — keep module importable under vitest.
+  }
+
+  // Diff lastSavedContent per-tab to catch internal auto-saves that the
+  // watcher suppresses via `write_ignore`. Mirror of the pattern in the
+  // previous embedPlugin.ts implementation (issue #27).
+  const lastSavedByTabId: Map<string, string> = new Map();
+  tabStore.subscribe((state) => {
+    for (const tab of state.tabs) {
+      const prev = lastSavedByTabId.get(tab.id);
+      if (prev !== tab.lastSavedContent) {
+        lastSavedByTabId.set(tab.id, tab.lastSavedContent);
+        const rel = toVaultRel(tab.filePath);
+        if (rel !== null) invalidate(rel);
+      }
+    }
+    const live = new Set(state.tabs.map((t) => t.id));
+    for (const id of Array.from(lastSavedByTabId.keys())) {
+      if (!live.has(id)) lastSavedByTabId.delete(id);
+    }
+  });
+
+  // Vault switch → full clear. Initial subscription call doesn't clear
+  // because `lastVaultPath` starts at the initial value.
+  let lastVaultPath: string | null | undefined = undefined;
+  vaultStore.subscribe((state) => {
+    if (lastVaultPath === undefined) {
+      lastVaultPath = state.currentPath;
+      return;
+    }
+    if (state.currentPath !== lastVaultPath) {
+      lastVaultPath = state.currentPath;
+      clear();
+    }
+  });
+}
+
+wireOnce();
+
+// --- Test hooks ---------------------------------------------------------
+
+export const __cacheForTests = {
+  get: (rel: string) => cache.get(rel),
+  set: (rel: string, content: string) => setCache(rel, content),
+  has: (rel: string) => cache.has(rel),
+  size: () => cache.size,
+  inFlightSize: () => inFlight.size,
+  queueLength: () => queue.length,
+  activeFetches: () => activeFetches,
+  limits: () => ({ LRU_MAX_ENTRIES, MAX_FILE_BYTES, MAX_CONCURRENT }),
+  reset: () => {
+    cache.clear();
+    inFlight.clear();
+    queue.length = 0;
+    activeFetches = 0;
+    generation.clear();
+    pendingBump = false;
+    versionStore.set(0);
+  },
+};

--- a/src/lib/vaultApiStoreBridge.ts
+++ b/src/lib/vaultApiStoreBridge.ts
@@ -9,6 +9,7 @@ import { bookmarksStore } from "../store/bookmarksStore";
 import { editorStore } from "../store/editorStore";
 import { createVaultRoot } from "./vaultApi";
 import type { VaultStores, VaultRoot } from "./vaultApi";
+import { readCached, requestLoad } from "./noteContentCache";
 
 function vaultNameFromPath(path: string | null): string {
   if (!path) return "";
@@ -30,10 +31,16 @@ function currentStores(): VaultStores {
     readTags: () => get(tagsStore).tags,
     readBookmarks: () => get(bookmarksStore).paths,
     readNoteContent: (relPath: string) => {
-      // In-memory only: the active editor tab. Non-active notes have no
-      // content available synchronously. See #283 follow-up.
+      // Active tab → live buffer (reflects unsaved edits).
       const s = get(editorStore);
-      return s.activePath === relPath ? s.content : null;
+      if (s.activePath === relPath) return s.content;
+      // Otherwise fall back to the shared on-disk cache (#319). A miss
+      // kicks an async load; the next render-tick — triggered by the
+      // `noteContentCacheVersion` store — will see the filled entry.
+      const cached = readCached(relPath);
+      if (cached !== null) return cached;
+      requestLoad(relPath);
+      return null;
     },
   };
 }

--- a/src/lib/vaultPath.ts
+++ b/src/lib/vaultPath.ts
@@ -1,0 +1,22 @@
+// Tiny path helpers shared by the embed plugin and the note-content cache.
+// Kept in their own module so two callers don't go out of sync on the
+// slash-normalisation rules (forward slashes, trim trailing separator).
+//
+// `vaultPath` is always the absolute filesystem path to the vault root —
+// possibly using backslashes on Windows. Relative paths are always
+// forward-slash, no leading slash, as stored in `vaultStore.fileList`.
+
+export function toVaultRel(absPath: string, vaultPath: string | null): string | null {
+  if (!vaultPath) return null;
+  const absFwd = absPath.replace(/\\/g, "/");
+  const vaultFwd = vaultPath.replace(/\\/g, "/").replace(/\/$/, "");
+  if (absFwd === vaultFwd) return "";
+  if (!absFwd.startsWith(vaultFwd + "/")) return null;
+  return absFwd.slice(vaultFwd.length + 1);
+}
+
+export function absFromRel(rel: string, vaultPath: string | null): string | null {
+  if (!vaultPath) return null;
+  const v = vaultPath.replace(/\\/g, "/").replace(/\/$/, "");
+  return `${v}/${rel}`;
+}


### PR DESCRIPTION
Closes #319.

## Summary

- `{{vault.notes.where(n => n.content.contains(\"X\"))}}` now matches every note in the vault, not just the active editor tab.
- Extracted the embed plugin's in-line note-content cache into `src/lib/noteContentCache.ts` so the `\`n.content\`` template path and the `\`![[…]]\`` embed path share one source of truth. Invalidation (watcher + autosave diff + vault switch) moves with it.
- New safety rails on the shared cache: LRU cap (1000 entries), per-file cap (256 KB), concurrency cap (8 in-flight fetches), generation tokens against delete-during-load / vault-switch-during-load races, and a microtask-batched version store so N parallel completions trigger one re-render tick.

## Why

`readNoteContent` in `vaultApiStoreBridge.ts` only served the currently-open tab; every other note resolved to `\"\"`, so `.contains(...)` was always false for unopened notes. This also meant the embed cache and the template layer had two separate caches with independent invalidation — the pre-condition for silent drift if one branch got fixed and the other didn't.

## Test plan

- [x] `pnpm test` — 1103 / 1103 pass (42 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [x] UAT: open `~/Documents/NMS/2026-04-21.md`, confirm the expression returns the list of Maestro notes within ~one render tick (after async file reads land)
- [x] UAT: edit an unrelated note in another pane, save, confirm the expression re-evaluates
- [x] UAT: regression check — `![[Foo]]` note embeds still render, still refresh on external edit

## Known follow-ups

- `.first()` / `.any()` may be non-deterministic during warm-up until every touched note has been read once. Tracked as a follow-up; not in scope here.
- No eager bulk pre-fetch at vault open — current design is lazy. Could layer on a background indexer later.
- Tantivy BM25 fast-path for `.contains(...)` is an independent optimization opportunity.