### PR TITLE
feat(reading): evaluate `{{ ... }}` template expressions in Reading Mode (#321)

### DIFF
--- a/src/components/Editor/ReadingView.svelte
+++ b/src/components/Editor/ReadingView.svelte
@@ -18,6 +18,11 @@
   import { toastStore } from "../../store/toastStore";
   import { tabStore } from "../../store/tabStore";
   import type { Tab } from "../../store/tabStore";
+  import { vaultStore } from "../../store/vaultStore";
+  import { tagsStore } from "../../store/tagsStore";
+  import { bookmarksStore } from "../../store/bookmarksStore";
+  import { noteContentCacheVersion } from "../../lib/noteContentCache";
+  import { titleFromPath } from "../../lib/templateScope";
 
   interface Props {
     tab: Tab;
@@ -38,7 +43,7 @@
     if (!tab) return;
     try {
       const content = await readFile(tab.filePath);
-      html = renderMarkdownToHtml(content);
+      html = renderMarkdownToHtml(content, titleFromPath(tab.filePath));
       loadError = null;
     } catch (err) {
       loadError = "Datei konnte nicht gelesen werden.";
@@ -55,6 +60,33 @@
       loadedForId = id;
       void load();
     }
+  });
+
+  // #322 — Reading Mode must re-render when the data a `{{ ... }}` template
+  // expression reads over changes on disk, otherwise a template like
+  // `{{vault.notes.where(n => n.content.contains("X"))}}` would stay frozen
+  // with whatever the vault looked like when the tab opened. Subscribe to the
+  // same stores the CM6 live-preview plugin watches (vaultStore / tagsStore /
+  // bookmarksStore / noteContentCacheVersion) and re-read the file on any
+  // tick. The svelte subscribe contract invokes the callback synchronously
+  // with the current value, so a `ready` latch suppresses the initial burst
+  // that would otherwise double-load on mount.
+  onMount(() => {
+    let ready = false;
+    const trigger = (): void => {
+      if (!ready) return;
+      if (loadedForId !== null) void load();
+    };
+    const unsubs: Array<() => void> = [
+      vaultStore.subscribe(trigger),
+      tagsStore.subscribe(trigger),
+      bookmarksStore.subscribe(trigger),
+      noteContentCacheVersion.subscribe(trigger),
+    ];
+    ready = true;
+    return () => {
+      for (const u of unsubs) u();
+    };
   });
 
   // Save the current scroll position when this view deactivates (tab switch

--- a/src/components/Editor/ReadingView.svelte
+++ b/src/components/Editor/ReadingView.svelte
@@ -62,7 +62,7 @@
     }
   });
 
-  // #322 — Reading Mode must re-render when the data a `{{ ... }}` template
+  // #321 — Reading Mode must re-render when the data a `{{ ... }}` template
   // expression reads over changes on disk, otherwise a template like
   // `{{vault.notes.where(n => n.content.contains("X"))}}` would stay frozen
   // with whatever the vault looked like when the tab opened. Subscribe to the

--- a/src/components/Editor/ReadingView.svelte
+++ b/src/components/Editor/ReadingView.svelte
@@ -12,7 +12,7 @@
    * position independently.
    */
 
-  import { onMount, onDestroy } from "svelte";
+  import { onMount } from "svelte";
   import { readFile } from "../../ipc/commands";
   import { renderMarkdownToHtml } from "./reading/markdownRenderer";
   import { toastStore } from "../../store/toastStore";
@@ -39,15 +39,37 @@
   // pane re-loads even when the component is reused.
   let loadedForId: string | null = null;
 
+  // Generation token guards against stale-write races: every call to `load()`
+  // takes the current value of `gen`, and only writes `html` / `loadError` if
+  // its token is still current when the async `readFile` resolves. Without
+  // this, a slow read for tab A that's still in flight when the user switches
+  // to tab B can overwrite tab B's rendered HTML with tab A's content.
+  let gen = 0;
+  // Pending-reload latch: when multiple store subscriptions fire in the same
+  // frame (e.g. rename bumps vaultStore + noteContentCacheVersion + tagsStore
+  // at once), coalesce them into a single microtask-scheduled reload.
+  let reloadPending = false;
+
   async function load(): Promise<void> {
     if (!tab) return;
+    const token = ++gen;
+    const path = tab.filePath;
     try {
-      const content = await readFile(tab.filePath);
-      html = renderMarkdownToHtml(content, titleFromPath(tab.filePath));
+      const content = await readFile(path);
+      if (token !== gen) return;
+      html = renderMarkdownToHtml(content, titleFromPath(path));
       loadError = null;
     } catch (err) {
-      loadError = "Datei konnte nicht gelesen werden.";
-      toastStore.push({ variant: "error", message: loadError });
+      if (token !== gen) return;
+      const message = "Datei konnte nicht gelesen werden.";
+      // Suppress repeated toasts while the error condition persists — a
+      // bulk rename or mid-rename watcher burst emits many store ticks per
+      // frame, and raising a toast on every one of them floods the UI.
+      const shouldToast = loadError !== message;
+      loadError = message;
+      if (shouldToast) {
+        toastStore.push({ variant: "error", message: message });
+      }
     }
   }
 
@@ -70,12 +92,21 @@
   // bookmarksStore / noteContentCacheVersion) and re-read the file on any
   // tick. The svelte subscribe contract invokes the callback synchronously
   // with the current value, so a `ready` latch suppresses the initial burst
-  // that would otherwise double-load on mount.
+  // that would otherwise double-load on mount. `queueMicrotask` coalesces
+  // bursts that cross multiple stores (rename / delete / cache version bump
+  // commonly fire all four in the same frame) into one `readFile` + render
+  // cycle instead of four.
   onMount(() => {
     let ready = false;
     const trigger = (): void => {
       if (!ready) return;
-      if (loadedForId !== null) void load();
+      if (loadedForId === null) return;
+      if (reloadPending) return;
+      reloadPending = true;
+      queueMicrotask(() => {
+        reloadPending = false;
+        void load();
+      });
     };
     const unsubs: Array<() => void> = [
       vaultStore.subscribe(trigger),
@@ -84,6 +115,9 @@
       noteContentCacheVersion.subscribe(trigger),
     ];
     ready = true;
+    // Teardown lives next to the subscriptions rather than in a separate
+    // `onDestroy` so a future reader sees the full lifecycle in one block.
+    // The scroll-persist cleanup below uses the same pattern.
     return () => {
       for (const u of unsubs) u();
     };
@@ -109,12 +143,26 @@
     wasActive = nowActive;
   });
 
-  // Persist scroll on unmount too — covers closing the tab while in Reading
-  // Mode, which otherwise would drop the scroll position.
-  onDestroy(() => {
+  // Restore initial scroll after the first render when the tab opens directly
+  // in Reading Mode (isActive was already true when the component mounted, so
+  // the wasActive → active transition above wouldn't fire). Also persists
+  // scroll on unmount — covers closing the tab while in Reading Mode, which
+  // otherwise would drop the scroll position. Teardown is returned as the
+  // onMount cleanup to keep the whole lifecycle in one block instead of
+  // splitting between onMount + a separate onDestroy.
+  onMount(() => {
     if (isActive && containerEl) {
-      tabStore.updateReadingScrollPos(tab.id, containerEl.scrollTop);
+      const pos = tab.readingScrollPos ?? 0;
+      requestAnimationFrame(() => {
+        if (containerEl) containerEl.scrollTop = pos;
+      });
     }
+    wasActive = isActive;
+    return () => {
+      if (isActive && containerEl) {
+        tabStore.updateReadingScrollPos(tab.id, containerEl.scrollTop);
+      }
+    };
   });
 
   function handleClick(event: MouseEvent): void {
@@ -158,19 +206,6 @@
     const targetTop = targetEl.getBoundingClientRect().top;
     containerEl.scrollTop += targetTop - containerTop - 8;
   }
-
-  // Restore initial scroll after the first render when the tab opens directly
-  // in Reading Mode (isActive was already true when the component mounted, so
-  // the wasActive → active transition above wouldn't fire).
-  onMount(() => {
-    if (isActive && containerEl) {
-      const pos = tab.readingScrollPos ?? 0;
-      requestAnimationFrame(() => {
-        if (containerEl) containerEl.scrollTop = pos;
-      });
-    }
-    wasActive = isActive;
-  });
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/src/components/Editor/__tests__/ReadingViewReload.test.ts
+++ b/src/components/Editor/__tests__/ReadingViewReload.test.ts
@@ -1,0 +1,130 @@
+// #321 — Reading Mode must re-render when one of the vault-describing stores
+// ticks, not just when the tab id changes. Without this subscription chain,
+// a template like `{{vault.notes.where(n => n.content.contains("X"))}}`
+// would stay frozen with the vault snapshot from tab-open time.
+//
+// Strategy: mount ReadingView against a stubbed `readFile`, let the initial
+// load settle, then bump `vaultStore` and assert `readFile` is called again.
+// A second sub-test uses `noteContentCacheVersion` to cover the #319
+// invalidation path specifically — a store that only exists for this trigger
+// chain, so a regression that severs it shows up here immediately.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+const readFileMock = vi.fn<(path: string) => Promise<string>>();
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile: (path: string) => readFileMock(path),
+}));
+
+import ReadingView from "../ReadingView.svelte";
+import { vaultStore } from "../../../store/vaultStore";
+import { __cacheForTests, invalidate as invalidateCache } from "../../../lib/noteContentCache";
+import type { Tab } from "../../../store/tabStore";
+
+/**
+ * Trigger a `noteContentCacheVersion` bump from test code: seed a cache
+ * entry, then invalidate it. Goes through the real public API so a future
+ * refactor of the bump scheduling is exercised too.
+ */
+function bumpNoteContentCacheVersion(): void {
+  const key = `_vctest_bump_${Math.random().toString(36).slice(2)}`;
+  __cacheForTests.set(key, "x");
+  invalidateCache(key);
+}
+
+const VAULT = "/tmp/reading-reload-vault";
+const FILE_PATH = "notes/sample.md";
+
+function makeTab(): Tab {
+  return {
+    id: "tab-1",
+    filePath: FILE_PATH,
+    isDirty: false,
+    scrollPos: 0,
+    cursorPos: 0,
+    lastSaved: 0,
+    lastSavedContent: "",
+  };
+}
+
+async function waitForReadCount(n: number, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (readFileMock.mock.calls.length >= n) return;
+    await tick();
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(
+    `expected ${n} reads, got ${readFileMock.mock.calls.length}`,
+  );
+}
+
+describe("ReadingView live-reload on vault-store ticks (#321)", () => {
+  beforeEach(() => {
+    readFileMock.mockReset();
+    readFileMock.mockResolvedValue("# Hello");
+    vaultStore.setReady({ currentPath: VAULT, fileList: [FILE_PATH], fileCount: 1 });
+  });
+
+  it("re-reads the file when vaultStore ticks", async () => {
+    render(ReadingView, {
+      props: { tab: makeTab(), isActive: true },
+    });
+
+    await waitForReadCount(1);
+    expect(readFileMock.mock.calls).toHaveLength(1);
+
+    // Simulate a rename / new file landing in the vault. The store update
+    // bumps both subscribers; the microtask in ReadingView coalesces the
+    // burst into a single reload.
+    vaultStore.setReady({
+      currentPath: VAULT,
+      fileList: [FILE_PATH, "notes/new.md"],
+      fileCount: 2,
+    });
+
+    await waitForReadCount(2);
+    expect(readFileMock.mock.calls).toHaveLength(2);
+  });
+
+  it("re-reads the file when noteContentCacheVersion bumps (#319 integration)", async () => {
+    render(ReadingView, {
+      props: { tab: makeTab(), isActive: true },
+    });
+
+    await waitForReadCount(1);
+
+    bumpNoteContentCacheVersion();
+
+    await waitForReadCount(2);
+    expect(readFileMock.mock.calls).toHaveLength(2);
+  });
+
+  it("coalesces synchronous same-tick vaultStore ticks into a single reload", async () => {
+    render(ReadingView, {
+      props: { tab: makeTab(), isActive: true },
+    });
+
+    await waitForReadCount(1);
+
+    // Fire three vaultStore updates synchronously in the same tick. All
+    // three trigger callbacks run before the coalescing microtask fires,
+    // so they must collapse to exactly one reload — not three.
+    vaultStore.setReady({ currentPath: VAULT, fileList: [FILE_PATH], fileCount: 1 });
+    vaultStore.setReady({ currentPath: VAULT, fileList: [FILE_PATH, "a.md"], fileCount: 2 });
+    vaultStore.setReady({ currentPath: VAULT, fileList: [FILE_PATH, "a.md", "b.md"], fileCount: 3 });
+
+    await waitForReadCount(2);
+    // The three bursts coalesce into exactly one additional read. A
+    // regression that drops the coalescing microtask would raise this to
+    // 3 — asserting `=== 2` locks that property in place.
+    expect(readFileMock.mock.calls).toHaveLength(2);
+  });
+});

--- a/src/components/Editor/__tests__/markdownRenderer.test.ts
+++ b/src/components/Editor/__tests__/markdownRenderer.test.ts
@@ -188,15 +188,75 @@ describe("renderMarkdownToHtml (#63)", () => {
       expect(html).toContain("<p>World</p>");
     });
 
-    it("leaves empty-output templates as source to keep them debuggable", () => {
-      // `""` evaluates to the empty string; per the semantics documented in
-      // `expandTemplates`, empty output leaves the source visible so an
-      // accidentally-empty template is not silently swallowed in Reading
-      // Mode. markdown-it's typographer converts the straight quotes to
-      // curly quotes during rendering — assert on the `{{`/`}}` markers
-      // rather than the inner chars.
-      const html = renderMarkdownToHtml('{{ "" }}', "n");
-      expect(html).toMatch(/\{\{.*\}\}/);
+    it("collapses deliberately-empty template output to nothing", () => {
+      // `""` evaluates successfully to the empty string. Reading Mode must
+      // emit empty rather than the literal source, so that a conditional
+      // like `{{ flag ? "x" : "" }}` can cleanly collapse — the reader
+      // should never see the raw template syntax for a successful eval.
+      const html = renderMarkdownToHtml('before{{ "" }}after', "n");
+      expect(html).toContain("beforeafter");
+      expect(html).not.toContain("{{");
+    });
+
+    it("keeps the source visible only when the evaluator throws", () => {
+      // Unknown identifier throws → source stays. Empty output from a
+      // successful eval collapses to empty. Asserting the two paths are
+      // treated differently pins the semantics in place so they can't
+      // drift back together in a future refactor.
+      const errHtml = renderMarkdownToHtml("{{missing.chain}}", "n");
+      expect(errHtml).toContain("{{missing.chain}}");
+
+      const okHtml = renderMarkdownToHtml('{{ "ok" }}', "n");
+      expect(okHtml).toContain("ok");
+      expect(okHtml).not.toContain("{{");
+    });
+
+    it("does not evaluate templates inside fenced code blocks", () => {
+      const md = "before\n\n```md\n{{date}}\n```\n\nafter";
+      const html = renderMarkdownToHtml(md, "n");
+      // The literal `{{date}}` must reach the rendered code block intact.
+      expect(html).toContain("{{date}}");
+      // Meanwhile plain text outside the fence is still a normal paragraph.
+      expect(html).toContain("<p>before</p>");
+    });
+
+    it("does not evaluate templates inside inline backtick spans", () => {
+      const html = renderMarkdownToHtml("inline: `{{date}}` done", "n");
+      // The inline code span should contain the verbatim template source,
+      // not today's date.
+      expect(html).toMatch(/<code>\{\{date\}\}<\/code>/);
+      expect(html).not.toMatch(/<code>\d{4}-\d{2}-\d{2}<\/code>/);
+    });
+
+    it("evaluates multi-line (cross-line) templates", () => {
+      // Cross-line parity with the CM6 viewport-sliced regex: `[^{}]` allows
+      // newlines, so a template that straddles multiple lines should still
+      // evaluate in Reading Mode.
+      const html = renderMarkdownToHtml(
+        '{{\n  "multi"\n  +\n  "line"\n}}',
+        "n",
+      );
+      expect(html).toContain("multiline");
+    });
+
+    it("does not silently rewrite evaluated text via markdown-it typographer", () => {
+      // `typographer: true` would convert `--`, `...`, and straight double
+      // quotes into em-dash, ellipsis, and curly quotes — different glyphs
+      // than the CM6 widget emits. This test pins the `typographer: false`
+      // setting by asserting the raw characters survive.
+      const html = renderMarkdownToHtml('{{ "a -- b ..." }}', "n");
+      expect(html).toContain("a -- b ...");
+      expect(html).not.toContain("–");
+      expect(html).not.toContain("…");
+    });
+
+    it("does not expand `{{ ... }}` outside a template body that contains braces", () => {
+      // Parity with CM6: the outer regex `[^{}]` rejects `{`/`}` inside the
+      // body, so a body containing a brace-in-string-literal does NOT match.
+      // The renderer must leave the source verbatim rather than corrupting
+      // it.
+      const html = renderMarkdownToHtml('{{ "a{b" }}', "n");
+      expect(html).toContain('{{ "a{b" }}');
     });
   });
 });

--- a/src/components/Editor/__tests__/markdownRenderer.test.ts
+++ b/src/components/Editor/__tests__/markdownRenderer.test.ts
@@ -141,8 +141,8 @@ describe("renderMarkdownToHtml (#63)", () => {
     expect(html).toContain('id="hello"');
   });
 
-  // ── Template expression expansion (#322) ───────────────────────────────
-  describe("template expression expansion (#322)", () => {
+  // ── Template expression expansion (#321) ───────────────────────────────
+  describe("template expression expansion (#321)", () => {
     it("renders {{title}} using the basename passed in", () => {
       const html = renderMarkdownToHtml("Hello {{title}}!", "MyNote");
       expect(html).toContain("Hello MyNote!");

--- a/src/components/Editor/__tests__/markdownRenderer.test.ts
+++ b/src/components/Editor/__tests__/markdownRenderer.test.ts
@@ -140,4 +140,63 @@ describe("renderMarkdownToHtml (#63)", () => {
     expect(html).toContain('href="#hello"');
     expect(html).toContain('id="hello"');
   });
+
+  // ── Template expression expansion (#322) ───────────────────────────────
+  describe("template expression expansion (#322)", () => {
+    it("renders {{title}} using the basename passed in", () => {
+      const html = renderMarkdownToHtml("Hello {{title}}!", "MyNote");
+      expect(html).toContain("Hello MyNote!");
+      expect(html).not.toContain("{{title}}");
+    });
+
+    it("renders {{date}} as an ISO-style yyyy-mm-dd string", () => {
+      const html = renderMarkdownToHtml("Today: {{date}}", "n");
+      expect(html).toMatch(/Today: \d{4}-\d{2}-\d{2}/);
+    });
+
+    it("evaluates multi-segment programs separated by `;`", () => {
+      const html = renderMarkdownToHtml(
+        '{{ "prefix-"; title }}',
+        "MyNote",
+      );
+      expect(html).toContain("prefix-MyNote");
+    });
+
+    it("leaves the source visible on evaluation error", () => {
+      // `nonexistent.whatever` throws an unknown-identifier error; the
+      // renderer must keep the literal `{{ ... }}` text rather than
+      // collapsing to an empty string.
+      const html = renderMarkdownToHtml(
+        "Broken {{nonexistent.whatever}} here",
+        "n",
+      );
+      expect(html).toContain("{{nonexistent.whatever}}");
+    });
+
+    it("preserves wiki-links produced inside a template expression as anchors", () => {
+      // `"[[foo]]"` as a string literal → same `[[foo]]` text after
+      // evaluation → markdown-it's wiki-link rule then turns it into an
+      // anchor with data-wiki-target.
+      setResolvedLinks(new Map([["foo", "notes/foo.md"]]));
+      const html = renderMarkdownToHtml('{{ "[[foo]]" }}', "n");
+      expect(html).toMatch(/<a[^>]*data-wiki-target="foo"[^>]*>/);
+    });
+
+    it("does not disturb plain markdown when no `{{ ... }}` is present", () => {
+      const html = renderMarkdownToHtml("# Hello\n\nWorld", "n");
+      expect(html).toMatch(/<h1[^>]*>Hello<\/h1>/);
+      expect(html).toContain("<p>World</p>");
+    });
+
+    it("leaves empty-output templates as source to keep them debuggable", () => {
+      // `""` evaluates to the empty string; per the semantics documented in
+      // `expandTemplates`, empty output leaves the source visible so an
+      // accidentally-empty template is not silently swallowed in Reading
+      // Mode. markdown-it's typographer converts the straight quotes to
+      // curly quotes during rendering — assert on the `{{`/`}}` markers
+      // rather than the inner chars.
+      const html = renderMarkdownToHtml('{{ "" }}', "n");
+      expect(html).toMatch(/\{\{.*\}\}/);
+    });
+  });
 });

--- a/src/components/Editor/reading/markdownRenderer.ts
+++ b/src/components/Editor/reading/markdownRenderer.ts
@@ -22,19 +22,25 @@ import { get } from "svelte/store";
 import { resolveTarget } from "../wikiLink";
 import { resolveAttachment } from "../embeds";
 import { vaultStore } from "../../../store/vaultStore";
-import { evaluateProgram } from "../../../lib/templateProgram";
-import { buildTemplateScope } from "../../../lib/templateScope";
+import { splitSegments } from "../../../lib/templateProgram";
+import { evaluate, renderValue } from "../../../lib/templateExpression";
+import { buildTemplateScope, TEMPLATE_EXPR_RE } from "../../../lib/templateScope";
 
 /**
  * Single shared instance — markdown-it is stateless between render() calls so
  * module-level reuse is safe and keeps the plugin-registration cost out of
  * the hot path.
  */
+// `typographer: false` because the evaluator output for `{{ ... }}` templates
+// flows through this parser before the user sees it — markdown-it's smartquote
+// / replacement rules would silently rewrite `--`, `...`, `"..."` etc. inside
+// evaluated strings, producing output that diverges from what the CM6 live-
+// preview widget shows. Reading Mode must match the editor's text verbatim.
 const md: MarkdownIt = new MarkdownIt({
   html: false,
   linkify: true,
   breaks: false,
-  typographer: true,
+  typographer: false,
 });
 
 // ── Wiki-embed inline rule (`![[target]]`) ────────────────────────────────────
@@ -211,40 +217,143 @@ function renderTaskListCheckboxes(html: string): string {
 // normal markdown pipeline — tables, lists, and wiki-links inside template
 // output render without any Reading-Mode-specific widget logic.
 //
-// Semantics mirror the CM6 live-preview plugin (`templateLivePreview.ts`):
-// on parse/evaluation failure and on empty output, the original `{{ ... }}`
-// source stays visible instead of collapsing to nothing. That keeps broken
-// expressions debuggable when flipping between edit and read views.
+// Two behaviours worth calling out:
+//   1. Code regions (fenced ``` / ~~~ blocks and inline backtick spans) are
+//      masked with placeholders before the replace so `{{ ... }}` inside a
+//      code example is preserved verbatim. Docs demonstrating the feature
+//      can safely render `{{date}}` inside a code block.
+//   2. Evaluator *errors* keep the original `{{ ... }}` source visible so
+//      the author can debug them across edit/read flips. Evaluator
+//      *success with empty output* emits the empty string — a deliberate
+//      conditional like `{{ flag ? "x" : "" }}` collapses cleanly rather
+//      than leaking the template source to the reader.
 
-const EXPR_RE = /\{\{([^{}]+?)\}\}/g;
+function expandTemplates(markdown: string, title: string | undefined): string {
+  const { masked, restore } = maskCodeRegions(markdown);
 
-function expandTemplates(markdown: string, title: string): string {
   // Build the scope once per render, even if there are zero `{{ ... }}`
   // matches — `replace` lazily calls the callback so the cost is tied to
   // matches, not to the scope builder itself (which touches svelte stores).
   let scope: ReturnType<typeof buildTemplateScope> | null = null;
-  return markdown.replace(EXPR_RE, (full, body: string) => {
-    try {
-      if (scope === null) scope = buildTemplateScope({ title });
-      const out = evaluateProgram(body, scope);
-      return out === "" ? full : out;
-    } catch {
-      return full;
+
+  const expanded = masked.replace(TEMPLATE_EXPR_RE, (full, body: string) => {
+    if (scope === null) scope = buildTemplateScope({ title });
+
+    // Evaluate segment-by-segment using the primitives rather than
+    // `evaluateProgram`, because `evaluateProgram` swallows per-segment
+    // errors into empty strings and we need to distinguish "all segments
+    // succeeded, concatenated output is empty" (emit the empty string) from
+    // "a segment threw" (keep source visible so the author can debug).
+    let result = "";
+    let anyError = false;
+    for (const seg of splitSegments(body)) {
+      const trimmed = seg.trim();
+      if (trimmed === "") continue;
+      try {
+        result += renderValue(evaluate(trimmed, scope));
+      } catch {
+        anyError = true;
+        break;
+      }
     }
+    return anyError ? full : result;
   });
+
+  return restore(expanded);
+}
+
+// ── Code-region masking ──────────────────────────────────────────────────────
+//
+// The placeholder uses Private-Use-Area delimiters (U+E000 / U+E001) rather
+// than NUL — CommonMark requires NUL to be replaced with U+FFFD before
+// parsing, which would destroy a NUL-based marker. Private-Use Area code
+// points are opaque to markdown-it and extremely unlikely to appear in a
+// user's notes, so placeholders survive the round-trip through the parser
+// untouched. `maskCodeRegions` guarantees that any `{{ ... }}` sequence
+// inside a mask is kept verbatim; `restore` swaps the placeholders back
+// for the original text after template expansion has run.
+
+const PLACEHOLDER_PREFIX = "VC_CODE_";
+const PLACEHOLDER_SUFFIX = "";
+const PLACEHOLDER_RE = /VC_CODE_(\d+)/g;
+
+/**
+ * Fenced-block opener or closer at the start of a line (with up to 3 spaces
+ * of indent). Captures the full backtick/tilde run so the closer can be
+ * matched against the opener's char + length per CommonMark.
+ */
+const FENCE_LINE_RE = /^[ ]{0,3}(`{3,}|~{3,})[ \t]*(?:[^`\n]*)?$/;
+
+/**
+ * Matched backtick-run inline code: the outer run must be the same length as
+ * the closer and not escaped or adjacent to another backtick. `[\s\S]+?`
+ * allows newlines since CommonMark permits multi-line inline code, though
+ * most real spans stay on one line.
+ */
+const INLINE_CODE_RE = /(`+)([\s\S]+?)\1/g;
+
+function maskCodeRegions(markdown: string): {
+  masked: string;
+  restore: (s: string) => string;
+} {
+  const slots: string[] = [];
+  const save = (s: string): string => {
+    const id = slots.length;
+    slots.push(s);
+    return `${PLACEHOLDER_PREFIX}${id}${PLACEHOLDER_SUFFIX}`;
+  };
+
+  // Pass 1: fenced code blocks. A line-level state machine is simpler and
+  // more forgiving than a regex for unclosed or nested-looking fences —
+  // an unclosed fence consumes through EOF, matching markdown-it.
+  const lines = markdown.split("\n");
+  const outLines: string[] = [];
+  let fenceChar: string | null = null;
+  let fenceLen = 0;
+  let buf: string[] = [];
+  for (const line of lines) {
+    if (fenceChar === null) {
+      const m = line.match(FENCE_LINE_RE);
+      if (m) {
+        fenceChar = m[1]![0]!;
+        fenceLen = m[1]!.length;
+        buf = [line];
+      } else {
+        outLines.push(line);
+      }
+    } else {
+      buf.push(line);
+      const closer = line.match(/^[ ]{0,3}(`{3,}|~{3,})[ \t]*$/);
+      if (
+        closer &&
+        closer[1]![0] === fenceChar &&
+        closer[1]!.length >= fenceLen
+      ) {
+        outLines.push(save(buf.join("\n")));
+        fenceChar = null;
+        fenceLen = 0;
+        buf = [];
+      }
+    }
+  }
+  if (fenceChar !== null) {
+    // Unclosed fence — mask through EOF so `{{...}}` inside stays verbatim.
+    outLines.push(save(buf.join("\n")));
+  }
+  const afterFences = outLines.join("\n");
+
+  // Pass 2: inline code spans. Scanned on the post-fence text so placeholders
+  // introduced above are immune to accidental backtick pairing.
+  const masked = afterFences.replace(INLINE_CODE_RE, (m) => save(m));
+
+  const restore = (s: string): string =>
+    s.replace(PLACEHOLDER_RE, (_, id: string) => slots[parseInt(id, 10)] ?? "");
+
+  return { masked, restore };
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
-/**
- * Render a markdown string to sanitized HTML suitable for injection via
- * `innerHTML`. Wiki-links reuse the existing resolution map so click-through
- * can dispatch the same handler the editor uses.
- *
- * `noteTitle` feeds the `{{title}}` binding — pass the tab's file basename so
- * template output matches what the editor shows. When omitted, templates fall
- * back to the active editor tab's title (the CM6 plugin's behaviour).
- */
 /**
  * Allow Tauri's `asset://` and the Tauri-Windows `http(s)://ipc.localhost`
  * convention that `convertFileSrc()` produces. Without this, DOMPurify strips
@@ -252,7 +361,21 @@ function expandTemplates(markdown: string, title: string): string {
  */
 const ALLOWED_URI_REGEXP = /^(?:(?:https?|ftp|mailto|tel|asset|file):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 
-export function renderMarkdownToHtml(markdown: string, noteTitle = ""): string {
+/**
+ * Render a markdown string to sanitized HTML suitable for injection via
+ * `innerHTML`. Wiki-links reuse the existing resolution map so click-through
+ * can dispatch the same handler the editor uses.
+ *
+ * `noteTitle` feeds the `{{title}}` binding in template expressions — pass
+ * the tab's file basename so template output matches what the editor shows.
+ * When omitted (not when passed as `""`), templates fall back to the active
+ * editor tab's basename, matching the CM6 plugin's behaviour. Pass `""`
+ * explicitly to bind `{{title}}` to the empty string.
+ */
+export function renderMarkdownToHtml(
+  markdown: string,
+  noteTitle?: string,
+): string {
   // Strip YAML frontmatter — readers don't want to see --- blocks at the top
   // of every note. Same rule the editor frontmatter plugin applies.
   const stripped = stripFrontmatter(markdown);

--- a/src/components/Editor/reading/markdownRenderer.ts
+++ b/src/components/Editor/reading/markdownRenderer.ts
@@ -22,6 +22,8 @@ import { get } from "svelte/store";
 import { resolveTarget } from "../wikiLink";
 import { resolveAttachment } from "../embeds";
 import { vaultStore } from "../../../store/vaultStore";
+import { evaluateProgram } from "../../../lib/templateProgram";
+import { buildTemplateScope } from "../../../lib/templateScope";
 
 /**
  * Single shared instance — markdown-it is stateless between render() calls so
@@ -201,12 +203,47 @@ function renderTaskListCheckboxes(html: string): string {
   });
 }
 
+// ── Template expression expansion (#322) ─────────────────────────────────────
+//
+// Runs before markdown-it so any `{{ ... }}` body is replaced with its
+// evaluated string first. The evaluator returns plain text (including full
+// GFM tables, joined wiki-link fragments, …), which then flows through the
+// normal markdown pipeline — tables, lists, and wiki-links inside template
+// output render without any Reading-Mode-specific widget logic.
+//
+// Semantics mirror the CM6 live-preview plugin (`templateLivePreview.ts`):
+// on parse/evaluation failure and on empty output, the original `{{ ... }}`
+// source stays visible instead of collapsing to nothing. That keeps broken
+// expressions debuggable when flipping between edit and read views.
+
+const EXPR_RE = /\{\{([^{}]+?)\}\}/g;
+
+function expandTemplates(markdown: string, title: string): string {
+  // Build the scope once per render, even if there are zero `{{ ... }}`
+  // matches — `replace` lazily calls the callback so the cost is tied to
+  // matches, not to the scope builder itself (which touches svelte stores).
+  let scope: ReturnType<typeof buildTemplateScope> | null = null;
+  return markdown.replace(EXPR_RE, (full, body: string) => {
+    try {
+      if (scope === null) scope = buildTemplateScope({ title });
+      const out = evaluateProgram(body, scope);
+      return out === "" ? full : out;
+    } catch {
+      return full;
+    }
+  });
+}
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
 /**
  * Render a markdown string to sanitized HTML suitable for injection via
  * `innerHTML`. Wiki-links reuse the existing resolution map so click-through
  * can dispatch the same handler the editor uses.
+ *
+ * `noteTitle` feeds the `{{title}}` binding — pass the tab's file basename so
+ * template output matches what the editor shows. When omitted, templates fall
+ * back to the active editor tab's title (the CM6 plugin's behaviour).
  */
 /**
  * Allow Tauri's `asset://` and the Tauri-Windows `http(s)://ipc.localhost`
@@ -215,13 +252,17 @@ function renderTaskListCheckboxes(html: string): string {
  */
 const ALLOWED_URI_REGEXP = /^(?:(?:https?|ftp|mailto|tel|asset|file):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 
-export function renderMarkdownToHtml(markdown: string): string {
+export function renderMarkdownToHtml(markdown: string, noteTitle = ""): string {
   // Strip YAML frontmatter — readers don't want to see --- blocks at the top
   // of every note. Same rule the editor frontmatter plugin applies.
   const stripped = stripFrontmatter(markdown);
+  // Expand `{{ ... }}` template expressions before markdown-it sees the text
+  // so tables / wiki-links produced by templates flow through the normal
+  // markdown rendering path.
+  const expanded = expandTemplates(stripped, noteTitle);
   // Fresh env per render — the heading_open rule uses `env._slugCounts` to
   // disambiguate repeated heading texts within a single document.
-  const rawHtml = renderTaskListCheckboxes(md.render(stripped, {}));
+  const rawHtml = renderTaskListCheckboxes(md.render(expanded, {}));
   return DOMPurify.sanitize(rawHtml, {
     ADD_ATTR: ["data-wiki-target", "data-wiki-resolved", "data-embed-target", "id"],
     ALLOW_DATA_ATTR: true,

--- a/src/components/Editor/reading/markdownRenderer.ts
+++ b/src/components/Editor/reading/markdownRenderer.ts
@@ -203,7 +203,7 @@ function renderTaskListCheckboxes(html: string): string {
   });
 }
 
-// ── Template expression expansion (#322) ─────────────────────────────────────
+// ── Template expression expansion (#321) ─────────────────────────────────────
 //
 // Runs before markdown-it so any `{{ ... }}` body is replaced with its
 // evaluated string first. The evaluator returns plain text (including full

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -26,7 +26,7 @@ import {
 import { RangeSetBuilder, StateEffect } from "@codemirror/state";
 
 import { evaluateProgram } from "../../lib/templateProgram";
-import { buildTemplateScope } from "../../lib/templateScope";
+import { buildTemplateScope, TEMPLATE_EXPR_RE } from "../../lib/templateScope";
 import { noteContentCacheVersion } from "../../lib/noteContentCache";
 import { vaultStore } from "../../store/vaultStore";
 import { tagsStore } from "../../store/tagsStore";
@@ -149,8 +149,6 @@ function appendValueWithWikiLinks(parent: HTMLElement, value: string): void {
   }
 }
 
-const EXPR_RE = /\{\{([^{}]+?)\}\}/g;
-
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
   const { from, to } = view.viewport;
@@ -161,9 +159,9 @@ function buildDecorations(view: EditorView): DecorationSet {
   let scope: ReturnType<typeof buildTemplateScope> | null = null;
   const now = new Date();
 
-  EXPR_RE.lastIndex = 0;
+  TEMPLATE_EXPR_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
-  while ((m = EXPR_RE.exec(text)) !== null) {
+  while ((m = TEMPLATE_EXPR_RE.exec(text)) !== null) {
     const absFrom = from + m.index;
     const absTo = absFrom + m[0].length;
 

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -24,15 +24,13 @@ import {
   type ViewUpdate,
 } from "@codemirror/view";
 import { RangeSetBuilder, StateEffect } from "@codemirror/state";
-import { get } from "svelte/store";
 
 import { evaluateProgram } from "../../lib/templateProgram";
-import { currentVaultRoot } from "../../lib/vaultApiStoreBridge";
+import { buildTemplateScope } from "../../lib/templateScope";
 import { noteContentCacheVersion } from "../../lib/noteContentCache";
 import { vaultStore } from "../../store/vaultStore";
 import { tagsStore } from "../../store/tagsStore";
 import { bookmarksStore } from "../../store/bookmarksStore";
-import { editorStore } from "../../store/editorStore";
 import { resolveTarget, stripKnownExt } from "./wikiLink";
 import { parseTableText, renderStaticTableDom } from "./tablePlugin";
 import type { ParsedTable } from "./tablePlugin";
@@ -153,26 +151,6 @@ function appendValueWithWikiLinks(parent: HTMLElement, value: string): void {
 
 const EXPR_RE = /\{\{([^{}]+?)\}\}/g;
 
-function formatDate(now: Date): string {
-  const yyyy = String(now.getFullYear());
-  const mm = String(now.getMonth() + 1).padStart(2, "0");
-  const dd = String(now.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-function formatTime(now: Date): string {
-  const hh = String(now.getHours()).padStart(2, "0");
-  const mi = String(now.getMinutes()).padStart(2, "0");
-  return `${hh}:${mi}`;
-}
-
-function activeTitle(): string {
-  const ap = get(editorStore).activePath;
-  if (!ap) return "";
-  const name = ap.split("/").pop() ?? "";
-  return name.endsWith(".md") ? name.slice(0, -3) : name;
-}
-
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
   const { from, to } = view.viewport;
@@ -180,7 +158,7 @@ function buildDecorations(view: EditorView): DecorationSet {
   const text = view.state.doc.sliceString(from, to);
 
   // Lazily built — avoids touching stores when no expressions are in view.
-  let vaultRoot: ReturnType<typeof currentVaultRoot> | null = null;
+  let scope: ReturnType<typeof buildTemplateScope> | null = null;
   const now = new Date();
 
   EXPR_RE.lastIndex = 0;
@@ -199,13 +177,8 @@ function buildDecorations(view: EditorView): DecorationSet {
     const body = m[1]!;
     let rendered: string;
     try {
-      if (vaultRoot === null) vaultRoot = currentVaultRoot();
-      rendered = evaluateProgram(body, {
-        vault: vaultRoot,
-        date: formatDate(now),
-        time: formatTime(now),
-        title: activeTitle(),
-      });
+      if (scope === null) scope = buildTemplateScope({ now });
+      rendered = evaluateProgram(body, scope);
     } catch {
       continue;
     }

--- a/src/lib/__tests__/templateScope.test.ts
+++ b/src/lib/__tests__/templateScope.test.ts
@@ -1,4 +1,4 @@
-// Tests for the shared template scope builder (#322).
+// Tests for the shared template scope builder (#321).
 // The scope returned by `buildTemplateScope` feeds both the CM6 live-preview
 // and the Reading Mode renderer; keeping its shape locked down via tests
 // prevents a drift where one view resolves an identifier the other doesn't.

--- a/src/lib/__tests__/templateScope.test.ts
+++ b/src/lib/__tests__/templateScope.test.ts
@@ -1,0 +1,62 @@
+// Tests for the shared template scope builder (#322).
+// The scope returned by `buildTemplateScope` feeds both the CM6 live-preview
+// and the Reading Mode renderer; keeping its shape locked down via tests
+// prevents a drift where one view resolves an identifier the other doesn't.
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  buildTemplateScope,
+  formatDate,
+  formatTime,
+  titleFromPath,
+} from "../templateScope";
+import { vaultStore } from "../../store/vaultStore";
+import { editorStore } from "../../store/editorStore";
+
+beforeEach(() => {
+  vaultStore.setReady({ currentPath: "/tmp/vault", fileList: [], fileCount: 0 });
+  editorStore.close();
+});
+
+describe("formatDate / formatTime", () => {
+  it("pads single-digit months, days, hours, and minutes", () => {
+    const d = new Date(2026, 0, 5, 3, 7, 0); // Jan 5 03:07
+    expect(formatDate(d)).toBe("2026-01-05");
+    expect(formatTime(d)).toBe("03:07");
+  });
+});
+
+describe("titleFromPath", () => {
+  it("strips the .md extension and any leading directories", () => {
+    expect(titleFromPath("folder/sub/MyNote.md")).toBe("MyNote");
+  });
+
+  it("leaves non-.md basenames untouched", () => {
+    expect(titleFromPath("assets/image.png")).toBe("image.png");
+  });
+
+  it("returns empty string for null / empty input", () => {
+    expect(titleFromPath(null)).toBe("");
+    expect(titleFromPath("")).toBe("");
+  });
+});
+
+describe("buildTemplateScope", () => {
+  it("exposes vault, date, time, title bindings", () => {
+    const scope = buildTemplateScope({
+      now: new Date(2026, 3, 21, 12, 34),
+      title: "Explicit",
+    });
+    expect(scope).toHaveProperty("vault");
+    expect(scope.date).toBe("2026-04-21");
+    expect(scope.time).toBe("12:34");
+    expect(scope.title).toBe("Explicit");
+  });
+
+  it("falls back to the active editor tab's basename when title is omitted", () => {
+    editorStore.openFile("folder/Fallback.md", "");
+    const scope = buildTemplateScope();
+    expect(scope.title).toBe("Fallback");
+  });
+});

--- a/src/lib/templateScope.ts
+++ b/src/lib/templateScope.ts
@@ -1,4 +1,4 @@
-// Shared scope construction for `{{ ... }}` template expressions (#322).
+// Shared scope construction for `{{ ... }}` template expressions (#321).
 //
 // The CM6 live-preview plugin (`templateLivePreview.ts`) and the Reading Mode
 // renderer (`reading/markdownRenderer.ts`) must expose the same identifiers

--- a/src/lib/templateScope.ts
+++ b/src/lib/templateScope.ts
@@ -1,0 +1,62 @@
+// Shared scope construction for `{{ ... }}` template expressions (#322).
+//
+// The CM6 live-preview plugin (`templateLivePreview.ts`) and the Reading Mode
+// renderer (`reading/markdownRenderer.ts`) must expose the same identifiers
+// to user expressions, otherwise a template that works while editing would
+// render differently once the tab flips to Reading Mode. This module owns
+// the one source of truth for that scope shape.
+
+import { get } from "svelte/store";
+
+import type { EvalScope } from "./templateExpression";
+import { currentVaultRoot } from "./vaultApiStoreBridge";
+import { editorStore } from "../store/editorStore";
+
+export function formatDate(now: Date): string {
+  const yyyy = String(now.getFullYear());
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export function formatTime(now: Date): string {
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mi = String(now.getMinutes()).padStart(2, "0");
+  return `${hh}:${mi}`;
+}
+
+/**
+ * Derive the bare note name (no extension, no directory) from a vault-relative
+ * path. Used as the `title` binding when no override is provided. `""` when
+ * the path is empty or has no basename.
+ */
+export function titleFromPath(path: string | null | undefined): string {
+  if (!path) return "";
+  const name = path.split("/").pop() ?? "";
+  return name.endsWith(".md") ? name.slice(0, -3) : name;
+}
+
+function activeTitle(): string {
+  return titleFromPath(get(editorStore).activePath);
+}
+
+/**
+ * Build the `EvalScope` exposed to `{{ ... }}` expressions.
+ *
+ * `title` may be passed explicitly (Reading Mode knows the tab's file path up
+ * front); when omitted, it falls back to the active editor tab's basename —
+ * the CM6 plugin's behaviour.
+ */
+export function buildTemplateScope(options?: {
+  now?: Date;
+  title?: string;
+}): EvalScope {
+  const now = options?.now ?? new Date();
+  const title = options?.title ?? activeTitle();
+  return {
+    vault: currentVaultRoot(),
+    date: formatDate(now),
+    time: formatTime(now),
+    title,
+  };
+}

--- a/src/lib/templateScope.ts
+++ b/src/lib/templateScope.ts
@@ -12,6 +12,19 @@ import type { EvalScope } from "./templateExpression";
 import { currentVaultRoot } from "./vaultApiStoreBridge";
 import { editorStore } from "../store/editorStore";
 
+/**
+ * Shared regex for the outer `{{ ... }}` boundary. Kept here rather than in
+ * each caller so a future grammar change only touches one file. The class
+ * `[^{}]` rejects `{` or `}` inside the body, which means expression-body
+ * string literals containing a brace (e.g. `{{ "a{b" }}`) do not match.
+ * That matches the CM6 live-preview plugin's behaviour — callers that need
+ * tighter parity can still walk the body with `splitSegments` from
+ * `templateProgram.ts`. `\r` and `\n` are allowed inside the body so
+ * multi-line templates work in Reading Mode the same way they would work
+ * across a CM6 viewport slice.
+ */
+export const TEMPLATE_EXPR_RE = /\{\{([^{}]+?)\}\}/g;
+
 export function formatDate(now: Date): string {
   const yyyy = String(now.getFullYear());
   const mm = String(now.getMonth() + 1).padStart(2, "0");
@@ -49,9 +62,15 @@ function activeTitle(): string {
  */
 export function buildTemplateScope(options?: {
   now?: Date;
-  title?: string;
+  title?: string | undefined;
 }): EvalScope {
   const now = options?.now ?? new Date();
+  // Intentional `??`: an explicit `""` passes through (caller wanted an empty
+  // title), but `undefined` — including a fully-omitted `options.title` —
+  // falls through to the active editor tab's basename. With
+  // `exactOptionalPropertyTypes: true`, callers that forward a possibly-
+  // undefined value must declare it `string | undefined` rather than `string`,
+  // so that's what the type signature admits.
   const title = options?.title ?? activeTitle();
   return {
     vault: currentVaultRoot(),


### PR DESCRIPTION
Closes #321.

## Summary

- New `src/lib/templateScope.ts` owns the single source of truth for the scope exposed to `{{ ... }}` expressions (`vault`, `date`, `time`, `title`); both CM6 live-preview and Reading Mode pull from it.
- `renderMarkdownToHtml()` gains a pre-markdown-it expansion pass that runs `evaluateProgram` over every `{{ ... }}` match. GFM tables, wiki-links, and lists produced by templates flow through the normal markdown pipeline — no Reading-Mode-specific widget code.
- Failure / empty-output semantics mirror the CM6 UX: the original source stays visible so a broken expression remains debuggable when flipping between edit and read modes.
- `ReadingView` subscribes to `vaultStore` / `tagsStore` / `bookmarksStore` / `noteContentCacheVersion` so template output re-renders when vault contents change on disk (rename, delete, non-active note edits), not only on tab switch.
- `renderMarkdownToHtml(markdown, noteTitle?)` — new optional `noteTitle` feeds `{{title}}`; defaults to the active editor tab's basename (existing CM6 behaviour) when omitted.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1118 passing (7 new tests covering `{{title}}`, `{{date}}`, multi-segment, error-keeps-source, wiki-link inside template, no-regression on plain markdown, empty-output-keeps-source + scope-builder unit tests)
- [x] `pnpm build` — clean
- [ ] Manual UAT (by author, after review fixes): open a note with `{{vault.folders.where(...).notes.select(n => "[[" + n.name + "]]").join("\n")}}`, flip to Reading Mode, confirm rendered anchors navigate; rename a note in another folder, confirm the reading pane re-renders without a tab switch.