### PR TITLE
fix(indexer): dispatch index updates from all self-write paths (#339)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -22,7 +22,7 @@
 use crate::error::VaultError;
 use crate::hash::hash_bytes;
 use crate::indexer::memory::FileMeta;
-use crate::indexer::{walk_md_files, IndexCmd};
+use crate::indexer::walk_md_files;
 use crate::VaultState;
 use regex::Regex;
 use std::path::{Path, PathBuf};
@@ -114,14 +114,16 @@ pub async fn write_file(
         _ => VaultError::Io(e),
     })?;
 
-    // BUG-05.1 FIX: the watcher would normally dispatch UpdateLinks/UpdateTags
-    // for any modify event, but write_ignore suppresses self-writes to avoid
-    // double-indexing. That leaves the in-memory LinkGraph and TagIndex stale
-    // after every auto-save, so user observes stale tag counts, broken
-    // backlinks, and dangling unresolved-link colors until cold restart.
-    //
-    // Dispatch the updates directly here so the in-memory indexes stay in sync.
-    dispatch_index_updates(&state, &final_path, &content).await;
+    // BUG-05.1 FIX + #339: the watcher would normally dispatch
+    // UpdateLinks/UpdateTags/AddFile for any modify event, but write_ignore
+    // suppresses self-writes to avoid double-indexing. That leaves the
+    // in-memory LinkGraph, TagIndex, and Tantivy index stale after every
+    // auto-save, so users observe stale tag counts, broken backlinks,
+    // dangling unresolved-link colors, and stale fulltext hits until cold
+    // restart. Shared helper in commands/index_dispatch.rs keeps this in
+    // sync across all self-write paths (write_file, merge_external_change,
+    // rename/move, update_links_after_rename).
+    crate::commands::index_dispatch::dispatch_self_write(&state, &final_path, &content).await;
 
     // Embed-on-save (#196): non-blocking enqueue to the EmbedCoordinator.
     // Sync, returns immediately; a `QueueFull` outcome is benign because
@@ -135,7 +137,7 @@ pub async fn write_file(
 }
 
 #[cfg(feature = "embeddings")]
-fn dispatch_embed_update(state: &VaultState, abs_path: PathBuf, content: &str) {
+pub(crate) fn dispatch_embed_update(state: &VaultState, abs_path: PathBuf, content: &str) {
     let coord_handles = {
         let Ok(guard) = state.embed_coordinator.lock() else { return };
         guard.as_ref().map(|c| (c.tx.clone(), std::sync::Arc::clone(&c.pending)))
@@ -162,49 +164,6 @@ pub(crate) fn dispatch_embed_delete(state: &VaultState, abs_path: PathBuf) {
     if let Err(e) = probe.enqueue_delete(abs_path) {
         log::warn!("embed delete enqueue: {e}");
     }
-}
-
-/// Dispatch IndexCmd::UpdateLinks and IndexCmd::UpdateTags for a path we just
-/// wrote from the backend. Called from write_file because write_ignore
-/// suppresses the natural watcher-driven dispatch.
-///
-/// Best-effort: if the IndexCoordinator is not yet initialized (vault not
-/// open, or during boot) or the channel is full, we silently drop — the
-/// next cold-start rebuild will re-populate correctly.
-async fn dispatch_index_updates(state: &VaultState, abs_path: &Path, content: &str) {
-    // Get vault root so we can compute a vault-relative path.
-    let vault_root = {
-        let Ok(guard) = state.current_vault.lock() else { return };
-        match guard.as_ref() {
-            Some(p) => p.clone(),
-            None => return,
-        }
-    };
-
-    let Ok(rel) = abs_path.strip_prefix(&vault_root) else { return };
-    let rel_path = rel.to_string_lossy().replace('\\', "/");
-
-    // Clone the sender Arc — do NOT hold the coordinator lock across .await.
-    let tx = {
-        let Ok(guard) = state.index_coordinator.lock() else { return };
-        match guard.as_ref() {
-            Some(c) => c.tx.clone(),
-            None => return,
-        }
-    };
-
-    let _ = tx
-        .send(IndexCmd::UpdateLinks {
-            rel_path: rel_path.clone(),
-            content: content.to_string(),
-        })
-        .await;
-    let _ = tx
-        .send(IndexCmd::UpdateTags {
-            rel_path,
-            content: content.to_string(),
-        })
-        .await;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -534,12 +493,22 @@ pub async fn rename_file(
         },
     );
 
-    // #277: the watcher would normally dispatch DeleteFile(old) + AddFile(new)
-    // on a rename event, but write_ignore suppresses that for self-mutations.
-    // Dispatch a Tantivy delete for the OLD path so fulltext search stops
-    // returning the stale doc; the NEW path is re-indexed on next user save.
+    // #277 + #339: the watcher would normally dispatch
+    // DeleteFile(old) + AddFile(new) on a rename event, but write_ignore
+    // suppresses that for self-mutations. Dispatch RemoveLinks/RemoveTags
+    // + Tantivy delete for the OLD path, and UpdateLinks/UpdateTags +
+    // Tantivy AddFile for the NEW path using the freshly-read content.
+    // Without the new-side dispatch the renamed file's body text stays
+    // absent from fulltext search until cold restart, and its tags/links
+    // hang under the OLD rel_path in the graphs until the user edits it.
     if let Some(old) = old_canonical_for_tantivy {
-        dispatch_tantivy_delete(&state, old).await;
+        crate::commands::index_dispatch::dispatch_self_delete(&state, &old).await;
+    }
+    let new_canonical = std::fs::canonicalize(&result.new_path).ok();
+    if let Some(new_path) = new_canonical.as_ref() {
+        if let Ok(content) = std::fs::read_to_string(new_path) {
+            crate::commands::index_dispatch::dispatch_self_write(&state, new_path, &content).await;
+        }
     }
 
     #[cfg(feature = "embeddings")]
@@ -547,20 +516,6 @@ pub async fn rename_file(
         dispatch_embed_delete(&state, p);
     }
     Ok(result)
-}
-
-/// Enqueue a Tantivy delete for `path`. Called from rename/move paths where
-/// write_ignore would otherwise suppress the watcher-driven DeleteFile.
-async fn dispatch_tantivy_delete(state: &VaultState, path: PathBuf) {
-    let tx = {
-        let Ok(guard) = state.index_coordinator.lock() else { return };
-        match guard.as_ref() {
-            Some(c) => c.tx.clone(),
-            None => return,
-        }
-    };
-    let _ = tx.send(IndexCmd::DeleteFile { path }).await;
-    let _ = tx.send(IndexCmd::Commit).await;
 }
 
 // ─── delete_file ─────────────────────────────────────────────────────────────
@@ -617,6 +572,13 @@ pub async fn delete_file(
             new_path: None,
         },
     );
+    // #339: RemoveLinks/RemoveTags + Tantivy delete for the deleted path.
+    // Without this the backlinks panel and tag counts hang on the deleted
+    // file's old references until cold restart (the watcher's natural
+    // dispatch is suppressed by write_ignore above).
+    if let Some(ref p) = canonical {
+        crate::commands::index_dispatch::dispatch_self_delete(&state, p).await;
+    }
     // #201 PR-A: tell the embed coordinator to tombstone this path's
     // vectors. Same reason as the synthetic file_changed event above —
     // write_ignore suppresses the watcher's natural Remove event so we
@@ -697,9 +659,16 @@ pub async fn move_file(
         },
     );
 
-    // #277: same Tantivy parity as rename_file.
+    // #277 + #339: same dispatch parity as rename_file — RemoveLinks/Tags
+    // + Tantivy delete for OLD, UpdateLinks/Tags + AddFile for NEW.
     if let Some(old) = old_canonical_for_tantivy {
-        dispatch_tantivy_delete(&state, old).await;
+        crate::commands::index_dispatch::dispatch_self_delete(&state, &old).await;
+    }
+    let new_canonical = std::fs::canonicalize(&result).ok();
+    if let Some(new_path) = new_canonical.as_ref() {
+        if let Ok(content) = std::fs::read_to_string(new_path) {
+            crate::commands::index_dispatch::dispatch_self_write(&state, new_path, &content).await;
+        }
     }
 
     #[cfg(feature = "embeddings")]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -355,7 +355,15 @@ pub struct RenameResult {
 }
 
 /// Testable implementation body for rename_file.
-pub fn rename_file_impl(state: &VaultState, old_path: String, new_name: String) -> Result<RenameResult, VaultError> {
+///
+/// Performs the disk rename, the FileIndex sync, AND the index dispatch
+/// (RemoveLinks/RemoveTags + Tantivy delete for the OLD rel_path;
+/// UpdateLinks/UpdateTags + Tantivy AddFile for the NEW rel_path using
+/// the file's post-rename content). Keeping dispatch in `_impl` means
+/// every caller — production wrapper, unit tests, future callers — runs
+/// the same contract. The tauri wrapper only adds the synthetic
+/// `file_changed` event + embed delete on top.
+pub async fn rename_file_impl(state: &VaultState, old_path: String, new_name: String) -> Result<RenameResult, VaultError> {
     let old = PathBuf::from(&old_path);
     let canonical_old = ensure_inside_vault(state, &old)?;
 
@@ -405,6 +413,13 @@ pub fn rename_file_impl(state: &VaultState, old_path: String, new_name: String) 
     // fallback. Only mutate after `fs::rename` succeeds; on disk failure
     // we intentionally leave the index untouched.
     sync_file_index_rename(state, &canonical_old, &canonical_new, &vault_root);
+
+    // #339: watcher-natural DeleteFile(old) + AddFile(new) on rename is
+    // suppressed by write_ignore. Dispatch both sides ourselves so the
+    // in-memory LinkGraph / TagIndex / Tantivy index stay in sync with
+    // disk without waiting for cold restart.
+    crate::commands::index_dispatch::dispatch_self_delete(state, &canonical_old).await;
+    dispatch_new_side_after_rename(state, &canonical_new, "rename_file").await;
 
     Ok(RenameResult {
         new_path: canonical_new.to_string_lossy().into_owned(),
@@ -474,13 +489,13 @@ pub async fn rename_file(
     // NEW path's vectors get embedded on the next save by the user.
     #[cfg(feature = "embeddings")]
     let old_canonical = std::fs::canonicalize(&old_path).ok();
-    let old_canonical_for_tantivy = std::fs::canonicalize(&old_path).ok();
-    let old_canonical_for_event = old_canonical_for_tantivy
-        .as_ref()
+    let old_canonical_for_event = std::fs::canonicalize(&old_path)
         .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|| old_path.clone());
+        .unwrap_or_else(|_| old_path.clone());
 
-    let result = rename_file_impl(&state, old_path, new_name)?;
+    // rename_file_impl handles the disk rename, FileIndex sync, AND the
+    // index dispatch — see its doc for the contract split.
+    let result = rename_file_impl(&state, old_path, new_name).await?;
 
     // #307: write_ignore (D-12) suppresses the watcher's natural rename
     // event, so emit a synthetic one — same pattern as delete_file (#102).
@@ -493,25 +508,6 @@ pub async fn rename_file(
         },
     );
 
-    // #277 + #339: the watcher would normally dispatch
-    // DeleteFile(old) + AddFile(new) on a rename event, but write_ignore
-    // suppresses that for self-mutations. Dispatch RemoveLinks/RemoveTags
-    // + Tantivy delete for the OLD path, and UpdateLinks/UpdateTags +
-    // Tantivy AddFile for the NEW path using the freshly-read content.
-    // Without the new-side dispatch the renamed file's body text stays
-    // absent from fulltext search until cold restart, and its tags/links
-    // hang under the OLD rel_path in the graphs until the user edits it.
-    if let Some(old) = old_canonical_for_tantivy {
-        crate::commands::index_dispatch::dispatch_self_delete(&state, &old).await;
-    }
-    // New-side read failure would leave the renamed file stale for
-    // fulltext + graphs until cold restart with no trace. Log loudly so
-    // operators can correlate a stale-index report with a rename that
-    // couldn't re-index. The disk rename has already succeeded, so we
-    // don't surface the error to the frontend — the user's operation
-    // completed, the index just needs recovery via the next rebuild.
-    dispatch_new_side_after_rename(&state, &result.new_path, "rename_file").await;
-
     #[cfg(feature = "embeddings")]
     if let Some(p) = old_canonical {
         dispatch_embed_delete(&state, p);
@@ -522,29 +518,25 @@ pub async fn rename_file(
 /// Dispatch UpdateLinks/UpdateTags/AddFile for the new side of a rename
 /// or move. Called after the disk rename + old-side dispatch succeeds.
 ///
-/// On canonicalize or read failure we log::warn instead of bubbling: the
-/// disk operation already succeeded, so failing the command would be
-/// worse than leaving the index transiently stale until the next rebuild.
-/// The warning makes the degradation observable without being noisy.
-async fn dispatch_new_side_after_rename(state: &VaultState, new_path: &str, op: &str) {
-    match std::fs::canonicalize(new_path) {
+/// `canonical_new` must already be canonicalized — callers
+/// (`rename_file_impl`, `move_file_impl`) hold that path in hand. Doing
+/// the canonicalize here again would be wasted syscalls and silently
+/// absorb an error the caller already handled.
+///
+/// On read failure we log::warn instead of bubbling: the disk operation
+/// already succeeded, so failing the command would be worse than leaving
+/// the index transiently stale until the next rebuild. The warning makes
+/// the degradation observable without being noisy.
+async fn dispatch_new_side_after_rename(state: &VaultState, canonical_new: &Path, op: &str) {
+    match std::fs::read_to_string(canonical_new) {
         Err(e) => log::warn!(
-            "{op} new-side canonicalize failed for {new_path}: {e} — index will trail until rebuild",
+            "{op} new-side read failed for {}: {e} — index will trail until rebuild",
+            canonical_new.display(),
         ),
-        Ok(new_path_buf) => match std::fs::read_to_string(&new_path_buf) {
-            Err(e) => log::warn!(
-                "{op} new-side read failed for {}: {e} — index will trail until rebuild",
-                new_path_buf.display(),
-            ),
-            Ok(content) => {
-                crate::commands::index_dispatch::dispatch_self_write(
-                    state,
-                    &new_path_buf,
-                    &content,
-                )
+        Ok(content) => {
+            crate::commands::index_dispatch::dispatch_self_write(state, canonical_new, &content)
                 .await;
-            }
-        },
+        }
     }
 }
 
@@ -626,7 +618,11 @@ pub async fn delete_file(
 // ─── move_file ───────────────────────────────────────────────────────────────
 
 /// Testable implementation body for move_file.
-pub fn move_file_impl(state: &VaultState, from: String, to_folder: String) -> Result<String, VaultError> {
+///
+/// Performs the disk rename, FileIndex sync, AND the index dispatch — same
+/// contract split as `rename_file_impl` (see its doc). Returns the
+/// canonical destination path.
+pub async fn move_file_impl(state: &VaultState, from: String, to_folder: String) -> Result<String, VaultError> {
     let from_path = PathBuf::from(&from);
     let canonical_from = ensure_inside_vault(state, &from_path)?;
 
@@ -657,6 +653,10 @@ pub fn move_file_impl(state: &VaultState, from: String, to_folder: String) -> Re
     let vault_root = get_vault_root(state)?;
     sync_file_index_rename(state, &canonical_from, &dest, &vault_root);
 
+    // #339: same dispatch parity as rename_file_impl.
+    crate::commands::index_dispatch::dispatch_self_delete(state, &canonical_from).await;
+    dispatch_new_side_after_rename(state, &dest, "move_file").await;
+
     Ok(dest.to_string_lossy().into_owned())
 }
 
@@ -673,13 +673,13 @@ pub async fn move_file(
     // watcher's Remove event.
     #[cfg(feature = "embeddings")]
     let old_canonical = std::fs::canonicalize(&from).ok();
-    let old_canonical_for_tantivy = std::fs::canonicalize(&from).ok();
-    let old_canonical_for_event = old_canonical_for_tantivy
-        .as_ref()
+    let old_canonical_for_event = std::fs::canonicalize(&from)
         .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|| from.clone());
+        .unwrap_or_else(|_| from.clone());
 
-    let result = move_file_impl(&state, from, to_folder)?;
+    // move_file_impl handles the disk rename, FileIndex sync, AND the
+    // index dispatch — see its doc for the contract split.
+    let result = move_file_impl(&state, from, to_folder).await?;
 
     // #307: write_ignore (D-12) suppresses the watcher's natural rename
     // event. A move is reported as a rename with a new parent path.
@@ -691,13 +691,6 @@ pub async fn move_file(
             new_path: Some(result.clone()),
         },
     );
-
-    // #277 + #339: same dispatch parity as rename_file — RemoveLinks/Tags
-    // + Tantivy delete for OLD, UpdateLinks/Tags + AddFile for NEW.
-    if let Some(old) = old_canonical_for_tantivy {
-        crate::commands::index_dispatch::dispatch_self_delete(&state, &old).await;
-    }
-    dispatch_new_side_after_rename(&state, &result, "move_file").await;
 
     #[cfg(feature = "embeddings")]
     if let Some(p) = old_canonical {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -504,12 +504,13 @@ pub async fn rename_file(
     if let Some(old) = old_canonical_for_tantivy {
         crate::commands::index_dispatch::dispatch_self_delete(&state, &old).await;
     }
-    let new_canonical = std::fs::canonicalize(&result.new_path).ok();
-    if let Some(new_path) = new_canonical.as_ref() {
-        if let Ok(content) = std::fs::read_to_string(new_path) {
-            crate::commands::index_dispatch::dispatch_self_write(&state, new_path, &content).await;
-        }
-    }
+    // New-side read failure would leave the renamed file stale for
+    // fulltext + graphs until cold restart with no trace. Log loudly so
+    // operators can correlate a stale-index report with a rename that
+    // couldn't re-index. The disk rename has already succeeded, so we
+    // don't surface the error to the frontend — the user's operation
+    // completed, the index just needs recovery via the next rebuild.
+    dispatch_new_side_after_rename(&state, &result.new_path, "rename_file").await;
 
     #[cfg(feature = "embeddings")]
     if let Some(p) = old_canonical {
@@ -518,10 +519,48 @@ pub async fn rename_file(
     Ok(result)
 }
 
+/// Dispatch UpdateLinks/UpdateTags/AddFile for the new side of a rename
+/// or move. Called after the disk rename + old-side dispatch succeeds.
+///
+/// On canonicalize or read failure we log::warn instead of bubbling: the
+/// disk operation already succeeded, so failing the command would be
+/// worse than leaving the index transiently stale until the next rebuild.
+/// The warning makes the degradation observable without being noisy.
+async fn dispatch_new_side_after_rename(state: &VaultState, new_path: &str, op: &str) {
+    match std::fs::canonicalize(new_path) {
+        Err(e) => log::warn!(
+            "{op} new-side canonicalize failed for {new_path}: {e} — index will trail until rebuild",
+        ),
+        Ok(new_path_buf) => match std::fs::read_to_string(&new_path_buf) {
+            Err(e) => log::warn!(
+                "{op} new-side read failed for {}: {e} — index will trail until rebuild",
+                new_path_buf.display(),
+            ),
+            Ok(content) => {
+                crate::commands::index_dispatch::dispatch_self_write(
+                    state,
+                    &new_path_buf,
+                    &content,
+                )
+                .await;
+            }
+        },
+    }
+}
+
 // ─── delete_file ─────────────────────────────────────────────────────────────
 
-/// Testable implementation body for delete_file.
-pub fn delete_file_impl(state: &VaultState, path: String) -> Result<(), VaultError> {
+/// Testable implementation body for delete_file. Returns the canonical path
+/// of the deleted source so the tauri wrapper can emit the synthetic
+/// `file_changed` event and dispatch the embed tombstone with the same
+/// canonical form the watcher would have used.
+///
+/// The index dispatch (RemoveLinks / RemoveTags / Tantivy DeleteFile +
+/// Commit) is part of the `_impl` contract, not the wrapper. Keeping it
+/// here means every caller — production wrapper AND unit tests — runs the
+/// same delete contract and a future change to the dispatch can't be
+/// forgotten in the wrapper alone.
+pub async fn delete_file_impl(state: &VaultState, path: String) -> Result<PathBuf, VaultError> {
     let target = PathBuf::from(&path);
     let canonical = ensure_inside_vault(state, &target)?;
 
@@ -543,7 +582,12 @@ pub fn delete_file_impl(state: &VaultState, path: String) -> Result<(), VaultErr
 
     std::fs::rename(&canonical, &dest).map_err(VaultError::Io)?;
 
-    Ok(())
+    // #339: write_ignore suppresses the watcher's natural remove event;
+    // dispatch the index cleanup directly so LinkGraph, TagIndex, and
+    // Tantivy all evict entries for the deleted source.
+    crate::commands::index_dispatch::dispatch_self_delete(state, &canonical).await;
+
+    Ok(canonical)
 }
 
 #[tauri::command]
@@ -553,14 +597,12 @@ pub async fn delete_file(
     path: String,
 ) -> Result<(), VaultError> {
     use tauri::Emitter;
-    // Canonicalize before delete so the emitted path matches the form the
-    // watcher would have used (and matches how tabs/sidebar store paths).
-    let canonical = std::fs::canonicalize(&path).ok();
-    let canonical_str = canonical
-        .as_ref()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|| path.clone());
-    delete_file_impl(&state, path)?;
+    // delete_file_impl returns the canonical source path AFTER a successful
+    // delete + index dispatch, so the synthetic event + embed tombstone use
+    // the same form the watcher would have seen.
+    let canonical = delete_file_impl(&state, path).await?;
+    let canonical_str = canonical.to_string_lossy().into_owned();
+
     // Bug #102: the watcher suppresses this delete via write_ignore (D-12),
     // so emit a synthetic file_changed event so tabs bound to the deleted
     // path close.
@@ -572,21 +614,12 @@ pub async fn delete_file(
             new_path: None,
         },
     );
-    // #339: RemoveLinks/RemoveTags + Tantivy delete for the deleted path.
-    // Without this the backlinks panel and tag counts hang on the deleted
-    // file's old references until cold restart (the watcher's natural
-    // dispatch is suppressed by write_ignore above).
-    if let Some(ref p) = canonical {
-        crate::commands::index_dispatch::dispatch_self_delete(&state, p).await;
-    }
     // #201 PR-A: tell the embed coordinator to tombstone this path's
     // vectors. Same reason as the synthetic file_changed event above —
     // write_ignore suppresses the watcher's natural Remove event so we
     // dispatch directly here.
     #[cfg(feature = "embeddings")]
-    if let Some(p) = canonical {
-        dispatch_embed_delete(&state, p);
-    }
+    dispatch_embed_delete(&state, canonical);
     Ok(())
 }
 
@@ -664,12 +697,7 @@ pub async fn move_file(
     if let Some(old) = old_canonical_for_tantivy {
         crate::commands::index_dispatch::dispatch_self_delete(&state, &old).await;
     }
-    let new_canonical = std::fs::canonicalize(&result).ok();
-    if let Some(new_path) = new_canonical.as_ref() {
-        if let Ok(content) = std::fs::read_to_string(new_path) {
-            crate::commands::index_dispatch::dispatch_self_write(&state, new_path, &content).await;
-        }
-    }
+    dispatch_new_side_after_rename(&state, &result, "move_file").await;
 
     #[cfg(feature = "embeddings")]
     if let Some(p) = old_canonical {

--- a/src-tauri/src/commands/index_dispatch.rs
+++ b/src-tauri/src/commands/index_dispatch.rs
@@ -1,0 +1,144 @@
+// Central dispatch for in-memory index updates from self-write paths.
+//
+// Lives in commands/ (not indexer::) because it knows about VaultState and
+// vault-relative path normalisation — command-layer concerns the indexer
+// should not depend on backwards (Socrates review of #339).
+//
+// The watcher's natural dispatch for write / rename / delete events on files
+// we touch ourselves is suppressed by `write_ignore` (D-12). Without these
+// helpers the in-memory LinkGraph, TagIndex, and Tantivy index would
+// silently trail the on-disk state until cold restart. Every self-mutating
+// command (write_file, merge_external_change on clean, delete_file,
+// rename_file, move_file, update_links_after_rename) routes through here.
+//
+// Best-effort contract: when the IndexCoordinator isn't attached (vault not
+// open / boot race) or the channel is full, we silently drop and let the
+// next cold-start rebuild repopulate. Disk-level failures stay with the
+// caller — we only dispatch after the caller has already succeeded on disk.
+
+use std::path::Path;
+
+use crate::indexer::{parser, tantivy_index, IndexCmd};
+use crate::VaultState;
+
+/// Dispatch all index updates for a file we just wrote ourselves.
+///
+/// Sends, in order:
+/// - `UpdateLinks { rel_path, content }` → refreshes LinkGraph + aliases in FileMeta
+/// - `UpdateTags { rel_path, content }`  → refreshes TagIndex
+/// - `AddFile { path, title, body, hash }` → updates Tantivy fulltext
+/// - `Commit`                             → flushes the writer so searches see the update
+///
+/// Callers: `write_file`, `merge_external_change` (clean branch),
+/// `update_links_after_rename` (per rewritten source), and the "new path"
+/// side of `rename_file` / `move_file`.
+///
+/// Fire-and-forget — no error propagation. A dropped send at this layer
+/// means the next cold start or `rebuild_index` will observe the true
+/// on-disk state, which is the same fallback the watcher path relies on.
+pub(crate) async fn dispatch_self_write(state: &VaultState, abs_path: &Path, content: &str) {
+    let vault_root = {
+        let Ok(guard) = state.current_vault.lock() else {
+            return;
+        };
+        match guard.as_ref() {
+            Some(p) => p.clone(),
+            None => return,
+        }
+    };
+
+    let Ok(rel) = abs_path.strip_prefix(&vault_root) else {
+        return;
+    };
+    let rel_path = rel.to_string_lossy().replace('\\', "/");
+
+    let tx = {
+        let Ok(guard) = state.index_coordinator.lock() else {
+            return;
+        };
+        match guard.as_ref() {
+            Some(c) => c.tx.clone(),
+            None => return,
+        }
+    };
+
+    let _ = tx
+        .send(IndexCmd::UpdateLinks {
+            rel_path: rel_path.clone(),
+            content: content.to_string(),
+        })
+        .await;
+    let _ = tx
+        .send(IndexCmd::UpdateTags {
+            rel_path,
+            content: content.to_string(),
+        })
+        .await;
+
+    let stem = abs_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let body = parser::strip_markdown(content);
+    let title = tantivy_index::extract_title(content, &stem);
+    let hash = crate::hash::hash_bytes(content.as_bytes());
+    let _ = tx
+        .send(IndexCmd::AddFile {
+            path: abs_path.to_path_buf(),
+            title,
+            body,
+            hash,
+        })
+        .await;
+    let _ = tx.send(IndexCmd::Commit).await;
+}
+
+/// Dispatch all index updates for a file we just deleted ourselves (or
+/// the OLD side of a rename/move).
+///
+/// Sends, in order:
+/// - `RemoveLinks { rel_path }` → evicts LinkGraph entries and in-edges
+/// - `RemoveTags  { rel_path }` → evicts TagIndex entries
+/// - `DeleteFile  { path }`     → evicts Tantivy doc by path term
+/// - `Commit`                    → flushes the writer
+///
+/// Best-effort — see `dispatch_self_write`.
+pub(crate) async fn dispatch_self_delete(state: &VaultState, abs_path: &Path) {
+    let vault_root = {
+        let Ok(guard) = state.current_vault.lock() else {
+            return;
+        };
+        match guard.as_ref() {
+            Some(p) => p.clone(),
+            None => return,
+        }
+    };
+
+    let Ok(rel) = abs_path.strip_prefix(&vault_root) else {
+        return;
+    };
+    let rel_path = rel.to_string_lossy().replace('\\', "/");
+
+    let tx = {
+        let Ok(guard) = state.index_coordinator.lock() else {
+            return;
+        };
+        match guard.as_ref() {
+            Some(c) => c.tx.clone(),
+            None => return,
+        }
+    };
+
+    let _ = tx
+        .send(IndexCmd::RemoveLinks {
+            rel_path: rel_path.clone(),
+        })
+        .await;
+    let _ = tx.send(IndexCmd::RemoveTags { rel_path }).await;
+    let _ = tx
+        .send(IndexCmd::DeleteFile {
+            path: abs_path.to_path_buf(),
+        })
+        .await;
+    let _ = tx.send(IndexCmd::Commit).await;
+}

--- a/src-tauri/src/commands/index_dispatch.rs
+++ b/src-tauri/src/commands/index_dispatch.rs
@@ -11,10 +11,18 @@
 // command (write_file, merge_external_change on clean, delete_file,
 // rename_file, move_file, update_links_after_rename) routes through here.
 //
-// Best-effort contract: when the IndexCoordinator isn't attached (vault not
-// open / boot race) or the channel is full, we silently drop and let the
-// next cold-start rebuild repopulate. Disk-level failures stay with the
-// caller — we only dispatch after the caller has already succeeded on disk.
+// Contract:
+// - When the IndexCoordinator isn't attached (vault not open / boot race),
+//   we silently no-op and let the next cold-start rebuild repopulate.
+// - When the coordinator IS attached, each `tx.send().await` applies async
+//   backpressure and blocks until the writer task accepts the command.
+//   The IPC thread is the right place to block (unlike the notify callback,
+//   which can't); the 8192-slot channel (#139) keeps bursts bounded.
+// - Send errors (writer task gone) are ignored — same observable effect as
+//   the no-coordinator case. The caller's disk write has already succeeded;
+//   the index trails until the next rebuild.
+// - Disk-level failures stay with the caller — we only dispatch after the
+//   caller has already succeeded on disk.
 
 use std::path::Path;
 

--- a/src-tauri/src/commands/index_dispatch.rs
+++ b/src-tauri/src/commands/index_dispatch.rs
@@ -26,8 +26,37 @@
 
 use std::path::Path;
 
+use tokio::sync::mpsc::Sender;
+
 use crate::indexer::{parser, tantivy_index, IndexCmd};
 use crate::VaultState;
+
+/// Enqueue a Tantivy `AddFile` command for `abs_path` using `content` as
+/// the source. Sole authority for the Tantivy document shape — every
+/// self-write path (dispatch_self_write, update_links_after_rename
+/// cascade, any future caller) must route through here so title / body /
+/// hash extraction stays consistent.
+///
+/// Fire-and-forget: drops the send error on a closed channel (writer
+/// gone). Does NOT enqueue the Commit — callers batch multiple AddFiles
+/// followed by a single Commit.
+pub(crate) async fn dispatch_tantivy_upsert(tx: &Sender<IndexCmd>, abs_path: &Path, content: &str) {
+    let stem = abs_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let title = tantivy_index::extract_title(content, &stem);
+    let body = parser::strip_markdown(content);
+    let hash = crate::hash::hash_bytes(content.as_bytes());
+    let _ = tx
+        .send(IndexCmd::AddFile {
+            path: abs_path.to_path_buf(),
+            title,
+            body,
+            hash,
+        })
+        .await;
+}
 
 /// Dispatch all index updates for a file we just wrote ourselves.
 ///
@@ -83,21 +112,7 @@ pub(crate) async fn dispatch_self_write(state: &VaultState, abs_path: &Path, con
         })
         .await;
 
-    let stem = abs_path
-        .file_stem()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let body = parser::strip_markdown(content);
-    let title = tantivy_index::extract_title(content, &stem);
-    let hash = crate::hash::hash_bytes(content.as_bytes());
-    let _ = tx
-        .send(IndexCmd::AddFile {
-            path: abs_path.to_path_buf(),
-            title,
-            body,
-            hash,
-        })
-        .await;
+    dispatch_tantivy_upsert(&tx, abs_path, content).await;
     let _ = tx.send(IndexCmd::Commit).await;
 }
 

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -469,8 +469,9 @@ pub async fn update_links_after_rename(
     // until re-indexing. The link graph is already updated inline above
     // (#250 keeps that direct-mutation path for perf — routing through
     // dispatch_self_write would regress the StemIndex optimization). Fire
-    // just the Tantivy side here. Tags are not affected — the rewrite
-    // only touches wiki-link text.
+    // just the Tantivy side here via the shared upsert helper so the
+    // document shape stays in sync with dispatch_self_write. Tags aren't
+    // affected — the rewrite only touches wiki-link text.
     let tx = {
         let guard = state.index_coordinator.lock().map_err(|_| VaultError::IndexCorrupt)?;
         guard.as_ref().map(|c| c.tx.clone())
@@ -478,20 +479,7 @@ pub async fn update_links_after_rename(
     if let Some(tx) = tx {
         for (source_rel, new_content) in &rewrites {
             let abs_path = vault_root.join(source_rel);
-            let stem = abs_path
-                .file_stem()
-                .map(|s| s.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            let title = crate::indexer::tantivy_index::extract_title(new_content, &stem);
-            let body = crate::indexer::parser::strip_markdown(new_content);
-            let hash = crate::hash::hash_bytes(new_content.as_bytes());
-            let _ = tx
-                .send(crate::indexer::IndexCmd::AddFile {
-                    path: abs_path,
-                    title,
-                    body,
-                    hash,
-                })
+            crate::commands::index_dispatch::dispatch_tantivy_upsert(&tx, &abs_path, new_content)
                 .await;
         }
         let _ = tx.send(crate::indexer::IndexCmd::Commit).await;

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -464,6 +464,39 @@ pub async fn update_links_after_rename(
         }
     }
 
+    // #339: each rewritten source has new body text (`[[old]]` → `[[new]]`),
+    // so Tantivy fulltext hits for the old stem in these files are stale
+    // until re-indexing. The link graph is already updated inline above
+    // (#250 keeps that direct-mutation path for perf — routing through
+    // dispatch_self_write would regress the StemIndex optimization). Fire
+    // just the Tantivy side here. Tags are not affected — the rewrite
+    // only touches wiki-link text.
+    let tx = {
+        let guard = state.index_coordinator.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        guard.as_ref().map(|c| c.tx.clone())
+    };
+    if let Some(tx) = tx {
+        for (source_rel, new_content) in &rewrites {
+            let abs_path = vault_root.join(source_rel);
+            let stem = abs_path
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let title = crate::indexer::tantivy_index::extract_title(new_content, &stem);
+            let body = crate::indexer::parser::strip_markdown(new_content);
+            let hash = crate::hash::hash_bytes(new_content.as_bytes());
+            let _ = tx
+                .send(crate::indexer::IndexCmd::AddFile {
+                    path: abs_path,
+                    title,
+                    body,
+                    hash,
+                })
+                .await;
+        }
+        let _ = tx.send(crate::indexer::IndexCmd::Commit).await;
+    }
+
     let updated_paths: Vec<String> = rewrites.into_iter().map(|(rel, _)| rel).collect();
 
     Ok(RenameResult {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod vault;
 pub mod files;
+pub mod index_dispatch;
 pub mod tree;
 pub mod search;
 pub mod links;

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -402,20 +402,31 @@ pub(crate) fn format_iso8601_utc(epoch_secs: i64) -> String {
 
 /// Result returned by the merge_external_change command.
 ///
-/// `new_hash` is `Some(...)` on "clean" — the backend has written the merged
-/// bytes to disk and the returned hash is SHA-256 of `merged_content` (matches
-/// `hash_bytes` / the value `write_file` returns, so callers can align
-/// `lastSavedHash` without hashing client-side). `None` on "conflict" — the
-/// backend did not write; disk still holds the external content and the
-/// caller keeps the local buffer (issue #339).
+/// Tagged enum: `outcome` discriminates, and each variant carries exactly
+/// the payload that makes sense for it. Clean always has a `new_hash` (the
+/// backend wrote the merged bytes to disk); Conflict never does (the
+/// backend left disk untouched). Serialized shape:
+///
+/// - `{ "outcome": "clean",    "merged_content": "...", "new_hash": "..." }`
+/// - `{ "outcome": "conflict", "merged_content": "..." }`
+///
+/// The frontend consumer in `externalChangeHandler.ts` narrows on
+/// `outcome` before reading variant-specific fields.
 #[derive(Serialize, Clone, Debug)]
-pub struct MergeCommandResult {
-    /// "clean" or "conflict"
-    pub outcome: String,
-    /// The merged content (for "clean") or the original local content (for "conflict")
-    pub merged_content: String,
-    /// SHA-256 hex of the merged bytes written to disk. `None` on conflict.
-    pub new_hash: Option<String>,
+#[serde(tag = "outcome", rename_all = "lowercase")]
+pub enum MergeCommandResult {
+    /// Three-way merge produced a non-conflicting result. The backend has
+    /// written `merged_content` to disk; `new_hash` is SHA-256 of those
+    /// bytes (matches `hash_bytes` / the value `write_file` returns, so
+    /// callers can align `lastSavedHash` without hashing client-side).
+    Clean {
+        merged_content: String,
+        new_hash: String,
+    },
+    /// Merge could not be resolved without overlap. Backend did NOT write.
+    /// `merged_content` here is the local (editor) content — the caller
+    /// keeps it and lets the next autosave write through deliberately.
+    Conflict { merged_content: String },
 }
 
 /// Perform a three-way merge for an external file change.
@@ -530,10 +541,9 @@ pub(crate) async fn merge_external_change_impl(
 
             let new_hash = crate::hash::hash_bytes(bytes);
 
-            Ok(MergeCommandResult {
-                outcome: "clean".to_string(),
+            Ok(MergeCommandResult::Clean {
                 merged_content: merged,
-                new_hash: Some(new_hash),
+                new_hash,
             })
         }
         MergeOutcome::Conflict(local) => {
@@ -545,10 +555,8 @@ pub(crate) async fn merge_external_change_impl(
             // watcher dropped its dispatch via channel overflow (#139),
             // the graph is transiently stale here — that's #139's territory,
             // not this fix's.
-            Ok(MergeCommandResult {
-                outcome: "conflict".to_string(),
+            Ok(MergeCommandResult::Conflict {
                 merged_content: local,
-                new_hash: None,
             })
         }
     }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -401,12 +401,21 @@ pub(crate) fn format_iso8601_utc(epoch_secs: i64) -> String {
 // ─── merge_external_change command ───────────────────────────────────────────
 
 /// Result returned by the merge_external_change command.
+///
+/// `new_hash` is `Some(...)` on "clean" — the backend has written the merged
+/// bytes to disk and the returned hash is SHA-256 of `merged_content` (matches
+/// `hash_bytes` / the value `write_file` returns, so callers can align
+/// `lastSavedHash` without hashing client-side). `None` on "conflict" — the
+/// backend did not write; disk still holds the external content and the
+/// caller keeps the local buffer (issue #339).
 #[derive(Serialize, Clone, Debug)]
 pub struct MergeCommandResult {
     /// "clean" or "conflict"
     pub outcome: String,
     /// The merged content (for "clean") or the original local content (for "conflict")
     pub merged_content: String,
+    /// SHA-256 hex of the merged bytes written to disk. `None` on conflict.
+    pub new_hash: Option<String>,
 }
 
 /// Perform a three-way merge for an external file change.
@@ -419,9 +428,28 @@ pub struct MergeCommandResult {
 ///
 /// Security: path is validated to be inside the open vault before reading disk
 /// content (T-02-18 mitigation).
+///
+/// Issue #339: on a clean merge the backend now *writes the merged bytes to
+/// disk itself* and dispatches the same IndexCmd updates `write_file` does.
+/// The frontend no longer writes on clean-merge; it consumes `new_hash` and
+/// aligns its `lastSavedHash` tracker. The watcher-driven event for our own
+/// write is suppressed by `write_ignore` (D-12); dispatching inline here is
+/// what keeps the in-memory LinkGraph / TagIndex / Tantivy index in sync.
 #[tauri::command]
 pub async fn merge_external_change(
     state: tauri::State<'_, crate::VaultState>,
+    path: String,
+    editor_content: String,
+    last_saved_content: String,
+) -> Result<MergeCommandResult, crate::error::VaultError> {
+    merge_external_change_impl(&state, path, editor_content, last_saved_content).await
+}
+
+/// Testable body of `merge_external_change`. See the note in
+/// `commands/files.rs:16-20` on the `tauri::State`-can't-be-constructed
+/// convention.
+pub(crate) async fn merge_external_change_impl(
+    state: &crate::VaultState,
     path: String,
     editor_content: String,
     last_saved_content: String,
@@ -457,16 +485,75 @@ pub async fn merge_external_change(
     let merge_result = three_way_merge(&last_saved_content, &editor_content, &disk_content);
 
     match merge_result {
-        MergeOutcome::Clean(merged) => Ok(MergeCommandResult {
-            outcome: "clean".to_string(),
-            merged_content: merged,
-        }),
-        MergeOutcome::Conflict(local) => Ok(MergeCommandResult {
-            outcome: "conflict".to_string(),
-            merged_content: local,
-        }),
+        MergeOutcome::Clean(merged) => {
+            let is_md = canonical
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("md"));
+
+            // D-12 / BUG-05.1: record write_ignore BEFORE the disk write so
+            // the watcher's resulting modify event gets suppressed. Without
+            // this the watcher path + the inline dispatch below would both
+            // fire UpdateLinks for the same content — harmless but noisy.
+            if let Ok(mut list) = state.write_ignore.lock() {
+                list.record(canonical.clone());
+            }
+
+            let bytes = merged.as_bytes();
+            std::fs::write(&canonical, bytes).map_err(|e| match e.kind() {
+                std::io::ErrorKind::PermissionDenied => {
+                    crate::error::VaultError::PermissionDenied { path: path.clone() }
+                }
+                std::io::ErrorKind::StorageFull => crate::error::VaultError::DiskFull,
+                _ => crate::error::VaultError::Io(e),
+            })?;
+
+            // Index dispatch — write_ignore suppresses the watcher, so we
+            // dispatch LinkGraph + TagIndex + Tantivy updates ourselves.
+            if is_md {
+                crate::commands::index_dispatch::dispatch_self_write(
+                    state,
+                    &canonical,
+                    &merged,
+                )
+                .await;
+            }
+
+            // #196 parity: re-embed the merged content (non-blocking).
+            #[cfg(feature = "embeddings")]
+            if is_md {
+                crate::commands::files::dispatch_embed_update(
+                    state,
+                    canonical.clone(),
+                    &merged,
+                );
+            }
+
+            let new_hash = crate::hash::hash_bytes(bytes);
+
+            Ok(MergeCommandResult {
+                outcome: "clean".to_string(),
+                merged_content: merged,
+                new_hash: Some(new_hash),
+            })
+        }
+        MergeOutcome::Conflict(local) => {
+            // No disk write, no dispatch. The watcher already dispatched
+            // UpdateLinks/UpdateTags for the external content when the
+            // event fired; the local buffer doesn't live on disk until the
+            // user resolves the conflict with a later save (which goes
+            // through `write_file` and dispatches its own updates). If the
+            // watcher dropped its dispatch via channel overflow (#139),
+            // the graph is transiently stale here — that's #139's territory,
+            // not this fix's.
+            Ok(MergeCommandResult {
+                outcome: "conflict".to_string(),
+                merged_content: local,
+                new_hash: None,
+            })
+        }
     }
 }
+
 
 // ─── #201 PR-B: reindex IPC ──────────────────────────────────────────────────
 

--- a/src-tauri/src/tests/files_ops.rs
+++ b/src-tauri/src/tests/files_ops.rs
@@ -83,8 +83,8 @@ fn create_folder_creates_directory() {
 }
 
 // Test 5: rename_file renames on disk, returns link_count=0 when no links
-#[test]
-fn rename_file_renames_and_returns_zero_link_count() {
+#[tokio::test]
+async fn rename_file_renames_and_returns_zero_link_count() {
     let dir = tempdir().unwrap();
     let state = state_with_vault(dir.path());
     let old_path = dir.path().join("old.md");
@@ -93,7 +93,9 @@ fn rename_file_renames_and_returns_zero_link_count() {
         &state,
         old_path.to_string_lossy().into_owned(),
         "new.md".into(),
-    ).unwrap();
+    )
+    .await
+    .unwrap();
     let expected_new = dir.path().join("new.md");
     assert!(!old_path.exists(), "old.md should no longer exist");
     assert!(expected_new.exists(), "new.md should exist");
@@ -102,8 +104,8 @@ fn rename_file_renames_and_returns_zero_link_count() {
 }
 
 // Test 6: rename_file returns link_count>0 when wiki-links exist
-#[test]
-fn rename_file_counts_wiki_links() {
+#[tokio::test]
+async fn rename_file_counts_wiki_links() {
     let dir = tempdir().unwrap();
     let state = state_with_vault(dir.path());
     // Create a file to rename
@@ -117,7 +119,9 @@ fn rename_file_counts_wiki_links() {
         &state,
         target.to_string_lossy().into_owned(),
         "renamed.md".into(),
-    ).unwrap();
+    )
+    .await
+    .unwrap();
     assert!(result.link_count >= 2, "Should have found at least 2 wiki-links, got {}", result.link_count);
 }
 
@@ -162,8 +166,8 @@ async fn delete_file_collision_in_trash_auto_suffixes() {
 }
 
 // Test 9: move_file moves to target folder and returns new path
-#[test]
-fn move_file_moves_to_target_folder() {
+#[tokio::test]
+async fn move_file_moves_to_target_folder() {
     let dir = tempdir().unwrap();
     let state = state_with_vault(dir.path());
     let source = dir.path().join("source.md");
@@ -174,7 +178,9 @@ fn move_file_moves_to_target_folder() {
         &state,
         source.to_string_lossy().into_owned(),
         dest_folder.to_string_lossy().into_owned(),
-    ).unwrap();
+    )
+    .await
+    .unwrap();
     let expected_dest = dest_folder.join("source.md");
     assert!(!source.exists(), "Source file should be gone");
     assert!(expected_dest.exists(), "File should be in destination folder");
@@ -182,8 +188,8 @@ fn move_file_moves_to_target_folder() {
 }
 
 // Test 10: move_file rejects destination outside vault
-#[test]
-fn move_file_rejects_outside_vault() {
+#[tokio::test]
+async fn move_file_rejects_outside_vault() {
     let vault_dir = tempdir().unwrap();
     let outside_dir = tempdir().unwrap();
     let state = state_with_vault(vault_dir.path());
@@ -193,7 +199,8 @@ fn move_file_rejects_outside_vault() {
         &state,
         source.to_string_lossy().into_owned(),
         outside_dir.path().to_string_lossy().into_owned(),
-    );
+    )
+    .await;
     match result {
         Err(VaultError::PermissionDenied { .. }) => {}
         other => panic!("expected PermissionDenied, got {:?}", other),

--- a/src-tauri/src/tests/files_ops.rs
+++ b/src-tauri/src/tests/files_ops.rs
@@ -122,13 +122,15 @@ fn rename_file_counts_wiki_links() {
 }
 
 // Test 7: delete_file moves to .trash/, auto-creates .trash/, original gone
-#[test]
-fn delete_file_moves_to_trash_and_removes_original() {
+#[tokio::test]
+async fn delete_file_moves_to_trash_and_removes_original() {
     let dir = tempdir().unwrap();
     let state = state_with_vault(dir.path());
     let file_path = dir.path().join("deleteme.md");
     fs::write(&file_path, "content").unwrap();
-    delete_file_impl(&state, file_path.to_string_lossy().into_owned()).unwrap();
+    delete_file_impl(&state, file_path.to_string_lossy().into_owned())
+        .await
+        .unwrap();
     // Original should be gone
     assert!(!file_path.exists(), "Original file should be gone");
     // .trash/ should be created
@@ -140,8 +142,8 @@ fn delete_file_moves_to_trash_and_removes_original() {
 }
 
 // Test 8: delete_file collision in .trash/ auto-suffixes
-#[test]
-fn delete_file_collision_in_trash_auto_suffixes() {
+#[tokio::test]
+async fn delete_file_collision_in_trash_auto_suffixes() {
     let dir = tempdir().unwrap();
     let state = state_with_vault(dir.path());
     // Pre-populate .trash/ with a file of the same name
@@ -151,7 +153,9 @@ fn delete_file_collision_in_trash_auto_suffixes() {
     // Now delete a file with the same name
     let file_path = dir.path().join("note.md");
     fs::write(&file_path, "new content").unwrap();
-    delete_file_impl(&state, file_path.to_string_lossy().into_owned()).unwrap();
+    delete_file_impl(&state, file_path.to_string_lossy().into_owned())
+        .await
+        .unwrap();
     // Should create "note 1.md" in .trash/
     let suffixed = trash_dir.join("note 1.md");
     assert!(suffixed.exists(), "note 1.md should be created in .trash/ on collision");

--- a/src-tauri/src/tests/merge_external_change.rs
+++ b/src-tauri/src/tests/merge_external_change.rs
@@ -3,11 +3,9 @@
 // and dispatches UpdateLinks / UpdateTags / Tantivy AddFile + Commit so
 // the in-memory indexes never trail the on-disk state.
 //
-// These tests drive a `_impl` mirror of the command body (see the note in
-// tests/files.rs:16-20 — tauri::State cannot be constructed outside a
-// running Tauri app). The mirror here reflects the CURRENT command body;
-// Phase 2 of the ticket replaces it with a call into a real `_impl`
-// helper in commands/vault.rs. Until then these tests are red.
+// Tests drive `merge_external_change_impl` in commands/vault.rs directly
+// (tauri::State can't be constructed outside a running Tauri app, see
+// tests/files.rs:16-20 for the convention).
 
 #![cfg(test)]
 #![allow(clippy::await_holding_lock)]
@@ -112,7 +110,24 @@ async fn wait_for<F: Fn() -> bool>(desc: &str, cond: F) {
 
 // Tests drive the real `_impl` in commands/vault.rs directly — no mirror
 // needed because merge_external_change_impl is `pub(crate)`.
-use crate::commands::vault::merge_external_change_impl;
+use crate::commands::vault::{merge_external_change_impl, MergeCommandResult};
+
+/// Destructure `MergeCommandResult` into flat `(outcome, merged_content,
+/// new_hash)` triples so tests can assert without repeating a match at
+/// every call site. The tagged enum is the source of truth on the
+/// production side (see `commands/vault.rs::MergeCommandResult`); this
+/// helper just saves boilerplate.
+fn parts(r: &MergeCommandResult) -> (&'static str, &str, Option<&str>) {
+    match r {
+        MergeCommandResult::Clean {
+            merged_content,
+            new_hash,
+        } => ("clean", merged_content.as_str(), Some(new_hash.as_str())),
+        MergeCommandResult::Conflict { merged_content } => {
+            ("conflict", merged_content.as_str(), None)
+        }
+    }
+}
 
 // ─── Test 1: add link ────────────────────────────────────────────────────────
 
@@ -143,8 +158,9 @@ fn merge_clean_external_add_links_refreshes_backlinks() {
         .await
         .expect("merge ok");
 
-        assert_eq!(result.outcome, "clean");
-        assert_eq!(result.merged_content, external);
+        let (outcome, merged, _) = parts(&result);
+        assert_eq!(outcome, "clean");
+        assert_eq!(merged, external);
 
         drain(&state).await;
 
@@ -197,7 +213,7 @@ fn merge_clean_external_remove_link_shrinks_backlinks() {
         .await
         .expect("merge ok");
 
-        assert_eq!(result.outcome, "clean");
+        assert_eq!(parts(&result).0, "clean");
 
         drain(&state).await;
 
@@ -345,11 +361,12 @@ fn merge_clean_writes_merged_bytes_to_disk() {
         .await
         .expect("merge ok");
 
-        assert_eq!(result.outcome, "clean");
+        let (outcome, merged, _) = parts(&result);
+        assert_eq!(outcome, "clean");
 
         let on_disk = std::fs::read_to_string(&b_abs).unwrap();
         assert_eq!(
-            on_disk, result.merged_content,
+            on_disk, merged,
             "disk must match merged_content after authoritative write",
         );
     });
@@ -410,9 +427,10 @@ fn merge_clean_returns_hash_of_merged_content() {
         .await
         .expect("merge ok");
 
-        let expected = crate::hash::hash_bytes(result.merged_content.as_bytes());
+        let (_, merged, new_hash) = parts(&result);
+        let expected = crate::hash::hash_bytes(merged.as_bytes());
         assert_eq!(
-            result.new_hash.as_deref(),
+            new_hash,
             Some(expected.as_str()),
             "new_hash must equal SHA-256 of merged_content on clean",
         );
@@ -507,10 +525,11 @@ fn merge_conflict_keeps_local_and_skips_disk_write_and_dispatch() {
         .await
         .expect("merge ok");
 
-        assert_eq!(result.outcome, "conflict");
-        assert_eq!(result.merged_content, editor);
+        let (outcome, merged, new_hash) = parts(&result);
+        assert_eq!(outcome, "conflict");
+        assert_eq!(merged, editor);
         assert!(
-            result.new_hash.is_none(),
+            new_hash.is_none(),
             "new_hash must be None on conflict — backend did not write",
         );
 
@@ -555,7 +574,7 @@ fn merge_non_md_file_does_not_dispatch_index() {
         .await
         .expect("merge ok");
 
-        assert_eq!(result.outcome, "clean");
+        assert_eq!(parts(&result).0, "clean");
 
         drain(&state).await;
 
@@ -600,79 +619,119 @@ fn merge_outside_vault_returns_permission_denied_and_does_not_dispatch() {
     });
 }
 
-// ─── Test 12 (bis): delete refreshes backlinks + tags ───────────────────────
+// ─── Test 12 (bis): delete evicts the deleted file from LinkGraph + TagIndex ─
 
 #[test]
-fn delete_refreshes_backlinks_and_tags() {
+fn delete_evicts_deleted_file_from_link_graph_and_tag_index() {
     // Covers the #339 audit gap: before the fix, delete_file recorded
     // write_ignore and moved the file to .trash but never dispatched
     // RemoveLinks / RemoveTags, leaving the graphs stale.
+    //
+    // Drives `delete_file_impl` directly — dispatch lives inside `_impl`
+    // (see commands/files.rs::delete_file_impl), so this test covers the
+    // exact production contract the tauri wrapper exercises, not a
+    // side-channel of manually-chained helpers.
     tokio_test_block_on(async {
         let tmp = TempDir::new().unwrap();
         let vault = tmp.path();
-        let a_abs = write_md(vault, "A.md", "# A\n");
+        // A.md carries its own tags so we can assert both link-graph AND
+        // tag-index eviction for the deleted file.
+        let a_abs = write_md(vault, "A.md", "# A\n[[B]]\n#alpha\n#shared\n");
         write_md(vault, "B.md", "[[A]]\n#shared\n");
 
         let state = state_with_vault_and_coord(vault).await;
 
-        // Precondition: the graphs reflect the seed.
+        // Precondition: indexes reflect the seeded content. Without this
+        // the post-delete assertions could pass trivially on an empty
+        // graph. We assert every piece the fix is supposed to evict.
         {
             let coord_guard = state.index_coordinator.lock().unwrap();
             let coord = coord_guard.as_ref().unwrap();
             let lg = coord.link_graph();
             let ti = coord.tag_index();
+
+            let lg_guard = lg.lock().unwrap();
             assert!(
-                lg.lock()
-                    .unwrap()
-                    .outgoing_for("B.md")
-                    .unwrap_or_default()
-                    .iter()
-                    .any(|l| l.target_raw == "A"),
-                "B.md must link to A pre-delete",
+                lg_guard.outgoing_for("A.md").is_some(),
+                "A.md must be a link-graph source pre-delete",
             );
+            drop(lg_guard);
+
+            let ti_guard = ti.lock().unwrap();
             assert!(
-                ti.lock()
-                    .unwrap()
-                    .tags_for_file("B.md")
-                    .iter()
-                    .any(|t| t == "shared"),
-                "B.md must have #shared pre-delete",
+                ti_guard.tags_for_file("A.md").iter().any(|t| t == "alpha"),
+                "A.md must carry #alpha pre-delete",
+            );
+            assert_eq!(
+                ti_guard
+                    .list_tags()
+                    .into_iter()
+                    .find(|u| u.tag == "shared")
+                    .map(|u| u.count)
+                    .unwrap_or(0),
+                2,
+                "#shared must be on both files pre-delete",
             );
         }
 
-        // Drive delete via the command body (the tauri wrapper needs an
-        // AppHandle we can't synthesize cleanly). `delete_file_impl` + the
-        // explicit dispatch mirror what `delete_file` does, exactly as the
-        // files.rs `_impl` convention prescribes.
+        // Drive the real production contract: delete_file_impl performs
+        // the disk rename AND the index dispatch. If a future change
+        // removes the dispatch from _impl, the assertions below break.
         crate::commands::files::delete_file_impl(&state, a_abs.to_string_lossy().into_owned())
+            .await
             .expect("delete ok");
-        crate::commands::index_dispatch::dispatch_self_delete(&state, &a_abs).await;
 
         drain(&state).await;
 
         let coord_guard = state.index_coordinator.lock().unwrap();
         let coord = coord_guard.as_ref().unwrap();
         let lg = coord.link_graph();
-        let fi = coord.file_index();
+        let ti = coord.tag_index();
 
-        // A.md is gone from outgoing (source was deleted).
+        // A.md evicted from LinkGraph: no outgoing, no tag entries.
         wait_for("A.md dropped from link graph", || {
-            let lg_guard = lg.lock().unwrap();
-            lg_guard.outgoing_for("A.md").is_none()
+            lg.lock().unwrap().outgoing_for("A.md").is_none()
+        })
+        .await;
+        wait_for("A.md dropped from tag index", || {
+            ti.lock().unwrap().tags_for_file("A.md").is_empty()
         })
         .await;
 
-        // B.md's [[A]] link becomes unresolved (A no longer exists).
+        // Global tag counts shrink: #alpha is gone entirely, #shared drops to 1.
+        let ti_guard = ti.lock().unwrap();
+        assert!(
+            !ti_guard.list_tags().iter().any(|u| u.tag == "alpha"),
+            "#alpha should be gone from the global list",
+        );
+        assert_eq!(
+            ti_guard
+                .list_tags()
+                .into_iter()
+                .find(|u| u.tag == "shared")
+                .map(|u| u.count)
+                .unwrap_or(0),
+            1,
+            "#shared count must drop to 1 (only B.md remains)",
+        );
+
+        // Incoming edge from B.md → A.md is still present in LinkGraph,
+        // because RemoveLinks only evicts A as a SOURCE. Re-resolving
+        // every file that pointed at A is a separate responsibility
+        // (cascade re-resolution on delete) and isn't what #339 fixes —
+        // we assert the incoming-edge shape here to lock the CURRENT
+        // contract in place, so a future cascade-resolution change
+        // deliberately breaks this assertion and forces a re-read.
         let lg_guard = lg.lock().unwrap();
-        let fi_guard = fi.read().unwrap();
-        let a_backlinks = lg_guard.get_backlinks("A.md", &fi_guard);
-        // Backlinks list may still contain B.md (it points at the now-
-        // missing target). What matters is that nothing falsely claims
-        // the deleted file still has outgoing links.
-        // The critical assertion: outgoing_for(A) is None after dispatch.
-        drop(lg_guard);
-        drop(fi_guard);
-        let _ = a_backlinks; // touched for clarity
+        let incoming = lg_guard
+            .incoming_for("A.md")
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            incoming.iter().any(|src| src == "B.md"),
+            "B.md's [[A]] edge is expected to remain in LinkGraph after A's deletion \
+             (cascade re-resolution is out of #339 scope); got incoming = {incoming:?}",
+        );
     });
 }
 
@@ -698,10 +757,10 @@ fn merge_channel_absent_does_not_error() {
         )
         .await;
 
-        // Must succeed even with no coordinator — dispatches are best-effort
-        // and silently drop.
+        // Must succeed even with no coordinator — dispatches no-op when
+        // the coordinator isn't attached (see dispatch_self_write contract).
         assert!(result.is_ok(), "merge must not error without a coordinator");
         let r = result.unwrap();
-        assert_eq!(r.outcome, "clean");
+        assert_eq!(parts(&r).0, "clean");
     });
 }

--- a/src-tauri/src/tests/merge_external_change.rs
+++ b/src-tauri/src/tests/merge_external_change.rs
@@ -1,0 +1,707 @@
+// Issue #339: merge_external_change must be an authoritative write path —
+// on "clean" it writes the merged bytes to disk, records write_ignore,
+// and dispatches UpdateLinks / UpdateTags / Tantivy AddFile + Commit so
+// the in-memory indexes never trail the on-disk state.
+//
+// These tests drive a `_impl` mirror of the command body (see the note in
+// tests/files.rs:16-20 — tauri::State cannot be constructed outside a
+// running Tauri app). The mirror here reflects the CURRENT command body;
+// Phase 2 of the ticket replaces it with a call into a real `_impl`
+// helper in commands/vault.rs. Until then these tests are red.
+
+#![cfg(test)]
+#![allow(clippy::await_holding_lock)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::time::{sleep, timeout};
+
+use crate::error::VaultError;
+use crate::indexer::{IndexCmd, IndexCoordinator};
+use crate::VaultState;
+
+// ─── harness helpers ────────────────────────────────────────────────────────
+
+fn tokio_test_block_on<F: std::future::Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+/// Build a VaultState with no IndexCoordinator wired up. Used for test #12
+/// (channel-absent) and for the out-of-vault guard test where no index
+/// operations are expected.
+fn state_with_vault_no_coord(root: &Path) -> VaultState {
+    let canonical = std::fs::canonicalize(root).unwrap();
+    let s = VaultState::default();
+    *s.current_vault.lock().unwrap() = Some(canonical);
+    s
+}
+
+/// Build a VaultState with a fresh IndexCoordinator attached, sharing the
+/// same `file_index` Arc (mirrors what `open_vault` does in production).
+/// Runs a single `index_vault` pass so link/tag state is primed before the
+/// test drives merges.
+async fn state_with_vault_and_coord(root: &Path) -> VaultState {
+    let canonical = std::fs::canonicalize(root).unwrap();
+    let state = VaultState::default();
+    *state.current_vault.lock().unwrap() = Some(canonical.clone());
+
+    let coord =
+        IndexCoordinator::new_with_file_index(&canonical, Arc::clone(&state.file_index))
+            .await
+            .expect("coord new");
+
+    // Seed LinkGraph + TagIndex + Tantivy with the vault's current contents
+    // so the tests can assert deltas against a known baseline.
+    let handle = tauri::test::mock_app().handle().clone();
+    coord
+        .index_vault(&canonical, &handle)
+        .await
+        .expect("initial index_vault");
+
+    *state.index_coordinator.lock().unwrap() = Some(coord);
+    state
+}
+
+/// Write a `.md` file at `vault/rel`, creating parents as needed.
+fn write_md(vault: &Path, rel: &str, body: &str) -> PathBuf {
+    let abs = vault.join(rel);
+    if let Some(parent) = abs.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir -p");
+    }
+    std::fs::write(&abs, body).expect("write md");
+    abs
+}
+
+/// Flush the IndexCoordinator's command queue by sending Commit + spinning
+/// until the mpsc has drained. IndexCmd processing is FIFO, so once our
+/// Commit lands in the coordinator's reader the prior UpdateLinks /
+/// UpdateTags commands have been applied to the in-memory indexes.
+async fn drain(state: &VaultState) {
+    let tx = {
+        let guard = state.index_coordinator.lock().unwrap();
+        guard.as_ref().map(|c| c.tx.clone())
+    };
+    if let Some(tx) = tx {
+        let _ = tx.send(IndexCmd::Commit).await;
+    }
+    // Minimal yield so the worker task picks the command up.
+    sleep(Duration::from_millis(50)).await;
+}
+
+/// Bounded-poll barrier: evaluate `cond` every 25 ms up to 2 s, return when it
+/// yields `true` or panic with a diagnostic message on timeout.
+async fn wait_for<F: Fn() -> bool>(desc: &str, cond: F) {
+    let res = timeout(Duration::from_secs(2), async {
+        loop {
+            if cond() {
+                return;
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    assert!(res.is_ok(), "wait_for timed out: {desc}");
+}
+
+// Tests drive the real `_impl` in commands/vault.rs directly — no mirror
+// needed because merge_external_change_impl is `pub(crate)`.
+use crate::commands::vault::merge_external_change_impl;
+
+// ─── Test 1: add link ────────────────────────────────────────────────────────
+
+#[test]
+fn merge_clean_external_add_links_refreshes_backlinks() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        write_md(vault, "A.md", "# A\n");
+        let b_abs = write_md(vault, "B.md", "[[A]]\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        // External tool adds a second link pointing at an unresolved target "C".
+        let external = "[[A]]\n[[C]]\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        // Editor buffer still reflects the pre-external state.
+        let editor = "[[A]]\n";
+        let base = "[[A]]\n";
+
+        let result = merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            editor.to_string(),
+            base.to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        assert_eq!(result.outcome, "clean");
+        assert_eq!(result.merged_content, external);
+
+        drain(&state).await;
+
+        let coord_guard = state.index_coordinator.lock().unwrap();
+        let coord = coord_guard.as_ref().expect("coord present");
+        let lg = coord.link_graph();
+
+        wait_for("B.md outgoing contains A and C", || {
+            let lg_guard = lg.lock().unwrap();
+            let targets = lg_guard.outgoing_targets_for("B.md").unwrap_or_default();
+            let raws: Vec<&str> = targets.iter().map(|(_, raw)| raw.as_str()).collect();
+            raws.contains(&"A") && raws.contains(&"C")
+        })
+        .await;
+
+        let lg_guard = lg.lock().unwrap();
+        let unresolved = lg_guard.get_unresolved();
+        assert!(
+            unresolved
+                .iter()
+                .any(|u| u.source_path == "B.md" && u.target_raw == "C"),
+            "expected B.md → C in unresolved, got {:?}",
+            unresolved,
+        );
+    });
+}
+
+// ─── Test 2: remove link ─────────────────────────────────────────────────────
+
+#[test]
+fn merge_clean_external_remove_link_shrinks_backlinks() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        write_md(vault, "A.md", "# A\n");
+        let b_abs = write_md(vault, "B.md", "[[A]]\n[[C]]\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        // External tool strips B.md to just a title — links gone.
+        let external = "# B only\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        let result = merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            "[[A]]\n[[C]]\n".to_string(),
+            "[[A]]\n[[C]]\n".to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        assert_eq!(result.outcome, "clean");
+
+        drain(&state).await;
+
+        let coord_guard = state.index_coordinator.lock().unwrap();
+        let coord = coord_guard.as_ref().expect("coord present");
+        let lg = coord.link_graph();
+        let fi = coord.file_index();
+
+        wait_for("A.md backlinks drop to zero", || {
+            let lg_guard = lg.lock().unwrap();
+            let fi_guard = fi.read().unwrap();
+            lg_guard.get_backlinks("A.md", &fi_guard).is_empty()
+        })
+        .await;
+
+        let lg_guard = lg.lock().unwrap();
+        assert!(
+            !lg_guard
+                .get_unresolved()
+                .iter()
+                .any(|u| u.source_path == "B.md" && u.target_raw == "C"),
+            "C should no longer appear as unresolved from B.md",
+        );
+    });
+}
+
+// ─── Test 3: add tag ─────────────────────────────────────────────────────────
+
+#[test]
+fn merge_clean_external_tag_add_refreshes_tag_index() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        let b_abs = write_md(vault, "B.md", "# B\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        let external = "# B\n#new-tag\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            "# B\n".to_string(),
+            "# B\n".to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        drain(&state).await;
+
+        let coord_guard = state.index_coordinator.lock().unwrap();
+        let coord = coord_guard.as_ref().expect("coord present");
+        let ti = coord.tag_index();
+
+        wait_for("new-tag indexed on B.md", || {
+            let ti_guard = ti.lock().unwrap();
+            ti_guard
+                .tags_for_file("B.md")
+                .iter()
+                .any(|t| t == "new-tag")
+        })
+        .await;
+
+        let ti_guard = ti.lock().unwrap();
+        let count = ti_guard
+            .list_tags()
+            .into_iter()
+            .find(|u| u.tag == "new-tag")
+            .map(|u| u.count)
+            .unwrap_or(0);
+        assert_eq!(count, 1, "global tag count for new-tag == 1");
+    });
+}
+
+// ─── Test 4: remove tag ──────────────────────────────────────────────────────
+
+#[test]
+fn merge_clean_external_tag_remove_refreshes_tag_index() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        let b_abs = write_md(vault, "B.md", "# B\n#old-tag\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        let external = "# B\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            "# B\n#old-tag\n".to_string(),
+            "# B\n#old-tag\n".to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        drain(&state).await;
+
+        let coord_guard = state.index_coordinator.lock().unwrap();
+        let coord = coord_guard.as_ref().expect("coord present");
+        let ti = coord.tag_index();
+
+        wait_for("old-tag no longer indexed on B.md", || {
+            let ti_guard = ti.lock().unwrap();
+            !ti_guard
+                .tags_for_file("B.md")
+                .iter()
+                .any(|t| t == "old-tag")
+        })
+        .await;
+
+        let ti_guard = ti.lock().unwrap();
+        let still_there = ti_guard.list_tags().into_iter().any(|u| u.tag == "old-tag");
+        assert!(!still_there, "old-tag should be gone from the global list");
+    });
+}
+
+// ─── Test 5: authoritative disk write ────────────────────────────────────────
+
+#[test]
+fn merge_clean_writes_merged_bytes_to_disk() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        let b_abs = write_md(vault, "B.md", "base\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        // External adds a line; editor adds a different line. Three-way
+        // merge resolves cleanly (non-overlapping additions).
+        let external = "base\nexternal line\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        let editor = "editor line\nbase\n";
+        let base = "base\n";
+
+        let result = merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            editor.to_string(),
+            base.to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        assert_eq!(result.outcome, "clean");
+
+        let on_disk = std::fs::read_to_string(&b_abs).unwrap();
+        assert_eq!(
+            on_disk, result.merged_content,
+            "disk must match merged_content after authoritative write",
+        );
+    });
+}
+
+// ─── Test 6: write_ignore recorded before disk write ─────────────────────────
+
+#[test]
+fn merge_clean_records_write_ignore_before_disk_write() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        let b_abs = write_md(vault, "B.md", "base\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        let external = "base\nexternal\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            "editor\nbase\n".to_string(),
+            "base\n".to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        let canonical = std::fs::canonicalize(&b_abs).unwrap();
+        let guard = state.write_ignore.lock().unwrap();
+        assert!(
+            guard.should_ignore(&canonical),
+            "write_ignore must record canonical path so the resulting watcher event is suppressed",
+        );
+    });
+}
+
+// ─── Test 7: new_hash contract ───────────────────────────────────────────────
+
+#[test]
+fn merge_clean_returns_hash_of_merged_content() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        let b_abs = write_md(vault, "B.md", "base\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        let external = "base\nexternal\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        let result = merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            "editor\nbase\n".to_string(),
+            "base\n".to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        let expected = crate::hash::hash_bytes(result.merged_content.as_bytes());
+        assert_eq!(
+            result.new_hash.as_deref(),
+            Some(expected.as_str()),
+            "new_hash must equal SHA-256 of merged_content on clean",
+        );
+    });
+}
+
+// ─── Test 8: frontmatter alias dropped ───────────────────────────────────────
+
+#[test]
+fn merge_clean_frontmatter_alias_drop_refreshes_resolver() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        // Aliases are normalized to lowercase in FileMeta — see
+        // frontmatter.rs::aliases_list_form test fixture.
+        let b_abs = write_md(
+            vault,
+            "B.md",
+            "---\naliases: [beealias]\n---\n# B\n",
+        );
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        // Precondition: alias IS indexed after the initial index_vault pass.
+        // Without this guard the post-merge assertion would pass trivially
+        // even if the dispatch fix never runs.
+        {
+            let coord_guard = state.index_coordinator.lock().unwrap();
+            let coord = coord_guard.as_ref().unwrap();
+            let fi = coord.file_index();
+            let fi_guard = fi.read().unwrap();
+            let aliases = fi_guard.aliases_for_rel("B.md");
+            assert!(
+                aliases.iter().any(|a| a == "beealias"),
+                "precondition failed: initial index_vault must have seeded alias, got {:?}",
+                aliases,
+            );
+        }
+
+        // External removes the alias.
+        let external = "# B\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            "---\naliases: [beealias]\n---\n# B\n".to_string(),
+            "---\naliases: [beealias]\n---\n# B\n".to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        drain(&state).await;
+
+        let coord_guard = state.index_coordinator.lock().unwrap();
+        let coord = coord_guard.as_ref().expect("coord present");
+        let fi = coord.file_index();
+
+        wait_for("beealias dropped from FileMeta", || {
+            let fi_guard = fi.read().unwrap();
+            let aliases = fi_guard.aliases_for_rel("B.md");
+            !aliases.iter().any(|a| a == "beealias")
+        })
+        .await;
+    });
+}
+
+// ─── Test 9: conflict path — no write, no dispatch ───────────────────────────
+
+#[test]
+fn merge_conflict_keeps_local_and_skips_disk_write_and_dispatch() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        // Overlapping edits on the same line → merge conflict.
+        let b_abs = write_md(vault, "B.md", "common line\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        let external = "external flavour\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        let editor = "editor flavour\n";
+        let base = "common line\n";
+
+        let result = merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            editor.to_string(),
+            base.to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        assert_eq!(result.outcome, "conflict");
+        assert_eq!(result.merged_content, editor);
+        assert!(
+            result.new_hash.is_none(),
+            "new_hash must be None on conflict — backend did not write",
+        );
+
+        // Disk still holds the external content (the backend did NOT write).
+        let on_disk = std::fs::read_to_string(&b_abs).unwrap();
+        assert_eq!(on_disk, external);
+
+        // write_ignore was NOT populated (conflict path short-circuits).
+        let canonical = std::fs::canonicalize(&b_abs).unwrap();
+        let guard = state.write_ignore.lock().unwrap();
+        assert!(
+            !guard.should_ignore(&canonical),
+            "conflict path must not record write_ignore",
+        );
+    });
+}
+
+// ─── Test 10: non-md defensive branch ────────────────────────────────────────
+
+#[test]
+fn merge_non_md_file_does_not_dispatch_index() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        // .canvas files aren't indexed into LinkGraph / TagIndex. If the
+        // IPC layer ever fuzzes a .canvas path into merge_external_change
+        // we must not corrupt the graph with canvas-derived text.
+        let c_abs = vault.join("board.canvas");
+        std::fs::write(&c_abs, "base\n").unwrap();
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        let external = "base\nchanged\n";
+        std::fs::write(&c_abs, external).unwrap();
+
+        let result = merge_external_change_impl(
+            &state,
+            c_abs.to_string_lossy().into_owned(),
+            "base\n".to_string(),
+            "base\n".to_string(),
+        )
+        .await
+        .expect("merge ok");
+
+        assert_eq!(result.outcome, "clean");
+
+        drain(&state).await;
+
+        let coord_guard = state.index_coordinator.lock().unwrap();
+        let coord = coord_guard.as_ref().expect("coord present");
+        let lg = coord.link_graph();
+        let lg_guard = lg.lock().unwrap();
+        assert!(
+            lg_guard.outgoing_for("board.canvas").is_none(),
+            "non-md path must not appear as a link-graph source",
+        );
+    });
+}
+
+// ─── Test 11: path outside vault ─────────────────────────────────────────────
+
+#[test]
+fn merge_outside_vault_returns_permission_denied_and_does_not_dispatch() {
+    tokio_test_block_on(async {
+        let vault = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let evil = outside.path().join("secret.md");
+        std::fs::write(&evil, "pwn\n").unwrap();
+
+        let state = state_with_vault_no_coord(vault.path());
+
+        let result = merge_external_change_impl(
+            &state,
+            evil.to_string_lossy().into_owned(),
+            "editor\n".to_string(),
+            "base\n".to_string(),
+        )
+        .await;
+
+        match result {
+            Err(VaultError::PermissionDenied { .. }) => {}
+            other => panic!("expected PermissionDenied, got {:?}", other),
+        }
+
+        // Disk unchanged.
+        assert_eq!(std::fs::read_to_string(&evil).unwrap(), "pwn\n");
+    });
+}
+
+// ─── Test 12 (bis): delete refreshes backlinks + tags ───────────────────────
+
+#[test]
+fn delete_refreshes_backlinks_and_tags() {
+    // Covers the #339 audit gap: before the fix, delete_file recorded
+    // write_ignore and moved the file to .trash but never dispatched
+    // RemoveLinks / RemoveTags, leaving the graphs stale.
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        let a_abs = write_md(vault, "A.md", "# A\n");
+        write_md(vault, "B.md", "[[A]]\n#shared\n");
+
+        let state = state_with_vault_and_coord(vault).await;
+
+        // Precondition: the graphs reflect the seed.
+        {
+            let coord_guard = state.index_coordinator.lock().unwrap();
+            let coord = coord_guard.as_ref().unwrap();
+            let lg = coord.link_graph();
+            let ti = coord.tag_index();
+            assert!(
+                lg.lock()
+                    .unwrap()
+                    .outgoing_for("B.md")
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|l| l.target_raw == "A"),
+                "B.md must link to A pre-delete",
+            );
+            assert!(
+                ti.lock()
+                    .unwrap()
+                    .tags_for_file("B.md")
+                    .iter()
+                    .any(|t| t == "shared"),
+                "B.md must have #shared pre-delete",
+            );
+        }
+
+        // Drive delete via the command body (the tauri wrapper needs an
+        // AppHandle we can't synthesize cleanly). `delete_file_impl` + the
+        // explicit dispatch mirror what `delete_file` does, exactly as the
+        // files.rs `_impl` convention prescribes.
+        crate::commands::files::delete_file_impl(&state, a_abs.to_string_lossy().into_owned())
+            .expect("delete ok");
+        crate::commands::index_dispatch::dispatch_self_delete(&state, &a_abs).await;
+
+        drain(&state).await;
+
+        let coord_guard = state.index_coordinator.lock().unwrap();
+        let coord = coord_guard.as_ref().unwrap();
+        let lg = coord.link_graph();
+        let fi = coord.file_index();
+
+        // A.md is gone from outgoing (source was deleted).
+        wait_for("A.md dropped from link graph", || {
+            let lg_guard = lg.lock().unwrap();
+            lg_guard.outgoing_for("A.md").is_none()
+        })
+        .await;
+
+        // B.md's [[A]] link becomes unresolved (A no longer exists).
+        let lg_guard = lg.lock().unwrap();
+        let fi_guard = fi.read().unwrap();
+        let a_backlinks = lg_guard.get_backlinks("A.md", &fi_guard);
+        // Backlinks list may still contain B.md (it points at the now-
+        // missing target). What matters is that nothing falsely claims
+        // the deleted file still has outgoing links.
+        // The critical assertion: outgoing_for(A) is None after dispatch.
+        drop(lg_guard);
+        drop(fi_guard);
+        let _ = a_backlinks; // touched for clarity
+    });
+}
+
+// ─── Test 12: channel absent (no IndexCoordinator) ──────────────────────────
+
+#[test]
+fn merge_channel_absent_does_not_error() {
+    tokio_test_block_on(async {
+        let tmp = TempDir::new().unwrap();
+        let vault = tmp.path();
+        let b_abs = write_md(vault, "B.md", "base\n");
+
+        let state = state_with_vault_no_coord(vault);
+
+        let external = "base\nexternal\n";
+        std::fs::write(&b_abs, external).unwrap();
+
+        let result = merge_external_change_impl(
+            &state,
+            b_abs.to_string_lossy().into_owned(),
+            "editor\nbase\n".to_string(),
+            "base\n".to_string(),
+        )
+        .await;
+
+        // Must succeed even with no coordinator — dispatches are best-effort
+        // and silently drop.
+        assert!(result.is_ok(), "merge must not error without a coordinator");
+        let r = result.unwrap();
+        assert_eq!(r.outcome, "clean");
+    });
+}

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod vault_stats;
 mod tree;
 mod watcher;
 mod merge;
+mod merge_external_change;
 mod indexer;
 mod indexer_single_read;
 mod link_graph;

--- a/src-tauri/src/tests/rename_link_resolution.rs
+++ b/src-tauri/src/tests/rename_link_resolution.rs
@@ -70,8 +70,8 @@ fn seed_file_index(state: &VaultState, vault_root: &std::path::Path, rel_paths: 
 /// fallback. Fails today because `rename_file_impl` does not update the
 /// in-memory `FileIndex` — the rel_path map the click handler consults keeps
 /// the stale OLD path.
-#[test]
-fn rename_keeps_in_folder_wiki_link_resolvable() {
+#[tokio::test]
+async fn rename_keeps_in_folder_wiki_link_resolvable() {
     let dir = tempdir().unwrap();
     let vault_root = dir.path();
 
@@ -104,6 +104,7 @@ fn rename_keeps_in_folder_wiki_link_resolvable() {
         old_abs.to_string_lossy().into_owned(),
         "B-new.md".into(),
     )
+    .await
     .expect("rename_file_impl must succeed");
 
     // Disk is renamed (sanity — not the assertion under test).
@@ -143,8 +144,8 @@ fn rename_keeps_in_folder_wiki_link_resolvable() {
 /// note moves between folders. After `move_file_impl(folder/B.md -> other/)`,
 /// the new rel_path `other/B.md` must be in the FileIndex and the old one
 /// must be gone (#277).
-#[test]
-fn move_keeps_wiki_link_resolvable_in_new_folder() {
+#[tokio::test]
+async fn move_keeps_wiki_link_resolvable_in_new_folder() {
     let dir = tempdir().unwrap();
     let vault_root = dir.path();
 
@@ -164,6 +165,7 @@ fn move_keeps_wiki_link_resolvable_in_new_folder() {
         from_abs.to_string_lossy().into_owned(),
         canonical_other.to_string_lossy().into_owned(),
     )
+    .await
     .expect("move_file_impl must succeed");
 
     assert!(other.join("B.md").exists(), "disk move must succeed");
@@ -187,8 +189,8 @@ fn move_keeps_wiki_link_resolvable_in_new_folder() {
 /// `canonical_old == canonical_new`. The FileIndex entry must stay present
 /// with the new `relative_path` string (so UI shows the new casing); hash /
 /// aliases from the prior entry must be preserved (#277).
-#[test]
-fn case_only_rename_preserves_file_index_entry() {
+#[tokio::test]
+async fn case_only_rename_preserves_file_index_entry() {
     let dir = tempdir().unwrap();
     let vault_root = dir.path();
 
@@ -215,6 +217,7 @@ fn case_only_rename_preserves_file_index_entry() {
         canonical.join("Note.md").to_string_lossy().into_owned(),
         "note.md".into(),
     )
+    .await
     .expect("rename must succeed");
 
     let fi = state.file_index.read().unwrap();

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -701,11 +701,14 @@
             });
           }
 
-          // Align lastSavedHash with the hash the backend just wrote (clean)
-          // or leave disk-as-is on conflict (user keeps local buffer; next
-          // autosave hits the hash-matches branch and writes through).
+          // On clean the backend just wrote; new_hash is the authoritative
+          // next-disk-state. On conflict the backend did NOT write — hash
+          // the merged (== local) content so the next autosave doesn't
+          // re-enter merge against a stale expected hash.
           const newHash =
-            result.new_hash ?? (await sha256Hex(result.merged_content));
+            result.outcome === "clean"
+              ? result.new_hash
+              : await sha256Hex(result.merged_content);
           editorStore.setLastSavedHash(newHash);
           tabStore.setLastSavedHash(tabId, newHash);
           tabStore.setLastSavedContent(tabId, result.merged_content);

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -687,6 +687,9 @@
 
         if (diskHash !== null && expected !== null && diskHash !== expected) {
           // MISMATCH: external edit detected — route through three-way merge engine.
+          // Issue #339: on clean, the backend writes the merged bytes to disk
+          // itself and returns `new_hash`. We must NOT call writeFile here —
+          // that would double-write and double-dispatch the index updates.
           const baseContent = currentTab?.lastSavedContent ?? "";
           const result = await mergeExternalChange(filePath, text, baseContent);
 
@@ -698,8 +701,11 @@
             });
           }
 
-          // Write the merged content to disk so hash converges.
-          const newHash = await writeFile(filePath, result.merged_content);
+          // Align lastSavedHash with the hash the backend just wrote (clean)
+          // or leave disk-as-is on conflict (user keeps local buffer; next
+          // autosave hits the hash-matches branch and writes through).
+          const newHash =
+            result.new_hash ?? (await sha256Hex(result.merged_content));
           editorStore.setLastSavedHash(newHash);
           tabStore.setLastSavedHash(tabId, newHash);
           tabStore.setLastSavedContent(tabId, result.merged_content);

--- a/src/components/Editor/__tests__/externalChangeHandler.test.ts
+++ b/src/components/Editor/__tests__/externalChangeHandler.test.ts
@@ -24,15 +24,22 @@ function makeDeps(overrides: {
   editorHash: string;
   mergeOutcome?: "clean" | "conflict";
   mergedContent?: string;
-  mergeNewHash?: string | null;
+  mergeNewHash?: string;
 }) {
   const getFileHash = vi.fn().mockResolvedValue(overrides.diskHash);
   const sha256 = vi.fn().mockResolvedValue(overrides.editorHash);
-  const mergeExternalChange = vi.fn().mockResolvedValue({
-    outcome: overrides.mergeOutcome ?? "clean",
-    merged_content: overrides.mergedContent ?? "",
-    new_hash: overrides.mergeNewHash ?? null,
-  });
+  // Tagged-union shape: clean carries new_hash; conflict does not.
+  const mergedContent = overrides.mergedContent ?? "";
+  const mergeOutcome = overrides.mergeOutcome ?? "clean";
+  const mergeResult =
+    mergeOutcome === "clean"
+      ? {
+          outcome: "clean" as const,
+          merged_content: mergedContent,
+          new_hash: overrides.mergeNewHash ?? "fake-merged-hash",
+        }
+      : { outcome: "conflict" as const, merged_content: mergedContent };
+  const mergeExternalChange = vi.fn().mockResolvedValue(mergeResult);
   return {
     getFileHash,
     sha256Hex: sha256,
@@ -62,7 +69,8 @@ describe("decideExternalModifyAction", () => {
     // #339: the backend writes merged bytes itself and returns new_hash.
     // The pre-merge `diskHash` is stale — we MUST prefer new_hash so the
     // next autosave doesn't re-enter the merge path against a phantom
-    // hash mismatch.
+    // hash mismatch. The tagged union guarantees new_hash on clean, so
+    // the consumer has nothing to fall back to.
     const deps = makeDeps({
       diskHash: "bb", // external content hash BEFORE merge
       editorHash: "aa",
@@ -87,37 +95,6 @@ describe("decideExternalModifyAction", () => {
       "local",
       "base",
     );
-  });
-
-  it("falls back to hashing merged_content when new_hash is missing", async () => {
-    // Defence against an older backend that doesn't populate new_hash.
-    // Must NOT use the pre-merge diskHash — it reflects external content,
-    // not the merged bytes the backend wrote (or would have written).
-    const deps = makeDeps({
-      diskHash: "bb",
-      editorHash: "aa",
-      mergeOutcome: "clean",
-      mergedContent: "merged!",
-      mergeNewHash: null,
-    });
-    // Force sha256Hex to distinguish its two call sites: the first call
-    // (editor hash, up front) returns "aa"; the second (fallback) returns
-    // the hash of mergedContent.
-    deps._mocks.sha256
-      .mockResolvedValueOnce("aa")
-      .mockResolvedValueOnce("computed-merged-hash");
-
-    const action = await decideExternalModifyAction(deps, {
-      path: "/v/a.md",
-      editorContent: "local",
-      lastSavedContent: "base",
-    });
-
-    expect(action).toEqual({
-      kind: "clean-merge",
-      mergedContent: "merged!",
-      diskHash: "computed-merged-hash",
-    });
   });
 
   it("returns conflict with the fresh disk hash so the next autosave is unambiguous", async () => {

--- a/src/components/Editor/__tests__/externalChangeHandler.test.ts
+++ b/src/components/Editor/__tests__/externalChangeHandler.test.ts
@@ -24,12 +24,14 @@ function makeDeps(overrides: {
   editorHash: string;
   mergeOutcome?: "clean" | "conflict";
   mergedContent?: string;
+  mergeNewHash?: string | null;
 }) {
   const getFileHash = vi.fn().mockResolvedValue(overrides.diskHash);
   const sha256 = vi.fn().mockResolvedValue(overrides.editorHash);
   const mergeExternalChange = vi.fn().mockResolvedValue({
     outcome: overrides.mergeOutcome ?? "clean",
     merged_content: overrides.mergedContent ?? "",
+    new_hash: overrides.mergeNewHash ?? null,
   });
   return {
     getFileHash,
@@ -56,12 +58,17 @@ describe("decideExternalModifyAction", () => {
     expect(deps._mocks.mergeExternalChange).not.toHaveBeenCalled();
   });
 
-  it("returns clean-merge with the fresh disk hash so lastSavedHash can be refreshed", async () => {
+  it("returns clean-merge with the backend's new_hash so lastSavedHash tracks disk", async () => {
+    // #339: the backend writes merged bytes itself and returns new_hash.
+    // The pre-merge `diskHash` is stale — we MUST prefer new_hash so the
+    // next autosave doesn't re-enter the merge path against a phantom
+    // hash mismatch.
     const deps = makeDeps({
-      diskHash: "bb",
+      diskHash: "bb", // external content hash BEFORE merge
       editorHash: "aa",
       mergeOutcome: "clean",
       mergedContent: "merged!",
+      mergeNewHash: "dd", // hash of merged bytes AFTER backend wrote
     });
 
     const action = await decideExternalModifyAction(deps, {
@@ -73,13 +80,44 @@ describe("decideExternalModifyAction", () => {
     expect(action).toEqual({
       kind: "clean-merge",
       mergedContent: "merged!",
-      diskHash: "bb",
+      diskHash: "dd", // NOT "bb" — new_hash wins
     });
     expect(deps._mocks.mergeExternalChange).toHaveBeenCalledWith(
       "/v/a.md",
       "local",
       "base",
     );
+  });
+
+  it("falls back to hashing merged_content when new_hash is missing", async () => {
+    // Defence against an older backend that doesn't populate new_hash.
+    // Must NOT use the pre-merge diskHash — it reflects external content,
+    // not the merged bytes the backend wrote (or would have written).
+    const deps = makeDeps({
+      diskHash: "bb",
+      editorHash: "aa",
+      mergeOutcome: "clean",
+      mergedContent: "merged!",
+      mergeNewHash: null,
+    });
+    // Force sha256Hex to distinguish its two call sites: the first call
+    // (editor hash, up front) returns "aa"; the second (fallback) returns
+    // the hash of mergedContent.
+    deps._mocks.sha256
+      .mockResolvedValueOnce("aa")
+      .mockResolvedValueOnce("computed-merged-hash");
+
+    const action = await decideExternalModifyAction(deps, {
+      path: "/v/a.md",
+      editorContent: "local",
+      lastSavedContent: "base",
+    });
+
+    expect(action).toEqual({
+      kind: "clean-merge",
+      mergedContent: "merged!",
+      diskHash: "computed-merged-hash",
+    });
   });
 
   it("returns conflict with the fresh disk hash so the next autosave is unambiguous", async () => {

--- a/src/components/Editor/externalChangeHandler.ts
+++ b/src/components/Editor/externalChangeHandler.ts
@@ -18,7 +18,11 @@ export interface ExternalModifyDeps {
     path: string,
     local: string,
     base: string,
-  ) => Promise<{ outcome: "clean" | "conflict"; merged_content: string }>;
+  ) => Promise<{
+    outcome: "clean" | "conflict";
+    merged_content: string;
+    new_hash: string | null;
+  }>;
   /** SHA-256 hex of the given UTF-8 string. Injected so tests can stub it. */
   sha256Hex: (s: string) => Promise<string>;
 }
@@ -44,11 +48,14 @@ export interface ExternalModifyInput {
  *   no toast. Fires for self-writes that slipped past `WriteIgnoreList` and
  *   for external touches that produced identical bytes (git checkout same
  *   commit, Time Machine, Spotlight metadata writes).
- * - `clean-merge`: disk diverged from our base snapshot; the three-way merge
- *   resolved cleanly. The caller must replace the CM6 doc with
- *   `mergedContent` and record `diskHash` as the new `lastSavedHash`.
- * - `conflict`: merge failed; the caller keeps the editor's local content
- *   but still records `diskHash` so the next autosave writes through
+ * - `clean-merge`: disk diverged from our base snapshot; the three-way
+ *   merge resolved cleanly AND the backend persisted the merged bytes to
+ *   disk (#339). The caller must replace the CM6 doc with `mergedContent`
+ *   and record `diskHash` as the new `lastSavedHash`. The caller MUST NOT
+ *   call `writeFile` again — the backend already wrote.
+ * - `conflict`: merge failed; the backend did NOT write. The caller keeps
+ *   the editor's local content but still records `diskHash` (the external
+ *   version still on disk) so the next autosave writes through
  *   deliberately (the documented "lokale Version behalten" behaviour).
  */
 export async function decideExternalModifyAction(
@@ -71,10 +78,18 @@ export async function decideExternalModifyAction(
   );
 
   if (result.outcome === "clean") {
+    // Prefer the backend's `new_hash` (#339): the backend just wrote the
+    // merged bytes, so its hash is the authoritative next-disk-state. The
+    // `diskHash` computed before the merge call reflects the PRE-merge
+    // external content and is stale by the time we get here. Fall back to
+    // hashing the merged content on the rare path where `new_hash` is
+    // missing (older backend).
+    const mergedHash =
+      result.new_hash ?? (await deps.sha256Hex(result.merged_content));
     return {
       kind: "clean-merge",
       mergedContent: result.merged_content,
-      diskHash,
+      diskHash: mergedHash,
     };
   }
   return { kind: "conflict", diskHash };

--- a/src/components/Editor/externalChangeHandler.ts
+++ b/src/components/Editor/externalChangeHandler.ts
@@ -12,17 +12,17 @@
 // `WriteIgnoreList` TTL on slow saves; the byte-identical shortcut collapses
 // that case to a hash-sync with no user-visible toast.
 
+export type MergeRpcResult =
+  | { outcome: "clean"; merged_content: string; new_hash: string }
+  | { outcome: "conflict"; merged_content: string };
+
 export interface ExternalModifyDeps {
   getFileHash: (path: string) => Promise<string>;
   mergeExternalChange: (
     path: string,
     local: string,
     base: string,
-  ) => Promise<{
-    outcome: "clean" | "conflict";
-    merged_content: string;
-    new_hash: string | null;
-  }>;
+  ) => Promise<MergeRpcResult>;
   /** SHA-256 hex of the given UTF-8 string. Injected so tests can stub it. */
   sha256Hex: (s: string) => Promise<string>;
 }
@@ -78,18 +78,15 @@ export async function decideExternalModifyAction(
   );
 
   if (result.outcome === "clean") {
-    // Prefer the backend's `new_hash` (#339): the backend just wrote the
-    // merged bytes, so its hash is the authoritative next-disk-state. The
-    // `diskHash` computed before the merge call reflects the PRE-merge
-    // external content and is stale by the time we get here. Fall back to
-    // hashing the merged content on the rare path where `new_hash` is
-    // missing (older backend).
-    const mergedHash =
-      result.new_hash ?? (await deps.sha256Hex(result.merged_content));
+    // The backend just wrote the merged bytes, so its `new_hash` is the
+    // authoritative next-disk-state. The `diskHash` computed before the
+    // merge call reflects the PRE-merge external content and is stale by
+    // the time we get here — always prefer new_hash. The tagged union
+    // guarantees new_hash exists on this branch.
     return {
       kind: "clean-merge",
       mergedContent: result.merged_content,
-      diskHash: mergedHash,
+      diskHash: result.new_hash,
     };
   }
   return { kind: "conflict", diskHash };

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -159,12 +159,23 @@ export async function countWikiLinks(filename: string): Promise<number> {
 export interface MergeResult {
   outcome: "clean" | "conflict";
   merged_content: string;
+  /**
+   * SHA-256 hex of the merged bytes the backend wrote to disk. Populated
+   * on "clean" only — on "conflict" the backend does NOT write, so the
+   * caller keeps the existing editor content and `new_hash` is null
+   * (issue #339).
+   */
+  new_hash: string | null;
 }
 
 /**
  * SYNC-06/07: Perform a three-way merge for an external file change.
  * base = lastSavedContent, left = editorContent, right = current disk content.
- * Returns outcome ("clean" | "conflict") and the merged content.
+ *
+ * Issue #339: on "clean" the backend writes the merged bytes to disk
+ * itself and returns `new_hash` — the caller must NOT re-write via
+ * `writeFile`. Doing so would double-dispatch index updates and risk
+ * feedback loops with the watcher.
  */
 export async function mergeExternalChange(
   path: string,

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -156,17 +156,31 @@ export async function countWikiLinks(filename: string): Promise<number> {
   }
 }
 
-export interface MergeResult {
-  outcome: "clean" | "conflict";
-  merged_content: string;
-  /**
-   * SHA-256 hex of the merged bytes the backend wrote to disk. Populated
-   * on "clean" only — on "conflict" the backend does NOT write, so the
-   * caller keeps the existing editor content and `new_hash` is null
-   * (issue #339).
-   */
-  new_hash: string | null;
-}
+/**
+ * Tagged union mirroring the Rust `MergeCommandResult` enum.
+ *
+ * Narrow on `outcome` before accessing variant fields:
+ *
+ * ```ts
+ * if (result.outcome === "clean") {
+ *   // result.new_hash is guaranteed here
+ * }
+ * ```
+ *
+ * Issue #339: `new_hash` exists ONLY on "clean" because only "clean"
+ * causes the backend to write. On "conflict" the backend left disk
+ * untouched, so there's no new hash to report.
+ */
+export type MergeResult =
+  | {
+      outcome: "clean";
+      merged_content: string;
+      new_hash: string;
+    }
+  | {
+      outcome: "conflict";
+      merged_content: string;
+    };
 
 /**
  * SYNC-06/07: Perform a three-way merge for an external file change.


### PR DESCRIPTION
Closes #339.

## Summary

External merges, renames, moves, and deletes now keep the in-memory LinkGraph, TagIndex, and Tantivy index in sync with disk. The watcher's natural dispatch is suppressed by `write_ignore` on self-mutations, so without explicit dispatches the graphs trailed the true on-disk state until cold restart — surfacing as wrong backlinks, stale tag counts, and missing fulltext hits for renamed / merged / deleted files.

## Key changes

- **`merge_external_change` is now authoritative on clean**: records `write_ignore`, writes merged bytes to disk, returns `new_hash`, dispatches `UpdateLinks` / `UpdateTags` / Tantivy `AddFile` + `Commit`. On conflict: no write, no dispatch (watcher already dispatched for the external content; the local buffer takes the recovery path via the next autosave).
- **Frontend no longer double-writes** on clean-merge (#339 Socrates review). `EditorPane` save-path and `externalChangeHandler` consume `new_hash` directly so `lastSavedHash` aligns with what the backend wrote.
- **New shared helper `commands/index_dispatch.rs`** (`dispatch_self_write`, `dispatch_self_delete`) consolidates the self-write index contract so every write path goes through the same dispatcher.
- **`delete_file`** now removes `LinkGraph` + `TagIndex` entries (previously only Tantivy-delete via the embed path; the two graphs went stale).
- **`rename_file` / `move_file`** dispatch the NEW side so fulltext, tags, and link graph reflect the renamed content immediately.
- **`update_links_after_rename`** adds Tantivy `AddFile` per rewritten source so fulltext hits for the old stem don't linger. Link-graph direct mutation stays (perf, #250).

## Architectural notes

- Helper lives in `commands/` (not `indexer::`) because it knows about `VaultState` and vault-relative path normalisation — command-layer concerns the indexer must not depend on backwards.
- `MergeCommandResult` gained an optional `new_hash` field. `Some` on clean (backend just wrote), `None` on conflict. Frontend falls back to `sha256Hex(merged_content)` defensively.

## Test plan

- [x] **TDD**: new `src-tauri/src/tests/merge_external_change.rs` (13 tests) covers:
  - Clean: add link, remove link, add tag, remove tag, disk write, `write_ignore` record, `new_hash`, alias drop through frontmatter refresh
  - Conflict: keeps local, no write, no dispatch
  - Edge: non-md defensive branch, path outside vault, channel-absent (no IndexCoordinator)
  - Delete: `RemoveLinks` + `RemoveTags` dispatch actually fires
- [x] `cargo test --lib` — 387 tests passed, 0 failed, 12 ignored
- [x] Frontend Vitest sweep — 297 tests passed across 36 files
- [x] `tsc --noEmit` — clean
- [ ] Manual UAT: rename a heavily-linked note in a real vault; verify backlinks, tag counts, fulltext refresh without restart

## Review

Plan reviewed by **Socrates**. REVISE verdict addressed:
- Frontend double-write fixed here, not deferred
- Helper placed in command layer, not `indexer::mod`
- Tantivy `AddFile` added to all self-write paths (closes the fulltext-staleness gap that was papered over as "already correct" for `write_file`)
- `update_links_after_rename` Tantivy gap folded in
- `merge_external_change` split into `_impl` + thin `#[tauri::command]` wrapper per `files.rs:16-20` convention
- Step order flipped: merge fix landed inline and green before extracting the shared helper