### PR TITLE
fix(canvas): skip wiki-links inside {{ ... }} template bodies

### DIFF
--- a/src/lib/canvas/__tests__/textTokens.test.ts
+++ b/src/lib/canvas/__tests__/textTokens.test.ts
@@ -83,4 +83,72 @@ describe("tokenizeCanvasText", () => {
       { kind: "link", target: "b", display: "b" },
     ]);
   });
+
+  it("treats [[...]] inside {{ ... }} as plain text (#332)", () => {
+    expect(tokenizeCanvasText("{{ [[Target]] }}")).toEqual([
+      { kind: "text", text: "{{ [[Target]] }}" },
+    ]);
+  });
+
+  it("treats complex template [[...]] as plain text", () => {
+    expect(tokenizeCanvasText('{{ "[[" + f.name + "]]" }}')).toEqual([
+      { kind: "text", text: '{{ "[[" + f.name + "]]" }}' },
+    ]);
+  });
+
+  it("treats ![[image.png]] inside {{ ... }} as plain text", () => {
+    expect(tokenizeCanvasText("{{ ![[photo.png]] }}")).toEqual([
+      { kind: "text", text: "{{ ![[photo.png]] }}" },
+    ]);
+  });
+
+  it("skips links inside templates but keeps real links outside", () => {
+    expect(tokenizeCanvasText("[[A]] before {{ [[B]] }} then [[C|cee]]")).toEqual([
+      { kind: "link", target: "A", display: "A" },
+      { kind: "text", text: " before {{ [[B]] }} then " },
+      { kind: "link", target: "C", display: "cee" },
+    ]);
+  });
+
+  it("treats [[...]] inside template as plain text when adjacent to a real link", () => {
+    expect(tokenizeCanvasText("[[A]]{{ [[B]] }}")).toEqual([
+      { kind: "link", target: "A", display: "A" },
+      { kind: "text", text: "{{ [[B]] }}" },
+    ]);
+  });
+
+  it("skips wiki-links inside multiple separate templates", () => {
+    expect(tokenizeCanvasText("{{ [[A]] }} x {{ [[B]] }} [[C]]")).toEqual([
+      { kind: "text", text: "{{ [[A]] }} x {{ [[B]] }} " },
+      { kind: "link", target: "C", display: "C" },
+    ]);
+  });
+
+  it("handles template at start of string", () => {
+    expect(tokenizeCanvasText("{{ [[A]] }} then [[B]]")).toEqual([
+      { kind: "text", text: "{{ [[A]] }} then " },
+      { kind: "link", target: "B", display: "B" },
+    ]);
+  });
+
+  it("handles template at end of string", () => {
+    expect(tokenizeCanvasText("[[A]] then {{ [[B]] }}")).toEqual([
+      { kind: "link", target: "A", display: "A" },
+      { kind: "text", text: " then {{ [[B]] }}" },
+    ]);
+  });
+
+  it("skips wiki-link whose span overlaps a template expression", () => {
+    expect(tokenizeCanvasText("[[foo{{bar}}baz]]")).toEqual([
+      { kind: "text", text: "[[foo{{bar}}baz]]" },
+    ]);
+  });
+
+  it("template with no wiki-links does not affect behaviour", () => {
+    expect(tokenizeCanvasText("see [[A]] and {{ date }}")).toEqual([
+      { kind: "text", text: "see " },
+      { kind: "link", target: "A", display: "A" },
+      { kind: "text", text: " and {{ date }}" },
+    ]);
+  });
 });

--- a/src/lib/canvas/textTokens.ts
+++ b/src/lib/canvas/textTokens.ts
@@ -10,11 +10,22 @@
 //   - `![[image.ext]]` (known image extension) → image segment
 //   - Any other `![[target]]` (note/canvas embed) falls back to a link
 //     segment — full note/canvas embeds are deferred (#162 out-of-scope)
+//
+// Template-body skip (#332): wiki-link text inside `{{ ... }}` is template
+// source code, not Markdown, so it must NOT surface as a clickable link
+// in canvas cards. We compute template ranges once per call and skip any
+// match whose span overlaps one — mirroring the guard used in
+// `lib/outgoingLinks.ts`.
 
 export type CanvasTextSegment =
   | { kind: "text"; text: string }
   | { kind: "link"; target: string; display: string }
   | { kind: "image"; target: string };
+
+import {
+  findTemplateExprRanges,
+  isInsideTemplateExpr,
+} from "../templateExprRanges";
 
 const WIKI_RE = /(!?)\[\[([^\]|]+?)(?:\|([^\]]*))?\]\]/g;
 
@@ -38,11 +49,20 @@ function hasImageExt(target: string): boolean {
 export function tokenizeCanvasText(text: string): CanvasTextSegment[] {
   if (text.length === 0) return [];
 
+  const templateRanges = findTemplateExprRanges(text);
+
   const out: CanvasTextSegment[] = [];
   WIKI_RE.lastIndex = 0;
   let idx = 0;
   let m: RegExpExecArray | null;
   while ((m = WIKI_RE.exec(text)) !== null) {
+    // Skip matches whose span overlaps a template expression body (#332).
+    // idx stays behind so the skipped [[...]] is swept into the next
+    // plain-text segment (or the tail slice after the loop).
+    if (isInsideTemplateExpr(templateRanges, m.index, m.index + m[0].length)) {
+      continue;
+    }
+
     if (m.index > idx) {
       out.push({ kind: "text", text: text.slice(idx, m.index) });
     }


### PR DESCRIPTION
## Summary

- Fixes #332 — canvas text-card tokenizer (`textTokens.ts`) had no template awareness, so `[[...]]` fragments inside `{{ ... }}` template bodies rendered as clickable links
- Applies the same skip-by-range guard already used in `outgoingLinks.ts`: import `findTemplateExprRanges` / `isInsideTemplateExpr`, compute ranges once per `tokenizeCanvasText` call, and `continue` past any match whose span overlaps a template range
- Adds 10 new test cases covering: basic template skip, embed skip, adjacent links, multiple templates, string boundaries, spanning overlap, and no-op template

## Test plan

- [x] All 1165 existing tests pass
- [x] 10 new test cases in `src/lib/canvas/__tests__/textTokens.test.ts` pass
- [x] TypeScript type-check clean