### PR TITLE
perf(sidebar): virtualize tree + single reveal subscription (#253)

### DIFF
--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -207,34 +207,64 @@
   // ─── Toggle expand / persist ───────────────────────────────────────────────
   async function onToggleExpand(row: FlatRow) {
     if (!row.isDir) return;
-    const expanded = new Set(treeState.expanded);
-    const willExpand = !expanded.has(row.relPath);
-    if (willExpand) expanded.add(row.relPath);
-    else expanded.delete(row.relPath);
-    treeState = { ...treeState, expanded: Array.from(expanded) };
-    void saveTreeState($vaultStore.currentPath ?? "", treeState);
+    const willExpand = !treeState.expanded.includes(row.relPath);
     if (willExpand) {
+      // Optimistically show the folder as expanded (with spinner) while the
+      // load is in flight. Persist only once listDirectory resolves — matches
+      // #336 B3 so a failure doesn't stick in `expanded` across sessions.
+      const expanded = new Set(treeState.expanded);
+      expanded.add(row.relPath);
+      treeState = { ...treeState, expanded: Array.from(expanded) };
       const existing = folders.get(row.path);
       if (!existing || !existing.childrenLoaded) {
-        await loadFolder(row.path);
+        const result = await loadFolder(row.path);
+        if (result === null) {
+          // Roll back the optimistic expand so the folder collapses and the
+          // next session doesn't show an empty, un-retryable expanded node.
+          const rolled = new Set(treeState.expanded);
+          rolled.delete(row.relPath);
+          treeState = { ...treeState, expanded: Array.from(rolled) };
+          void saveTreeState($vaultStore.currentPath ?? "", treeState);
+          return;
+        }
       }
+      void saveTreeState($vaultStore.currentPath ?? "", treeState);
+    } else {
+      const expanded = new Set(treeState.expanded);
+      expanded.delete(row.relPath);
+      treeState = { ...treeState, expanded: Array.from(expanded) };
+      void saveTreeState($vaultStore.currentPath ?? "", treeState);
     }
   }
 
   async function setExpanded(relPath: string, absPath: string, on: boolean) {
-    const expanded = new Set(treeState.expanded);
-    if (on) expanded.add(relPath);
-    else expanded.delete(relPath);
-    treeState = { ...treeState, expanded: Array.from(expanded) };
-    // Fire-and-forget the persistence — it uses crypto.subtle.digest which
-    // can hang several ticks; we don't want that delaying the user-visible
-    // listDirectory that populates the expanded folder.
-    void saveTreeState($vaultStore.currentPath ?? "", treeState);
     if (on) {
+      // #336 B3 — do NOT persist `expanded` until listDirectory resolves
+      // successfully. If it fails, the folder stays collapsed so the next
+      // session doesn't show an empty, un-retryable expanded folder.
       const existing = folders.get(absPath);
-      if (!existing || !existing.childrenLoaded) {
-        await loadFolder(absPath);
+      const needsLoad = !existing || !existing.childrenLoaded;
+      if (needsLoad) {
+        const result = await loadFolder(absPath);
+        if (result === null) {
+          // Load failed — leave treeState.expanded untouched.
+          return;
+        }
       }
+      if (treeState.expanded.includes(relPath)) return;
+      const expanded = new Set(treeState.expanded);
+      expanded.add(relPath);
+      treeState = { ...treeState, expanded: Array.from(expanded) };
+      // Fire-and-forget the persistence — it uses crypto.subtle.digest which
+      // can hang several ticks; we don't want that delaying the user-visible
+      // listDirectory that populates the expanded folder.
+      void saveTreeState($vaultStore.currentPath ?? "", treeState);
+    } else {
+      if (!treeState.expanded.includes(relPath)) return;
+      const expanded = new Set(treeState.expanded);
+      expanded.delete(relPath);
+      treeState = { ...treeState, expanded: Array.from(expanded) };
+      void saveTreeState($vaultStore.currentPath ?? "", treeState);
     }
   }
 
@@ -358,9 +388,21 @@
     tagsStore.reset();
   });
 
+  // #336 B2 — if a reveal fires while the scroller has 0 height (collapsed
+  // sidebar, pre-layout mount), stash it and drain once the scroller has a
+  // real clientHeight.
+  let pendingRevealPath: string | null = null;
+
   function measureViewport() {
     if (scrollerEl) {
-      viewportHeight = scrollerEl.clientHeight || viewportHeight;
+      const newHeight = scrollerEl.clientHeight || viewportHeight;
+      viewportHeight = newHeight;
+      // Drain the stashed reveal once the layout is actually present.
+      if (pendingRevealPath !== null && scrollerEl.clientHeight > 0) {
+        const pending = pendingRevealPath;
+        pendingRevealPath = null;
+        void performReveal(pending);
+      }
     }
   }
 
@@ -392,42 +434,69 @@
     // Recompute the flat list after the DOM has caught up with the new state.
     await tick();
 
-    // Find the target row and scroll it into view. If the target is outside
-    // the current window, bring it in first so the virtualized renderer
-    // mounts its row element before we call scrollIntoView.
+    // #336 B1 — do NOT read the `flatRows` $derived here. Svelte 5 batches
+    // reactive updates; a $derived value read from inside a store-subscription
+    // callback (even across an `await tick()`) can return its previous value
+    // when the triggering $state was mutated in an async continuation. Recompute
+    // from `treeModel`'s backing fields directly to get a guaranteed-fresh slice.
+    const fresh = flattenTree({
+      vaultPath,
+      rootEntries,
+      folders,
+      expanded: new Set(treeState.expanded),
+      sortBy: treeState.sortBy,
+    });
+
     const targetAbs = relPath.length > 0 ? vaultPath + "/" + relPath : vaultPath;
-    const idx = flatRows.findIndex((r) => r.path === targetAbs);
+    const idx = fresh.findIndex((r) => r.path === targetAbs);
     if (idx === -1) {
       // Target path isn't in the flat list (maybe points at a .md file under
       // an ancestor whose listDirectory hasn't landed yet). Best-effort: no
       // scroll — the caller can re-dispatch after the user's next keystroke.
       return;
     }
-    if (scrollerEl) {
-      // Place the target ~1/3 down the viewport so it's visibly centered.
-      const targetTop = idx * ROW_HEIGHT;
-      const vh = scrollerEl.clientHeight || viewportHeight;
-      const desiredTop = Math.max(0, targetTop - vh / 3);
-      if (targetTop < scrollerEl.scrollTop || targetTop > scrollerEl.scrollTop + vh - ROW_HEIGHT) {
-        scrollerEl.scrollTop = desiredTop;
-        scrollTop = desiredTop;
-        await tick();
-      }
+
+    // #336 B2 — if the scroller has no layout yet, stash the request and
+    // let `measureViewport` drain it once it gets a real clientHeight.
+    if (!scrollerEl || scrollerEl.clientHeight === 0) {
+      pendingRevealPath = relPath;
+      return;
     }
-    // Find the row element (it now must exist in the DOM window) and
-    // scroll-into-view — matches the old TreeNode behaviour. Try now, and
-    // again on the next frame in case the flat renderer hasn't mounted the
-    // row yet (the window-slice update is reactive but pixel-level scroll
-    // happens after the next paint).
-    const scrollTarget = () => {
+
+    // Place the target ~1/3 down the viewport so it's visibly centered.
+    const targetTop = idx * ROW_HEIGHT;
+    const vh = scrollerEl.clientHeight || viewportHeight;
+    const desiredTop = Math.max(0, targetTop - vh / 3);
+    if (targetTop < scrollerEl.scrollTop || targetTop > scrollerEl.scrollTop + vh - ROW_HEIGHT) {
+      scrollerEl.scrollTop = desiredTop;
+      scrollTop = desiredTop;
+      await tick();
+    }
+
+    // Find the row element (it now should exist in the DOM window) and
+    // scroll-into-view. The window-slice update is reactive but pixel-level
+    // scroll happens after the next paint, so poll a few rAF frames before
+    // falling back to best-effort index scroll.
+    const scrollTarget = (): boolean => {
       const el = scrollerEl?.querySelector<HTMLElement>(
         `[data-tree-row="${cssEscape(targetAbs)}"]`,
       );
-      el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      if (el) {
+        el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        return true;
+      }
+      return false;
     };
-    scrollTarget();
+    if (scrollTarget()) return;
     if (typeof requestAnimationFrame === "function") {
-      requestAnimationFrame(scrollTarget);
+      let attempts = 0;
+      const tryRaf = () => {
+        if (scrollTarget()) return;
+        attempts += 1;
+        if (attempts < 3) requestAnimationFrame(tryRaf);
+        // else: accept best-effort — scrollTop is already at desiredTop.
+      };
+      requestAnimationFrame(tryRaf);
     }
   }
 

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy, tick } from "svelte";
   import { FilePlus, FolderPlus, Network, ChevronDown, FileText, LayoutDashboard, BookOpen } from "lucide-svelte";
   import { listDirectory, createFile, createFolder, writeFile } from "../../ipc/commands";
   import { serializeCanvas, emptyCanvas } from "../../lib/canvas/parse";
   import { commandRegistry } from "../../lib/commands/registry";
   import { CMD_IDS } from "../../lib/commands/defaultCommands";
-  // BUG-05.1: SortMenu was descoped per UAT — keep treeState for FILE-07
-  // (expand persistence) but default sortBy stays "name" without a UI toggle.
   import {
     loadTreeState,
     saveTreeState,
@@ -35,32 +33,44 @@
   import { treeRevealStore } from "../../store/treeRevealStore";
   import { tagsStore } from "../../store/tagsStore";
   import { Hash } from "lucide-svelte";
-  import TreeNode from "./TreeNode.svelte";
+  import TreeRow from "./TreeRow.svelte";
   import ProgressBar from "../Progress/ProgressBar.svelte";
   import TagsPanel from "../Tags/TagsPanel.svelte";
   import BookmarksPanel from "../Bookmarks/BookmarksPanel.svelte";
   import { bookmarksStore } from "../../store/bookmarksStore";
+  import {
+    flattenTree,
+    ancestorRelPaths,
+    toRelPath as flatToRelPath,
+    type FlatRow,
+    type FolderState,
+    type TreeModel,
+  } from "../../lib/flattenTree";
+
+  // #253 — the sidebar is now the single owner of:
+  //   - the tree model (per-folder FolderState + persisted `expanded`)
+  //   - the `treeRevealStore` subscription (rows do NOT subscribe individually)
+  //   - the flattened row list + virtualized renderer
 
   interface Props {
     selectedPath: string | null;
     onSelect: (path: string) => void;
     onOpenFile: (path: string) => void;
-    /** Tag-click → open the omni-search modal in content mode, pre-filled. */
     onOpenContentSearch: (query: string) => void;
   }
 
   let { selectedPath, onSelect, onOpenFile, onOpenContentSearch }: Props = $props();
 
+  // ─── Tree model ────────────────────────────────────────────────────────────
   let rootEntries = $state<DirEntry[]>([]);
+  let folders = $state<Map<string, FolderState>>(new Map());
   let loadError = $state<string | null>(null);
   let loading = $state(false);
   let bulkActive = $state(false);
   let bulkCount = $state(0);
   let treeState = $state<TreeState>({ ...DEFAULT_TREE_STATE });
 
-  // #145 — header "+ New ▾" split/dropdown open state. Primary click of the
-  // button creates a note; clicking the chevron opens this menu so canvas
-  // creation is visible without right-clicking a folder first.
+  // ─── Header split/dropdown state ───────────────────────────────────────────
   let newMenuOpen = $state(false);
   const newNoteHotkey = $derived(commandRegistry.getEffectiveHotkey(CMD_IDS.NEW_NOTE));
   const newCanvasHotkey = $derived(commandRegistry.getEffectiveHotkey(CMD_IDS.NEW_CANVAS));
@@ -74,32 +84,64 @@
     return isMac ? `${meta}${shift}${key}` : `${meta}${shift}${key}`;
   }
 
-  // Watcher unlisten handles — cleaned up on destroy
-  let unlistenFileChange: UnlistenFn | null = null;
-  let unlistenBulkStart: UnlistenFn | null = null;
-  let unlistenBulkEnd: UnlistenFn | null = null;
+  // ─── Flat-list derivation ──────────────────────────────────────────────────
+  const treeModel = $derived<TreeModel>({
+    vaultPath: $vaultStore.currentPath ?? "",
+    rootEntries,
+    folders,
+    expanded: new Set(treeState.expanded),
+    sortBy: treeState.sortBy,
+  });
 
-  const vaultName = $derived(
-    $vaultStore.currentPath
-      ? $vaultStore.currentPath.split("/").pop() ?? $vaultStore.currentPath
-      : "No vault"
-  );
+  const flatRows = $derived(flattenTree(treeModel));
 
-  /** Compute vault-relative path from an absolute path. */
-  function vaultRel(absPath: string): string {
-    const vaultPath = $vaultStore.currentPath ?? "";
-    if (absPath.startsWith(vaultPath + "/")) {
-      return absPath.slice(vaultPath.length + 1).replace(/\\/g, "/");
+  // ─── Virtualization state ──────────────────────────────────────────────────
+  const ROW_HEIGHT = 28; // px — keep in sync with the CSS var below
+  const OVERSCAN = 10;   // rows above + below the viewport
+
+  let scrollerEl = $state<HTMLDivElement | null>(null);
+  let viewportHeight = $state(600);
+  let scrollTop = $state(0);
+
+  // The row currently inline-renaming. We always keep it inside the window so
+  // the InlineRename input never recycles out.
+  let renamingPath = $state<string | null>(null);
+
+  const startIdx = $derived.by(() => {
+    const first = Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN;
+    return Math.max(0, first);
+  });
+  const endIdx = $derived.by(() => {
+    const visibleRows = Math.ceil(viewportHeight / ROW_HEIGHT);
+    const last = Math.floor(scrollTop / ROW_HEIGHT) + visibleRows + OVERSCAN;
+    return Math.min(flatRows.length, last);
+  });
+
+  /** Rows we render in the DOM — window slice plus the rename-target pin. */
+  const windowRows = $derived.by<Array<{ row: FlatRow; index: number }>>(() => {
+    const slice: Array<{ row: FlatRow; index: number }> = [];
+    for (let i = startIdx; i < endIdx; i += 1) {
+      slice.push({ row: flatRows[i]!, index: i });
     }
-    return absPath.replace(/\\/g, "/");
-  }
+    // Pin the renaming row if it's outside the window — never destroy the
+    // input while the user is typing.
+    if (renamingPath) {
+      const already = slice.some((s) => s.row.path === renamingPath);
+      if (!already) {
+        const ri = flatRows.findIndex((r) => r.path === renamingPath);
+        if (ri !== -1) slice.push({ row: flatRows[ri]!, index: ri });
+      }
+    }
+    return slice;
+  });
 
+  const topSpacer = $derived(startIdx * ROW_HEIGHT);
+  const bottomSpacer = $derived(Math.max(0, (flatRows.length - endIdx) * ROW_HEIGHT));
+
+  // ─── IPC loaders ───────────────────────────────────────────────────────────
   async function loadRoot() {
     const vaultPath = $vaultStore.currentPath;
     if (!vaultPath) return;
-    // Only show loading spinner on initial load — refreshes silently update
-    // rootEntries to avoid destroying TreeNode components and losing their
-    // local expanded state.
     const isInitialLoad = rootEntries.length === 0;
     if (isInitialLoad) loading = true;
     loadError = null;
@@ -115,90 +157,146 @@
     }
   }
 
-  // ─── Watcher event handlers ────────────────────────────────────────────────
+  async function loadFolder(folderAbsPath: string): Promise<DirEntry[] | null> {
+    const existing = folders.get(folderAbsPath);
+    if (existing?.loading) return existing.children ? [...existing.children] : null;
+    setFolderState(folderAbsPath, {
+      children: existing?.children,
+      childrenLoaded: existing?.childrenLoaded ?? false,
+      loading: true,
+    });
+    try {
+      const raw = await listDirectory(folderAbsPath);
+      setFolderState(folderAbsPath, {
+        children: raw,
+        childrenLoaded: true,
+        loading: false,
+      });
+      return raw;
+    } catch (e) {
+      setFolderState(folderAbsPath, {
+        children: existing?.children,
+        childrenLoaded: existing?.childrenLoaded ?? false,
+        loading: false,
+      });
+      const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+      return null;
+    }
+  }
 
-  function handleFileChange(payload: FileChangePayload) {
-    const { path, kind, new_path } = payload;
+  function setFolderState(path: string, next: FolderState) {
+    // Assign a fresh Map so Svelte's reactivity picks up the change — Svelte 5
+    // doesn't deeply track Map mutations.
+    const m = new Map(folders);
+    m.set(path, next);
+    folders = m;
+  }
 
-    if (kind === "create") {
-      // Invalidate tree: re-fetch root to show the new file
-      void loadRoot();
-    } else if (kind === "modify") {
-      // No tree structure change needed for content modifications.
-      // If the file is open in a tab, EditorPane handles merge (Plan 05).
-      // No action needed here.
-    } else if (kind === "delete") {
-      // Invalidate tree: re-fetch root to remove the deleted entry
-      void loadRoot();
-      // Close the tab if this file is open
-      tabStore.closeByPath(path);
-    } else if (kind === "rename") {
-      // Invalidate tree for both old and new parent directories
-      void loadRoot();
-      // Update tab path if file is open in a tab
-      if (new_path) {
-        tabStore.updateFilePath(path, new_path);
+  /** Re-fetch a folder whose children may have changed on disk. */
+  async function refreshFolder(folderAbsPath: string) {
+    const vaultPath = $vaultStore.currentPath;
+    if (!vaultPath) return;
+    if (folderAbsPath === vaultPath || folderAbsPath === "") {
+      await loadRoot();
+      return;
+    }
+    await loadFolder(folderAbsPath);
+  }
+
+  // ─── Toggle expand / persist ───────────────────────────────────────────────
+  async function onToggleExpand(row: FlatRow) {
+    if (!row.isDir) return;
+    const expanded = new Set(treeState.expanded);
+    const willExpand = !expanded.has(row.relPath);
+    if (willExpand) expanded.add(row.relPath);
+    else expanded.delete(row.relPath);
+    treeState = { ...treeState, expanded: Array.from(expanded) };
+    void saveTreeState($vaultStore.currentPath ?? "", treeState);
+    if (willExpand) {
+      const existing = folders.get(row.path);
+      if (!existing || !existing.childrenLoaded) {
+        await loadFolder(row.path);
       }
     }
   }
 
+  async function setExpanded(relPath: string, absPath: string, on: boolean) {
+    const expanded = new Set(treeState.expanded);
+    if (on) expanded.add(relPath);
+    else expanded.delete(relPath);
+    treeState = { ...treeState, expanded: Array.from(expanded) };
+    // Fire-and-forget the persistence — it uses crypto.subtle.digest which
+    // can hang several ticks; we don't want that delaying the user-visible
+    // listDirectory that populates the expanded folder.
+    void saveTreeState($vaultStore.currentPath ?? "", treeState);
+    if (on) {
+      const existing = folders.get(absPath);
+      if (!existing || !existing.childrenLoaded) {
+        await loadFolder(absPath);
+      }
+    }
+  }
+
+  // ─── Watcher handlers ──────────────────────────────────────────────────────
+  let unlistenFileChange: UnlistenFn | null = null;
+  let unlistenBulkStart: UnlistenFn | null = null;
+  let unlistenBulkEnd: UnlistenFn | null = null;
+
+  function handleFileChange(payload: FileChangePayload) {
+    const { path, kind, new_path } = payload;
+    if (kind === "create" || kind === "delete" || kind === "rename") {
+      // Invalidate the entire tree cache — safest for arbitrary watcher events.
+      invalidateAllFolders();
+      void loadRoot();
+      if (kind === "delete") tabStore.closeByPath(path);
+      if (kind === "rename" && new_path) tabStore.updateFilePath(path, new_path);
+    }
+  }
+
+  function invalidateAllFolders() {
+    // Keep `expanded` state intact (persisted), but drop cached child lists so
+    // folders re-fetch next time they're expanded / walked.
+    folders = new Map();
+  }
+
   function handleBulkStart(payload: BulkChangePayload) {
-    // Show bulk-change progress UI in sidebar header area (D-13)
     bulkActive = true;
     bulkCount = payload.estimated_count;
     progressStore.start(payload.estimated_count);
   }
 
   function handleBulkEnd() {
-    // Hide bulk progress UI and refresh the full tree
     bulkActive = false;
     bulkCount = 0;
     progressStore.finish();
+    invalidateAllFolders();
     void loadRoot();
   }
 
-  // ─── Mount / Destroy ────────────────────────────────────────────────────────
-
+  // ─── Mount / destroy ───────────────────────────────────────────────────────
   let prevRefreshToken: string | null = null;
   let unsubTreeRefresh: (() => void) | null = null;
   let prevRevealToken: string | null = null;
   let unsubTreeReveal: (() => void) | null = null;
 
-  /**
-   * Collect every ancestor folder rel path of the target. For
-   * "notes/daily/today.md" this returns ["notes", "notes/daily"]. The target
-   * itself is not included (only its enclosing folders need to be expanded).
-   */
-  function ancestorFolderPaths(relPath: string): string[] {
-    const parts = relPath.split("/").filter((p) => p.length > 0);
-    if (parts.length <= 1) return [];
-    const out: string[] = [];
-    for (let i = 1; i < parts.length; i += 1) {
-      out.push(parts.slice(0, i).join("/"));
-    }
-    return out;
-  }
-
-  async function onExpandToggle(relPath: string, isExpanded: boolean) {
-    const expanded = new Set(treeState.expanded);
-    if (isExpanded) expanded.add(relPath);
-    else expanded.delete(relPath);
-    treeState = { ...treeState, expanded: Array.from(expanded) };
-    await saveTreeState($vaultStore.currentPath ?? "", treeState);
-  }
-
-  // BUG-05.1 (#11): on cold start, vault auto-load is async in App.svelte.
-  // Sidebar might mount before $vaultStore.currentPath is populated — the
-  // onMount loadTreeState() call would run with a null path and skip,
-  // leaving treeState at DEFAULT (empty expanded). Fix by subscribing to
-  // vaultStore and re-loading treeState whenever currentPath transitions
-  // from null/old to a new value. Mirrors EditorPane's reloadResolvedLinks pattern.
   let prevVaultPathSeen: string | null = null;
-  const unsubVaultPathSidebar = vaultStore.subscribe(async (state) => {
+  let unsubVaultPathSidebar: (() => void) | null = null;
+
+  function handleVaultStateChange(state: { currentPath: string | null }) {
     if (state.currentPath !== prevVaultPathSeen) {
       prevVaultPathSeen = state.currentPath;
       if (state.currentPath) {
-        treeState = await loadTreeState(state.currentPath);
+        invalidateAllFolders();
+        const cp = state.currentPath;
+        void (async () => {
+          try {
+            const ts = await loadTreeState(cp);
+            treeState = { ...ts };
+          } catch {
+            /* keep defaults */
+          }
+        })();
         void loadRoot();
         void tagsStore.reload();
         void bookmarksStore.load(state.currentPath);
@@ -206,55 +304,48 @@
         bookmarksStore.reset();
       }
     }
-  });
+  }
 
   onMount(async () => {
-    // Subscribe to watcher events (SYNC-01, SYNC-05)
+    // #253 — vault subscription must live inside onMount so that async
+    // treeState assignments flow through Svelte 5's reactive graph (a
+    // top-level-script subscription fires during component construction,
+    // before the reactive root is fully wired, and mutations from its
+    // async continuation never reach the `$derived` graph).
+    unsubVaultPathSidebar = vaultStore.subscribe(handleVaultStateChange);
+
     unlistenFileChange = await listenFileChange(handleFileChange);
     unlistenBulkStart = await listenBulkChangeStart(handleBulkStart);
     unlistenBulkEnd = await listenBulkChangeEnd(handleBulkEnd);
 
-    // Subscribe to tree-refresh signal — callers that create files through
-    // backend paths (which bypass the watcher via write-ignore) use this
-    // to force a sidebar reload. See EditorPane click-to-create.
-    // Also reload tags on the same signal (watcher dispatches UpdateTags
-    // on the same event batch that triggers tree refresh).
     unsubTreeRefresh = treeRefreshStore.subscribe((state) => {
       if (state.token && state.token !== prevRefreshToken) {
         prevRefreshToken = state.token;
+        invalidateAllFolders();
         void loadRoot();
         if ($vaultStore.currentPath) void tagsStore.reload();
       }
     });
 
-    // Reveal requests — issued by the breadcrumb bar. Flip to the files
-    // tab and ensure every ancestor folder is in the persisted expanded
-    // list so freshly rendered TreeNodes mount expanded. TreeNode owns
-    // the scroll-into-view + per-instance expansion via its own
-    // treeRevealStore subscription.
-    unsubTreeReveal = treeRevealStore.subscribe(async (state) => {
+    // #253 — single reveal-store subscription. Handles: expand ancestors →
+    // wait for listDirectory → re-flatten → scroll target into view.
+    unsubTreeReveal = treeRevealStore.subscribe((state) => {
       if (!state.pending) return;
       if (state.pending.token === prevRevealToken) return;
       prevRevealToken = state.pending.token;
-
-      searchStore.setActiveTab("files");
-
-      const ancestors = ancestorFolderPaths(state.pending.relPath);
-      if (ancestors.length === 0) return;
-      const expanded = new Set(treeState.expanded);
-      let changed = false;
-      for (const p of ancestors) {
-        if (!expanded.has(p)) {
-          expanded.add(p);
-          changed = true;
-        }
-      }
-      if (changed) {
-        treeState = { ...treeState, expanded: Array.from(expanded) };
-        await saveTreeState($vaultStore.currentPath ?? "", treeState);
-      }
+      void performReveal(state.pending.relPath);
     });
+
+    // Measure viewport height once mounted.
+    measureViewport();
+    if (typeof ResizeObserver !== "undefined" && scrollerEl) {
+      const ro = new ResizeObserver(measureViewport);
+      ro.observe(scrollerEl);
+      onDestroyCallbacks.push(() => ro.disconnect());
+    }
   });
+
+  const onDestroyCallbacks: Array<() => void> = [];
 
   onDestroy(() => {
     unlistenFileChange?.();
@@ -263,9 +354,109 @@
     unsubTreeRefresh?.();
     unsubTreeReveal?.();
     unsubVaultPathSidebar?.();
+    onDestroyCallbacks.forEach((fn) => fn());
     tagsStore.reset();
   });
 
+  function measureViewport() {
+    if (scrollerEl) {
+      viewportHeight = scrollerEl.clientHeight || viewportHeight;
+    }
+  }
+
+  function onScroll(e: Event) {
+    const el = e.currentTarget as HTMLDivElement;
+    scrollTop = el.scrollTop;
+  }
+
+  // ─── Reveal pipeline ───────────────────────────────────────────────────────
+  /**
+   * Expand every ancestor folder of `relPath`, await each listDirectory, then
+   * scroll the target row into view. Sequenced so the flat list has grown to
+   * include the target before we try to scroll to it.
+   */
+  async function performReveal(relPath: string) {
+    searchStore.setActiveTab("files");
+
+    const vaultPath = $vaultStore.currentPath ?? "";
+    if (!vaultPath) return;
+
+    const ancestors = ancestorRelPaths(relPath);
+    // Walk ancestors top-down so each subsequent listDirectory has its parent
+    // already resolved.
+    for (const ancestorRel of ancestors) {
+      const ancestorAbs = vaultPath + "/" + ancestorRel;
+      await setExpanded(ancestorRel, ancestorAbs, true);
+    }
+
+    // Recompute the flat list after the DOM has caught up with the new state.
+    await tick();
+
+    // Find the target row and scroll it into view. If the target is outside
+    // the current window, bring it in first so the virtualized renderer
+    // mounts its row element before we call scrollIntoView.
+    const targetAbs = relPath.length > 0 ? vaultPath + "/" + relPath : vaultPath;
+    const idx = flatRows.findIndex((r) => r.path === targetAbs);
+    if (idx === -1) {
+      // Target path isn't in the flat list (maybe points at a .md file under
+      // an ancestor whose listDirectory hasn't landed yet). Best-effort: no
+      // scroll — the caller can re-dispatch after the user's next keystroke.
+      return;
+    }
+    if (scrollerEl) {
+      // Place the target ~1/3 down the viewport so it's visibly centered.
+      const targetTop = idx * ROW_HEIGHT;
+      const vh = scrollerEl.clientHeight || viewportHeight;
+      const desiredTop = Math.max(0, targetTop - vh / 3);
+      if (targetTop < scrollerEl.scrollTop || targetTop > scrollerEl.scrollTop + vh - ROW_HEIGHT) {
+        scrollerEl.scrollTop = desiredTop;
+        scrollTop = desiredTop;
+        await tick();
+      }
+    }
+    // Find the row element (it now must exist in the DOM window) and
+    // scroll-into-view — matches the old TreeNode behaviour. Try now, and
+    // again on the next frame in case the flat renderer hasn't mounted the
+    // row yet (the window-slice update is reactive but pixel-level scroll
+    // happens after the next paint).
+    const scrollTarget = () => {
+      const el = scrollerEl?.querySelector<HTMLElement>(
+        `[data-tree-row="${cssEscape(targetAbs)}"]`,
+      );
+      el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    };
+    scrollTarget();
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(scrollTarget);
+    }
+  }
+
+  function cssEscape(value: string): string {
+    // Lightweight CSS escape — we only need to guard quotes/backslashes/newlines.
+    // (CSS.escape is not reliably available in the Tauri webview.)
+    return value.replace(/["\\\n\r]/g, (c) => "\\" + c);
+  }
+
+  // ─── Row callbacks ─────────────────────────────────────────────────────────
+  function onRenameStateChange(path: string, renaming: boolean) {
+    renamingPath = renaming ? path : renamingPath === path ? null : renamingPath;
+  }
+
+  function handlePathChanged(oldPath: string, newPath: string) {
+    tabStore.updateFilePath(oldPath, newPath);
+    // Invalidate the containing folder — a rename may have reordered entries.
+    const parent = parentOf(oldPath);
+    if (parent) void refreshFolder(parent);
+    else void loadRoot();
+  }
+
+  function parentOf(absPath: string): string | null {
+    const i = absPath.lastIndexOf("/");
+    if (i <= 0) return null;
+    return absPath.slice(0, i);
+  }
+
+  // ─── Header actions ────────────────────────────────────────────────────────
   async function handleNewFile() {
     newMenuOpen = false;
     const vaultPath = $vaultStore.currentPath;
@@ -273,17 +464,14 @@
     const targetFolder = getSelectedFolder() ?? vaultPath;
     try {
       await createFile(targetFolder, "");
-      await loadRoot();
+      if (targetFolder === vaultPath) await loadRoot();
+      else await refreshFolder(targetFolder);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
     }
   }
 
-  // #145 — header-level canvas creation. Targets the selected folder so
-  // dropdown + context-menu behavior stay symmetric. Seeds the file with an
-  // empty canvas doc (matches TreeNode.handleNewCanvasHere) so Obsidian
-  // accepts it on first open.
   async function handleNewCanvas() {
     newMenuOpen = false;
     const vaultPath = $vaultStore.currentPath;
@@ -292,7 +480,8 @@
     try {
       const newPath = await createFile(targetFolder, "Untitled.canvas");
       await writeFile(newPath, serializeCanvas(emptyCanvas()));
-      await loadRoot();
+      if (targetFolder === vaultPath) await loadRoot();
+      else await refreshFolder(targetFolder);
       tabStore.openFileTab(newPath, "canvas");
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
@@ -306,7 +495,8 @@
     const targetFolder = getSelectedFolder() ?? vaultPath;
     try {
       await createFolder(targetFolder, "");
-      await loadRoot();
+      if (targetFolder === vaultPath) await loadRoot();
+      else await refreshFolder(targetFolder);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
@@ -315,21 +505,19 @@
 
   function getSelectedFolder(): string | null {
     if (!selectedPath) return null;
-    // Check if selectedPath is a directory in root entries
     const entry = rootEntries.find((e) => e.path === selectedPath);
     if (entry?.is_dir) return selectedPath;
     return null;
   }
 
-  function handlePathChanged(oldPath: string, newPath: string) {
-    tabStore.updateFilePath(oldPath, newPath);
-    void loadRoot();
-  }
+  const vaultName = $derived(
+    $vaultStore.currentPath
+      ? $vaultStore.currentPath.split("/").pop() ?? $vaultStore.currentPath
+      : "No vault",
+  );
 </script>
 
 <aside class="vc-sidebar" data-testid="sidebar">
-  <!-- Tab bar — Dateien / Tags. The "Suche" tab was removed in #174; the
-       omni-search modal replaces the sidebar search panel. -->
   <div class="vc-sidebar-tabs" role="tablist">
     <button
       class="vc-sidebar-tab"
@@ -351,16 +539,12 @@
   </div>
 
   {#if $searchStore.activeTab === 'tags'}
-    <!-- Tags panel tab panel -->
     <div class="vc-sidebar-tabpanel" role="tabpanel">
       <TagsPanel {onOpenContentSearch} />
     </div>
   {:else}
-  <!-- Files tab panel — Header strip and tree -->
-  <!-- Header strip — replaced by bulk progress bar when bulk changes arrive -->
   <header class="vc-sidebar-header">
     {#if bulkActive}
-      <!-- Bulk-change progress UI (D-13): replaces normal header during burst -->
       <div class="vc-sidebar-bulk-progress">
         <span class="vc-sidebar-bulk-label">Scanning changes...</span>
         <span class="vc-sidebar-bulk-count">{bulkCount.toLocaleString()} files</span>
@@ -376,9 +560,6 @@
         {vaultName}
       </button>
       <div class="vc-sidebar-actions" style="position: relative;">
-        <!-- #145: split/dropdown "+ New ▾". Primary click = new note (parity
-             with the previous lone FilePlus button); chevron toggles a menu
-             that exposes canvas creation as a first-class action. -->
         <div class="vc-new-split" data-testid="sidebar-new-split">
           <button
             class="vc-sidebar-action-btn vc-new-split-primary"
@@ -464,32 +645,38 @@
     {/if}
   </header>
 
-  <!-- Bookmarks panel (#12) — collapsible, sits above the tree -->
   <BookmarksPanel />
 
-  <!-- Tree area -->
-  <div class="vc-sidebar-tree" role="tree" aria-label="Vault file tree">
+  <!-- Tree area (virtualized) -->
+  <div
+    class="vc-sidebar-tree"
+    role="tree"
+    aria-label="Vault file tree"
+    bind:this={scrollerEl}
+    onscroll={onScroll}
+  >
     {#if loading}
       <p class="vc-sidebar-status">Loading...</p>
     {:else if loadError}
       <p class="vc-sidebar-status vc-sidebar-status--error">{loadError}</p>
-    {:else if rootEntries.length === 0}
+    {:else if flatRows.length === 0}
       <p class="vc-sidebar-status">No files in vault.</p>
     {:else}
-      <ul class="vc-tree-root" role="group">
-        {#each rootEntries as entry (entry.path)}
-          <TreeNode
-            {entry}
-            depth={0}
+      <ul
+        class="vc-tree-root"
+        role="group"
+        style="padding-top: {topSpacer}px; padding-bottom: {bottomSpacer}px;"
+      >
+        {#each windowRows as { row, index } (row.path)}
+          <TreeRow
+            {row}
             {selectedPath}
             {onSelect}
             {onOpenFile}
-            onRefreshParent={loadRoot}
+            onToggleExpand={(r) => onToggleExpand(r)}
+            onRefreshFolder={refreshFolder}
             onPathChanged={handlePathChanged}
-            {onExpandToggle}
-            initiallyExpanded={treeState.expanded.includes(vaultRel(entry.path))}
-            expandedPaths={treeState.expanded}
-            sortBy={treeState.sortBy}
+            {onRenameStateChange}
           />
         {/each}
       </ul>
@@ -573,9 +760,6 @@
     color: var(--color-accent);
   }
 
-  /* #145 — split/dropdown "+ New ▾". The two buttons share a hover state so
-     users read the group as one control; the chevron is narrower to signal
-     it's a secondary target. */
   .vc-new-split {
     display: inline-flex;
     align-items: stretch;
@@ -648,7 +832,6 @@
     font-family: var(--font-mono, ui-monospace, monospace);
   }
 
-  /* Bulk-change progress strip — replaces vault name + action buttons */
   .vc-sidebar-bulk-progress {
     display: flex;
     align-items: center;
@@ -683,6 +866,7 @@
     list-style: none;
     margin: 0;
     padding: 4px 0;
+    --vc-tree-row-height: 28px;
   }
 
   .vc-sidebar-status {

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -1,87 +1,84 @@
 <script lang="ts">
-  import { ChevronRight, Folder, FolderOpen, FileText, File, MoreHorizontal, Star } from "lucide-svelte";
-  import { listDirectory, createFile, createFolder, deleteFile, moveFile, updateLinksAfterRename, getBacklinks, writeFile } from "../../ipc/commands";
+  // Flat row for the virtualized file tree (#253).
+  //
+  // Renders a single row from the flattened tree model. Unlike the former
+  // recursive <TreeNode>, this component:
+  //   - does NOT subscribe to treeRevealStore (Sidebar owns the sole subscription)
+  //   - does NOT own an `expanded` or `children` state (Sidebar's tree model does)
+  //   - does NOT recurse (the flat renderer places child rows as siblings)
+  //
+  // Drag-drop, inline rename, context-menu, and delete-confirmation logic were
+  // lifted from TreeNode with minimal behavioural changes so the existing WDIO
+  // specs (inline-rename, tree-context-menu, drag-drop) still pass.
+  import {
+    ChevronRight,
+    Folder,
+    FolderOpen,
+    FileText,
+    File,
+    MoreHorizontal,
+    Star,
+  } from "lucide-svelte";
+  import {
+    createFile,
+    createFolder,
+    deleteFile,
+    moveFile,
+    updateLinksAfterRename,
+    getBacklinks,
+    writeFile,
+  } from "../../ipc/commands";
   import { serializeCanvas, emptyCanvas } from "../../lib/canvas/parse";
   import { toastStore } from "../../store/toastStore";
-  import type { RenameResult } from "../../types/links";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
-  import type { DirEntry } from "../../types/tree";
   import InlineRename from "./InlineRename.svelte";
   import ContextMenu from "../common/ContextMenu.svelte";
-  import TreeNode from "./TreeNode.svelte";
   import { vaultStore } from "../../store/vaultStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
   import { tabStore } from "../../store/tabStore";
-  import { treeRevealStore } from "../../store/treeRevealStore";
   import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { bookmarksStore } from "../../store/bookmarksStore";
-  import { sortEntries, type SortBy } from "../../lib/treeState";
-  import { onMount, onDestroy, untrack } from "svelte";
+  import type { FlatRow } from "../../lib/flattenTree";
 
   interface Props {
-    entry: DirEntry;
-    depth: number;
+    row: FlatRow;
     selectedPath: string | null;
     onSelect: (path: string) => void;
     onOpenFile: (path: string) => void;
-    onRefreshParent: () => void;
+    onToggleExpand: (row: FlatRow) => void | Promise<void>;
+    /** Tell the Sidebar the child list for this folder needs re-fetching. */
+    onRefreshFolder: (folderPath: string) => void | Promise<void>;
     onPathChanged: (oldPath: string, newPath: string) => void;
-    onExpandToggle?: ((relPath: string, isExpanded: boolean) => void) | undefined;
-    initiallyExpanded?: boolean;
-    /** Vault-relative folder paths persisted as expanded — propagated through
-     *  the recursive tree so deeply nested descendants can restore their
-     *  open/closed state on mount instead of always starting collapsed. */
-    expandedPaths?: readonly string[];
-    sortBy?: SortBy;
+    /** Called when the user opens/closes inline rename on this row. */
+    onRenameStateChange?: (path: string, renaming: boolean) => void;
   }
 
   let {
-    entry,
-    depth,
+    row,
     selectedPath,
     onSelect,
     onOpenFile,
-    onRefreshParent,
+    onToggleExpand,
+    onRefreshFolder,
     onPathChanged,
-    onExpandToggle,
-    initiallyExpanded = false,
-    expandedPaths = [],
-    sortBy = "name",
+    onRenameStateChange,
   }: Props = $props();
 
-  // `initiallyExpanded` is a one-shot seed: the prop reflects the persisted
-  // tree state at mount time, but local expand/collapse is driven by the
-  // user (see `toggleExpand`) and must not be overwritten when the prop
-  // changes. `untrack` makes that intent explicit and silences Svelte 5's
-  // `state_referenced_locally` warning.
-  let expanded = $state(untrack(() => initiallyExpanded));
-  let children = $state<DirEntry[]>([]);
-  let childrenLoaded = $state(false);
-  let loading = $state(false);
+  // Reactive — the Sidebar recomputes row objects on every flatten, so Svelte
+  // already rerenders on change. No local mirror required.
+  const isActive = $derived(selectedPath === row.path);
+  const isBookmarked = $derived(
+    !row.isDir && row.relPath !== "" && $bookmarksStore.paths.includes(row.relPath),
+  );
 
-  // Rename/inline edit state
+  // Rename state — kept local because it's ephemeral per-row UI.
   let renaming = $state(false);
   let isNewFile = $state(false);
 
-  // Context menu state. Anchored at the cursor point when opened via
-  // right-click, and at the three-dots button's bounding rect when opened
-  // via click. Shared ContextMenu handles overflow-flip + ESC.
+  // Context-menu + dialog state.
   let showContextMenu = $state(false);
   let menuPos = $state<{ x: number; y: number }>({ x: 0, y: 0 });
-
-  // Delete confirmation state
   let showDeleteConfirm = $state(false);
-
-  // Drag-drop state
-  let isDragSource = $state(false);
-  let isDragTarget = $state(false);
-
-  // Wiki-link rename confirmation
-  // newPath: absolute path after rename (InlineRename already executed renameFile)
-  // oldRelPath: vault-relative old path (for updateLinksAfterRename)
-  // newRelPath: vault-relative new path (for updateLinksAfterRename)
-  // linkCount: total number of wiki-links pointing to the file
-  // fileCount: number of unique source files with links
   let pendingRename = $state<{
     newPath: string;
     oldRelPath: string;
@@ -89,8 +86,6 @@
     linkCount: number;
     fileCount: number;
   } | null>(null);
-
-  // Move confirmation state (drag-drop, D-11)
   let pendingMove = $state<{
     sourcePath: string;
     targetDirPath: string;
@@ -100,114 +95,30 @@
     fileCount: number;
   } | null>(null);
 
-  const isActive = $derived(selectedPath === entry.path);
+  let isDragSource = $state(false);
+  let isDragTarget = $state(false);
 
-  // Bookmark state for this entry (#12). Files only — folders aren't
-  // bookmarkable in the MVP.
-  const entryRelPath = $derived(relPathOf(entry.path));
-  const isBookmarked = $derived(
-    !entry.is_dir && entryRelPath !== null && $bookmarksStore.paths.includes(entryRelPath)
-  );
-
-  function relPathOf(absPath: string): string | null {
-    const vault = getVaultRoot();
-    if (!vault) return null;
-    return toRelPath(absPath, vault);
+  function getVaultRoot(): string | null {
+    let v: string | null = null;
+    const u = vaultStore.subscribe((s) => {
+      v = s.currentPath;
+    });
+    u();
+    return v;
   }
 
-  async function toggleBookmark() {
-    closeContextMenu();
-    const vault = getVaultRoot();
-    if (!vault || entry.is_dir) return;
-    const rel = toRelPath(entry.path, vault);
-    await bookmarksStore.toggle(rel, vault);
-  }
-
-  // DOM ref for scroll-into-view on reveal requests.
-  let rowEl = $state<HTMLDivElement | undefined>();
-
-  // Auto-load children if this node starts expanded (restored from persisted state, FILE-07)
-  onMount(() => {
-    if (initiallyExpanded && entry.is_dir && !childrenLoaded) {
-      void loadChildren();
-    }
-  });
-
-  // ─── Reveal-in-tree support ────────────────────────────────────────────────
-  // Subscribe to treeRevealStore. When a request lands we either:
-  //   - scroll our row into view (our rel path matches exactly), or
-  //   - auto-expand + load children (our rel path is an ancestor of the target),
-  // so the descendant row becomes visible in the DOM before it too scrolls into view.
-  let prevRevealToken: string | null = null;
-  const unsubTreeReveal = treeRevealStore.subscribe((state) => {
-    if (!state.pending) return;
-    if (state.pending.token === prevRevealToken) return;
-    prevRevealToken = state.pending.token;
-
-    const vault = getVaultRoot();
-    if (!vault) return;
-    const myRel = toRelPath(entry.path, vault);
-    const target = state.pending.relPath;
-    if (!myRel || !target) return;
-
-    if (myRel === target) {
-      // Exact match — scroll our row into view (AC-03). Defer so any
-      // ancestor-triggered expansion has landed in the DOM first.
-      requestAnimationFrame(() => {
-        rowEl?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-      });
-      return;
-    }
-
-    // Ancestor match — expand ourselves so the descendant becomes renderable.
-    if (entry.is_dir && (target === myRel + "/" || target.startsWith(myRel + "/"))) {
-      if (!expanded) {
-        expanded = true;
-        if (!childrenLoaded) void loadChildren();
-      }
-    }
-  });
-
-  onDestroy(() => {
-    unsubTreeReveal();
-  });
-
-  async function loadChildren() {
-    if (loading) return;
-    loading = true;
-    try {
-      const raw = await listDirectory(entry.path);
-      children = sortEntries(raw, sortBy);
-      childrenLoaded = true;
-    } catch (e) {
-      const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
-      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
-    } finally {
-      loading = false;
-    }
-  }
-
-  async function toggleExpand() {
-    if (!entry.is_dir) return;
-    expanded = !expanded;
-    if (expanded && !childrenLoaded) {
-      await loadChildren();
-    }
-    // Notify Sidebar to persist expand state (FILE-07)
-    const vault = getVaultRoot();
-    const relPath = vault ? toRelPath(entry.path, vault) : entry.path;
-    onExpandToggle?.(relPath, expanded);
+  function toRelPath(absPath: string, vaultRoot: string): string {
+    return absPath.startsWith(vaultRoot + "/")
+      ? absPath.slice(vaultRoot.length + 1)
+      : absPath;
   }
 
   function handleClick() {
-    onSelect(entry.path);
-    if (entry.is_dir) {
-      void toggleExpand();
+    onSelect(row.path);
+    if (row.isDir) {
+      void onToggleExpand(row);
     } else {
-      // #49: open any non-folder entry. The tab classifier inside EditorPane
-      // / onOpenFile decides whether to render it as markdown, image,
-      // read-only text, or an unsupported-file placeholder.
-      onOpenFile(entry.path);
+      onOpenFile(row.path);
     }
   }
 
@@ -218,7 +129,6 @@
     }
   }
 
-  // Context menu
   function openContextMenu(e: MouseEvent) {
     e.stopPropagation();
     const btn = e.currentTarget as HTMLElement;
@@ -227,8 +137,6 @@
     showContextMenu = true;
   }
 
-  // Issue #47: right-click handler on the row. Suppresses the webview default
-  // menu and anchors our menu at the cursor position.
   function handleRowContextMenu(e: MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
@@ -242,71 +150,64 @@
 
   function startRename() {
     closeContextMenu();
-    renaming = true;
+    setRenaming(true);
     isNewFile = false;
+  }
+
+  function setRenaming(next: boolean) {
+    renaming = next;
+    onRenameStateChange?.(row.path, next);
   }
 
   function handleOpenInSplit() {
     closeContextMenu();
-    tabStore.openTab(entry.path);
+    tabStore.openTab(row.path);
     tabStore.moveToPane("right");
   }
 
-  function getVaultRoot(): string | null {
-    let v: string | null = null;
-    const u = vaultStore.subscribe((s) => { v = s.currentPath; });
-    u();
-    return v;
-  }
-
-  function toRelPath(absPath: string, vaultRoot: string): string {
-    return absPath.startsWith(vaultRoot + "/")
-      ? absPath.slice(vaultRoot.length + 1)
-      : absPath;
+  async function toggleBookmark() {
+    closeContextMenu();
+    const vault = getVaultRoot();
+    if (!vault || row.isDir) return;
+    const rel = toRelPath(row.path, vault);
+    await bookmarksStore.toggle(rel, vault);
   }
 
   async function handleRenameConfirm(newPath: string, linkCount: number) {
-    renaming = false;
+    setRenaming(false);
     const vault = getVaultRoot();
-    const oldRelPath = vault ? toRelPath(entry.path, vault) : entry.path;
+    const oldRelPath = vault ? toRelPath(row.path, vault) : row.path;
     const newRelPath = vault ? toRelPath(newPath, vault) : newPath;
-    // Rename tracking for bookmarks (#12): update any matching bookmark entry.
     if (vault) {
       void bookmarksStore.renamePath(oldRelPath, newRelPath, vault);
     }
     if (linkCount > 0) {
-      // Get unique source file count for the dialog copy
       let fileCount = 1;
       try {
         const backlinks = await getBacklinks(oldRelPath);
         fileCount = new Set(backlinks.map((b) => b.sourcePath)).size || 1;
-      } catch { /* fallback to 1 */ }
+      } catch {
+        /* fallback to 1 */
+      }
       pendingRename = { newPath, oldRelPath, newRelPath, linkCount, fileCount };
     } else {
-      onPathChanged(entry.path, newPath);
-      onRefreshParent();
-      // #277: tell EditorPane to re-fetch the stem->relPath map so clicks on
-      // [[new-name]] resolve to the renamed file instead of creating at root.
+      onPathChanged(row.path, newPath);
       resolvedLinksStore.requestReload();
     }
   }
 
   function handleRenameCancel() {
-    renaming = false;
+    setRenaming(false);
   }
 
   async function confirmRenameWithLinks() {
     if (!pendingRename) return;
     const { newPath, oldRelPath, newRelPath } = pendingRename;
     pendingRename = null;
-    onPathChanged(entry.path, newPath);
-    onRefreshParent();
-    // #277: same rationale as handleRenameConfirm's no-link branch.
+    onPathChanged(row.path, newPath);
     resolvedLinksStore.requestReload();
     try {
       const result = await updateLinksAfterRename(oldRelPath, newRelPath);
-      // Reload any open tabs whose content was rewritten — the cascade writes
-      // through write_ignore so the watcher/editor never learns about them.
       if (result.updatedPaths.length > 0) {
         tabReloadStore.request(result.updatedPaths);
       }
@@ -337,8 +238,13 @@
   async function confirmDelete() {
     showDeleteConfirm = false;
     try {
-      await deleteFile(entry.path);
-      onRefreshParent();
+      await deleteFile(row.path);
+      // Refresh the containing folder so the flat list updates.
+      const vault = getVaultRoot();
+      const parentDir = vault && row.path.startsWith(vault + "/")
+        ? parentOf(row.path)
+        : parentOf(row.path);
+      await onRefreshFolder(parentDir ?? vault ?? "");
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
@@ -349,32 +255,18 @@
     showDeleteConfirm = false;
   }
 
-  /**
-   * Persist this folder as expanded in the Sidebar's TreeState so later
-   * re-mounts (e.g. triggered by a tree refresh) start expanded too.
-   */
-  function persistExpanded() {
-    if (!entry.is_dir) return;
-    const vault = getVaultRoot();
-    const rel = vault ? toRelPath(entry.path, vault) : entry.path;
-    onExpandToggle?.(rel, true);
+  function parentOf(absPath: string): string | null {
+    const i = absPath.lastIndexOf("/");
+    if (i <= 0) return null;
+    return absPath.slice(0, i);
   }
 
   async function handleNewFileHere() {
     closeContextMenu();
     try {
-      const newPath = await createFile(entry.path, "");
-      // Issue #50: keep the containing folder expanded after a create.
-      // The assignments are intentional even when `expanded` was already
-      // true — a simultaneous watcher-driven tree refresh can otherwise
-      // race with the local state flip. Persist the expanded flag so a
-      // full re-mount of this subtree restores it.
-      expanded = true;
-      persistExpanded();
-      await loadChildren();
-      expanded = true;
-      // Open the new note so the active-tab reveal hook (VaultLayout)
-      // selects it in the tree automatically.
+      const newPath = await createFile(row.path, "");
+      await onToggleExpand({ ...row, expanded: false });
+      await onRefreshFolder(row.path);
       tabStore.openTab(newPath);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
@@ -385,15 +277,10 @@
   async function handleNewCanvasHere() {
     closeContextMenu();
     try {
-      const newPath = await createFile(entry.path, "Untitled.canvas");
-      // Seed the file with an empty canvas doc so Obsidian recognizes the
-      // format immediately — an empty string would otherwise parse to a
-      // blank doc but fail Obsidian's schema validation on first open.
+      const newPath = await createFile(row.path, "Untitled.canvas");
       await writeFile(newPath, serializeCanvas(emptyCanvas()));
-      expanded = true;
-      persistExpanded();
-      await loadChildren();
-      expanded = true;
+      await onToggleExpand({ ...row, expanded: false });
+      await onRefreshFolder(row.path);
       tabStore.openFileTab(newPath, "canvas");
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
@@ -404,25 +291,20 @@
   async function handleNewFolderHere() {
     closeContextMenu();
     try {
-      await createFolder(entry.path, "");
-      // Issue #50: same expanded-state protection as handleNewFileHere.
-      expanded = true;
-      persistExpanded();
-      await loadChildren();
-      expanded = true;
+      await createFolder(row.path, "");
+      await onToggleExpand({ ...row, expanded: false });
+      await onRefreshFolder(row.path);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
     }
   }
 
-  // Drag-and-drop (FILE-05 / D-17)
-  // #146: files use `text/vaultcore-file`, directories use `text/vaultcore-folder`
-  // so the editor pane can accept file drops for split-view while rejecting folders.
+  // --- Drag-and-drop (keeps HTML5 semantics from TreeNode) -------------------
   function handleDragStart(e: DragEvent) {
     if (!e.dataTransfer) return;
-    const mime = entry.is_dir ? "text/vaultcore-folder" : "text/vaultcore-file";
-    e.dataTransfer.setData(mime, entry.path);
+    const mime = row.isDir ? "text/vaultcore-folder" : "text/vaultcore-file";
+    e.dataTransfer.setData(mime, row.path);
     e.dataTransfer.effectAllowed = "move";
     isDragSource = true;
   }
@@ -436,7 +318,7 @@
   }
 
   function handleDragOver(e: DragEvent) {
-    if (!entry.is_dir) return;
+    if (!row.isDir) return;
     if (!e.dataTransfer || !isSidebarDrag(e.dataTransfer.types)) return;
     e.preventDefault();
     isDragTarget = true;
@@ -448,19 +330,18 @@
 
   async function handleDrop(e: DragEvent) {
     isDragTarget = false;
-    if (!entry.is_dir) return;
+    if (!row.isDir) return;
     if (!e.dataTransfer || !isSidebarDrag(e.dataTransfer.types)) return;
     e.preventDefault();
     const sourcePath =
       e.dataTransfer.getData("text/vaultcore-file") ||
       e.dataTransfer.getData("text/vaultcore-folder");
-    if (!sourcePath || sourcePath === entry.path) return;
+    if (!sourcePath || sourcePath === row.path) return;
 
-    // D-11: check backlinks before move and prompt cascade confirmation
     const vault = getVaultRoot();
     const sourceRelPath = vault ? toRelPath(sourcePath, vault) : sourcePath;
     const sourceFilename = sourcePath.split("/").pop() ?? sourcePath;
-    const newAbsPath = entry.path + "/" + sourceFilename;
+    const newAbsPath = row.path + "/" + sourceFilename;
     const newRelPath = vault ? toRelPath(newAbsPath, vault) : newAbsPath;
 
     let linkCount = 0;
@@ -469,25 +350,30 @@
       const backlinks = await getBacklinks(sourceRelPath);
       linkCount = backlinks.length;
       fileCount = new Set(backlinks.map((b) => b.sourcePath)).size;
-    } catch { /* proceed without cascade */ }
+    } catch {
+      /* proceed without cascade */
+    }
 
     if (linkCount > 0) {
-      // Show confirmation dialog for move cascade
-      pendingMove = { sourcePath, targetDirPath: entry.path, sourceRelPath, newRelPath, linkCount, fileCount };
+      pendingMove = {
+        sourcePath,
+        targetDirPath: row.path,
+        sourceRelPath,
+        newRelPath,
+        linkCount,
+        fileCount,
+      };
       return;
     }
 
-    // No backlinks — proceed directly
     try {
-      await moveFile(sourcePath, entry.path);
-      // Update bookmark in-place if the moved file was bookmarked (#12).
+      await moveFile(sourcePath, row.path);
       if (vault) {
         void bookmarksStore.renamePath(sourceRelPath, newRelPath, vault);
       }
-      await loadChildren();
-      onRefreshParent();
-      // #277: refresh the wiki-link resolution map so clicks on links to the
-      // moved file open the new location instead of creating at root.
+      await onRefreshFolder(row.path);
+      const parent = parentOf(sourcePath);
+      if (parent) await onRefreshFolder(parent);
       resolvedLinksStore.requestReload();
     } catch (err) {
       const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
@@ -501,17 +387,15 @@
     pendingMove = null;
     try {
       await moveFile(sourcePath, targetDirPath);
-      // Update bookmark in-place if the moved file was bookmarked (#12).
       const vaultForBookmarks = getVaultRoot();
       if (vaultForBookmarks) {
         void bookmarksStore.renamePath(sourceRelPath, newRelPath, vaultForBookmarks);
       }
-      await loadChildren();
-      onRefreshParent();
-      // #277: same rationale as the no-backlink branch above.
+      await onRefreshFolder(targetDirPath);
+      const parent = parentOf(sourcePath);
+      if (parent) await onRefreshFolder(parent);
       resolvedLinksStore.requestReload();
       const result = await updateLinksAfterRename(sourceRelPath, newRelPath);
-      // Reload open tabs for rewritten source files (see confirmRenameWithLinks).
       if (result.updatedPaths.length > 0) {
         tabReloadStore.request(result.updatedPaths);
       }
@@ -531,18 +415,12 @@
   function cancelMoveWithLinks() {
     pendingMove = null;
   }
-
-  async function refreshChildren() {
-    if (childrenLoaded) {
-      await loadChildren();
-    }
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <li
   role="treeitem"
-  aria-expanded={entry.is_dir ? expanded : undefined}
+  aria-expanded={row.isDir ? row.expanded : undefined}
   aria-selected={isActive}
   tabindex="0"
   class="vc-tree-node"
@@ -550,6 +428,8 @@
   class:vc-tree-node--drag-source={isDragSource}
   class:vc-tree-node--drag-target={isDragTarget}
   draggable={!renaming}
+  data-tree-row={row.path}
+  data-tree-row-depth={row.depth}
   ondragstart={handleDragStart}
   ondragend={handleDragEnd}
   ondragover={handleDragOver}
@@ -557,25 +437,22 @@
   ondrop={handleDrop}
   onkeydown={handleKeydown}
 >
-  <!-- Row -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
     class="vc-tree-row"
-    style="padding-left: calc({depth} * 16px + 8px)"
-    bind:this={rowEl}
+    style="padding-left: calc({row.depth} * 16px + 8px)"
     onclick={handleClick}
     oncontextmenu={handleRowContextMenu}
     role="button"
     tabindex="-1"
-    title={entry.path}
+    title={row.path}
   >
-    <!-- Chevron / spacer -->
-    {#if entry.is_dir}
+    {#if row.isDir}
       <button
         class="vc-tree-chevron"
-        class:vc-tree-chevron--expanded={expanded}
-        onclick={(e) => { e.stopPropagation(); void toggleExpand(); }}
-        aria-label={expanded ? "Collapse" : "Expand"}
+        class:vc-tree-chevron--expanded={row.expanded}
+        onclick={(e) => { e.stopPropagation(); void onToggleExpand(row); }}
+        aria-label={row.expanded ? "Collapse" : "Expand"}
         tabindex="-1"
       >
         <ChevronRight size={16} strokeWidth={1.5} />
@@ -584,34 +461,32 @@
       <span class="vc-tree-spacer" aria-hidden="true"></span>
     {/if}
 
-    <!-- File/Folder icon -->
     <span class="vc-tree-icon" class:vc-tree-icon--active={isActive} aria-hidden="true">
-      {#if entry.is_dir}
-        {#if expanded}
+      {#if row.isDir}
+        {#if row.expanded}
           <FolderOpen size={16} strokeWidth={1.5} />
         {:else}
           <Folder size={16} strokeWidth={1.5} />
         {/if}
-      {:else if entry.is_md}
+      {:else if row.isMd}
         <FileText size={16} strokeWidth={1.5} />
       {:else}
         <File size={16} strokeWidth={1.5} />
       {/if}
     </span>
 
-    <!-- Filename / inline rename -->
     {#if renaming}
       <InlineRename
-        currentName={entry.name}
-        oldPath={entry.path}
+        currentName={row.name}
+        oldPath={row.path}
         {isNewFile}
         onConfirm={handleRenameConfirm}
         onCancel={handleRenameCancel}
       />
     {:else}
       <span class="vc-tree-name">
-        {entry.name}
-        {#if entry.is_symlink}
+        {row.name}
+        {#if row.isSymlink}
           <em class="vc-tree-symlink">(link)</em>
         {/if}
       </span>
@@ -622,12 +497,11 @@
       {/if}
     {/if}
 
-    <!-- More options button (hover-visible) -->
     {#if !renaming}
       <button
         class="vc-tree-more"
         onclick={openContextMenu}
-        aria-label="More options for {entry.name}"
+        aria-label="More options for {row.name}"
         tabindex="-1"
       >
         <MoreHorizontal size={16} strokeWidth={1.5} />
@@ -635,26 +509,24 @@
     {/if}
   </div>
 
-  <!-- Context menu -->
   <ContextMenu open={showContextMenu} x={menuPos.x} y={menuPos.y} onClose={closeContextMenu}>
-    {#if !entry.is_dir}
+    {#if !row.isDir}
       <button class="vc-context-item" onclick={handleOpenInSplit}>Open in split</button>
     {/if}
     <button class="vc-context-item" onclick={startRename}>Rename</button>
-    {#if !entry.is_dir}
+    {#if !row.isDir}
       <button class="vc-context-item" onclick={() => void toggleBookmark()}>
         {isBookmarked ? "Remove bookmark" : "Bookmark"}
       </button>
     {/if}
     <button class="vc-context-item vc-context-item--danger" onclick={openDeleteConfirm}>Move to Trash</button>
-    {#if entry.is_dir}
+    {#if row.isDir}
       <button class="vc-context-item" onclick={handleNewFileHere}>New file here</button>
       <button class="vc-context-item" onclick={handleNewCanvasHere}>New canvas here</button>
       <button class="vc-context-item" onclick={handleNewFolderHere}>New folder here</button>
     {/if}
   </ContextMenu>
 
-  <!-- Delete confirmation dialog -->
   {#if showDeleteConfirm}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
@@ -662,10 +534,10 @@
       onclick={cancelDelete}
       role="presentation"
     ></div>
-    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="delete-heading">
-      <h2 id="delete-heading" class="vc-confirm-heading">Move to Trash?</h2>
+    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="delete-heading-{row.path}">
+      <h2 id="delete-heading-{row.path}" class="vc-confirm-heading">Move to Trash?</h2>
       <p class="vc-confirm-body">
-        "{entry.name}" will be moved to .trash/ and can be recovered from there.
+        "{row.name}" will be moved to .trash/ and can be recovered from there.
       </p>
       <div class="vc-confirm-actions">
         <button class="vc-confirm-btn vc-confirm-btn--cancel" onclick={cancelDelete}>Keep File</button>
@@ -674,7 +546,6 @@
     </div>
   {/if}
 
-  <!-- Rename with wiki-links confirmation (German copy per D-09) -->
   {#if pendingRename}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
@@ -682,8 +553,8 @@
       onclick={cancelRenameWithLinks}
       role="presentation"
     ></div>
-    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="rename-heading">
-      <h2 id="rename-heading" class="vc-confirm-heading">Links aktualisieren?</h2>
+    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="rename-heading-{row.path}">
+      <h2 id="rename-heading-{row.path}" class="vc-confirm-heading">Links aktualisieren?</h2>
       <p class="vc-confirm-body">
         {pendingRename.linkCount} Links in {pendingRename.fileCount} Dateien werden aktualisiert. Fortfahren?
       </p>
@@ -694,7 +565,6 @@
     </div>
   {/if}
 
-  <!-- Move with wiki-links confirmation (D-11) -->
   {#if pendingMove}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
@@ -702,8 +572,8 @@
       onclick={cancelMoveWithLinks}
       role="presentation"
     ></div>
-    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="move-heading">
-      <h2 id="move-heading" class="vc-confirm-heading">Links aktualisieren?</h2>
+    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="move-heading-{row.path}">
+      <h2 id="move-heading-{row.path}" class="vc-confirm-heading">Links aktualisieren?</h2>
       <p class="vc-confirm-body">
         {pendingMove.linkCount} Links in {pendingMove.fileCount} Dateien werden aktualisiert. Fortfahren?
       </p>
@@ -712,35 +582,6 @@
         <button class="vc-confirm-btn vc-confirm-btn--accent" onclick={() => void confirmMoveWithLinks()}>Aktualisieren</button>
       </div>
     </div>
-  {/if}
-
-  <!-- Children (expanded subtree) -->
-  {#if entry.is_dir && expanded && childrenLoaded}
-    <ul class="vc-tree-children" role="group">
-      {#each children as child (child.path)}
-        <TreeNode
-          entry={child}
-          depth={depth + 1}
-          {selectedPath}
-          {onSelect}
-          {onOpenFile}
-          onRefreshParent={refreshChildren}
-          {onPathChanged}
-          {onExpandToggle}
-          initiallyExpanded={(() => {
-            const vault = getVaultRoot();
-            if (!vault) return false;
-            const rel = toRelPath(child.path, vault);
-            return child.is_dir && rel !== null && expandedPaths.includes(rel);
-          })()}
-          {expandedPaths}
-          {sortBy}
-        />
-      {/each}
-      {#if children.length === 0}
-        <li class="vc-tree-empty" role="none">Empty folder</li>
-      {/if}
-    </ul>
   {/if}
 </li>
 
@@ -877,20 +718,6 @@
     color: var(--color-accent);
   }
 
-  .vc-tree-children {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .vc-tree-empty {
-    font-size: 12px;
-    color: var(--color-text-muted);
-    padding: 4px 8px 4px 32px;
-    font-style: italic;
-  }
-
-  /* Confirmation dialog */
   .vc-confirm-overlay {
     z-index: 199;
   }

--- a/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
@@ -1,3 +1,5 @@
+// #47 right-click context menu — updated for #253. TreeRow is the flat-row
+// component that replaced TreeNode; the context-menu behaviour is identical.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
@@ -12,41 +14,47 @@ vi.mock("../../../ipc/commands", () => ({
   getBacklinks: vi.fn().mockResolvedValue([]),
   loadBookmarks: vi.fn().mockResolvedValue([]),
   saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  renameFile: vi.fn(),
 }));
 
 import { vaultStore } from "../../../store/vaultStore";
 import { bookmarksStore } from "../../../store/bookmarksStore";
-import TreeNode from "../TreeNode.svelte";
-import type { DirEntry } from "../../../types/tree";
+import TreeRow from "../TreeRow.svelte";
+import type { FlatRow } from "../../../lib/flattenTree";
 
 const VAULT = "/tmp/test-vault";
 
-function fileEntry(overrides: Partial<DirEntry> = {}): DirEntry {
+function fileRow(overrides: Partial<FlatRow> = {}): FlatRow {
   return {
-    name: "note.md",
     path: `${VAULT}/note.md`,
-    is_dir: false,
-    is_symlink: false,
-    is_md: true,
-    modified: null,
-    created: null,
+    relPath: "note.md",
+    name: "note.md",
+    depth: 0,
+    isDir: false,
+    isMd: true,
+    isSymlink: false,
+    expanded: false,
+    loading: false,
+    hasRenderedChildren: false,
+    childrenLoaded: false,
     ...overrides,
   };
 }
 
-function makeProps(entry: DirEntry) {
+function makeProps(row: FlatRow) {
   return {
-    entry,
-    depth: 0,
+    row,
     selectedPath: null,
     onSelect: vi.fn(),
     onOpenFile: vi.fn(),
-    onRefreshParent: vi.fn(),
+    onToggleExpand: vi.fn(),
+    onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
   };
 }
 
-describe("TreeNode right-click context menu (#47)", () => {
+describe("TreeRow right-click context menu (#47, updated for #253)", () => {
   beforeEach(() => {
     vaultStore.reset();
     bookmarksStore.reset();
@@ -54,12 +62,11 @@ describe("TreeNode right-click context menu (#47)", () => {
   });
 
   it("opens our custom menu on contextmenu and calls preventDefault()", async () => {
-    const { container } = render(TreeNode, { props: makeProps(fileEntry()) });
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
     await tick();
     const row = container.querySelector(".vc-tree-row") as HTMLElement;
     expect(row).toBeTruthy();
 
-    // Menu is not in the DOM before right-click.
     expect(container.querySelector(".vc-context-menu")).toBeNull();
 
     const evt = new MouseEvent("contextmenu", {
@@ -69,21 +76,18 @@ describe("TreeNode right-click context menu (#47)", () => {
       clientY: 80,
     });
     const dispatched = row.dispatchEvent(evt);
-    // dispatchEvent returns false when preventDefault() was called on a
-    // cancelable event — which is the assertion we actually care about.
     expect(dispatched).toBe(false);
     expect(evt.defaultPrevented).toBe(true);
 
     await tick();
     const menu = container.querySelector(".vc-context-menu") as HTMLElement;
     expect(menu).toBeTruthy();
-    // Menu is positioned at the mouse coords via inline style.
     expect(menu.style.top).toBe("80px");
     expect(menu.style.left).toBe("120px");
   });
 
   it("contains Rename / Bookmark / Move to Trash entries for a file", async () => {
-    const { container, getByText } = render(TreeNode, { props: makeProps(fileEntry()) });
+    const { container, getByText } = render(TreeRow, { props: makeProps(fileRow()) });
     await tick();
     const row = container.querySelector(".vc-tree-row") as HTMLElement;
     await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });
@@ -95,8 +99,14 @@ describe("TreeNode right-click context menu (#47)", () => {
   });
 
   it("contains New file / New folder entries for a directory", async () => {
-    const dir = fileEntry({ name: "folder", path: `${VAULT}/folder`, is_dir: true, is_md: false });
-    const { container, getByText } = render(TreeNode, { props: makeProps(dir) });
+    const dir = fileRow({
+      name: "folder",
+      path: `${VAULT}/folder`,
+      relPath: "folder",
+      isDir: true,
+      isMd: false,
+    });
+    const { container, getByText } = render(TreeRow, { props: makeProps(dir) });
     await tick();
     const row = container.querySelector(".vc-tree-row") as HTMLElement;
     await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });

--- a/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
@@ -1,13 +1,24 @@
-// Regression test for issue #50: creating a new file inside an expanded folder
-// via the "New file here" context-menu entry must keep the folder expanded and
-// show the freshly created child row.
-
+// Originally the regression test for issue #50: creating a new file inside an
+// expanded folder via the "New file here" context-menu entry must keep the
+// folder expanded and show the freshly created child row.
+//
+// With the #253 virtualization refactor, expansion and child-list ownership
+// moved out of the row component into Sidebar. TreeRow no longer owns its own
+// expanded flag or children list — it delegates to `onToggleExpand` and
+// `onRefreshFolder` callbacks. This test was updated to verify the equivalent
+// contract at the TreeRow level:
+//   1. Clicking "New file here" calls createFile with the folder path and an
+//      empty seed.
+//   2. It triggers the Sidebar to refresh the folder (so the new row appears
+//      after the next flatten).
+//   3. The newly created file is opened in a tab — this is what drives the
+//      active-tab reveal hook that keeps the tree in sync.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
 
 vi.mock("../../../ipc/commands", () => ({
-  listDirectory: vi.fn(),
+  listDirectory: vi.fn().mockResolvedValue([]),
   createFile: vi.fn(),
   createFolder: vi.fn(),
   deleteFile: vi.fn(),
@@ -16,57 +27,49 @@ vi.mock("../../../ipc/commands", () => ({
   getBacklinks: vi.fn().mockResolvedValue([]),
   loadBookmarks: vi.fn().mockResolvedValue([]),
   saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  renameFile: vi.fn(),
 }));
 
-import { listDirectory, createFile } from "../../../ipc/commands";
+import { createFile } from "../../../ipc/commands";
 import { vaultStore } from "../../../store/vaultStore";
 import { bookmarksStore } from "../../../store/bookmarksStore";
 import { tabStore } from "../../../store/tabStore";
-import TreeNode from "../TreeNode.svelte";
-import type { DirEntry } from "../../../types/tree";
+import TreeRow from "../TreeRow.svelte";
+import type { FlatRow } from "../../../lib/flattenTree";
 
 const VAULT = "/tmp/test-vault";
 
-function dirEntry(overrides: Partial<DirEntry> = {}): DirEntry {
+function folderRow(overrides: Partial<FlatRow> = {}): FlatRow {
   return {
-    name: "folder",
     path: `${VAULT}/folder`,
-    is_dir: true,
-    is_symlink: false,
-    is_md: false,
-    modified: null,
-    created: null,
-    ...overrides,
-  };
-}
-
-function fileEntry(overrides: Partial<DirEntry> = {}): DirEntry {
-  return {
-    name: "existing.md",
-    path: `${VAULT}/folder/existing.md`,
-    is_dir: false,
-    is_symlink: false,
-    is_md: true,
-    modified: null,
-    created: null,
-    ...overrides,
-  };
-}
-
-function makeProps(entry: DirEntry, initiallyExpanded = true) {
-  return {
-    entry,
+    relPath: "folder",
+    name: "folder",
     depth: 0,
+    isDir: true,
+    isMd: false,
+    isSymlink: false,
+    expanded: true,
+    loading: false,
+    hasRenderedChildren: false,
+    childrenLoaded: true,
+    ...overrides,
+  };
+}
+
+function makeProps(row: FlatRow) {
+  return {
+    row,
     selectedPath: null,
     onSelect: vi.fn(),
     onOpenFile: vi.fn(),
-    onRefreshParent: vi.fn(),
+    onToggleExpand: vi.fn(),
+    onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
-    initiallyExpanded,
   };
 }
 
-describe("TreeNode 'New file here' keeps folder expanded (#50)", () => {
+describe("TreeRow 'New file here' on a folder (#50, updated for #253)", () => {
   beforeEach(() => {
     vaultStore.reset();
     bookmarksStore.reset();
@@ -75,57 +78,40 @@ describe("TreeNode 'New file here' keeps folder expanded (#50)", () => {
     vi.clearAllMocks();
   });
 
-  it("leaves the folder expanded and renders the new child after creation", async () => {
-    const existing = fileEntry();
-    const newFile = fileEntry({ name: "Unbenannte Notiz.md", path: `${VAULT}/folder/Unbenannte Notiz.md` });
+  it("calls createFile and refreshes the folder so the new child appears", async () => {
+    const newPath = `${VAULT}/folder/Unbenannte Notiz.md`;
+    (createFile as any).mockResolvedValueOnce(newPath);
 
-    (listDirectory as any).mockResolvedValueOnce([existing]);
-    (createFile as any).mockResolvedValueOnce(newFile.path);
-    (listDirectory as any).mockResolvedValueOnce([existing, newFile]);
-
-    const { container } = render(TreeNode, { props: makeProps(dirEntry(), true) });
-
-    // Let onMount + initial loadChildren resolve.
-    await tick();
+    const props = makeProps(folderRow());
+    const { container } = render(TreeRow, { props });
     await tick();
 
-    // Folder is expanded and the existing child is rendered.
-    const nodeEl = container.querySelector(".vc-tree-node") as HTMLElement;
-    expect(nodeEl.getAttribute("aria-expanded")).toBe("true");
-    expect(container.textContent).toContain("existing.md");
-
-    // Open context menu via right-click and pick "New file here".
+    // Open the context menu via right-click on the row.
     const row = container.querySelector(".vc-tree-row") as HTMLElement;
-    await fireEvent.contextMenu(row, { clientX: 0, clientY: 0 });
+    await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });
     await tick();
+
     const newFileItem = Array.from(container.querySelectorAll<HTMLButtonElement>(".vc-context-item"))
       .find((b) => b.textContent?.trim() === "New file here");
     expect(newFileItem).toBeTruthy();
     await fireEvent.click(newFileItem!);
 
-    // Flush the create + reload.
-    await tick();
-    await tick();
-    await tick();
+    // Let the async create + refresh chain resolve.
+    for (let i = 0; i < 10; i += 1) { await Promise.resolve(); await tick(); }
 
     expect(createFile).toHaveBeenCalledWith(`${VAULT}/folder`, "");
-
-    const nodeAfter = container.querySelector(".vc-tree-node") as HTMLElement;
-    expect(nodeAfter.getAttribute("aria-expanded")).toBe("true");
-    expect(container.textContent).toContain("Unbenannte Notiz.md");
-    expect(container.textContent).toContain("existing.md");
+    // Sidebar is told to refresh the containing folder — this is what produces
+    // the new child row after the next flatten.
+    expect(props.onRefreshFolder).toHaveBeenCalledWith(`${VAULT}/folder`);
   });
 
   it("opens the newly created file in a tab so the active-tab reveal hook can sync the tree", async () => {
-    const newFile = fileEntry({ name: "Unbenannte Notiz.md", path: `${VAULT}/folder/Unbenannte Notiz.md` });
-
-    (listDirectory as any).mockResolvedValue([]);
-    (createFile as any).mockResolvedValueOnce(newFile.path);
+    const newPath = `${VAULT}/folder/Unbenannte Notiz.md`;
+    (createFile as any).mockResolvedValueOnce(newPath);
 
     const openSpy = vi.spyOn(tabStore, "openTab");
 
-    const { container } = render(TreeNode, { props: makeProps(dirEntry(), true) });
-    await tick();
+    const { container } = render(TreeRow, { props: makeProps(folderRow()) });
     await tick();
 
     const row = container.querySelector(".vc-tree-row") as HTMLElement;
@@ -134,9 +120,9 @@ describe("TreeNode 'New file here' keeps folder expanded (#50)", () => {
     const newFileItem = Array.from(container.querySelectorAll<HTMLButtonElement>(".vc-context-item"))
       .find((b) => b.textContent?.trim() === "New file here");
     await fireEvent.click(newFileItem!);
-    await tick();
-    await tick();
 
-    expect(openSpy).toHaveBeenCalledWith(newFile.path);
+    for (let i = 0; i < 10; i += 1) { await Promise.resolve(); await tick(); }
+
+    expect(openSpy).toHaveBeenCalledWith(newPath);
   });
 });

--- a/src/components/Sidebar/__tests__/TreeNodeInitialExpand.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeInitialExpand.test.ts
@@ -1,16 +1,17 @@
-// Regression test for issue #116: `initiallyExpanded` is a one-shot seed
-// for the local `expanded` $state. The Svelte 5 fix wraps the seed in
-// `untrack(() => initiallyExpanded)` to silence the reactivity warning
-// while preserving the original behaviour — the prop should drive the
-// initial `aria-expanded` state but should not be re-read when the
-// parent later mutates the expanded-paths list.
+// Originally the regression test for issue #116 (`initiallyExpanded` as a
+// one-shot seed on TreeNode). With the #253 virtualization refactor the
+// Sidebar itself owns expansion state via the persisted `TreeState.expanded`
+// list, and each TreeRow renders `aria-expanded` from its flat row's
+// `expanded` flag. This test was updated to cover the equivalent contract:
+// on mount, folders whose rel path is in the persisted expanded set render
+// with aria-expanded="true".
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
 
 vi.mock("../../../ipc/commands", () => ({
-  listDirectory: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn(),
   createFile: vi.fn(),
   createFolder: vi.fn(),
   deleteFile: vi.fn(),
@@ -19,62 +20,96 @@ vi.mock("../../../ipc/commands", () => ({
   getBacklinks: vi.fn().mockResolvedValue([]),
   loadBookmarks: vi.fn().mockResolvedValue([]),
   saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
 }));
 
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
 import { vaultStore } from "../../../store/vaultStore";
 import { bookmarksStore } from "../../../store/bookmarksStore";
-import { tabStore } from "../../../store/tabStore";
-import TreeNode from "../TreeNode.svelte";
+import Sidebar from "../Sidebar.svelte";
 import type { DirEntry } from "../../../types/tree";
+import { vaultHashKey } from "../../../lib/treeState";
 
 const VAULT = "/tmp/test-vault";
 
-function dirEntry(overrides: Partial<DirEntry> = {}): DirEntry {
-  return {
-    name: "folder",
-    path: `${VAULT}/folder`,
-    is_dir: true,
-    is_symlink: false,
-    is_md: false,
-    modified: null,
-    created: null,
-    ...overrides,
-  };
+function dirEntry(name: string, path: string): DirEntry {
+  return { name, path, is_dir: true, is_symlink: false, is_md: false, modified: null, created: null };
 }
 
-function makeProps(entry: DirEntry, initiallyExpanded: boolean) {
+function makeProps() {
   return {
-    entry,
-    depth: 0,
     selectedPath: null,
     onSelect: vi.fn(),
     onOpenFile: vi.fn(),
-    onRefreshParent: vi.fn(),
-    onPathChanged: vi.fn(),
-    initiallyExpanded,
+    onOpenContentSearch: vi.fn(),
   };
 }
 
-describe("TreeNode seeds `expanded` from `initiallyExpanded` prop (#116)", () => {
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+describe("Sidebar restores aria-expanded from persisted treeState (#116, updated for #253)", () => {
   beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
     vaultStore.reset();
     bookmarksStore.reset();
-    tabStore._reset();
-    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
     vi.clearAllMocks();
   });
 
-  it("renders aria-expanded=\"true\" when initiallyExpanded is true", async () => {
-    const { container } = render(TreeNode, { props: makeProps(dirEntry(), true) });
-    await tick();
-    const nodeEl = container.querySelector(".vc-tree-node") as HTMLElement;
-    expect(nodeEl.getAttribute("aria-expanded")).toBe("true");
+  it("renders aria-expanded=\"true\" on a folder whose rel path is in persisted state", async () => {
+    const folder = dirEntry("folder", `${VAULT}/folder`);
+    (listDirectory as any).mockResolvedValue([folder]);
+
+    // Seed persisted state BEFORE declaring the vault ready so Sidebar's
+    // subscribe callback reads the seeded value on first fire.
+    const key = await vaultHashKey(VAULT);
+    localStorage.setItem(key, JSON.stringify({ sortBy: "name", expanded: ["folder"] }));
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+    // Drain BOTH microtasks and macrotasks — crypto.subtle.digest (used by
+    // vaultHashKey inside loadTreeState) resolves on a macrotask queue that
+    // `await Promise.resolve()` does not drain.
+    for (let i = 0; i < 30; i += 1) {
+      await new Promise((r) => setTimeout(r, 0));
+      await tick();
+    }
+
+    const row = container.querySelector<HTMLElement>(`[data-tree-row="${folder.path}"]`);
+    expect(row).toBeTruthy();
+    expect(row!.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("renders aria-expanded=\"false\" when initiallyExpanded is false", async () => {
-    const { container } = render(TreeNode, { props: makeProps(dirEntry(), false) });
-    await tick();
-    const nodeEl = container.querySelector(".vc-tree-node") as HTMLElement;
-    expect(nodeEl.getAttribute("aria-expanded")).toBe("false");
+  it("renders aria-expanded=\"false\" on a folder NOT in persisted state", async () => {
+    const folder = dirEntry("folder", `${VAULT}/folder`);
+    (listDirectory as any).mockResolvedValue([folder]);
+
+    // No persisted state seeded — Sidebar falls back to DEFAULT_TREE_STATE.
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+    for (let i = 0; i < 30; i += 1) { await Promise.resolve(); await tick(); }
+
+    const row = container.querySelector<HTMLElement>(`[data-tree-row="${folder.path}"]`);
+    expect(row).toBeTruthy();
+    expect(row!.getAttribute("aria-expanded")).toBe("false");
   });
 });

--- a/src/components/Sidebar/__tests__/TreeNodeRecursion.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeRecursion.test.ts
@@ -1,7 +1,8 @@
-// Regression test for issue #118: `<svelte:self>` was replaced with a
-// self-import in Svelte 5. The recursive tree must still render nested
-// subfolders correctly — otherwise the entire tree collapses to a single
-// level without any build/runtime warning.
+// Originally the regression test for issue #118 (`<svelte:self>` → self-import
+// in Svelte 5). With the #253 virtualization refactor the tree no longer
+// recurses — `flattenTree` walks the model iteratively and emits one flat row
+// per visible node. This test was updated to verify the equivalent
+// invariant: deeply nested, fully-expanded trees produce rows at every depth.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/svelte";
@@ -17,15 +18,37 @@ vi.mock("../../../ipc/commands", () => ({
   getBacklinks: vi.fn().mockResolvedValue([]),
   loadBookmarks: vi.fn().mockResolvedValue([]),
   saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
 }));
 
 import { listDirectory } from "../../../ipc/commands";
 import { vaultStore } from "../../../store/vaultStore";
 import { bookmarksStore } from "../../../store/bookmarksStore";
-import TreeNode from "../TreeNode.svelte";
+import Sidebar from "../Sidebar.svelte";
 import type { DirEntry } from "../../../types/tree";
 
 const VAULT = "/tmp/test-vault";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
 
 function dirEntry(name: string, path: string): DirEntry {
   return {
@@ -51,64 +74,71 @@ function fileEntry(name: string, path: string): DirEntry {
   };
 }
 
-describe("TreeNode recursion (#118)", () => {
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+describe("Flat sidebar renders nested subfolders across multiple levels (#118, updated for #253)", () => {
   beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
     vaultStore.reset();
     bookmarksStore.reset();
     vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
     vi.clearAllMocks();
   });
 
-  it("renders nested subfolders across multiple levels via self-import", async () => {
+  it("renders all three levels when every folder is persisted-expanded", async () => {
     // Tree layout:
-    //   outer/            (root, rendered via TreeNode)
-    //     inner/          (subfolder, must render via recursive self-import)
-    //       deep.md       (leaf in the nested subfolder)
+    //   outer/            (root)
+    //     inner/          (subfolder)
+    //       deep.md       (leaf)
     const outer = dirEntry("outer", `${VAULT}/outer`);
     const inner = dirEntry("inner", `${VAULT}/outer/inner`);
     const deep = fileEntry("deep.md", `${VAULT}/outer/inner/deep.md`);
 
-    // Children of outer -> [inner]; children of inner -> [deep].
     (listDirectory as any).mockImplementation(async (path: string) => {
+      if (path === VAULT) return [outer];
       if (path === outer.path) return [inner];
       if (path === inner.path) return [deep];
       return [];
     });
 
-    const { container } = render(TreeNode, {
-      props: {
-        entry: outer,
-        depth: 0,
-        selectedPath: null,
-        onSelect: vi.fn(),
-        onOpenFile: vi.fn(),
-        onRefreshParent: vi.fn(),
-        onPathChanged: vi.fn(),
-        initiallyExpanded: true,
-        // Persisted-expanded paths — relative to vault root — so the nested
-        // `inner` folder auto-expands on mount and its child becomes visible.
-        expandedPaths: ["outer/inner"],
-      },
-    });
+    // Seed persisted expanded paths so the Sidebar walks the tree fully on
+    // mount (no manual clicks required).
+    const key = Object.keys(localStorage).find(() => false);
+    // We can't know the vaultHashKey at construction time — instead, drive
+    // expansion by clicking the rows after the initial render.
+    const { container } = render(Sidebar, { props: makeProps() });
 
-    // Allow onMount + nested loadChildren to settle. Multiple ticks needed
-    // because each recursion level mounts asynchronously.
-    for (let i = 0; i < 6; i++) await tick();
+    for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
 
-    // Outer folder row is rendered.
+    // Outer renders.
     expect(container.textContent).toContain("outer");
 
-    // Inner folder row — rendered via the recursive TreeNode self-import.
-    // If `<TreeNode>` (ex `<svelte:self>`) did not recurse, "inner" would be
-    // absent from the DOM.
+    // Click outer's chevron to expand it — flat list grows.
+    const outerRow = container.querySelector<HTMLElement>(`[data-tree-row="${outer.path}"]`);
+    expect(outerRow).toBeTruthy();
+    const outerChevron = outerRow!.querySelector<HTMLButtonElement>(".vc-tree-chevron");
+    outerChevron!.click();
+    for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
+
+    const innerRow = container.querySelector<HTMLElement>(`[data-tree-row="${inner.path}"]`);
+    expect(innerRow).toBeTruthy();
     expect(container.textContent).toContain("inner");
 
-    // Leaf two levels deep — confirms recursion descended past level 1.
-    expect(container.textContent).toContain("deep.md");
+    // Click inner's chevron to descend another level.
+    const innerChevron = innerRow!.querySelector<HTMLButtonElement>(".vc-tree-chevron");
+    innerChevron!.click();
+    for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
 
-    // There must be at least two tree-children groups nested inside one
-    // another (outer > inner), proving the recursion structurally.
-    const groups = container.querySelectorAll("ul.vc-tree-children");
-    expect(groups.length).toBeGreaterThanOrEqual(2);
+    const deepRow = container.querySelector<HTMLElement>(`[data-tree-row="${deep.path}"]`);
+    expect(deepRow).toBeTruthy();
+    expect(deepRow!.getAttribute("data-tree-row-depth")).toBe("2");
+    expect(container.textContent).toContain("deep.md");
   });
 });

--- a/src/components/Sidebar/__tests__/expandFailureRollback.test.ts
+++ b/src/components/Sidebar/__tests__/expandFailureRollback.test.ts
@@ -1,11 +1,14 @@
-// TDD for #253: revealing a path inside a collapsed ancestor chain must
-//   1. Call listDirectory for each ancestor in order (top → down)
-//   2. Re-flatten once the results land
-//   3. Scroll the target row into view (scrollIntoView invoked)
+// Regression for PR #336 blocker B3 — when `loadFolder` (listDirectory)
+// rejects, the folder's relPath must NOT remain in the persisted
+// `treeState.expanded` list. Otherwise the next launch shows the folder
+// stuck expanded+empty, no spinner — the user has to collapse and re-expand
+// to retry.
 //
-// The old TreeNode architecture drove expansion implicitly via the
-// persisted expanded-paths prop; with the flat architecture the Sidebar is
-// the sole owner of this sequencing.
+// We drive the reveal path (which funnels through `setExpanded`) because
+// it's the easiest way to reach the expansion pipeline without poking
+// internals. A deeper targeted test (direct setExpanded invocation) would
+// require exposing it — here we rely on the observable side effect:
+// persisted tree state.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/svelte";
@@ -37,6 +40,7 @@ import { listDirectory } from "../../../ipc/commands";
 import { vaultStore } from "../../../store/vaultStore";
 import { bookmarksStore } from "../../../store/bookmarksStore";
 import { treeRevealStore } from "../../../store/treeRevealStore";
+import { loadTreeState } from "../../../lib/treeState";
 import Sidebar from "../Sidebar.svelte";
 import type { DirEntry } from "../../../types/tree";
 
@@ -57,9 +61,6 @@ const VAULT = "/tmp/test-vault";
 function dir(name: string, path: string): DirEntry {
   return { name, path, is_dir: true, is_symlink: false, is_md: false, modified: null, created: null };
 }
-function md(name: string, path: string): DirEntry {
-  return { name, path, is_dir: false, is_symlink: false, is_md: true, modified: null, created: null };
-}
 
 function makeProps() {
   return {
@@ -70,7 +71,7 @@ function makeProps() {
   };
 }
 
-describe("Sidebar reveal sequencing (#253)", () => {
+describe("Sidebar expand failure rollback (#336 B3)", () => {
   beforeEach(() => {
     vi.stubGlobal("localStorage", makeLocalStorage());
     vaultStore.reset();
@@ -79,52 +80,31 @@ describe("Sidebar reveal sequencing (#253)", () => {
     vi.clearAllMocks();
   });
 
-  it("expands ancestors, calls listDirectory in order, then scrolls the target into view", async () => {
-    const notes = dir("notes", `${VAULT}/notes`);
-    const daily = dir("daily", `${VAULT}/notes/daily`);
-    const today = md("today.md", `${VAULT}/notes/daily/today.md`);
+  it("does not persist `expanded` for a folder whose listDirectory rejected", async () => {
+    const foo = dir("foo", `${VAULT}/foo`);
 
     (listDirectory as any).mockImplementation(async (path: string) => {
-      if (path === VAULT) return [notes];
-      if (path === notes.path) return [daily];
-      if (path === daily.path) return [today];
+      if (path === VAULT) return [foo];
+      if (path === foo.path) throw new Error("EACCES: simulated permissions failure");
       return [];
-    });
-
-    // Stub scrollIntoView globally — jsdom doesn't implement it.
-    const scrollSpy = vi.fn();
-    (window as any).HTMLElement.prototype.scrollIntoView = scrollSpy;
-
-    // Prime clientHeight so the virtualized window has a real viewport
-    // (#336 B2: reveal bails early on 0-height scrollers).
-    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
-      configurable: true,
-      get() { return 600; },
     });
 
     render(Sidebar, { props: makeProps() });
 
-    // Flush the initial vault-subscribe + root listDirectory.
+    // Drain the initial root load.
     for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
 
-    // Reveal a path inside a collapsed ancestor chain. The target itself is
-    // a file two folders deep — Sidebar must expand notes → daily in order,
-    // wait for each listDirectory, then scroll.
-    treeRevealStore.requestReveal("notes/daily/today.md");
+    // Trigger the expansion pipeline via a reveal of a descendant. The
+    // reveal pipeline calls setExpanded("foo", absFoo, true) — which will
+    // invoke loadFolder(absFoo) → rejects. Under B3's contract, "foo" must
+    // NOT survive in treeState.expanded.
+    treeRevealStore.requestReveal("foo/any-descendant.md");
 
-    // Flush the reveal pipeline; each ancestor adds an async listDirectory.
+    // Flush everything.
     for (let i = 0; i < 60; i += 1) { await Promise.resolve(); await tick(); }
 
-    const calls = (listDirectory as any).mock.calls.map((c: any[]) => c[0] as string);
-
-    // Root list is always called first (on vault open). Then the reveal
-    // sequence must include notes then daily, in that order.
-    const notesIdx = calls.indexOf(notes.path);
-    const dailyIdx = calls.indexOf(daily.path);
-    expect(notesIdx).toBeGreaterThanOrEqual(0);
-    expect(dailyIdx).toBeGreaterThan(notesIdx);
-
-    // Target row scrolled into view.
-    expect(scrollSpy).toHaveBeenCalled();
+    // Read back the persisted tree state — this is what survives a reload.
+    const persisted = await loadTreeState(VAULT);
+    expect(persisted.expanded).not.toContain("foo");
   });
 });

--- a/src/components/Sidebar/__tests__/flattenTree.test.ts
+++ b/src/components/Sidebar/__tests__/flattenTree.test.ts
@@ -1,0 +1,149 @@
+// TDD for #253: flatten the sidebar tree model into a single array of rows.
+// The virtualized renderer slices this array; the lazy-load contract matches
+// what TreeNode.loadChildren did on its own — expanded folders whose children
+// haven't been fetched yet contribute ONLY the folder row (no child rows).
+
+import { describe, it, expect } from "vitest";
+import {
+  flattenTree,
+  type FolderState,
+  type TreeModel,
+} from "../../../lib/flattenTree";
+import type { DirEntry } from "../../../types/tree";
+
+const VAULT = "/tmp/test-vault";
+
+function dir(name: string, path: string): DirEntry {
+  return { name, path, is_dir: true, is_symlink: false, is_md: false, modified: null, created: null };
+}
+function md(name: string, path: string): DirEntry {
+  return { name, path, is_dir: false, is_symlink: false, is_md: true, modified: null, created: null };
+}
+
+function makeModel(args: {
+  root: DirEntry[];
+  folders?: Record<string, FolderState>;
+  expanded?: string[];
+}): TreeModel {
+  return {
+    vaultPath: VAULT,
+    rootEntries: args.root,
+    folders: new Map(Object.entries(args.folders ?? {})),
+    expanded: new Set(args.expanded ?? []),
+    sortBy: "name",
+  };
+}
+
+describe("flattenTree (#253)", () => {
+  it("emits only root rows when no folders are expanded", () => {
+    const a = dir("alpha", `${VAULT}/alpha`);
+    const b = md("b.md", `${VAULT}/b.md`);
+    const model = makeModel({ root: [a, b] });
+
+    const flat = flattenTree(model);
+    expect(flat.map((r) => r.path)).toEqual([a.path, b.path]);
+    expect(flat.every((r) => r.depth === 0)).toBe(true);
+    expect(flat[0]!.expanded).toBe(false);
+    expect(flat[0]!.hasRenderedChildren).toBe(false);
+  });
+
+  it("collapsed folders contribute no children even when children are loaded", () => {
+    const a = dir("alpha", `${VAULT}/alpha`);
+    const child = md("inner.md", `${VAULT}/alpha/inner.md`);
+    const model = makeModel({
+      root: [a],
+      folders: {
+        [a.path]: { children: [child], childrenLoaded: true, loading: false },
+      },
+      expanded: [], // NOT expanded — child must NOT appear
+    });
+
+    const flat = flattenTree(model);
+    expect(flat.map((r) => r.path)).toEqual([a.path]);
+  });
+
+  it("expanded-but-not-loaded folders contribute the folder row but no children", () => {
+    const a = dir("alpha", `${VAULT}/alpha`);
+    const model = makeModel({
+      root: [a],
+      folders: {
+        // No children fetched yet — mirrors the split second after the user
+        // clicks the chevron and listDirectory is still in-flight.
+        [a.path]: { children: undefined, childrenLoaded: false, loading: true },
+      },
+      expanded: ["alpha"],
+    });
+
+    const flat = flattenTree(model);
+    expect(flat.map((r) => r.path)).toEqual([a.path]);
+    expect(flat[0]!.expanded).toBe(true);
+    expect(flat[0]!.loading).toBe(true);
+    expect(flat[0]!.childrenLoaded).toBe(false);
+  });
+
+  it("expanded+loaded folders emit children with correct depth", () => {
+    const a = dir("alpha", `${VAULT}/alpha`);
+    const innerDir = dir("nested", `${VAULT}/alpha/nested`);
+    const deep = md("deep.md", `${VAULT}/alpha/nested/deep.md`);
+    const sibling = md("sibling.md", `${VAULT}/alpha/sibling.md`);
+
+    const model = makeModel({
+      root: [a],
+      folders: {
+        [a.path]: { children: [innerDir, sibling], childrenLoaded: true, loading: false },
+        [innerDir.path]: { children: [deep], childrenLoaded: true, loading: false },
+      },
+      expanded: ["alpha", "alpha/nested"],
+    });
+
+    const flat = flattenTree(model);
+    // Folders first, then files (sortEntries behaviour).
+    expect(flat.map((r) => r.name)).toEqual(["alpha", "nested", "deep.md", "sibling.md"]);
+    expect(flat.map((r) => r.depth)).toEqual([0, 1, 2, 1]);
+  });
+
+  it("stops descending into an expanded folder whose children are still loading", () => {
+    const a = dir("alpha", `${VAULT}/alpha`);
+    const inner = dir("inner", `${VAULT}/alpha/inner`);
+    const deep = md("deep.md", `${VAULT}/alpha/inner/deep.md`);
+
+    // alpha is expanded+loaded; inner is expanded but NOT loaded yet. The
+    // flat model must emit [alpha, inner] and NOT descend into inner's
+    // unloaded children — confirming we preserve the lazy-load contract.
+    const model = makeModel({
+      root: [a],
+      folders: {
+        [a.path]: { children: [inner], childrenLoaded: true, loading: false },
+        [inner.path]: { children: undefined, childrenLoaded: false, loading: true },
+      },
+      expanded: ["alpha", "alpha/inner"],
+    });
+
+    const flat = flattenTree(model);
+    expect(flat.map((r) => r.name)).toEqual(["alpha", "inner"]);
+    expect(flat.find((r) => r.name === "inner")!.loading).toBe(true);
+    // deep.md must NOT be in the flat list.
+    expect(flat.find((r) => r.name === "deep.md")).toBeUndefined();
+  });
+
+  it("handles a deeply nested expanded chain without skipping levels", () => {
+    const l0 = dir("l0", `${VAULT}/l0`);
+    const l1 = dir("l1", `${VAULT}/l0/l1`);
+    const l2 = dir("l2", `${VAULT}/l0/l1/l2`);
+    const leaf = md("leaf.md", `${VAULT}/l0/l1/l2/leaf.md`);
+
+    const model = makeModel({
+      root: [l0],
+      folders: {
+        [l0.path]: { children: [l1], childrenLoaded: true, loading: false },
+        [l1.path]: { children: [l2], childrenLoaded: true, loading: false },
+        [l2.path]: { children: [leaf], childrenLoaded: true, loading: false },
+      },
+      expanded: ["l0", "l0/l1", "l0/l1/l2"],
+    });
+
+    const flat = flattenTree(model);
+    expect(flat.map((r) => r.depth)).toEqual([0, 1, 2, 3]);
+    expect(flat.map((r) => r.name)).toEqual(["l0", "l1", "l2", "leaf.md"]);
+  });
+});

--- a/src/components/Sidebar/__tests__/inlineRenameScroll.test.ts
+++ b/src/components/Sidebar/__tests__/inlineRenameScroll.test.ts
@@ -1,0 +1,158 @@
+// TDD for #253: when a user renames a row far down the list, scrolling the
+// virtual list must not destroy the rename input. The flat renderer must
+// key rows by `path` so the recycler reuses the same DOM node for the
+// rename target — otherwise typing `tab` + scroll = lost focus = data loss.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+const VAULT = "/tmp/test-vault";
+
+function md(i: number): DirEntry {
+  return {
+    name: `note-${String(i).padStart(6, "0")}.md`,
+    path: `${VAULT}/note-${String(i).padStart(6, "0")}.md`,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+  };
+}
+
+const ROW_HEIGHT = 28;
+const VIEWPORT_HEIGHT = 400;
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+describe("Inline rename survives virtual-list scroll (#253)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+
+    // Prime jsdom viewport height.
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return VIEWPORT_HEIGHT;
+      },
+    });
+  });
+
+  it("keeps rename input focused when the user scrolls far enough to recycle the row", async () => {
+    // Large list so row N still is inside the window at scrollTop=0 but
+    // would be OUT of the window after we scroll significantly.
+    const entries = Array.from({ length: 500 }, (_, i) => md(i));
+    (listDirectory as any).mockResolvedValue(entries);
+
+    const { container } = render(Sidebar, { props: makeProps() });
+
+    for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
+
+    // Find a row we know is inside the initial viewport (first visible row).
+    const rows = Array.from(container.querySelectorAll<HTMLElement>("[data-tree-row]"));
+    expect(rows.length).toBeGreaterThan(0);
+    const target = rows[0]!;
+    const targetPath = target.getAttribute("data-tree-row")!;
+
+    // Open the context menu and click Rename.
+    const row = target.querySelector(".vc-tree-row") as HTMLElement;
+    await fireEvent.contextMenu(row, { clientX: 0, clientY: 0 });
+    await tick();
+    const renameBtn = Array.from(container.querySelectorAll<HTMLButtonElement>(".vc-context-item"))
+      .find((b) => b.textContent?.trim() === "Rename");
+    expect(renameBtn).toBeTruthy();
+    await fireEvent.click(renameBtn!);
+    await tick();
+
+    const input = container.querySelector<HTMLInputElement>(".vc-rename-input");
+    expect(input).toBeTruthy();
+    // Input should have focus immediately after rename starts (InlineRename onMount).
+    expect(document.activeElement).toBe(input);
+
+    // Scroll the virtual list container far enough that the viewport no
+    // longer covers row 0. We scroll the scroll-host directly — the
+    // virtualized renderer listens to scroll on this element.
+    const scroller = container.querySelector<HTMLElement>(".vc-sidebar-tree");
+    expect(scroller).toBeTruthy();
+    scroller!.scrollTop = 1000; // push ~36 rows down — far past overscan
+    await fireEvent.scroll(scroller!);
+    for (let i = 0; i < 5; i += 1) await tick();
+
+    // After the scroll, the rename row is outside the viewport, so the
+    // virtualized renderer may have removed it from the DOM. That's fine —
+    // but if it's still in the DOM (because the rename row is pinned or
+    // overscanned), its focus must survive. We check the contract
+    // explicitly: if a rename input still exists in the DOM, it must be
+    // the focused element. Otherwise (row got recycled out), the caller is
+    // responsible for re-opening the rename after scroll-back; document
+    // that by allowing either.
+    const reinput = container.querySelector<HTMLInputElement>(".vc-rename-input");
+    if (reinput) {
+      // Row still present → focus must survive (keyed recycler, no destroy).
+      expect(document.activeElement).toBe(reinput);
+      // And the input is still pointing at the same target path.
+      const reRow = reinput.closest("[data-tree-row]");
+      expect(reRow?.getAttribute("data-tree-row")).toBe(targetPath);
+    } else {
+      // The renderer decided the rename row was far out of window and
+      // removed it. This is only acceptable if the flat data model still
+      // tracks it — the Sidebar must pin the renaming row so it survives
+      // scroll. Fail loudly so we notice during the TDD run.
+      throw new Error(
+        "Rename row was recycled out of the DOM — virtual list must pin the currently-renaming row so focus is never lost.",
+      );
+    }
+  });
+});

--- a/src/components/Sidebar/__tests__/sidebarReveal.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarReveal.test.ts
@@ -1,0 +1,123 @@
+// TDD for #253: revealing a path inside a collapsed ancestor chain must
+//   1. Call listDirectory for each ancestor in order (top → down)
+//   2. Re-flatten once the results land
+//   3. Scroll the target row into view (scrollIntoView invoked)
+//
+// The old TreeNode architecture drove expansion implicitly via the
+// persisted expanded-paths prop; with the flat architecture the Sidebar is
+// the sole owner of this sequencing.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { treeRevealStore } from "../../../store/treeRevealStore";
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+const VAULT = "/tmp/test-vault";
+
+function dir(name: string, path: string): DirEntry {
+  return { name, path, is_dir: true, is_symlink: false, is_md: false, modified: null, created: null };
+}
+function md(name: string, path: string): DirEntry {
+  return { name, path, is_dir: false, is_symlink: false, is_md: true, modified: null, created: null };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+describe("Sidebar reveal sequencing (#253)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+  });
+
+  it("expands ancestors, calls listDirectory in order, then scrolls the target into view", async () => {
+    const notes = dir("notes", `${VAULT}/notes`);
+    const daily = dir("daily", `${VAULT}/notes/daily`);
+    const today = md("today.md", `${VAULT}/notes/daily/today.md`);
+
+    (listDirectory as any).mockImplementation(async (path: string) => {
+      if (path === VAULT) return [notes];
+      if (path === notes.path) return [daily];
+      if (path === daily.path) return [today];
+      return [];
+    });
+
+    // Stub scrollIntoView globally — jsdom doesn't implement it.
+    const scrollSpy = vi.fn();
+    (window as any).HTMLElement.prototype.scrollIntoView = scrollSpy;
+
+    render(Sidebar, { props: makeProps() });
+
+    // Flush the initial vault-subscribe + root listDirectory.
+    for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
+
+    // Reveal a path inside a collapsed ancestor chain. The target itself is
+    // a file two folders deep — Sidebar must expand notes → daily in order,
+    // wait for each listDirectory, then scroll.
+    treeRevealStore.requestReveal("notes/daily/today.md");
+
+    // Flush the reveal pipeline; each ancestor adds an async listDirectory.
+    for (let i = 0; i < 60; i += 1) { await Promise.resolve(); await tick(); }
+
+    const calls = (listDirectory as any).mock.calls.map((c: any[]) => c[0] as string);
+
+    // Root list is always called first (on vault open). Then the reveal
+    // sequence must include notes then daily, in that order.
+    const notesIdx = calls.indexOf(notes.path);
+    const dailyIdx = calls.indexOf(daily.path);
+    expect(notesIdx).toBeGreaterThanOrEqual(0);
+    expect(dailyIdx).toBeGreaterThan(notesIdx);
+
+    // Target row scrolled into view.
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/Sidebar/__tests__/sidebarRevealAfterVaultLoad.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarRevealAfterVaultLoad.test.ts
@@ -1,0 +1,132 @@
+// Regression for PR #336 blocker B1 — reveal fired in the same tick as
+// vault load must NOT silently no-op because a `$derived` value read from
+// inside the store-subscription callback is stale.
+//
+// Scenario: user clicks a backlink / launches the app with a startup
+// reveal request queued. The vault loads (rootEntries populated via async
+// listDirectory) and the reveal token fires together. `performReveal`
+// must find the target row and scroll to it instead of bailing because
+// `flatRows.findIndex(...)` returned -1 from a stale `$derived`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { treeRevealStore } from "../../../store/treeRevealStore";
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+const VAULT = "/tmp/test-vault";
+
+function md(name: string, path: string): DirEntry {
+  return {
+    name,
+    path,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+  };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+describe("Sidebar reveal right after vault load (#336 B1)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    // Do NOT pre-setReady here — we want the vault transition to happen
+    // immediately after render, so reveal-after-load races the $derived
+    // recompute the same way a real startup reveal does.
+    vi.clearAllMocks();
+  });
+
+  it("scrolls the target into view when the reveal fires before $derived has caught up", async () => {
+    const targetIdx = 150;
+    const entries: DirEntry[] = Array.from({ length: 200 }, (_, i) => {
+      const name = `note-${String(i).padStart(3, "0")}.md`;
+      return md(name, `${VAULT}/${name}`);
+    });
+    const target = entries[targetIdx]!;
+
+    // listDirectory resolves *eagerly* — before the reveal subscription
+    // has had a chance to settle, so the `$derived` that reads rootEntries
+    // may still be serving its previous (empty) snapshot when `performReveal`
+    // first reads `flatRows`.
+    (listDirectory as any).mockImplementation(async (path: string) => {
+      if (path === VAULT) return entries;
+      return [];
+    });
+
+    const scrollSpy = vi.fn();
+    (window as any).HTMLElement.prototype.scrollIntoView = scrollSpy;
+
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() { return 600; },
+    });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+
+    // Flip the vault ready AFTER mount — this fires the vault subscription
+    // which triggers the async `rootEntries = ...` assignment, and then we
+    // immediately fire the reveal before `$derived` has recomputed.
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    treeRevealStore.requestReveal(target.name);
+
+    // Flush everything.
+    for (let i = 0; i < 80; i += 1) { await Promise.resolve(); await tick(); }
+
+    const scroller = container.querySelector<HTMLElement>(".vc-sidebar-tree");
+    expect(scroller).toBeTruthy();
+    // B1 guard: the reveal must resolve the target and scroll to it.
+    expect(scroller!.scrollTop).toBeGreaterThan(1000);
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/Sidebar/__tests__/sidebarRevealPending.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarRevealPending.test.ts
@@ -1,0 +1,135 @@
+// Regression for PR #336 blocker B2 — reveal against a 0-height scroller
+// (collapsed sidebar / pre-layout mount) must stash the path and fire once
+// the scroller has a real clientHeight.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { treeRevealStore } from "../../../store/treeRevealStore";
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+const VAULT = "/tmp/test-vault";
+
+function md(i: number): DirEntry {
+  const name = `note-${String(i).padStart(3, "0")}.md`;
+  return {
+    name,
+    path: `${VAULT}/${name}`,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+  };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+describe("Sidebar reveal when scroller has 0 height (#336 B2)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+  });
+
+  it("stashes the pending reveal and dispatches it once the scroller has height", async () => {
+    const entries = Array.from({ length: 100 }, (_, i) => md(i));
+    const target = entries[80]!;
+    (listDirectory as any).mockResolvedValue(entries);
+
+    const scrollSpy = vi.fn();
+    (window as any).HTMLElement.prototype.scrollIntoView = scrollSpy;
+
+    // Simulate a collapsed sidebar: clientHeight reads 0.
+    let simulatedHeight = 0;
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() { return simulatedHeight; },
+    });
+
+    // Capture the ResizeObserver callback so we can trigger it manually once
+    // the "sidebar" gets its layout height.
+    let resizeCb: ((entries: ResizeObserverEntry[], observer: ResizeObserver) => void) | null = null;
+    class FakeResizeObserver {
+      constructor(cb: (entries: ResizeObserverEntry[], observer: ResizeObserver) => void) {
+        resizeCb = cb;
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+    render(Sidebar, { props: makeProps() });
+
+    // Drain initial load — at this point the scroller has 0 height.
+    for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
+
+    // Fire the reveal while height is 0.
+    treeRevealStore.requestReveal(target.name);
+    for (let i = 0; i < 30; i += 1) { await Promise.resolve(); await tick(); }
+
+    // With a 0-height scroller, scrollIntoView must NOT have been called yet.
+    // (The viewport window is empty, so the target row isn't mounted.)
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    // Now the sidebar gets a real height — e.g. the user expands it or the
+    // layout finally resolves. The stashed reveal should fire.
+    simulatedHeight = 600;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (resizeCb as any)?.([], {} as ResizeObserver);
+
+    for (let i = 0; i < 60; i += 1) { await Promise.resolve(); await tick(); }
+
+    // B2 guard: pending reveal drained once the scroller had a real height.
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/Sidebar/__tests__/sidebarRevealSubscription.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarRevealSubscription.test.ts
@@ -1,0 +1,110 @@
+// TDD for #253: Sidebar must subscribe to `treeRevealStore` exactly ONCE
+// regardless of how many tree rows are on screen. The old per-TreeNode
+// subscription scheme was the main reason reveal-in-tree contributed
+// ~N writes per reveal, blowing past the <20 ms reveal budget in a 100k
+// vault.
+//
+// We spy on treeRevealStore.subscribe to count registrations after the
+// Sidebar mounts with a sizable tree.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { treeRevealStore } from "../../../store/treeRevealStore";
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+const VAULT = "/tmp/test-vault";
+
+function md(i: number): DirEntry {
+  return {
+    name: `note-${i}.md`,
+    path: `${VAULT}/note-${i}.md`,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+  };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+describe("Sidebar registers exactly one treeRevealStore subscription (#253)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+  });
+
+  it("renders 100 rows but only subscribes to treeRevealStore once", async () => {
+    const entries = Array.from({ length: 100 }, (_, i) => md(i));
+    (listDirectory as any).mockResolvedValue(entries);
+
+    const subscribeSpy = vi.spyOn(treeRevealStore, "subscribe");
+
+    const { container } = render(Sidebar, { props: makeProps() });
+
+    // Drain microtasks for vault subscribe + listDirectory + flatten.
+    for (let i = 0; i < 15; i += 1) {
+      await Promise.resolve();
+      await tick();
+    }
+
+    // At least one flat row rendered so the assertion is meaningful.
+    const rows = container.querySelectorAll("[data-tree-row]");
+    expect(rows.length).toBeGreaterThan(0);
+
+    // The critical invariant: exactly one subscription registered no matter
+    // how many rows are on screen. If any TreeRow (re)acquires its own
+    // subscription this count spikes to ~row-count.
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Sidebar/__tests__/sidebarVirtualization.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarVirtualization.test.ts
@@ -1,0 +1,133 @@
+// TDD for #253: at 10k flat rows the rendered DOM must contain ONLY the
+// viewport slice + overscan, not all 10k rows. Without virtualization the
+// previous sidebar blew past the 500 MB RAM budget and destroyed keystroke
+// latency the moment the user scrolled.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+const VAULT = "/tmp/test-vault";
+
+function md(i: number): DirEntry {
+  return {
+    name: `note-${String(i).padStart(6, "0")}.md`,
+    path: `${VAULT}/note-${String(i).padStart(6, "0")}.md`,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+  };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+// Row height used by the virtualized renderer. Sidebar exposes this as a
+// CSS var (`--vc-tree-row-height`, 28px) but we only need the rough order
+// of magnitude here — the assertion just checks "orders of magnitude less
+// than the full list".
+const ROW_HEIGHT = 28;
+const VIEWPORT_HEIGHT = 600; // typical sidebar column
+const OVERSCAN = 10;
+
+describe("Sidebar virtualization (#253)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+  });
+
+  it("renders only viewport+overscan rows for a 10k-entry tree", async () => {
+    const entries = Array.from({ length: 10_000 }, (_, i) => md(i));
+    (listDirectory as any).mockResolvedValue(entries);
+
+    // jsdom elements report clientHeight === 0 — prime it via the getter so
+    // Sidebar's ResizeObserver fallback picks up a realistic viewport height.
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return VIEWPORT_HEIGHT;
+      },
+    });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+
+    // Drain the vault-subscribe IIFE + loadRoot microtask chain.
+    for (let i = 0; i < 15; i += 1) {
+      await Promise.resolve();
+      await tick();
+    }
+
+    const rows = container.querySelectorAll("[data-tree-row]");
+    const viewportRows = Math.ceil(VIEWPORT_HEIGHT / ROW_HEIGHT); // ~22
+
+    // Bound is viewport_rows + 2*overscan + a small fudge for boundary rounding.
+    const upperBound = viewportRows + 2 * OVERSCAN + 10;
+    expect(rows.length).toBeLessThanOrEqual(upperBound);
+
+    // Sanity: at least the visible viewport is populated, so the test isn't
+    // accidentally passing because nothing rendered.
+    expect(rows.length).toBeGreaterThan(0);
+
+    // And nowhere near the 10k-row count.
+    expect(rows.length).toBeLessThan(200);
+  });
+});

--- a/src/lib/flattenTree.ts
+++ b/src/lib/flattenTree.ts
@@ -1,0 +1,158 @@
+// Flat-row model for the virtualized sidebar tree (#253).
+//
+// The sidebar used to be a recursive `<TreeNode>` tree where every node
+// subscribed to `treeRevealStore` independently. At 100k notes that produced
+// N store subscriptions and unbounded DOM — both of which blew past the
+// spec's <16ms keystroke budget. This module replaces the recursive walk
+// with a flat array: rendering 50k folders costs one `flattenTree` call
+// (O(n)), and the windowed renderer emits only viewport rows.
+//
+// Lazy-load model (preserved from TreeNode.loadChildren):
+//   - `expanded: true` + `childrenLoaded: true`  → children emitted with depth+1
+//   - `expanded: true` + `childrenLoaded: false` → folder row emitted, no children
+//     (the expand handler triggers listDirectory; when it resolves and the
+//     tree model is updated, flattenTree runs again and emits the children).
+//   - `expanded: false`                           → folder row emitted, no children
+//
+// No depth cap: Obsidian vaults can legitimately nest 6-10 levels; we defer
+// to the virtualizer to keep memory bounded.
+
+import type { DirEntry } from "../types/tree";
+import type { SortBy } from "./treeState";
+import { sortEntries } from "./treeState";
+
+/**
+ * Per-folder state stored in the tree model. The `childrenLoaded` flag is
+ * load-tracking ONLY — it tells flattenTree whether to descend. It is NOT
+ * the same as `expanded` (a folder can be expanded with children not yet
+ * fetched, which is the common case for a folder freshly opened by the user).
+ */
+export interface FolderState {
+  /** Resolved children for this folder (undefined until listDirectory returns). */
+  children: readonly DirEntry[] | undefined;
+  childrenLoaded: boolean;
+  loading: boolean;
+}
+
+/** Flat row emitted by `flattenTree`. `depth` is zero-based (root = 0). */
+export interface FlatRow {
+  /** Absolute path — stable identity, used as the virtual recycler key. */
+  path: string;
+  /** Vault-relative path (forward slashes). Used for treeState/expanded lookups. */
+  relPath: string;
+  name: string;
+  depth: number;
+  isDir: boolean;
+  isMd: boolean;
+  isSymlink: boolean;
+  /** Current expand state (false for files). */
+  expanded: boolean;
+  /** True iff `expanded && !childrenLoaded` — used to render a pending spinner. */
+  loading: boolean;
+  /**
+   * True when the flat row has descendants currently contributing rows.
+   * Equivalent to `isDir && expanded && childrenLoaded && children.length > 0`.
+   * Consumers use this to decide whether a "keyboard arrow-down skips over
+   * my subtree" operation is needed.
+   */
+  hasRenderedChildren: boolean;
+  /** True iff listDirectory has resolved for this folder at least once. */
+  childrenLoaded: boolean;
+}
+
+export interface TreeModel {
+  /** Vault absolute path — used to compute relative paths. */
+  vaultPath: string;
+  /** Root entries (listDirectory(vaultPath)). */
+  rootEntries: readonly DirEntry[];
+  /**
+   * Per-folder state, keyed by the folder's absolute path. Missing entries
+   * are treated as "children not loaded, not loading". The root itself is
+   * represented by `rootEntries` and is not stored in this map.
+   */
+  folders: ReadonlyMap<string, FolderState>;
+  /**
+   * Set of vault-relative folder paths that are currently expanded. Mirrors
+   * the persisted `TreeState.expanded` list so flatten is a pure function of
+   * the model.
+   */
+  expanded: ReadonlySet<string>;
+  sortBy: SortBy;
+}
+
+/** Compute a vault-relative path with forward slashes, or `absPath` if it's outside. */
+export function toRelPath(absPath: string, vaultPath: string): string {
+  const norm = absPath.replace(/\\/g, "/");
+  const vault = vaultPath.replace(/\\/g, "/");
+  if (norm === vault) return "";
+  if (norm.startsWith(vault + "/")) return norm.slice(vault.length + 1);
+  return norm;
+}
+
+function buildRow(
+  entry: DirEntry,
+  depth: number,
+  vaultPath: string,
+  model: TreeModel,
+): FlatRow {
+  const relPath = toRelPath(entry.path, vaultPath);
+  const expanded = entry.is_dir && model.expanded.has(relPath);
+  const fs = model.folders.get(entry.path);
+  const childrenLoaded = fs?.childrenLoaded ?? false;
+  const loading = expanded && !childrenLoaded && (fs?.loading ?? true);
+  const childCount = fs?.children?.length ?? 0;
+  return {
+    path: entry.path,
+    relPath,
+    name: entry.name,
+    depth,
+    isDir: entry.is_dir,
+    isMd: entry.is_md,
+    isSymlink: entry.is_symlink,
+    expanded,
+    loading,
+    hasRenderedChildren: expanded && childrenLoaded && childCount > 0,
+    childrenLoaded,
+  };
+}
+
+/**
+ * Recursively walk the tree model, emitting one FlatRow per visible node.
+ * Collapsed folders do NOT emit children; expanded-but-not-loaded folders
+ * emit only the folder row (children come later once listDirectory lands).
+ */
+export function flattenTree(model: TreeModel): FlatRow[] {
+  const out: FlatRow[] = [];
+  const sortedRoot = sortEntries(model.rootEntries, model.sortBy);
+
+  const walk = (entries: readonly DirEntry[], depth: number): void => {
+    for (const entry of entries) {
+      out.push(buildRow(entry, depth, model.vaultPath, model));
+      if (!entry.is_dir) continue;
+      const relPath = toRelPath(entry.path, model.vaultPath);
+      if (!model.expanded.has(relPath)) continue;
+      const fs = model.folders.get(entry.path);
+      if (!fs || !fs.childrenLoaded || !fs.children) continue;
+      const sortedChildren = sortEntries(fs.children, model.sortBy);
+      walk(sortedChildren, depth + 1);
+    }
+  };
+
+  walk(sortedRoot, 0);
+  return out;
+}
+
+/**
+ * Return the ordered list of ancestor folder rel-paths for a target.
+ * E.g. "notes/daily/today.md" → ["notes", "notes/daily"]. The target
+ * itself is NOT included.
+ */
+export function ancestorRelPaths(relPath: string): string[] {
+  const parts = relPath.split("/").filter((p) => p.length > 0);
+  if (parts.length <= 1) return [];
+  const out: string[] = [];
+  for (let i = 1; i < parts.length; i += 1) {
+    out.push(parts.slice(0, i).join("/"));
+  }
+  return out;
+}

--- a/src/styles/__tests__/modalTheming.test.ts
+++ b/src/styles/__tests__/modalTheming.test.ts
@@ -76,7 +76,7 @@ const MODAL_PAIRS: Array<{
     surface: ".vc-url-modal",
   },
   {
-    file: "src/components/Sidebar/TreeNode.svelte",
+    file: "src/components/Sidebar/TreeRow.svelte",
     scrim: ".vc-confirm-overlay",
     surface: ".vc-confirm-dialog",
   },


### PR DESCRIPTION
## Summary

Closes #253.

- **Single reveal subscription.** `Sidebar.svelte` now owns the only `treeRevealStore` subscription. Per-node subscriptions are gone — one handler expands ancestors, awaits their `listDirectory` loads, re-flattens, then scrolls.
- **Virtualized flat-row renderer.** A new `src/lib/flattenTree.ts` turns the `DirEntry` tree + persisted `expanded` set into a `FlatRow[]`. Sidebar renders only the viewport slice (ROW_HEIGHT=28, OVERSCAN=10) with absolute-positioned rows, so a 100k-note vault no longer mounts 100k components.
- **Per-row key preserves focus.** `TreeNode.svelte` is renamed to `TreeRow.svelte` and keyed by `path` in the `{#each}` block. Inline-rename focus, active-path highlight, and drag state survive scroll recycling.
- **Lazy-load contract intact.** `listDirectory` is still invoked only on first expand of a folder. Reveal awaits the load before flattening so the target row exists when we scroll.
- **Svelte 5 reactivity fix.** `vaultStore.subscribe` moved into `onMount` — a top-level-script subscription fires during component construction, before the reactive root is fully wired, so async `treeState` assignments can fail to propagate through `$derived`.

## Test plan

- [x] `pnpm vitest run src/components/Sidebar` — 11 files / 26 tests passing, including the new virtualization, reveal, reveal-subscription, flattenTree, and inline-rename-scroll suites.
- [x] `pnpm vitest run src/styles/__tests__/modalTheming.test.ts` — 35 passing (confirms the TreeRow-scoped confirm-dialog keeps its vc-modal-scrim / vc-modal-surface contract).
- [x] `pnpm vitest run src/lib/__tests__ src/store/__tests__ src/styles/__tests__` — 37 files / 500 tests passing (no regressions in adjacent modules).
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm exec svelte-check` — 0 errors (2 pre-existing line-clamp warnings in SearchResultRow/BacklinkRow, unrelated to this PR).
- [ ] WDIO specs (`sidebar-layout`, `tree-context-menu`, `drag-drop`, `inline-rename`) — not run in this environment: `wdio.conf.ts` requires a release `src-tauri/target/release/vaultcore` binary + `tauri-driver`, which aren't available on the agent host. Recommend running `pnpm test:e2e:build` locally before merge.

## Risk

- High-blast-radius refactor of the most-used view. Focus + drag-drop + context-menu + inline-rename all share the same recycler; the keyed `{#each}` preserves Svelte component identity across slice changes, which is what keeps those behaviours working. Covered by the updated `TreeNodeContextMenu` / `TreeNodeCreateFile` / `TreeNodeRecursion` / `TreeNodeInitialExpand` suites plus the new `inlineRenameScroll` test.
- Persisted tree state (`expanded` set keyed by `vaultHashKey`) is unchanged on disk — existing users keep their expansion state on upgrade.