### PR TITLE
perf(editor): viewport-bounded scan in wikiLink + embedPlugin (#247)

### DIFF
--- a/src/components/Editor/__tests__/editorPluginDocToStringAudit.test.ts
+++ b/src/components/Editor/__tests__/editorPluginDocToStringAudit.test.ts
@@ -1,0 +1,89 @@
+// Audit: no CM6 editor-plugin hot path may call `view.state.doc.toString()`
+// (or `state.doc.toString()`, etc.) on a per-update path — see issue #247.
+//
+// Full-doc serialisation on every docChanged / viewportChanged / selectionSet
+// transaction allocates O(doc length) per keystroke and directly eats the
+// 16ms keystroke budget on medium+ notes. This test is the tripwire that
+// catches any regression where a plugin adds a fresh `doc.toString()` call.
+//
+// Scope: only non-recursive `src/components/Editor/*.ts` — Svelte components
+// and `src/components/Editor/__tests__/**` are out of scope; several call
+// sites there (EditorPane.svelte, App.svelte, PropertiesPanel.svelte, etc.)
+// run on explicit user actions, not the CM6 update path.
+//
+// Allowlist:
+//   - `autoSave.ts`       — runs on a debounced save, not on keystroke.
+//   - `countsPlugin.ts`   — has its own doc-ref cache; the toString is guarded
+//                            by an identity check and skipped on identity-
+//                            equal docs.
+//   - `templateAutocomplete.ts` — CodeMirror CompletionSource (not a
+//                                 ViewPlugin / StateField hot path). Fires
+//                                 only when the autocomplete engine requests
+//                                 completions, not on every keystroke. The
+//                                 standalone `doc.toString()` here is
+//                                 acceptable and out of scope for this issue.
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EDITOR_DIR = resolve(HERE, "..");
+
+/**
+ * Non-recursive list of .ts files directly under src/components/Editor —
+ * excludes __tests__ (subdirectory) and any .svelte files.
+ */
+function editorPluginFiles(): string[] {
+  return readdirSync(EDITOR_DIR)
+    .filter((name) => {
+      const full = join(EDITOR_DIR, name);
+      if (!statSync(full).isFile()) return false;
+      return name.endsWith(".ts") && !name.endsWith(".d.ts");
+    })
+    .map((name) => join(EDITOR_DIR, name));
+}
+
+const DOC_TO_STRING_RE = /doc\.toString\(\)/;
+
+/**
+ * Files explicitly allowed to call `doc.toString()`. Any other Editor plugin
+ * file that introduces the call fails this audit.
+ */
+const ALLOWLIST = new Set([
+  "autoSave.ts",
+  "countsPlugin.ts",
+  "templateAutocomplete.ts",
+]);
+
+describe("editor plugins — no doc.toString() on the hot path (#247)", () => {
+  it("no non-allowlisted Editor plugin file calls doc.toString()", () => {
+    const files = editorPluginFiles();
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const path of files) {
+      const base = path.slice(EDITOR_DIR.length + 1);
+      if (ALLOWLIST.has(base)) continue;
+      const content = readFileSync(path, "utf8");
+      if (DOC_TO_STRING_RE.test(content)) {
+        offenders.push(base);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("the allowlist itself is minimal — every entry still exists on disk", () => {
+    // Guard against forgotten allowlist entries that drift out of sync with
+    // the codebase. If a file is removed or renamed, the allowlist must be
+    // updated to match.
+    const diskFiles = new Set(
+      editorPluginFiles().map((p) => p.slice(EDITOR_DIR.length + 1)),
+    );
+    for (const name of ALLOWLIST) {
+      expect(diskFiles.has(name)).toBe(true);
+    }
+  });
+});

--- a/src/components/Editor/__tests__/embedPluginViewportScan.test.ts
+++ b/src/components/Editor/__tests__/embedPluginViewportScan.test.ts
@@ -1,0 +1,182 @@
+// Regression tests for issue #247 (viewport-bounded scan in embedPlugin).
+//
+// Before the fix, `buildDecorations` called `view.state.doc.toString()` and
+// ran both WIKI_EMBED_RE and MD_IMAGE_RE over the entire document on every
+// docChanged / viewportChanged / selectionSet transaction — two full-doc
+// regex passes on top of the full-doc allocation. Same hot path as
+// wikiLink.ts; same fix shape.
+//
+// The fix slices only `view.viewport.from..view.viewport.to` (± 512 bytes
+// widen margin so embeds that straddle the viewport boundary still get
+// decorated) and offsets every absolute position by the widened-window
+// `from`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EditorState, EditorSelection } from "@codemirror/state";
+import { EditorView, Decoration } from "@codemirror/view";
+
+// Stub the IPC layer — the plugin subscribes to listenFileChange + readFile
+// at import time, and neither is available in jsdom.
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+}));
+vi.mock("../../../ipc/commands", () => ({
+  readFile: vi.fn().mockResolvedValue(""),
+}));
+
+import { embedPlugin } from "../embedPlugin";
+import { setResolvedAttachments } from "../embeds";
+import { setResolvedLinks } from "../wikiLink";
+
+function mount(doc: string, cursor = 0): { view: EditorView; parent: HTMLElement } {
+  const state = EditorState.create({
+    doc,
+    selection: { anchor: cursor },
+    extensions: [embedPlugin],
+  });
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({ state, parent });
+  return { view, parent };
+}
+
+function overrideViewport(view: EditorView, from: number, to: number): void {
+  Object.defineProperty(view, "viewport", {
+    value: { from, to },
+    configurable: true,
+  });
+}
+
+interface Deco {
+  from: number;
+  to: number;
+}
+
+function collectDecos(view: EditorView): Deco[] {
+  const out: Deco[] = [];
+  for (const plugin of (view as unknown as {
+    plugins: Array<{ value?: { decorations?: unknown } }>;
+  }).plugins) {
+    const deco = plugin.value?.decorations;
+    if (!deco) continue;
+    const set = deco as ReturnType<typeof Decoration.none.update>;
+    const iter = set.iter();
+    while (iter.value) {
+      out.push({ from: iter.from, to: iter.to });
+      iter.next();
+    }
+  }
+  return out;
+}
+
+describe("embedPlugin — viewport-bounded scan (#247)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    setResolvedAttachments(new Map([["img.png", "images/img.png"]]));
+    setResolvedLinks(new Map());
+  });
+
+  it("decorates a wiki-embed inside the viewport at the correct absolute offset", () => {
+    const prefix = "a".repeat(1_000);
+    const embed = "![[img.png|500]]";
+    const suffix = "b".repeat(30_000);
+    const doc = prefix + embed + suffix;
+    const embedFrom = prefix.length;
+    const embedTo = embedFrom + embed.length;
+
+    const { view, parent } = mount(doc, 0);
+    overrideViewport(view, 0, 5_000);
+    view.dispatch({ selection: EditorSelection.cursor(0) });
+
+    const decos = collectDecos(view);
+    // The embed region must carry at least one decoration (the replace widget).
+    const inEmbed = decos.filter((d) => d.from >= embedFrom && d.to <= embedTo);
+    expect(inEmbed.length).toBeGreaterThan(0);
+    // Exact-match assertion: the decoration spans the full embed.
+    expect(inEmbed.some((d) => d.from === embedFrom && d.to === embedTo)).toBe(true);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("does NOT decorate wiki-embeds far outside the viewport + widen margin", () => {
+    // Load-bearing regression test. On main, the full-doc scan decorates
+    // `![[img.png]]` at offset 30_000 even when the viewport is [0, 1_000].
+    const filler = "x".repeat(30_000);
+    const embed = "![[img.png|200]]";
+    const tail = "y".repeat(10_000);
+    const doc = filler + embed + tail;
+    const embedFrom = filler.length;
+    const embedTo = embedFrom + embed.length;
+
+    const { view, parent } = mount(doc, 0);
+    overrideViewport(view, 0, 1_000);
+    view.dispatch({ selection: EditorSelection.cursor(500) });
+
+    const decos = collectDecos(view);
+    const overlapping = decos.filter(
+      (d) => d.to > embedFrom && d.from < embedTo,
+    );
+    expect(overlapping).toEqual([]);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("detects a wiki-embed whose sizing tail `|500]]` straddles the viewport end (widen works)", () => {
+    // Opening `![[img.png` is inside the viewport but the `|500]]` tail sits
+    // just past `viewport.to`. The 512-byte widen on the right margin must
+    // recover the full match.
+    const before = "p".repeat(1_000);
+    const embed = "![[img.png|500]]"; // 16 chars
+    const after = "s".repeat(3_000);
+    const doc = before + embed + after;
+    const embedFrom = before.length;
+    const embedTo = embedFrom + embed.length;
+
+    const { view, parent } = mount(doc, 0);
+    // End the viewport inside the embed so `|500]]` is past viewport.to
+    // but well inside the widen margin.
+    const viewportFrom = 0;
+    const viewportTo = embedFrom + 4; // 4 bytes in — the `|500]]` is past
+    overrideViewport(view, viewportFrom, viewportTo);
+    view.dispatch({ selection: EditorSelection.cursor(0) });
+
+    const decos = collectDecos(view);
+    const matching = decos.filter(
+      (d) => d.from === embedFrom && d.to === embedTo,
+    );
+    expect(matching.length).toBeGreaterThan(0);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("detects a markdown image `![alt](url)` straddling the viewport start (widen works)", () => {
+    // Opening `![alt](` begins before the viewport; widen margin must reach
+    // back and absolute-offset math must produce the correct doc coordinates.
+    const lead = "z".repeat(2_000);
+    const md = "![alt](images/img.png)";
+    const trail = "w".repeat(3_000);
+    const doc = lead + md + trail;
+    const mdFrom = lead.length;
+    const mdTo = mdFrom + md.length;
+
+    const { view, parent } = mount(doc, 0);
+    // Viewport starts mid-image so the opening `![alt](` is behind
+    // viewport.from but inside the 512-byte widen.
+    const viewportFrom = mdFrom + 5; // 5 bytes in → margin 5 < 512
+    const viewportTo = viewportFrom + 1_000;
+    overrideViewport(view, viewportFrom, viewportTo);
+    view.dispatch({ selection: EditorSelection.cursor(viewportFrom + 100) });
+
+    const decos = collectDecos(view);
+    const matching = decos.filter(
+      (d) => d.from === mdFrom && d.to === mdTo,
+    );
+    expect(matching.length).toBeGreaterThan(0);
+
+    view.destroy();
+    parent.remove();
+  });
+});

--- a/src/components/Editor/__tests__/wikiLinkViewportScan.test.ts
+++ b/src/components/Editor/__tests__/wikiLinkViewportScan.test.ts
@@ -1,0 +1,197 @@
+// Regression tests for issue #247 (viewport-bounded scan in wikiLinkPlugin).
+//
+// Before the fix, `buildDecorations` called `view.state.doc.toString()` and
+// ran the wiki-link regex over the ENTIRE document on every docChanged /
+// viewportChanged / selectionSet transaction. On a 50k-char doc that allocates
+// a full-doc string and burns the 16ms keystroke budget.
+//
+// The fix slices only `view.viewport.from..view.viewport.to` (with a 512-byte
+// widen margin on each side so wiki-links and `{{ ... }}` template bodies that
+// straddle the viewport boundary still get detected) and offsets every
+// absolute position by the widened-window `from`.
+//
+// These tests lock in the viewport-bounded behaviour by overriding
+// `view.viewport` on a jsdom-mounted EditorView (jsdom has no layout so the
+// default viewport covers the whole doc, which would hide the regression).
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { EditorState, EditorSelection } from "@codemirror/state";
+import { EditorView, Decoration } from "@codemirror/view";
+
+import { wikiLinkPlugin, setResolvedLinks } from "../wikiLink";
+
+function mount(doc: string, cursor = 0): { view: EditorView; parent: HTMLElement } {
+  const state = EditorState.create({
+    doc,
+    selection: { anchor: cursor },
+    extensions: [wikiLinkPlugin],
+  });
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({ state, parent });
+  return { view, parent };
+}
+
+function overrideViewport(view: EditorView, from: number, to: number): void {
+  Object.defineProperty(view, "viewport", {
+    value: { from, to },
+    configurable: true,
+  });
+}
+
+interface Deco {
+  from: number;
+  to: number;
+}
+
+function collectDecos(view: EditorView): Deco[] {
+  const out: Deco[] = [];
+  for (const plugin of (view as unknown as {
+    plugins: Array<{ value?: { decorations?: unknown } }>;
+  }).plugins) {
+    const deco = plugin.value?.decorations;
+    if (!deco) continue;
+    const set = deco as ReturnType<typeof Decoration.none.update>;
+    const iter = set.iter();
+    while (iter.value) {
+      out.push({ from: iter.from, to: iter.to });
+      iter.next();
+    }
+  }
+  return out;
+}
+
+describe("wikiLinkPlugin — viewport-bounded scan (#247)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    setResolvedLinks(new Map([["foo", "Foo.md"]]));
+  });
+
+  it("decorates a wiki-link inside the viewport at the correct absolute offset", () => {
+    // 50k-char doc. A `[[foo]]` lives well inside the viewport window.
+    const prefix = "a".repeat(1_000);
+    const link = "[[foo]]";
+    const suffix = "b".repeat(50_000);
+    const doc = prefix + link + suffix;
+    const linkFrom = prefix.length;
+    const linkTo = linkFrom + link.length;
+
+    const { view, parent } = mount(doc, 0);
+    // Viewport covers the link. Cursor is at 0 so the link is off-cursor and
+    // the plugin installs its HIDE + mark decorations.
+    overrideViewport(view, 0, 5_000);
+    // Trigger a rebuild under the restricted viewport.
+    view.dispatch({ selection: EditorSelection.cursor(0) });
+
+    const decos = collectDecos(view);
+    // At least one decoration must land inside the link range.
+    const inLink = decos.filter((d) => d.from >= linkFrom && d.to <= linkTo);
+    expect(inLink.length).toBeGreaterThan(0);
+    // Proves absolute-offset math: no decoration should have been placed
+    // before the link at offset 0..linkFrom (no stray link in prefix).
+    const beforeLink = decos.filter((d) => d.to <= linkFrom);
+    expect(beforeLink).toEqual([]);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("does NOT decorate wiki-links far outside the viewport + widen margin", () => {
+    // This is the load-bearing regression test. On main the plugin scans the
+    // full doc and decorates a `[[foo]]` at offset 30_000 even when the
+    // viewport is [0, 1_000]. After the fix, the scan is bounded to
+    // viewport ± 512 bytes, so a link at 30_000 must NOT be decorated.
+    const filler = "x".repeat(30_000);
+    const link = "[[foo]]";
+    const tail = "y".repeat(10_000);
+    const doc = filler + link + tail;
+    const linkFrom = filler.length;
+    const linkTo = linkFrom + link.length;
+
+    const { view, parent } = mount(doc, 0);
+    overrideViewport(view, 0, 1_000);
+    view.dispatch({ selection: EditorSelection.cursor(500) });
+
+    const decos = collectDecos(view);
+    // No decoration may overlap the distant link range.
+    const overlapping = decos.filter(
+      (d) => d.to > linkFrom && d.from < linkTo,
+    );
+    expect(overlapping).toEqual([]);
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("still detects a wiki-link alias straddling the viewport start (widen margin works)", () => {
+    // Place `[[foo|bar]]` so the opening `[[` is *before* the viewport start
+    // but still within the 512-byte widen margin. The absolute-offset math
+    // must place the decoration at the correct original-doc coordinates.
+    const before = "p".repeat(2_000);
+    const link = "[[foo|bar]]";
+    const after = "s".repeat(3_000);
+    const doc = before + link + after;
+    const linkFrom = before.length;
+    const linkTo = linkFrom + link.length;
+
+    const { view, parent } = mount(doc, 0);
+    // Put the viewport so it starts a few hundred bytes AFTER the link opens
+    // but the widen margin (512) still reaches back to the `[[`.
+    const viewportFrom = linkFrom + 4; // 4 bytes into the link → opening `[[` is viewportFrom-4, inside widen
+    const viewportTo = viewportFrom + 1_000;
+    overrideViewport(view, viewportFrom, viewportTo);
+    view.dispatch({ selection: EditorSelection.cursor(viewportFrom + 100) });
+
+    const decos = collectDecos(view);
+    const overlapping = decos.filter(
+      (d) => d.to > linkFrom && d.from < linkTo,
+    );
+    expect(overlapping.length).toBeGreaterThan(0);
+    // Sanity: the overlapping decorations must sit inside the actual link
+    // range — proves the baseOffset math is correct (not a doc-local slice
+    // offset leaking through).
+    for (const d of overlapping) {
+      expect(d.from).toBeGreaterThanOrEqual(linkFrom);
+      expect(d.to).toBeLessThanOrEqual(linkTo);
+    }
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("excludes a [[...]] inside a {{ ... }} template even when the expression straddles the viewport", () => {
+    // The `{{` opens before the viewport; the closing `}}` is inside it. The
+    // wiki-link guard (isInsideTemplateExpr) must still recognise the range —
+    // which means findTemplateExprRanges must be offset by the widened-window
+    // `from`, not the slice-local 0.
+    const lead = "z".repeat(2_000);
+    const expr = '{{vault.notes.select(n => "[[foo]]").join("\\n")}}';
+    const trail = "w".repeat(3_000);
+    const doc = lead + expr + trail;
+
+    const exprFrom = lead.length;
+    const exprTo = exprFrom + expr.length;
+    const innerLinkFrom = doc.indexOf("[[foo]]");
+    const innerLinkTo = innerLinkFrom + "[[foo]]".length;
+
+    const { view, parent } = mount(doc, 0);
+    // Viewport starts INSIDE the expression body so `{{` is behind the
+    // viewport.from. With a 512-byte widen, the `{{` at exprFrom (2_000) must
+    // be recoverable when viewportFrom = 2_400 (margin 400 < 512).
+    const viewportFrom = exprFrom + 400;
+    const viewportTo = exprTo + 500;
+    overrideViewport(view, viewportFrom, viewportTo);
+    view.dispatch({ selection: EditorSelection.cursor(viewportFrom + 50) });
+
+    const decos = collectDecos(view);
+    // No wiki-link decoration may overlap the inner `[[foo]]` — it lives
+    // inside the template body and the guard must exclude it.
+    const overlapping = decos.filter(
+      (d) => d.to > innerLinkFrom && d.from < innerLinkTo,
+    );
+    expect(overlapping).toEqual([]);
+
+    view.destroy();
+    parent.remove();
+  });
+});

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -527,11 +527,32 @@ export function parseSizePx(raw: string | undefined): number | null {
 
 // ── Build decorations ──────────────────────────────────────────────────────────
 
+/**
+ * Bytes to extend on each side of `view.viewport` so wiki-embeds and
+ * markdown images that straddle the viewport boundary are still detected by
+ * the scan (#247). Same rationale as wikiLink.ts — templates may be
+ * multi-line; 512 covers realistic expression bodies with margin.
+ */
+const VIEWPORT_WIDEN_BYTES = 512;
+
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
-  const text = view.state.doc.toString();
-  const head = view.state.selection.main.head;
-  const exprRanges = findTemplateExprRanges(text);
+  const state = view.state;
+  const docLength = state.doc.length;
+
+  // #247 — viewport-bounded scan. See wikiLink.ts for the same change; this
+  // file ran TWO full-doc regex passes (WIKI_EMBED_RE + MD_IMAGE_RE) on top
+  // of the full-doc allocation on every update. Slice the visible region
+  // ± VIEWPORT_WIDEN_BYTES and offset absolute positions by windowFrom.
+  // Lezer `syntaxTree` lookups stay at absolute coordinates.
+  const windowFrom = Math.max(0, view.viewport.from - VIEWPORT_WIDEN_BYTES);
+  const windowTo = Math.min(docLength, view.viewport.to + VIEWPORT_WIDEN_BYTES);
+  const text = state.sliceDoc(windowFrom, windowTo);
+  const head = state.selection.main.head;
+  // Template ranges MUST be offset by windowFrom so `isInsideTemplateExpr`
+  // checks against absolute document coordinates (same guarantee as in
+  // wikiLink.ts, livePreview.ts).
+  const exprRanges = findTemplateExprRanges(text, windowFrom);
 
   const matches: EmbedMatch[] = [];
 
@@ -541,11 +562,11 @@ function buildDecorations(view: EditorView): DecorationSet {
   while ((m = WIKI_EMBED_RE.exec(text)) !== null) {
     const rawTarget = m[1];
     if (rawTarget === undefined) continue;
-    const from = m.index;
+    const from = windowFrom + m.index;
     const to = from + m[0].length;
 
     // Skip code blocks / inline code.
-    if (isInsideCodeBlock(view.state, from)) continue;
+    if (isInsideCodeBlock(state, from)) continue;
     if (isInsideTemplateExpr(exprRanges, from, to)) continue;
 
     // Cursor inside → show raw syntax, do not replace.
@@ -604,10 +625,10 @@ function buildDecorations(view: EditorView): DecorationSet {
   while ((m = MD_IMAGE_RE.exec(text)) !== null) {
     const rawPath = m[1];
     if (rawPath === undefined) continue;
-    const from = m.index;
+    const from = windowFrom + m.index;
     const to = from + m[0].length;
 
-    if (isInsideCodeBlock(view.state, from)) continue;
+    if (isInsideCodeBlock(state, from)) continue;
     if (isInsideTemplateExpr(exprRanges, from, to)) continue;
     if (head >= from && head <= to) continue;
 

--- a/src/components/Editor/wikiLink.ts
+++ b/src/components/Editor/wikiLink.ts
@@ -110,11 +110,34 @@ interface DecoratedRange {
   decoration: Decoration;
 }
 
+/**
+ * Bytes to extend on each side of `view.viewport` so wiki-links and
+ * `{{ ... }}` template bodies that straddle the viewport boundary are still
+ * detected by the scan (#247). Wiki-links are tiny; templates can be
+ * multi-line but rarely exceed a few hundred bytes in practice. 512 is
+ * comfortably above both.
+ */
+const VIEWPORT_WIDEN_BYTES = 512;
+
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
-  const text = view.state.doc.toString();
-  const head = view.state.selection.main.head;
-  const exprRanges = findTemplateExprRanges(text);
+  const state = view.state;
+  const docLength = state.doc.length;
+
+  // #247 — viewport-bounded scan. The old full-doc serialisation allocated
+  // O(doc length) per keystroke and burned the 16ms budget on medium+ notes.
+  // Slice only the visible region (± VIEWPORT_WIDEN_BYTES so straddling
+  // wiki-links and template bodies still match) and offset absolute positions
+  // by `windowFrom`. Code-block detection keeps using `syntaxTree(state)` with
+  // absolute coordinates — the slice is a scanning input, not an index space.
+  const windowFrom = Math.max(0, view.viewport.from - VIEWPORT_WIDEN_BYTES);
+  const windowTo = Math.min(docLength, view.viewport.to + VIEWPORT_WIDEN_BYTES);
+  const text = state.sliceDoc(windowFrom, windowTo);
+  const head = state.selection.main.head;
+  // Template ranges MUST be offset by windowFrom — otherwise every
+  // `{{ ... }}` exclusion breaks and literal `[[...]]` inside an expression
+  // gets decorated.
+  const exprRanges = findTemplateExprRanges(text, windowFrom);
 
   const matches: WikiMatch[] = [];
 
@@ -124,10 +147,10 @@ function buildDecorations(view: EditorView): DecorationSet {
     const rawTarget: string | undefined = m[1];
     if (rawTarget === undefined) continue;
 
-    const from = m.index;
+    const from = windowFrom + m.index;
     const to = from + m[0].length;
 
-    if (isInsideCodeBlock(view.state, from)) continue;
+    if (isInsideCodeBlock(state, from)) continue;
     if (isInsideTemplateExpr(exprRanges, from, to)) continue;
 
     const stem: string = stripKnownExt(rawTarget);
@@ -137,9 +160,11 @@ function buildDecorations(view: EditorView): DecorationSet {
     let aliasStart: number | null = null;
     let aliasEnd: number | null = null;
     if (aliasText !== undefined) {
-      const pipePos = text.indexOf("|", from + 2);
-      if (pipePos !== -1) {
-        aliasStart = pipePos;
+      // `text` is the widened-window slice; searching for `|` in it and
+      // translating back via windowFrom keeps absolute coordinates correct.
+      const pipePosInSlice = text.indexOf("|", m.index + 2);
+      if (pipePosInSlice !== -1) {
+        aliasStart = windowFrom + pipePosInSlice;
         aliasEnd = to - 2;
       }
     }


### PR DESCRIPTION
## Summary

- `buildDecorations` in `wikiLink.ts` and `embedPlugin.ts` used to call `view.state.doc.toString()` and run a full-document regex pass (two passes in `embedPlugin.ts`) on every `docChanged` / `viewportChanged` / `selectionSet` transaction. On a 50k-char note that allocates O(doc length) per keystroke and directly eats the 16ms budget.
- Replace both scans with a viewport-bounded slice widened by 512 bytes on each side so wiki-links and `{{ ... }}` template expressions that straddle the viewport boundary still match. Absolute positions are recomputed via `windowFrom + m.index`; `findTemplateExprRanges` receives `windowFrom` so `isInsideTemplateExpr` stays in absolute coordinates; `syntaxTree(state)` lookups are unchanged and absolute.
- Closes #247.

## Test Plan

- [x] `src/components/Editor/__tests__/wikiLinkViewportScan.test.ts` — decoration correctness under a restricted viewport (jsdom override), widen-margin detection, and template-exclusion offset math.
- [x] `src/components/Editor/__tests__/embedPluginViewportScan.test.ts` — same for wiki-embeds, embed sizing tails (`|500]]`) straddling `viewport.to`, and markdown `![alt](url)` straddling `viewport.from`.
- [x] `src/components/Editor/__tests__/editorPluginDocToStringAudit.test.ts` — static audit over `src/components/Editor/*.ts` (non-recursive, excluding `__tests__`) asserting the only files calling `doc.toString()` are the allowlisted ones (`autoSave.ts`, `countsPlugin.ts`, `templateAutocomplete.ts`).
- [x] Full `src/components/Editor` vitest suite: no regressions in the existing `frontmatter`, `livePreview`, `embed`, `wikiLink`, `canvasEmbed`, `inlineGuardsInTemplate`, `canvasWikiLink`, `templateLivePreview`, `EditorPaneWikiLinkClickResolve` suites.
- [x] `pnpm tsc --noEmit` clean; `pnpm svelte-check` shows only pre-existing unrelated CSS warnings.

Note: `largeFile.test.ts`'s 500ms wall-clock budget is flaky under full-suite jsdom load (reproducible on untouched `main`). Test passes in isolation and this PR does not affect its hot path — our changes make the plugins strictly faster.