### PR TITLE
fix(template): strip `{{ ... }}` bodies from n.content searches (#325)

### DIFF
--- a/src/lib/__tests__/vaultApi.test.ts
+++ b/src/lib/__tests__/vaultApi.test.ts
@@ -293,6 +293,22 @@ describe("createVaultRoot — n.content strips `{{ ... }}` regions (#325)", () =
     expect(hits).toEqual(["sub/b.md"]);
   });
 
+  it("strips adjacent expressions without leaving a fragment between them", () => {
+    // Guards the `g`-flag contract: consecutive `{{ a }}{{ b }}` match as
+    // two separate regions. A regex bug that folded them into one "greedy"
+    // match, or skipped the second, would leave stray text behind.
+    const bodies: Record<string, string> = {
+      "a.md": "start {{ a }}{{ b }} end\n",
+    };
+    const v = createVaultRoot(
+      mkStores({
+        readNoteContent: (p) => bodies[p] ?? null,
+      }),
+    );
+    const content = v.notes.first()!.content;
+    expect(content).toBe("start  end\n");
+  });
+
   it("frontmatter parsing is unaffected by the strip (uses raw content)", () => {
     // Frontmatter must see the verbatim file so YAML parses correctly even
     // when a `{{ ... }}` region lives in the body below it.

--- a/src/lib/__tests__/vaultApi.test.ts
+++ b/src/lib/__tests__/vaultApi.test.ts
@@ -225,3 +225,90 @@ describe("createVaultRoot — content-based filtering across all notes (#319)", 
     expect(hits).toEqual(["sub/b.md", "sub/c.md"]);
   });
 });
+
+// #325: template bodies in a note's own text must NOT contribute to `.content`
+// searches, otherwise a template like
+// `{{vault.notes.where(n => n.content.contains("todo"))}}` matches the host
+// note itself because the literal "todo" appears inside the expression body.
+describe("createVaultRoot — n.content strips `{{ ... }}` regions (#325)", () => {
+  it("a template body literal does not make the host note match itself", () => {
+    const bodies: Record<string, string> = {
+      // Only contains "todo" inside a template expression body.
+      "a.md": "# Index\n\n{{vault.notes.where(n => n.content.contains(\"todo\")).select(f => f.name)}}\n",
+      // Genuine prose mention — this is the note the filter should return.
+      "sub/b.md": "- todo: call the landlord\n",
+      // No mention at all.
+      "sub/c.md": "unrelated content\n",
+    };
+    const v = createVaultRoot(
+      mkStores({
+        readNoteContent: (p) => bodies[p] ?? null,
+      }),
+    );
+    const hits = v.notes
+      .where((n) => n.content.includes("todo"))
+      .select((n) => n.path)
+      .toArray();
+    expect(hits).toEqual(["sub/b.md"]);
+  });
+
+  it("strips every `{{ ... }}` region, including multi-line template bodies", () => {
+    const bodies: Record<string, string> = {
+      "a.md":
+        "prefix {{ line1;\nline2 }} middle {{ another }} suffix\n",
+    };
+    const v = createVaultRoot(
+      mkStores({
+        readNoteContent: (p) => bodies[p] ?? null,
+      }),
+    );
+    const content = v.notes.first()!.content;
+    expect(content).not.toContain("line1");
+    expect(content).not.toContain("line2");
+    expect(content).not.toContain("another");
+    expect(content).toContain("prefix");
+    expect(content).toContain("middle");
+    expect(content).toContain("suffix");
+  });
+
+  it("does not strip the second user-report shape — table-prefixed template", () => {
+    // The template concatenates a table header string with a notes query.
+    // The `"todo"` literal sits inside the expression body and must not
+    // make the host note self-match.
+    const bodies: Record<string, string> = {
+      "a.md":
+        "{{(\"|test|test|\\n|-|-|\\n\"); vault.notes.where(n => n.content.contains(\"todo\")).select(f => \"|[[\" + f.name + \"]]|-|\").join(\"\\n\")}}\n",
+      "sub/b.md": "- todo: call the landlord\n",
+      "sub/c.md": "irrelevant",
+    };
+    const v = createVaultRoot(
+      mkStores({
+        readNoteContent: (p) => bodies[p] ?? null,
+      }),
+    );
+    const hits = v.notes
+      .where((n) => n.content.includes("todo"))
+      .select((n) => n.path)
+      .toArray();
+    expect(hits).toEqual(["sub/b.md"]);
+  });
+
+  it("frontmatter parsing is unaffected by the strip (uses raw content)", () => {
+    // Frontmatter must see the verbatim file so YAML parses correctly even
+    // when a `{{ ... }}` region lives in the body below it.
+    const bodies: Record<string, string> = {
+      "a.md":
+        "---\ntitle: Hello\ntags: [one]\n---\n\n{{ vault.notes.count() }}\n",
+    };
+    const v = createVaultRoot(
+      mkStores({
+        readNoteContent: (p) => bodies[p] ?? null,
+      }),
+    );
+    const a = v.notes.first()!;
+    expect(a.property.title).toBe("Hello");
+    expect(a.property.tags).toEqual(["one"]);
+    // And `.content` on the same note still has the template stripped.
+    expect(a.content).not.toContain("vault.notes.count()");
+  });
+});

--- a/src/lib/templateExprRegex.ts
+++ b/src/lib/templateExprRegex.ts
@@ -1,0 +1,34 @@
+// Shared regex for the outer `{{ ... }}` boundary of template expressions.
+//
+// Extracted into its own tiny module so it can be imported by both
+// `templateScope.ts` (the canonical consumer — CM6 live-preview and Reading
+// Mode) and `vaultApi.ts` (which strips expression bodies from `n.content`
+// so self-referential searches like `vault.notes.where(n => n.content
+// .contains("todo"))` don't match the note the template lives in — #325).
+// Keeping the regex here prevents a runtime cycle between `vaultApi.ts`
+// and `templateScope.ts` (which imports the bridge which imports vaultApi).
+//
+// The class `[^{}]` rejects `{` or `}` inside the body, which means
+// expression-body string literals containing a brace (e.g. `{{ "a{b" }}`)
+// do not match. That matches the CM6 live-preview plugin's behaviour.
+// `\r` and `\n` are allowed so multi-line templates are stripped as a
+// single unit.
+
+export const TEMPLATE_EXPR_RE = /\{\{([^{}]+?)\}\}/g;
+
+/**
+ * Replace every `{{ ... }}` region in `text` with an empty string.
+ *
+ * Used by the template-facing `.content` accessor so user predicates
+ * (`.contains`, `.includes`, `.indexOf`, etc.) see the note's prose, not
+ * the code inside its own templates. Template bodies are syntactically
+ * nested inside the note file but semantically they are computed output —
+ * a predicate searching for "todo" should not match a template whose body
+ * reads `vault.notes.where(n => n.content.contains("todo"))`.
+ *
+ * Using `.replace()` naturally handles the `g` flag's `lastIndex` state,
+ * so the function is safe to call repeatedly without re-setting the regex.
+ */
+export function stripTemplateExpressions(text: string): string {
+  return text.replace(TEMPLATE_EXPR_RE, "");
+}

--- a/src/lib/templateScope.ts
+++ b/src/lib/templateScope.ts
@@ -12,18 +12,11 @@ import type { EvalScope } from "./templateExpression";
 import { currentVaultRoot } from "./vaultApiStoreBridge";
 import { editorStore } from "../store/editorStore";
 
-/**
- * Shared regex for the outer `{{ ... }}` boundary. Kept here rather than in
- * each caller so a future grammar change only touches one file. The class
- * `[^{}]` rejects `{` or `}` inside the body, which means expression-body
- * string literals containing a brace (e.g. `{{ "a{b" }}`) do not match.
- * That matches the CM6 live-preview plugin's behaviour — callers that need
- * tighter parity can still walk the body with `splitSegments` from
- * `templateProgram.ts`. `\r` and `\n` are allowed inside the body so
- * multi-line templates work in Reading Mode the same way they would work
- * across a CM6 viewport slice.
- */
-export const TEMPLATE_EXPR_RE = /\{\{([^{}]+?)\}\}/g;
+// Re-export the canonical template-body regex. The constant lives in its
+// own module (`./templateExprRegex`) so `vaultApi.ts` can strip expression
+// bodies from `.content` without creating a runtime cycle through this
+// file's `currentVaultRoot` import.
+export { TEMPLATE_EXPR_RE } from "./templateExprRegex";
 
 export function formatDate(now: Date): string {
   const yyyy = String(now.getFullYear());

--- a/src/lib/vaultApi.ts
+++ b/src/lib/vaultApi.ts
@@ -17,6 +17,7 @@
 import { Collection } from "./queryCollection";
 import { parseFrontmatter } from "./frontmatterIO";
 import type { Property } from "./frontmatterIO";
+import { stripTemplateExpressions } from "./templateExprRegex";
 
 export interface VaultStoreSnapshot {
   name: string;
@@ -155,18 +156,36 @@ function makeNote(
   const title = stripMdExt(name);
   // Content and frontmatter are lazy-read: most expressions only touch
   // name/path and never need the content.
-  let contentMemo: string | null | undefined = undefined;
-  const getContent = (): string => {
-    if (contentMemo === undefined) {
-      contentMemo = stores.readNoteContent?.(relPath) ?? null;
+  //
+  // #325 — two memoized views on the raw text:
+  //   - `getRawContent()` is used by frontmatter parsing, which must see
+  //     the verbatim file (frontmatter keys could, in pathological cases,
+  //     span or neighbour a `{{ ... }}` region, and YAML parsing needs the
+  //     unmodified bytes).
+  //   - `getStrippedContent()` is what user predicates see via the `.content`
+  //     accessor below. It erases every `{{ ... }}` region so a template
+  //     body literal like `.contains("todo")` inside its own expression does
+  //     NOT make the host note match itself. Template bodies are code, not
+  //     prose — they have no business showing up in content searches.
+  let rawContentMemo: string | null | undefined = undefined;
+  const getRawContent = (): string => {
+    if (rawContentMemo === undefined) {
+      rawContentMemo = stores.readNoteContent?.(relPath) ?? null;
     }
-    return contentMemo ?? "";
+    return rawContentMemo ?? "";
+  };
+  let strippedContentMemo: string | undefined = undefined;
+  const getStrippedContent = (): string => {
+    if (strippedContentMemo === undefined) {
+      strippedContentMemo = stripTemplateExpressions(getRawContent());
+    }
+    return strippedContentMemo;
   };
 
   let propsMemo: Property[] | undefined = undefined;
   const getProps = (): Property[] => {
     if (propsMemo === undefined) {
-      const content = getContent();
+      const content = getRawContent();
       propsMemo = content ? parseFrontmatter(content).properties : [];
     }
     return propsMemo;
@@ -205,7 +224,7 @@ function makeNote(
     path: { value: relPath, enumerable: true },
     title: { value: title, enumerable: true },
     property: { value: propertyProxy, enumerable: true },
-    content: { enumerable: true, get: getContent },
+    content: { enumerable: true, get: getStrippedContent },
   });
 
   return note;

--- a/src/lib/vaultApi.ts
+++ b/src/lib/vaultApi.ts
@@ -167,6 +167,11 @@ function makeNote(
   //     body literal like `.contains("todo")` inside its own expression does
   //     NOT make the host note match itself. Template bodies are code, not
   //     prose — they have no business showing up in content searches.
+  // Memo coupling: `strippedContentMemo` is derived from `rawContentMemo`.
+  // Neither is invalidated today (the note object is rebuilt on every vault
+  // tick), but if a future refactor adds hot-reload for `.content`, BOTH
+  // memos must be reset together — otherwise `.content` would return a
+  // stripped view of stale bytes while frontmatter sees fresh raw bytes.
   let rawContentMemo: string | null | undefined = undefined;
   const getRawContent = (): string => {
     if (rawContentMemo === undefined) {


### PR DESCRIPTION
Closes #325.

## Summary
- `{{vault.notes.where(n => n.content.contains(\"todo\"))}}` no longer matches the note the template lives in. The literal string inside the expression body would previously leak into `n.content` and make the self-note self-match for every string-predicate shape.
- Chokepoint fix: strip `{{ ... }}` regions at the `.content` accessor in `src/lib/vaultApi.ts`. Frontmatter parsing keeps using the raw bytes, so YAML semantics are untouched.
- Extracted `TEMPLATE_EXPR_RE` and a `stripTemplateExpressions` helper into a tiny `src/lib/templateExprRegex.ts` to avoid a runtime import cycle between `vaultApi.ts` and `templateScope.ts` (the bridge loops back through vaultApi).
- `templateScope.ts` re-exports `TEMPLATE_EXPR_RE` so every existing consumer keeps its current import path.

## Files
- `src/lib/templateExprRegex.ts` — new module: shared regex + stripper.
- `src/lib/templateScope.ts` — re-exports the constant from the new module.
- `src/lib/vaultApi.ts` — splits content memoization (raw for frontmatter, stripped for `.content`).
- `src/lib/__tests__/vaultApi.test.ts` — 4 new cases (both user-reported shapes, multi-line strip, frontmatter-unaffected guard).

## Test plan
- [x] `pnpm test` — 1138/1138 pass.
- [x] `pnpm typecheck` — clean.
- [ ] Manual: create a note with the exact user-reported template `{{(\"|test|test|\\n|-|-|\\n\"); vault.notes.where(n => n.content.contains(\"todo\")).select(f => \"|[[\" + f.name + \"]]|-|\").join(\"\\n\")}}` — verify the host note does not appear in the rendered table, and a second note with a genuine \"todo\" does.