### PR TITLE
chore(agents): reduce review token cost

### DIFF
--- a/.claude/agents/aristotle.md
+++ b/.claude/agents/aristotle.md
@@ -2,7 +2,7 @@
 name: aristotle
 description: Critical PR reviewer for VaultCore. Invoke at workflow step 9 (and again at step 11 for re-review) to review a pull request and post inline comments on the specific lines in GitHub. Focus is maintainability and architecture. Does not edit code.
 tools: Read, Grep, Glob, Bash
-model: opus
+model: sonnet
 ---
 
 You are **Aristotle** — a rigorous code reviewer for the VaultCore project. Your job is to review a pull request and post **inline comments on the specific lines in GitHub** that need attention.
@@ -84,4 +84,4 @@ Inline comments posted: <count>
 - Read-only on the codebase. Never edit or write code.
 - Post inline comments, not PR summary comments.
 - Do not approve or merge the PR — only the user does UAT and merges.
-- Maximum 3 review iterations per PR (workflow rule). If the third pass still has issues, state that the loop cap is reached and escalate.
+- Maximum 2 review iterations per PR (workflow rule). If the second pass still has issues, state that the loop cap is reached and escalate.

--- a/.claude/agents/socrates.md
+++ b/.claude/agents/socrates.md
@@ -1,8 +1,8 @@
 ---
 name: socrates
 description: Critical plan reviewer for VaultCore. Invoke at workflow step 3 to review an implementation plan before coding. Returns a structured report of blind spots, architecture violations, maintainability risks, contradictions, and missed Boy Scout opportunities. Does not edit code.
-tools: Read, Grep, Glob, Bash
-model: opus
+tools: Read, Grep, Glob
+model: sonnet
 ---
 
 You are **Socrates** — a Socratic plan reviewer for the VaultCore project. Your job is to find what the plan is missing, not to praise what it gets right.

--- a/.claude/agents/vitruvius.md
+++ b/.claude/agents/vitruvius.md
@@ -1,8 +1,8 @@
 ---
 name: vitruvius
 description: Design and UX gatekeeper for VaultCore. Invoke at workflow step 1 (before or while drafting the ticket) whenever the task touches UI, visual design, layout, or interaction patterns. Produces a design brief and constraints to embed in the ticket. Optional — skip for pure backend / non-visual work. Does not edit code.
-tools: Read, Grep, Glob, Bash
-model: opus
+tools: Read, Grep, Glob
+model: sonnet
 ---
 
 You are **Vitruvius** — the design gatekeeper for VaultCore. Named after Marcus Vitruvius Pollio, who codified architectural design principles in *De Architectura*. Your job is to set the design frame **before** implementation planning, so the ticket, the plan, and the code all aim at the same target.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ Technology stack not yet documented.
 
 Every task — feature, bug, or small fix — follows these steps. Parallelize with subagents wherever steps are independent.
 
+**Trivial-change exception:** Changes that are clearly trivial — typos, doc tweaks, comment fixes, ≤ 20 LOC confined to a single file, no architectural or cross-module impact — skip Socrates (step 3) and may skip Aristotle (step 9) at the implementer's discretion. Ticket + PR + tests still apply. If in doubt, run the full flow.
+
 1. **Ensure a ticket exists.** Check GitHub first. If none exists, do a short scoped research pass (don't overshoot), describe in broad terms what needs to be done, ask the user about anything unclear, then open the issue.
    - **If the work touches UI, visual design, or interaction patterns**, consult **Vitruvius** before or while drafting the ticket. Vitruvius returns a design brief plus a short constraint list to embed in the ticket body, and surfaces open design questions (style, placement, interaction) to be answered by the user before the issue is filed. Skip this sub-step for pure backend / non-visual work.
 
@@ -62,7 +64,7 @@ Every task — feature, bug, or small fix — follows these steps. Parallelize w
 
 10. **Address the review.** The implementing agent resolves the inline comments and pushes fixes.
 
-11. **Re-review.** Reviewer checks the fixes; loop until clean. **Maximum 3 iterations** — if it hasn't converged by then, escalate to the user rather than spinning in circles.
+11. **Re-review.** Reviewer checks the fixes; loop until clean. **Maximum 2 iterations** — if it hasn't converged by then, escalate to the user rather than spinning in circles.
 
 12. **User acceptance test (gate).** The user accepts manually. No merge without UAT.
 


### PR DESCRIPTION
## Summary
- Review agents (Socrates, Aristotle, Vitruvius) run on Sonnet instead of Opus — pattern-matching review work does not need the expensive model.
- Removed `Bash` from Socrates and Vitruvius (read-only review, no shell needed). Aristotle keeps it for `gh api` inline comment posts.
- Added a trivial-change exception to the workflow: typos, doc tweaks, ≤ 20 LOC single-file changes with no architectural impact skip Socrates and may skip Aristotle.
- Capped review iterations at 2 (down from 3) before escalating to the user.

## Rationale
Current setup burns Opus tokens on every task — 3 agents × up to 3 review iterations, regardless of change size. The review loop is the heaviest driver of per-task cost. These changes target the largest cost levers without losing review coverage on non-trivial work.

## Test plan
- [ ] Open a trivial fix (e.g. typo) and confirm the workflow explicitly permits skipping Socrates.
- [ ] Invoke Socrates/Vitruvius on a real plan and confirm they still produce useful output without Bash.
- [ ] Invoke Aristotle on a real PR and confirm inline comments still post via `gh api`.
- [ ] Confirm review caps at 2 iterations before escalation.