### PR TITLE
fix(links): resolve `[[X]]` from template output after async map refresh (#309)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -289,6 +289,12 @@
       setResolvedLinks(new Map());
       setResolvedAttachments(new Map());
     }
+    // #309 — bump readyToken AFTER the map has been swapped in (success or
+    // soft-fail) so decoration layers that outlive EditorPane's refresh — CM6
+    // template live-preview, Reading Mode — can rebuild against the fresh
+    // map. Without this, their subscriptions would either never fire or fire
+    // on requestToken and rebuild against the still-stale map.
+    resolvedLinksStore.markReady();
   }
 
   /**
@@ -303,9 +309,19 @@
     u();
     if (!vault) return;
 
-    if (detail.resolved) {
+    // #309 — the decoration's `data-wiki-resolved` attribute reflects the
+    // resolved-links map at decoration-build time. When a file is created or
+    // moved between render and click (e.g. template re-renders on vaultStore
+    // tick before the async resolvedLinks refetch lands), the attribute can
+    // be stale-`false` while the live map now resolves the target. Re-check
+    // synchronously here so a stale decoration never routes into the
+    // create-at-root fallback.
+    const liveRelPath = resolveTarget(detail.target);
+    const effectivelyResolved = detail.resolved || liveRelPath !== null;
+
+    if (effectivelyResolved) {
       // LINK-03: synchronous lookup — zero IPC at click time
-      const relPath = resolveTarget(detail.target);
+      const relPath = liveRelPath ?? resolveTarget(detail.target);
       if (!relPath) {
         // Map out of sync (rare: file deleted between decoration and click)
         void reloadResolvedLinks();
@@ -361,10 +377,13 @@
   // rel_path until a manual reload. TreeNode fires `resolvedLinksStore.requestReload()`
   // after every rename/move so we refresh here and the click handler stops
   // routing [[new-name]] into the create-at-root fallback.
-  let prevResolvedLinksToken: string | null = null;
+  let prevResolvedLinksRequestToken: string | null = null;
   const unsubResolvedLinks = resolvedLinksStore.subscribe((state) => {
-    if (state.token && state.token !== prevResolvedLinksToken) {
-      prevResolvedLinksToken = state.token;
+    if (
+      state.requestToken &&
+      state.requestToken !== prevResolvedLinksRequestToken
+    ) {
+      prevResolvedLinksRequestToken = state.requestToken;
       void reloadResolvedLinks();
     }
   });

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -315,18 +315,16 @@
     // tick before the async resolvedLinks refetch lands), the attribute can
     // be stale-`false` while the live map now resolves the target. Re-check
     // synchronously here so a stale decoration never routes into the
-    // create-at-root fallback.
+    // create-at-root fallback. Zero IPC — `resolveTarget` is a `Map.get`.
     const liveRelPath = resolveTarget(detail.target);
-    const effectivelyResolved = detail.resolved || liveRelPath !== null;
 
-    if (effectivelyResolved) {
-      // LINK-03: synchronous lookup — zero IPC at click time
-      const relPath = liveRelPath ?? resolveTarget(detail.target);
-      if (!relPath) {
+    if (detail.resolved || liveRelPath !== null) {
+      if (!liveRelPath) {
         // Map out of sync (rare: file deleted between decoration and click)
         void reloadResolvedLinks();
         return;
       }
+      const relPath = liveRelPath;
       const absPath = `${vault}/${relPath}`;
       // #147 — `.canvas` targets need the canvas viewer; plain notes keep
       // the synchronous `openTab` fast path so markdown clicks stay on the

--- a/src/components/Editor/ReadingView.svelte
+++ b/src/components/Editor/ReadingView.svelte
@@ -21,6 +21,7 @@
   import { vaultStore } from "../../store/vaultStore";
   import { tagsStore } from "../../store/tagsStore";
   import { bookmarksStore } from "../../store/bookmarksStore";
+  import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { noteContentCacheVersion } from "../../lib/noteContentCache";
   import { titleFromPath } from "../../lib/templateScope";
 
@@ -108,11 +109,23 @@
         void load();
       });
     };
+    // #309: re-read + re-render when the resolved-links map becomes fresh so
+    // `[[New Note]]` rendered from a `{{ ... }}` template expression flips
+    // from unresolved to resolved without a manual tab reload. Guard on
+    // `readyToken` only — firing on `requestToken` would re-render against
+    // the still-stale map.
+    let prevReadyToken: string | null = null;
     const unsubs: Array<() => void> = [
       vaultStore.subscribe(trigger),
       tagsStore.subscribe(trigger),
       bookmarksStore.subscribe(trigger),
       noteContentCacheVersion.subscribe(trigger),
+      resolvedLinksStore.subscribe((state) => {
+        if (state.readyToken && state.readyToken !== prevReadyToken) {
+          prevReadyToken = state.readyToken;
+          trigger();
+        }
+      }),
     ];
     ready = true;
     // Teardown lives next to the subscriptions rather than in a separate

--- a/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
+++ b/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
@@ -13,13 +13,15 @@
  * `createFile` is not called.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/svelte";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
 import { tick } from "svelte";
 
-const { readFile, createFile } = vi.hoisted(() => ({
+const { readFile, createFile, getResolvedLinks, getResolvedAttachments } = vi.hoisted(() => ({
   readFile: vi.fn().mockResolvedValue(""),
   createFile: vi.fn().mockResolvedValue(""),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
 }));
 
 vi.mock("../../../ipc/commands", () => ({
@@ -28,8 +30,8 @@ vi.mock("../../../ipc/commands", () => ({
   writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
   getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
   mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
-  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
-  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  getResolvedLinks,
+  getResolvedAttachments,
   getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
   getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
   getBacklinks: vi.fn().mockResolvedValue([]),
@@ -86,7 +88,19 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     tabStore._reset();
     vaultStore.reset();
     createFile.mockReset().mockResolvedValue("");
+    getResolvedLinks.mockReset().mockResolvedValue(new Map());
+    getResolvedAttachments.mockReset().mockResolvedValue(new Map());
     setResolvedLinks(new Map());
+  });
+
+  afterEach(() => {
+    // svelte-testing-library doesn't auto-unmount on the version pinned here,
+    // so subscriptions (vault / resolvedLinks / tabStore) from one test stay
+    // live during the next and can replay async callbacks in an unrelated
+    // test's timeline. `cleanup()` tears down every render() + spy set up by
+    // the test.
+    cleanup();
+    vi.restoreAllMocks();
   });
 
   /**
@@ -127,6 +141,41 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
 
     expect(createFile).not.toHaveBeenCalled();
     expect(openTabSpy).toHaveBeenCalledWith("/vault/test/Untitled.md");
+  });
+
+  it("triggers a reload without opening or creating when the live map lost the target (resolved=true, liveRelPath=null)", async () => {
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md"],
+      fileCount: 1,
+    });
+    const cm = await mountMarkdownTabAndGetCm();
+
+    // Baseline: `getResolvedLinks` was called once at vault-open. Clear so we
+    // can isolate the reload the click handler triggers.
+    getResolvedLinks.mockClear();
+
+    // Stale decoration says resolved=true but the live map has no entry —
+    // matches the "file deleted between decoration and click" scenario.
+    setResolvedLinks(new Map());
+
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+    const openFileTabSpy = vi.spyOn(tabStore, "openFileTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: "DeletedNote", resolved: true },
+      }),
+    );
+    await flushAsync();
+
+    // Neither open nor create: the click short-circuits into a reload so
+    // the next render's decoration reflects the true state.
+    expect(openTabSpy).not.toHaveBeenCalled();
+    expect(openFileTabSpy).not.toHaveBeenCalled();
+    expect(createFile).not.toHaveBeenCalled();
+    expect(getResolvedLinks).toHaveBeenCalled();
   });
 
   it("still falls back to create-at-root when the live map also lacks the target", async () => {

--- a/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
+++ b/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #309 — `EditorPane.handleWikiLinkClick()` must synchronously re-check the
+ * resolved-links map before routing into the create-at-root fallback. The
+ * CM6 template live-preview widget bakes `data-wiki-resolved` into the DOM
+ * at decoration-build time; between that moment and the click, a file
+ * create / rename / move can make the once-unresolved target resolvable. If
+ * the click handler trusted the stale attribute, it would spawn a duplicate
+ * note at the vault root instead of opening the real file.
+ *
+ * This test dispatches a `wiki-link-click` CustomEvent with
+ * `detail.resolved = false` but seeds the resolved-links map with a live
+ * entry. Expected behaviour: `tabStore.openTab` fires on the resolved path;
+ * `createFile` is not called.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const { readFile, createFile } = vi.hoisted(() => ({
+  readFile: vi.fn().mockResolvedValue(""),
+  createFile: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile,
+  createFile,
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  // @ts-ignore
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+vi.mock("../../Graph/graphRender", () => ({
+  mountGraph: vi.fn(),
+  updateGraph: vi.fn(),
+  destroyGraph: vi.fn(),
+  DEFAULT_FORCE_SETTINGS: {},
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import { setResolvedLinks } from "../wikiLink";
+import EditorPane from "../EditorPane.svelte";
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+describe("EditorPane wiki-link click — live-lookup against stale decoration (#309)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    createFile.mockReset().mockResolvedValue("");
+    setResolvedLinks(new Map());
+  });
+
+  /**
+   * `wiki-link-click` is dispatched on the CM6 view's own DOM node, not the
+   * pane root. Mount a markdown tab so EditorPane wires up a CM6 EditorView,
+   * then grab its `.cm-editor` root to fire the event from there.
+   */
+  async function mountMarkdownTabAndGetCm(): Promise<HTMLElement> {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await flushAsync();
+    tabStore.openFileTab("/vault/host.md", "markdown");
+    await flushAsync();
+    const cm = container.querySelector(".cm-editor") as HTMLElement | null;
+    if (!cm) throw new Error("CM6 editor did not mount");
+    return cm;
+  }
+
+  it("opens the file via the resolved branch even when detail.resolved is stale-false", async () => {
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md", "test/Untitled.md"],
+      fileCount: 2,
+    });
+    const cm = await mountMarkdownTabAndGetCm();
+
+    // Stage the live map: `Untitled` is now resolvable to `test/Untitled.md`.
+    setResolvedLinks(new Map([["untitled", "test/Untitled.md"]]));
+
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: "Untitled", resolved: false },
+      }),
+    );
+    await flushAsync();
+
+    expect(createFile).not.toHaveBeenCalled();
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/test/Untitled.md");
+  });
+
+  it("still falls back to create-at-root when the live map also lacks the target", async () => {
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md"],
+      fileCount: 1,
+    });
+    const cm = await mountMarkdownTabAndGetCm();
+
+    createFile.mockResolvedValueOnce("/vault/Ghost.md");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: "Ghost", resolved: false },
+      }),
+    );
+    await flushAsync();
+
+    expect(createFile).toHaveBeenCalledWith("/vault", "Ghost.md");
+  });
+});

--- a/src/components/Editor/__tests__/ReadingViewReload.test.ts
+++ b/src/components/Editor/__tests__/ReadingViewReload.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../../ipc/commands", () => ({
 
 import ReadingView from "../ReadingView.svelte";
 import { vaultStore } from "../../../store/vaultStore";
+import { resolvedLinksStore } from "../../../store/resolvedLinksStore";
 import { __cacheForTests, invalidate as invalidateCache } from "../../../lib/noteContentCache";
 import type { Tab } from "../../../store/tabStore";
 
@@ -102,6 +103,24 @@ describe("ReadingView live-reload on vault-store ticks (#321)", () => {
     await waitForReadCount(1);
 
     bumpNoteContentCacheVersion();
+
+    await waitForReadCount(2);
+    expect(readFileMock.mock.calls).toHaveLength(2);
+  });
+
+  // #309 — Reading Mode renders wiki-links from template output with a
+  // snapshot of the resolved-links map at render time. After a new file
+  // lands, `resolvedLinksStore.markReady()` fires to signal the map is fresh
+  // and Reading Mode must re-read + re-render so `[[New Note]]` flips from
+  // unresolved to resolved without a manual tab reload.
+  it("re-reads the file when resolvedLinksStore.markReady() fires (#309)", async () => {
+    render(ReadingView, {
+      props: { tab: makeTab(), isActive: true },
+    });
+
+    await waitForReadCount(1);
+
+    resolvedLinksStore.markReady();
 
     await waitForReadCount(2);
     expect(readFileMock.mock.calls).toHaveLength(2);

--- a/src/components/Editor/__tests__/ReadingViewReload.test.ts
+++ b/src/components/Editor/__tests__/ReadingViewReload.test.ts
@@ -126,6 +126,29 @@ describe("ReadingView live-reload on vault-store ticks (#321)", () => {
     expect(readFileMock.mock.calls).toHaveLength(2);
   });
 
+  // #309 two-token invariant: a bare `requestReload()` must NOT cause Reading
+  // Mode to re-read. `requestReload` is the "map is stale, please refetch"
+  // edge; re-rendering at that edge would paint against the still-stale map.
+  // Only `markReady()` — fired after `setResolvedLinks()` has landed — is a
+  // valid trigger. This test locks that invariant so a future regression
+  // (e.g. subscribing to every store change indiscriminately) is caught.
+  it("does NOT re-read when resolvedLinksStore.requestReload() fires alone (#309)", async () => {
+    render(ReadingView, {
+      props: { tab: makeTab(), isActive: true },
+    });
+
+    await waitForReadCount(1);
+    expect(readFileMock.mock.calls).toHaveLength(1);
+
+    resolvedLinksStore.requestReload();
+
+    // Give ample time for any errant subscriber to fire — then confirm the
+    // read count did not increase.
+    for (let i = 0; i < 10; i++) await tick();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(readFileMock.mock.calls).toHaveLength(1);
+  });
+
   it("coalesces synchronous same-tick vaultStore ticks into a single reload", async () => {
     render(ReadingView, {
       props: { tab: makeTab(), isActive: true },

--- a/src/components/Editor/__tests__/templateLivePreview.test.ts
+++ b/src/components/Editor/__tests__/templateLivePreview.test.ts
@@ -60,6 +60,7 @@ vi.mock("../../../store/editorStore", () => {
 import { templateLivePlugin } from "../templateLivePreview";
 // Pull the store handles to flip their values between tests.
 import { vaultStore } from "../../../store/vaultStore";
+import { resolvedLinksStore } from "../../../store/resolvedLinksStore";
 import { setResolvedLinks } from "../wikiLink";
 
 function mount(doc: string, cursor = 0): EditorView {
@@ -442,5 +443,36 @@ describe("templateLivePlugin — rendering", () => {
     });
 
     expect(widgets(view)[0]!.text).toBe("OtherVault");
+  });
+
+  // #309 — regression: a file created between render and click left the
+  // rendered wiki-link span with `data-wiki-resolved="false"`, routing the
+  // click into the create-at-root fallback even after the resolved-links map
+  // had been refreshed. The fix rebuilds decorations on
+  // `resolvedLinksStore.markReady()` so the attribute flips live.
+  it("rebuilds decorations when resolvedLinksStore.markReady() fires after setResolvedLinks", () => {
+    // Start with an empty resolution map — `[[Untitled]]` is unresolved.
+    setResolvedLinks(new Map());
+    const doc = 'x {{"[[Untitled]]"}} y';
+    const view = mount(doc, 0);
+
+    const initialAnchor = view.dom.querySelector(
+      ".vc-template-rendered [data-wiki-target]",
+    );
+    expect(initialAnchor).not.toBeNull();
+    expect(initialAnchor!.getAttribute("data-wiki-resolved")).toBe("false");
+
+    // Simulate the flow after a sidebar "New note": EditorPane's async
+    // reloadResolvedLinks lands, setResolvedLinks is called, then markReady()
+    // bumps the readyToken. Template plugin must pick that up and rebuild.
+    setResolvedLinks(new Map([["untitled", "test/Untitled.md"]]));
+    resolvedLinksStore.markReady();
+
+    const refreshedAnchor = view.dom.querySelector(
+      ".vc-template-rendered [data-wiki-target]",
+    );
+    expect(refreshedAnchor).not.toBeNull();
+    expect(refreshedAnchor!.getAttribute("data-wiki-resolved")).toBe("true");
+    expect(refreshedAnchor!.classList.contains("cm-wikilink-resolved")).toBe(true);
   });
 });

--- a/src/components/Editor/__tests__/templateLivePreview.test.ts
+++ b/src/components/Editor/__tests__/templateLivePreview.test.ts
@@ -445,6 +445,35 @@ describe("templateLivePlugin — rendering", () => {
     expect(widgets(view)[0]!.text).toBe("OtherVault");
   });
 
+  // #309 two-token invariant: `requestReload()` is the "map stale, refetch"
+  // edge and must NOT trigger a decoration rebuild — rebuilding at that edge
+  // would paint against the still-stale map. Only `markReady()`, fired after
+  // `setResolvedLinks()` lands, is a valid trigger. This test locks the
+  // invariant so a future regression (e.g. subscribing to every store tick
+  // indiscriminately) is caught.
+  it("does NOT rebuild decorations when resolvedLinksStore.requestReload() fires alone (#309)", () => {
+    setResolvedLinks(new Map());
+    const doc = 'x {{"[[Ghost]]"}} y';
+    const view = mount(doc, 0);
+
+    const before = view.dom.querySelector(
+      ".vc-template-rendered [data-wiki-target]",
+    );
+    expect(before).not.toBeNull();
+    const beforeNode = before as HTMLElement;
+    expect(beforeNode.getAttribute("data-wiki-resolved")).toBe("false");
+
+    // Simulate the stale-edge only — the map is NOT updated.
+    resolvedLinksStore.requestReload();
+
+    // The exact same DOM node must still be present (no rebuild happened).
+    const after = view.dom.querySelector(
+      ".vc-template-rendered [data-wiki-target]",
+    );
+    expect(after).toBe(beforeNode);
+    expect(after!.getAttribute("data-wiki-resolved")).toBe("false");
+  });
+
   // #309 — regression: a file created between render and click left the
   // rendered wiki-link span with `data-wiki-resolved="false"`, routing the
   // click into the create-at-root fallback even after the resolved-links map

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -87,6 +87,12 @@ function sameTable(a: ParsedTable, b: ParsedTable): boolean {
 // `data-wiki-resolved="false"` on a link the user now expects to resolve.
 // Snapshot the resolution state of every `[[target]]` in the rendered text
 // so eq() can detect "same text, different resolution" and force a rebuild.
+//
+// COUPLING: this function and `appendValueWithWikiLinks` MUST share the same
+// link-matching semantics (regex `WIKI_LINK_IN_RENDER_RE`). If snapshotting
+// missed a form that the DOM-builder emits, eq() could false-positive and
+// leave stale `data-wiki-resolved` on that specific form. Both sites already
+// use the same module-level regex — keep them in sync if you change one.
 function wikiLinkResolutionSnapshot(text: string): string {
   const parts: string[] = [];
   WIKI_LINK_IN_RENDER_RE.lastIndex = 0;

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -31,6 +31,7 @@ import { noteContentCacheVersion } from "../../lib/noteContentCache";
 import { vaultStore } from "../../store/vaultStore";
 import { tagsStore } from "../../store/tagsStore";
 import { bookmarksStore } from "../../store/bookmarksStore";
+import { resolvedLinksStore } from "../../store/resolvedLinksStore";
 import { resolveTarget, stripKnownExt } from "./wikiLink";
 import { parseTableText, renderStaticTableDom } from "./tablePlugin";
 import type { ParsedTable } from "./tablePlugin";
@@ -79,10 +80,46 @@ function sameTable(a: ParsedTable, b: ParsedTable): boolean {
   return true;
 }
 
+// #309 — the rendered widget's DOM bakes in each embedded `[[target]]`'s
+// resolution status at build time. When the resolved-links map changes but
+// the rendered string stays identical, the default identity check in
+// WidgetType.eq would tell CM6 to reuse the stale DOM, leaving
+// `data-wiki-resolved="false"` on a link the user now expects to resolve.
+// Snapshot the resolution state of every `[[target]]` in the rendered text
+// so eq() can detect "same text, different resolution" and force a rebuild.
+function wikiLinkResolutionSnapshot(text: string): string {
+  const parts: string[] = [];
+  WIKI_LINK_IN_RENDER_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WIKI_LINK_IN_RENDER_RE.exec(text)) !== null) {
+    const rawTarget = m[1]!;
+    const resolved = resolveTarget(rawTarget) !== null;
+    parts.push(`${rawTarget}=${resolved ? "1" : "0"}`);
+  }
+  return parts.join("|");
+}
+
+function tableWikiLinkResolutionSnapshot(table: ParsedTable): string {
+  const parts: string[] = [];
+  for (const row of table.rows) {
+    for (const cell of row) {
+      const snap = wikiLinkResolutionSnapshot(cell);
+      if (snap.length > 0) parts.push(snap);
+    }
+  }
+  return parts.join("||");
+}
+
 class RenderedTableWidget extends WidgetType {
-  constructor(readonly table: ParsedTable) { super(); }
+  readonly linkResolutionSnapshot: string;
+  constructor(readonly table: ParsedTable) {
+    super();
+    this.linkResolutionSnapshot = tableWikiLinkResolutionSnapshot(table);
+  }
   override eq(other: WidgetType): boolean {
-    return other instanceof RenderedTableWidget && sameTable(other.table, this.table);
+    return other instanceof RenderedTableWidget
+      && sameTable(other.table, this.table)
+      && other.linkResolutionSnapshot === this.linkResolutionSnapshot;
   }
   toDOM(): HTMLElement {
     const wrap = renderStaticTableDom(this.table, (cell, text) =>
@@ -99,9 +136,15 @@ class RenderedTableWidget extends WidgetType {
 }
 
 class RenderedValueWidget extends WidgetType {
-  constructor(readonly value: string) { super(); }
+  readonly linkResolutionSnapshot: string;
+  constructor(readonly value: string) {
+    super();
+    this.linkResolutionSnapshot = wikiLinkResolutionSnapshot(value);
+  }
   override eq(other: WidgetType): boolean {
-    return other instanceof RenderedValueWidget && other.value === this.value;
+    return other instanceof RenderedValueWidget
+      && other.value === this.value
+      && other.linkResolutionSnapshot === this.linkResolutionSnapshot;
   }
   toDOM(): HTMLElement {
     const el = document.createElement("span");
@@ -214,6 +257,10 @@ export const templateLivePlugin = ViewPlugin.fromClass(
         if (!ready) return;
         view.dispatch({ effects: refreshEffect.of(undefined) });
       };
+      // #309: track the readyToken we last reacted to so the svelte
+      // synchronous-initial-value quirk doesn't trigger on mount and
+      // idempotent re-emits don't cause spurious rebuilds.
+      let prevReadyToken: string | null = null;
       this.unsubs.push(
         vaultStore.subscribe(trigger),
         tagsStore.subscribe(trigger),
@@ -222,6 +269,20 @@ export const templateLivePlugin = ViewPlugin.fromClass(
         // `{{vault.notes.where(n => n.content.contains("X"))}}` fills in
         // once the backing note contents have been read from disk.
         noteContentCacheVersion.subscribe(trigger),
+        // #309: rebuild after `setResolvedLinks()` lands a fresh stem->path
+        // map so `[[Untitled]]` in rendered output flips from unresolved to
+        // resolved without waiting for an unrelated vault tick. Guard on
+        // `readyToken` only — firing on `requestToken` would rebuild against
+        // the still-stale map.
+        resolvedLinksStore.subscribe((state) => {
+          if (
+            state.readyToken &&
+            state.readyToken !== prevReadyToken
+          ) {
+            prevReadyToken = state.readyToken;
+            trigger();
+          }
+        }),
       );
       ready = true;
     }

--- a/src/store/resolvedLinksStore.ts
+++ b/src/store/resolvedLinksStore.ts
@@ -1,5 +1,5 @@
-// resolvedLinksStore — one-shot signal that the wiki-link resolution map in
-// `components/Editor/wikiLink.ts` is stale and must be re-fetched.
+// resolvedLinksStore — signals for the wiki-link resolution map in
+// `components/Editor/wikiLink.ts`.
 //
 // The module-level `resolvedLinks: Map<stem, relPath>` is populated once per
 // vault open via EditorPane and refreshed on click-to-create. It does NOT
@@ -10,24 +10,40 @@
 // so EditorPane re-runs `getResolvedLinks` + `getResolvedAttachments` and
 // nudges every mounted view to rebuild decorations (#277).
 //
-// Pattern mirrors treeRefreshStore / scrollStore: monotonic token signals a
-// new request; consumer (EditorPane) watches for changes and calls
-// reloadResolvedLinks().
+// Two tokens so producers and consumers see the right edge:
+//   - requestToken — bumped by `requestReload()`. Owned by EditorPane, which
+//     watches it and kicks off the async fetch.
+//   - readyToken   — bumped by `markReady()` after `setResolvedLinks()` has
+//     landed the new map. Watched by decoration layers (CM6 template plugin,
+//     Reading Mode) that must rebuild against the *fresh* map. Without this
+//     split, subscribers firing on `requestReload` would rebuild against the
+//     stale map and the decoration would stay unresolved until the next
+//     unrelated vault tick (#309).
 
 import { writable } from "svelte/store";
 
 interface ResolvedLinksReloadState {
-  /** Opaque token — changes on every request. */
-  token: string | null;
+  /** Bumped by `requestReload()` — map is stale, EditorPane should refetch. */
+  requestToken: string | null;
+  /** Bumped by `markReady()` after `setResolvedLinks()` lands — decoration layers should rebuild. */
+  readyToken: string | null;
 }
 
-const _store = writable<ResolvedLinksReloadState>({ token: null });
+const _store = writable<ResolvedLinksReloadState>({
+  requestToken: null,
+  readyToken: null,
+});
 
 export const resolvedLinksStore = {
   subscribe: _store.subscribe,
 
   /** Signal that the stem->relPath map is stale and should be re-fetched. */
   requestReload(): void {
-    _store.set({ token: crypto.randomUUID() });
+    _store.update((s) => ({ ...s, requestToken: crypto.randomUUID() }));
+  },
+
+  /** Signal that `setResolvedLinks()` has just landed a fresh map; decorations should rebuild. */
+  markReady(): void {
+    _store.update((s) => ({ ...s, readyToken: crypto.randomUUID() }));
   },
 };


### PR DESCRIPTION
Closes #309.

## Summary
- Wiki-links rendered inside a `{{ ... }}` template expression no longer fall through to the create-at-root branch when their target file was just created via the sidebar / rename / move.
- Splits `resolvedLinksStore` into `requestToken` (stale → refetch) + `readyToken` (fresh map available → rebuild decorations) so decoration layers react to the post-`setResolvedLinks` edge, not the pre-refetch edge.
- CM6 template widgets (`RenderedValueWidget`, `RenderedTableWidget`) now include a wiki-link resolution snapshot in `eq()` so identical rendered text with different resolution forces a DOM rebuild.
- `EditorPane.handleWikiLinkClick` re-checks resolution synchronously before taking the create branch — defense-in-depth so a stale-`false` decoration can't spawn a duplicate note even in a pathological race.

## Files
- `src/store/resolvedLinksStore.ts` — two-token API (`requestToken` / `readyToken`), new `markReady()`.
- `src/components/Editor/EditorPane.svelte` — watch `requestToken`, call `markReady()` after `setResolvedLinks()`, live-lookup in click handler.
- `src/components/Editor/templateLivePreview.ts` — subscribe to `readyToken`, include wiki-link resolution snapshot in widget `eq()`.
- `src/components/Editor/ReadingView.svelte` — subscribe to `readyToken` through the existing coalesced reload path.

## Test plan
- [x] `pnpm test` — 1129/1129 pass (includes two new regression tests).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm exec svelte-check` — 0 errors (only pre-existing CSS warnings).
- [ ] Manual: open a template `{{ vault.folders.where(f => f.name == "test").first().notes.select(n => "[[" + n.name + "]]").join("\n") }}`, create `test/Untitled.md` via sidebar → click `[[Untitled]]` → editor opens the real file at `test/Untitled.md` (not an empty note at vault root).
- [ ] Manual: same flow in Reading Mode — `[[Untitled]]` flips from grey-dashed to accent-coloured without a tab reload.