### PR TITLE
ci(minerva): post inline review comments on PRs

### DIFF
--- a/.github/scripts/minerva_build_review.py
+++ b/.github/scripts/minerva_build_review.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate Minerva JSON findings against a unified diff and build a GitHub
+pull-request review payload. Findings that point at a file:line outside the
+diff hunks are dropped from the inline set and listed in the review body
+instead, so the reviewer always sees them even if the inline location is bad.
+
+Inputs (paths, read):
+  sys.argv[1]  unified diff (same bytes that were sent to the model)
+  sys.argv[2]  model JSON output {verdict, findings:[{path,line,side,severity,body}]}
+Env:
+  COMMIT_ID    PR head SHA (required by the reviews API for inline comments)
+Output (path, written):
+  sys.argv[3]  JSON payload for POST /repos/:owner/:repo/pulls/:num/reviews
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+
+HUNK_RE = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def parse_diff_lines(diff: str) -> dict[str, dict[str, set[int]]]:
+    """Return {path: {"RIGHT": {lines}, "LEFT": {lines}}} for every file in the diff."""
+    files: dict[str, dict[str, set[int]]] = {}
+    cur_path: str | None = None
+    new_ln = old_ln = 0
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            cur_path = None
+            continue
+        if line.startswith("+++ "):
+            p = line[4:].strip()
+            if p.startswith("b/"):
+                p = p[2:]
+            cur_path = None if p == "/dev/null" else p
+            if cur_path is not None:
+                files.setdefault(cur_path, {"RIGHT": set(), "LEFT": set()})
+            continue
+        if cur_path is None:
+            continue
+        m = HUNK_RE.match(line)
+        if m:
+            old_ln = int(m.group(1))
+            new_ln = int(m.group(2))
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            files[cur_path]["RIGHT"].add(new_ln)
+            new_ln += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            files[cur_path]["LEFT"].add(old_ln)
+            old_ln += 1
+        elif line.startswith(" "):
+            files[cur_path]["RIGHT"].add(new_ln)
+            files[cur_path]["LEFT"].add(old_ln)
+            new_ln += 1
+            old_ln += 1
+    return files
+
+
+def main() -> int:
+    diff_path, review_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    with open(diff_path, "r", encoding="utf-8", errors="replace") as f:
+        diff = f.read()
+    with open(review_path, "r", encoding="utf-8") as f:
+        review = json.load(f)
+
+    valid = parse_diff_lines(diff)
+    verdict = (review.get("verdict") or "").strip() or "No verdict provided."
+    findings = review.get("findings") or []
+
+    inline: list[dict] = []
+    rejected: list[dict] = []
+    for fi in findings:
+        path = fi.get("path") or ""
+        side = (fi.get("side") or "RIGHT").upper()
+        if side not in ("LEFT", "RIGHT"):
+            side = "RIGHT"
+        try:
+            line = int(fi.get("line"))
+        except (TypeError, ValueError):
+            rejected.append(fi)
+            continue
+        body = (fi.get("body") or "").strip()
+        sev = (fi.get("severity") or "").strip()
+        if not path or not body:
+            rejected.append(fi)
+            continue
+        sides = valid.get(path)
+        if not sides or line not in sides.get(side, set()):
+            rejected.append(fi)
+            continue
+        prefix = f"**[{sev}]** " if sev else ""
+        inline.append({"path": path, "line": line, "side": side, "body": prefix + body})
+
+    body_parts = ["### Minerva Review (GLM 5.1)", "", verdict]
+    if rejected:
+        body_parts += [
+            "",
+            "<details><summary>Findings without a valid diff location (could not be placed inline)</summary>",
+            "",
+        ]
+        for fi in rejected:
+            p = fi.get("path", "?")
+            ln = fi.get("line", "?")
+            sev = fi.get("severity", "")
+            b = (fi.get("body") or "").strip()
+            tag = f"[{sev}] " if sev else ""
+            body_parts.append(f"- `{p}:{ln}` — {tag}{b}")
+        body_parts += ["", "</details>"]
+    if not inline and not rejected:
+        body_parts += ["", "_No issues flagged._"]
+
+    payload = {
+        "commit_id": os.environ["COMMIT_ID"],
+        "body": "\n".join(body_parts),
+        "event": "COMMENT",
+        "comments": inline,
+    }
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    print(f"inline={len(inline)} rejected={len(rejected)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/minerva-review.yml
+++ b/.github/workflows/minerva-review.yml
@@ -54,22 +54,75 @@ jobs:
             echo "You are a senior code reviewer. Review the PR diff below."
             echo "Focus on: correctness bugs, security issues, race conditions, missing or weak tests, obvious regressions."
             echo "Skip style nits and subjective preferences."
-            echo "Be terse and specific — cite file:line when flagging issues."
-            echo "If the diff looks clean, say so in one line."
-            echo "Output GitHub-flavored markdown. Start with a one-line verdict, then bullet findings."
+            echo
+            echo "Output STRICT JSON only — no prose, no markdown fences. Shape:"
+            echo '{'
+            echo '  "verdict": "one-line summary",'
+            echo '  "findings": ['
+            echo '    {"path": "relative/file/path", "line": 42, "side": "RIGHT", "severity": "bug|security|risk|nit", "body": "short explanation"}'
+            echo '  ]'
+            echo '}'
+            echo
+            echo "Rules:"
+            echo "- path must match a file in the diff exactly (no a/ or b/ prefix)."
+            echo "- line must be a line number that appears in the diff hunks (added or context line on the RIGHT side, i.e. the post-change file)."
+            echo "- Use side=RIGHT for added/modified lines; use side=LEFT only when flagging a removed line."
+            echo "- Keep body terse (1-3 sentences), cite concrete reasoning."
+            echo "- If the diff looks clean, return empty findings with a positive verdict."
+            echo "- Do NOT wrap output in code fences."
             echo
             echo "=== PR DIFF ==="
             cat /tmp/pr.diff
           } > /tmp/prompt.txt
-          opencode run -m openrouter/z-ai/glm-5.1 "$(cat /tmp/prompt.txt)" > /tmp/review.md
+          opencode run -m openrouter/z-ai/glm-5.1 "$(cat /tmp/prompt.txt)" > /tmp/review.raw
+          # Strip optional code fences just in case.
+          sed -e 's/^```json//' -e 's/^```//' -e '/^```$/d' /tmp/review.raw > /tmp/review.json
+          if ! jq -e . /tmp/review.json >/dev/null 2>&1; then
+            echo "Model output was not valid JSON — will fall back to plain comment."
+            echo "INVALID_JSON=1" >> "$GITHUB_ENV"
+          fi
 
-      - name: Post review comment
+      - name: Post review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          {
-            echo "### Minerva Review (GLM 5.1)"
-            echo
-            cat /tmp/review.md
-          } > /tmp/review-final.md
-          gh pr comment "${{ github.event.issue.number }}" --body-file /tmp/review-final.md
+          set -euo pipefail
+
+          # Fallback: invalid JSON → post raw output as a normal PR comment.
+          if [ "${INVALID_JSON:-0}" = "1" ]; then
+            {
+              echo "### Minerva Review (GLM 5.1)"
+              echo
+              echo "_Model did not return valid JSON — posting raw output._"
+              echo
+              cat /tmp/review.raw
+            } > /tmp/review-final.md
+            gh pr comment "$PR_NUMBER" --body-file /tmp/review-final.md
+            exit 0
+          fi
+
+          COMMIT_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)
+          export COMMIT_ID
+
+          python3 .github/scripts/minerva_build_review.py \
+            /tmp/pr.diff /tmp/review.json /tmp/review-payload.json
+
+          # Post the review (single API call, inline comments attached).
+          # If the API rejects it (e.g. a line slips past our validator) fall
+          # back to a plain PR comment so the review is not lost.
+          if ! gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+                --input /tmp/review-payload.json; then
+            echo "Review API call failed — falling back to plain PR comment." >&2
+            {
+              jq -r '.body' /tmp/review-payload.json
+              echo
+              echo "#### Findings"
+              jq -r '.comments[] | "- `\(.path):\(.line)` — \(.body)"' /tmp/review-payload.json
+            } > /tmp/review-fallback.md
+            gh pr comment "$PR_NUMBER" --body-file /tmp/review-fallback.md
+          fi


### PR DESCRIPTION
## Summary
- Switch the Minerva workflow from one bulk PR comment to a proper pull-request review with inline `file:line` comments.
- Prompt GLM 5.1 for strict JSON findings; validate every `(path, line, side)` against the diff hunks before sending inline.
- Findings that fail validation are kept in a collapsed section of the review body, so nothing is silently dropped.
- Fall back to a plain PR comment if the model returns non-JSON or the reviews API rejects the payload.

## Test plan
- [x] Local smoke test of `minerva_build_review.py` against a synthetic diff + mix of valid/invalid findings (2 inline, 2 rejected).
- [ ] Trigger the workflow on this PR by commenting `@minerva` and confirm inline comments appear in "Files changed".
- [ ] Confirm the review body still renders the verdict + the "could not be placed inline" disclosure when applicable.