### PR TITLE
refactor(tabStore): split into lifecycle + layout + reload facades (#341)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
+  import { get } from "svelte/store";
   import { EditorView } from "@codemirror/view";
   import { EditorState } from "@codemirror/state";
   import TabBar from "../Tabs/TabBar.svelte";
@@ -304,9 +305,7 @@
    */
   function handleWikiLinkClick(event: Event): void {
     const detail = (event as CustomEvent).detail as { target: string; resolved: boolean };
-    let vault: string | null = null;
-    const u = vaultStore.subscribe((s) => { vault = s.currentPath; });
-    u();
+    const vault = get(vaultStore).currentPath;
     if (!vault) return;
 
     // #309 — the decoration's `data-wiki-resolved` attribute reflects the
@@ -397,11 +396,8 @@
     if (state.pending.token === prevReloadToken) return;
     prevReloadToken = state.pending.token;
 
-    let vault: string | null = null;
-    const u = vaultStore.subscribe((s) => { vault = s.currentPath; });
-    u();
-    if (!vault) return;
-    const vaultPath = vault as string;
+    const vaultPath = get(vaultStore).currentPath;
+    if (!vaultPath) return;
 
     for (const relPath of state.pending.paths) {
       const absPath = `${vaultPath}/${relPath}`;

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -540,8 +540,8 @@
       cycleTabNext: () => { tabStore.cycleTab(1); },
       cycleTabPrev: () => { tabStore.cycleTab(-1); },
       closeActiveTab: () => {
-        const activeId = get(tabStore).activeTabId;
-        if (activeId) tabStore.closeTab(activeId);
+        const active = tabStore.getActiveTab();
+        if (active) tabStore.closeTab(active.id);
       },
       createNewNote: () => { void createNewNote(); },
       createNewCanvas: () => { void createNewCanvas(); },

--- a/src/components/Tabs/TabBar.svelte
+++ b/src/components/Tabs/TabBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Tab from "./Tab.svelte";
   import { tabStore } from "../../store/tabStore";
+  import { tabLayoutStore } from "../../store/tabLayoutStore";
   import type { Tab as TabType } from "../../store/tabStore";
 
   let {
@@ -58,7 +59,7 @@
       currentIds.splice(insertAt, 0, draggedTabId);
 
       // Apply reorder to store
-      tabStore._reorderPane(paneId, currentIds);
+      tabLayoutStore.reorderPane(paneId, currentIds);
     } else if (fromIdx === -1 && draggedTabId) {
       // Tab from other pane — move it to this pane
       tabStore.activateTab(draggedTabId);

--- a/src/store/tabLayoutStore.test.ts
+++ b/src/store/tabLayoutStore.test.ts
@@ -33,13 +33,25 @@ describe("tabLayoutStore", () => {
       expect(state.splitState.right).toEqual([]);
     });
 
-    it("moving from source pane that becomes empty closes the split", () => {
+    it("moving right-pane's last tab back to left collapses the split", () => {
       const id1 = tabLifecycleStore.openTab("/vault/a.md");
       tabLayoutStore.moveToPane("right");
       tabLayoutStore.moveToPane("left");
       const state = get(tabLayoutStore);
       expect(state.splitState.right).toEqual([]);
       expect(state.splitState.left).toContain(id1);
+    });
+
+    it("moving left-pane's last tab to right also collapses into left (not right)", () => {
+      // Pins counter-intuitive contract: the collapse branch always dumps
+      // surviving tabs into `left` regardless of which pane was the target.
+      // Matches pre-#341 behavior — see comment in tabLayoutStore.moveToPane.
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      tabLayoutStore.moveToPane("right");
+      const state = get(tabLayoutStore);
+      expect(state.splitState.right).toEqual([]);
+      expect(state.splitState.left).toEqual([id1]);
+      expect(state.splitState.activePane).toBe("left");
     });
   });
 
@@ -48,15 +60,20 @@ describe("tabLayoutStore", () => {
       const id1 = tabLifecycleStore.openTab("/vault/a.md");
       const id2 = tabLifecycleStore.openTab("/vault/b.md");
       const id3 = tabLifecycleStore.openTab("/vault/c.md");
+      // Activate a tab that is NOT first in the target permutation so the
+      // "active stays put" assertion cannot coincide with the "incidentally
+      // first" tab.
+      tabLifecycleStore.activateTab(id2);
       const before = get(tabLayoutStore);
       expect(before.splitState.left).toEqual([id1, id2, id3]);
+      expect(before.activeTabId).toBe(id2);
 
       tabLayoutStore.reorderPane("left", [id3, id1, id2]);
 
       const after = get(tabLayoutStore);
       expect(after.splitState.left).toEqual([id3, id1, id2]);
       expect(after.tabs).toHaveLength(3);
-      expect(after.activeTabId).toBe(id3);
+      expect(after.activeTabId).toBe(id2); // unchanged despite id3 now first
       expect(after.splitState.right).toEqual([]);
     });
 

--- a/src/store/tabLayoutStore.test.ts
+++ b/src/store/tabLayoutStore.test.ts
@@ -1,0 +1,79 @@
+// tabLayoutStore tests — covers moveToPane (split creation + collapse)
+// and reorderPane. Cross-concern behavior (e.g. closeTab spanning lifecycle
+// and layout) lives in tabStore.test.ts.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { tabLifecycleStore } from "./tabLifecycleStore";
+import { tabLayoutStore } from "./tabLayoutStore";
+import { _reset } from "./tabStoreCore";
+
+beforeEach(() => {
+  _reset();
+});
+
+describe("tabLayoutStore", () => {
+  describe("moveToPane", () => {
+    it("moves active tab to right pane, creating split if empty", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.activateTab(id2);
+      tabLayoutStore.moveToPane("right");
+      const state = get(tabLayoutStore);
+      expect(state.splitState.left).toContain(id1);
+      expect(state.splitState.left).not.toContain(id2);
+      expect(state.splitState.right).toContain(id2);
+    });
+
+    it("moving to current pane does nothing", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      tabLayoutStore.moveToPane("left");
+      const state = get(tabLayoutStore);
+      expect(state.splitState.left).toContain(id1);
+      expect(state.splitState.right).toEqual([]);
+    });
+
+    it("moving from source pane that becomes empty closes the split", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      tabLayoutStore.moveToPane("right");
+      tabLayoutStore.moveToPane("left");
+      const state = get(tabLayoutStore);
+      expect(state.splitState.right).toEqual([]);
+      expect(state.splitState.left).toContain(id1);
+    });
+  });
+
+  describe("reorderPane", () => {
+    it("replaces pane tab-id order without touching tabs list or active", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      const id3 = tabLifecycleStore.openTab("/vault/c.md");
+      const before = get(tabLayoutStore);
+      expect(before.splitState.left).toEqual([id1, id2, id3]);
+
+      tabLayoutStore.reorderPane("left", [id3, id1, id2]);
+
+      const after = get(tabLayoutStore);
+      expect(after.splitState.left).toEqual([id3, id1, id2]);
+      expect(after.tabs).toHaveLength(3);
+      expect(after.activeTabId).toBe(id3);
+      expect(after.splitState.right).toEqual([]);
+    });
+
+    it("reorders right pane independently", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.activateTab(id2);
+      tabLayoutStore.moveToPane("right");
+      const id3 = tabLifecycleStore.openTab("/vault/c.md");
+      tabLayoutStore.moveToPane("right");
+      const before = get(tabLayoutStore);
+      expect(before.splitState.right).toEqual([id2, id3]);
+
+      tabLayoutStore.reorderPane("right", [id3, id2]);
+
+      expect(get(tabLayoutStore).splitState.right).toEqual([id3, id2]);
+      expect(get(tabLayoutStore).splitState.left).toEqual([id1]);
+    });
+  });
+});

--- a/src/store/tabLayoutStore.ts
+++ b/src/store/tabLayoutStore.ts
@@ -49,12 +49,30 @@ export const tabLayoutStore = {
 
   /**
    * Reorder the tab IDs in a specific pane (used by drag-to-reorder in TabBar).
-   * Callers are responsible for passing a permutation of the current pane IDs.
+   * `newIds` MUST be a permutation of the current pane IDs — anything else
+   * breaks the `splitState ⊆ tabs` invariant. Validated in dev builds so a
+   * caller bug fails loudly instead of producing torn state.
    */
   reorderPane(pane: "left" | "right", newIds: string[]): void {
-    _core.update((state) => ({
-      ...state,
-      splitState: { ...state.splitState, [pane]: newIds },
-    }));
+    _core.update((state) => {
+      const current = state.splitState[pane];
+      if (import.meta.env?.DEV) {
+        const isPermutation =
+          current.length === newIds.length &&
+          new Set(current).size === new Set(newIds).size &&
+          current.every((id) => newIds.includes(id));
+        if (!isPermutation) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[tabLayoutStore] reorderPane(${pane}) called with non-permutation`,
+            { current, newIds },
+          );
+        }
+      }
+      return {
+        ...state,
+        splitState: { ...state.splitState, [pane]: newIds },
+      };
+    });
   },
 };

--- a/src/store/tabLayoutStore.ts
+++ b/src/store/tabLayoutStore.ts
@@ -1,0 +1,60 @@
+// tabLayoutStore — pane arrangement (#341).
+//
+// Owns: moveToPane (split creation + collapse) and reorderPane (drag-to-
+// reorder). Shares the writable in tabStoreCore.ts with tabLifecycleStore
+// and tabReloadStore.
+import { _core, whichPane, type SplitState } from "./tabStoreCore";
+
+export const tabLayoutStore = {
+  subscribe: _core.subscribe,
+
+  /**
+   * Move the currently active tab to the specified pane.
+   * Creates a split if the target pane was empty.
+   * If the source pane becomes empty, closes that pane (merge back to one pane).
+   */
+  moveToPane(targetPane: "left" | "right"): void {
+    _core.update((state) => {
+      const activeTabId = state.activeTabId;
+      if (!activeTabId) return state;
+
+      const sourcePane = whichPane(state, activeTabId);
+      if (sourcePane === null) return state;
+      if (sourcePane === targetPane) return state;
+
+      const newSourceIds = state.splitState[sourcePane].filter((id) => id !== activeTabId);
+      const newTargetIds = [...state.splitState[targetPane], activeTabId];
+
+      let newSplitState: SplitState;
+      if (newSourceIds.length === 0) {
+        // Source pane empty — collapse split into left pane regardless of
+        // which pane was the target. All tabs end up on the left.
+        newSplitState = {
+          left: newTargetIds,
+          right: [],
+          activePane: "left",
+        };
+      } else {
+        newSplitState = {
+          ...state.splitState,
+          [sourcePane]: newSourceIds,
+          [targetPane]: newTargetIds,
+          activePane: targetPane,
+        };
+      }
+
+      return { ...state, splitState: newSplitState };
+    });
+  },
+
+  /**
+   * Reorder the tab IDs in a specific pane (used by drag-to-reorder in TabBar).
+   * Callers are responsible for passing a permutation of the current pane IDs.
+   */
+  reorderPane(pane: "left" | "right", newIds: string[]): void {
+    _core.update((state) => ({
+      ...state,
+      splitState: { ...state.splitState, [pane]: newIds },
+    }));
+  },
+};

--- a/src/store/tabLifecycleStore.test.ts
+++ b/src/store/tabLifecycleStore.test.ts
@@ -1,0 +1,302 @@
+// tabLifecycleStore tests — covers open/close/activate/cycle and per-tab
+// metadata mutations (dirty, view mode, scroll, rename, closeByPath,
+// getActiveTab). Companion tests in tabLayoutStore.test.ts and
+// tabReloadStore.test.ts cover the other two concerns; cross-concern
+// behavior lives in tabStore.test.ts.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { tabLifecycleStore } from "./tabLifecycleStore";
+import { _reset } from "./tabStoreCore";
+
+beforeEach(() => {
+  _reset();
+});
+
+describe("tabLifecycleStore", () => {
+  describe("initial state", () => {
+    it("has empty tabs array, null activeTabId, splitState with empty right pane", () => {
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toEqual([]);
+      expect(state.activeTabId).toBeNull();
+      expect(state.splitState.left).toEqual([]);
+      expect(state.splitState.right).toEqual([]);
+      expect(state.splitState.activePane).toBe("left");
+    });
+  });
+
+  describe("openTab", () => {
+    it("adds a tab and sets it as activeTabId", () => {
+      const id = tabLifecycleStore.openTab("/vault/note-a.md");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(1);
+      expect(state.tabs[0]!.filePath).toBe("/vault/note-a.md");
+      expect(state.tabs[0]!.id).toBe(id);
+      expect(state.activeTabId).toBe(id);
+      expect(state.splitState.left).toContain(id);
+    });
+
+    it("opening a second file adds another tab", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/note-a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/note-b.md");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(2);
+      expect(state.activeTabId).toBe(id2);
+      expect(state.splitState.left).toEqual([id1, id2]);
+    });
+
+    it("opening a duplicate filePath activates existing tab (no duplicate)", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/note-a.md");
+      tabLifecycleStore.openTab("/vault/note-b.md");
+      const id1Again = tabLifecycleStore.openTab("/vault/note-a.md");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(2);
+      expect(id1Again).toBe(id1);
+      expect(state.activeTabId).toBe(id1);
+    });
+  });
+
+  describe("closeTab", () => {
+    it("removes the tab from the store", () => {
+      const id = tabLifecycleStore.openTab("/vault/note-a.md");
+      tabLifecycleStore.closeTab(id);
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(0);
+      expect(state.splitState.left).not.toContain(id);
+    });
+
+    it("if active, activates the left sibling (preferred)", () => {
+      tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      const id3 = tabLifecycleStore.openTab("/vault/c.md");
+      tabLifecycleStore.closeTab(id3);
+      expect(get(tabLifecycleStore).activeTabId).toBe(id2);
+    });
+
+    it("falls back to right sibling when closing leftmost active tab", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.activateTab(id1);
+      tabLifecycleStore.closeTab(id1);
+      expect(get(tabLifecycleStore).activeTabId).toBe(id2);
+    });
+
+    it("sets activeTabId to null when last tab is closed", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.closeTab(id);
+      expect(get(tabLifecycleStore).activeTabId).toBeNull();
+    });
+  });
+
+  describe("cycleTab", () => {
+    it("cycles forward through tabs in same pane (wraps around)", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      const id3 = tabLifecycleStore.openTab("/vault/c.md");
+      tabLifecycleStore.activateTab(id1);
+
+      tabLifecycleStore.cycleTab(1);
+      expect(get(tabLifecycleStore).activeTabId).toBe(id2);
+      tabLifecycleStore.cycleTab(1);
+      expect(get(tabLifecycleStore).activeTabId).toBe(id3);
+      tabLifecycleStore.cycleTab(1);
+      expect(get(tabLifecycleStore).activeTabId).toBe(id1);
+    });
+
+    it("cycles backward through tabs (wraps around)", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      const id3 = tabLifecycleStore.openTab("/vault/c.md");
+      tabLifecycleStore.activateTab(id3);
+
+      tabLifecycleStore.cycleTab(-1);
+      expect(get(tabLifecycleStore).activeTabId).toBe(id2);
+
+      tabLifecycleStore.activateTab(id1);
+      tabLifecycleStore.cycleTab(-1);
+      expect(get(tabLifecycleStore).activeTabId).toBe(id3);
+    });
+  });
+
+  describe("setDirty", () => {
+    it("setDirty(tabId, true) sets isDirty to true", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.setDirty(id, true);
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.isDirty).toBe(true);
+    });
+
+    it("setDirty(tabId, false) clears isDirty", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.setDirty(id, true);
+      tabLifecycleStore.setDirty(id, false);
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.isDirty).toBe(false);
+    });
+  });
+
+  describe("updateScrollPos", () => {
+    it("persists scrollPos and cursorPos for a tab", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.updateScrollPos(id, 42, 100);
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.scrollPos).toBe(42);
+      expect(tab?.cursorPos).toBe(100);
+    });
+  });
+
+  describe("updateFilePath", () => {
+    it("updates the filePath of a tab when renamed", () => {
+      const id = tabLifecycleStore.openTab("/vault/old-name.md");
+      tabLifecycleStore.updateFilePath("/vault/old-name.md", "/vault/new-name.md");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.filePath).toBe("/vault/new-name.md");
+    });
+
+    it("does nothing if oldPath does not match any tab", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.updateFilePath("/vault/nonexistent.md", "/vault/other.md");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.filePath).toBe("/vault/a.md");
+    });
+  });
+
+  describe("closeByPath", () => {
+    it("closes any tab with matching filePath", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.closeByPath("/vault/a.md");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs.find((t) => t.id === id1)).toBeUndefined();
+      expect(state.tabs.find((t) => t.id === id2)).toBeDefined();
+    });
+
+    it("is a no-op when no tab has the given path", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.closeByPath("/vault/missing.md");
+      expect(get(tabLifecycleStore).tabs.find((t) => t.id === id)).toBeDefined();
+    });
+  });
+
+  describe("openGraphTab", () => {
+    it("creates a singleton graph tab and activates it", () => {
+      const id = tabLifecycleStore.openGraphTab();
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(1);
+      const tab = state.tabs.find((t) => t.id === id);
+      expect(tab?.type).toBe("graph");
+      expect(tab?.filePath).toBe("vault://graph");
+      expect(state.activeTabId).toBe(id);
+    });
+
+    it("focuses the existing graph tab when called twice (no duplicate)", () => {
+      const id1 = tabLifecycleStore.openGraphTab();
+      tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openGraphTab();
+      const state = get(tabLifecycleStore);
+      expect(id2).toBe(id1);
+      expect(state.tabs.filter((t) => t.type === "graph")).toHaveLength(1);
+      expect(state.activeTabId).toBe(id1);
+    });
+
+    it("graph tab can be closed like any other tab", () => {
+      tabLifecycleStore.openTab("/vault/a.md");
+      const gid = tabLifecycleStore.openGraphTab();
+      tabLifecycleStore.closeTab(gid);
+      const state = get(tabLifecycleStore);
+      expect(state.tabs.find((t) => t.type === "graph")).toBeUndefined();
+    });
+
+    it("cycleTab traverses graph + file tabs uniformly", () => {
+      const a = tabLifecycleStore.openTab("/vault/a.md");
+      const gid = tabLifecycleStore.openGraphTab();
+      tabLifecycleStore.activateTab(a);
+      tabLifecycleStore.cycleTab(1);
+      expect(get(tabLifecycleStore).activeTabId).toBe(gid);
+    });
+
+    it("file tabs default to type undefined (backwards-compatible)", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.type).toBeUndefined();
+    });
+  });
+
+  describe("activateTab", () => {
+    it("sets activeTabId and switches activePane", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.activateTab(id2);
+      // move id2 to right via the tabStore shim would be nicer but this keeps
+      // the test within lifecycle; use the core through a direct move-to-pane
+      // integration in tabStore.test.ts instead. Here, just confirm identity.
+      tabLifecycleStore.activateTab(id1);
+      const state = get(tabLifecycleStore);
+      expect(state.activeTabId).toBe(id1);
+      expect(state.splitState.activePane).toBe("left");
+    });
+  });
+
+  describe("getActiveTab", () => {
+    it("returns null when no tabs are open", () => {
+      expect(tabLifecycleStore.getActiveTab()).toBeNull();
+    });
+
+    it("returns the active tab snapshot", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      const tab = tabLifecycleStore.getActiveTab();
+      expect(tab?.id).toBe(id);
+      expect(tab?.filePath).toBe("/vault/a.md");
+    });
+  });
+
+  describe("closeAll", () => {
+    it("clears all tabs and resets split/active state", () => {
+      tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.closeAll();
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toEqual([]);
+      expect(state.activeTabId).toBeNull();
+      expect(state.splitState.left).toEqual([]);
+      expect(state.splitState.right).toEqual([]);
+    });
+  });
+
+  describe("Issue #63: Reading Mode per-tab view mode", () => {
+    it("new tabs default viewMode to undefined (implicitly 'edit')", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBeUndefined();
+    });
+
+    it("setViewMode('read') flips the tab to Reading Mode", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.setViewMode(id, "read");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBe("read");
+    });
+
+    it("toggleViewMode flips between edit and read, treating undefined as edit", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.toggleViewMode(id);
+      expect(get(tabLifecycleStore).tabs.find((t) => t.id === id)?.viewMode).toBe("read");
+      tabLifecycleStore.toggleViewMode(id);
+      expect(get(tabLifecycleStore).tabs.find((t) => t.id === id)?.viewMode).toBe("edit");
+    });
+
+    it("toggleViewMode is scoped to the given tab id", () => {
+      const a = tabLifecycleStore.openTab("/vault/a.md");
+      const b = tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.toggleViewMode(a);
+      expect(get(tabLifecycleStore).tabs.find((t) => t.id === a)?.viewMode).toBe("read");
+      expect(get(tabLifecycleStore).tabs.find((t) => t.id === b)?.viewMode).toBeUndefined();
+    });
+
+    it("updateReadingScrollPos persists the reader's scroll position", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.updateReadingScrollPos(id, 420);
+      expect(get(tabLifecycleStore).tabs.find((t) => t.id === id)?.readingScrollPos).toBe(420);
+    });
+  });
+});

--- a/src/store/tabLifecycleStore.test.ts
+++ b/src/store/tabLifecycleStore.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { get } from "svelte/store";
 import { tabLifecycleStore } from "./tabLifecycleStore";
-import { _reset } from "./tabStoreCore";
+import { _core, _reset } from "./tabStoreCore";
 
 beforeEach(() => {
   _reset();
@@ -223,17 +223,32 @@ describe("tabLifecycleStore", () => {
   });
 
   describe("activateTab", () => {
-    it("sets activeTabId and switches activePane", () => {
+    it("sets activeTabId on same-pane activation and keeps activePane unchanged", () => {
       const id1 = tabLifecycleStore.openTab("/vault/a.md");
-      const id2 = tabLifecycleStore.openTab("/vault/b.md");
-      tabLifecycleStore.activateTab(id2);
-      // move id2 to right via the tabStore shim would be nicer but this keeps
-      // the test within lifecycle; use the core through a direct move-to-pane
-      // integration in tabStore.test.ts instead. Here, just confirm identity.
+      tabLifecycleStore.openTab("/vault/b.md");
       tabLifecycleStore.activateTab(id1);
       const state = get(tabLifecycleStore);
       expect(state.activeTabId).toBe(id1);
       expect(state.splitState.activePane).toBe("left");
+    });
+
+    it("flips activePane when the target tab lives in the other pane", () => {
+      // Seed state directly via _core to keep this lifecycle-scoped test from
+      // depending on tabLayoutStore.moveToPane.
+      const id1 = tabLifecycleStore.openTab("/vault/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/b.md");
+      _core.update((s) => ({
+        ...s,
+        splitState: { left: [id1], right: [id2], activePane: "left" },
+        activeTabId: id1,
+      }));
+      expect(get(tabLifecycleStore).splitState.activePane).toBe("left");
+
+      tabLifecycleStore.activateTab(id2);
+
+      const state = get(tabLifecycleStore);
+      expect(state.activeTabId).toBe(id2);
+      expect(state.splitState.activePane).toBe("right");
     });
   });
 
@@ -247,6 +262,45 @@ describe("tabLifecycleStore", () => {
       const tab = tabLifecycleStore.getActiveTab();
       expect(tab?.id).toBe(id);
       expect(tab?.filePath).toBe("/vault/a.md");
+    });
+  });
+
+  describe("save-snapshot per-tab metadata", () => {
+    it("setLastSavedContent persists the base snapshot for three-way merge", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.setLastSavedContent(id, "snapshot body");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.lastSavedContent).toBe("snapshot body");
+    });
+
+    it("setLastSavedHash records the disk hash on the tab", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      tabLifecycleStore.setLastSavedHash(id, "abc123");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.lastSavedHash).toBe("abc123");
+    });
+
+    it("setLastSavedHash(id, null) is distinguishable from never-set (#80)", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      const before = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(before?.lastSavedHash).toBeUndefined();
+      tabLifecycleStore.setLastSavedHash(id, null);
+      const after = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(after?.lastSavedHash).toBeNull();
+      expect(after?.lastSavedHash === undefined).toBe(false);
+    });
+
+    it("save-snapshot mutations are scoped to the given tab", () => {
+      const a = tabLifecycleStore.openTab("/vault/a.md");
+      const b = tabLifecycleStore.openTab("/vault/b.md");
+      tabLifecycleStore.setLastSavedContent(a, "A body");
+      tabLifecycleStore.setLastSavedHash(a, "hash-a");
+      const tabA = get(tabLifecycleStore).tabs.find((t) => t.id === a);
+      const tabB = get(tabLifecycleStore).tabs.find((t) => t.id === b);
+      expect(tabA?.lastSavedContent).toBe("A body");
+      expect(tabA?.lastSavedHash).toBe("hash-a");
+      expect(tabB?.lastSavedContent).toBe("");
+      expect(tabB?.lastSavedHash).toBeUndefined();
     });
   });
 

--- a/src/store/tabLifecycleStore.ts
+++ b/src/store/tabLifecycleStore.ts
@@ -321,4 +321,28 @@ export const tabLifecycleStore = {
       splitState: { left: [], right: [], activePane: "left" },
     });
   },
+
+  /**
+   * Update the base snapshot content used for three-way merge (Plan 05).
+   * Called after auto-save completes, so the snapshot tracks what's on disk.
+   */
+  setLastSavedContent(tabId: string, content: string): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedContent: content } : t)),
+    }));
+  },
+
+  /**
+   * Record the SHA-256 hash VaultCore wrote for this tab's last save.
+   * Called by EditorPane after every successful writeFile so the auto-save
+   * merge-check can compare disk hash against the per-tab expected hash
+   * (#80 — global editorStore.lastSavedHash leaked across tabs).
+   */
+  setLastSavedHash(tabId: string, hash: string | null): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedHash: hash } : t)),
+    }));
+  },
 };

--- a/src/store/tabLifecycleStore.ts
+++ b/src/store/tabLifecycleStore.ts
@@ -1,0 +1,324 @@
+// tabLifecycleStore — tab identity + per-tab metadata (#341).
+//
+// Owns: open/close/replace/activate/cycle and per-tab attribute mutation
+// (dirty flag, view mode, scroll positions, rename). Shares the single
+// writable in tabStoreCore.ts with tabLayoutStore and tabReloadStore.
+import { get } from "svelte/store";
+import {
+  _core,
+  findTabById,
+  GRAPH_TAB_PATH,
+  whichPane,
+  type SplitState,
+  type Tab,
+  type TabViewer,
+  type TabViewMode,
+} from "./tabStoreCore";
+
+function openInActivePane(state: { tabs: Tab[]; splitState: SplitState }, tab: Tab) {
+  const activePane = state.splitState.activePane;
+  const newPaneIds = [...state.splitState[activePane], tab.id];
+  return {
+    tabs: [...state.tabs, tab],
+    splitState: { ...state.splitState, [activePane]: newPaneIds },
+  };
+}
+
+export const tabLifecycleStore = {
+  subscribe: _core.subscribe,
+
+  /**
+   * Open a tab for the given file path.
+   * If a tab with the same path already exists, activate it (no duplicate).
+   * Otherwise, create a new tab in the currently active pane.
+   * Returns the tab ID.
+   */
+  openTab(filePath: string): string {
+    let returnId = "";
+    _core.update((state) => {
+      const existing = state.tabs.find((t) => t.filePath === filePath);
+      if (existing) {
+        returnId = existing.id;
+        const pane = whichPane(state, existing.id) ?? "left";
+        return {
+          ...state,
+          activeTabId: existing.id,
+          splitState: { ...state.splitState, activePane: pane },
+        };
+      }
+
+      const id = crypto.randomUUID();
+      returnId = id;
+      const tab: Tab = {
+        id,
+        filePath,
+        isDirty: false,
+        scrollPos: 0,
+        cursorPos: 0,
+        lastSaved: Date.now(),
+        lastSavedContent: "",
+      };
+      const opened = openInActivePane(state, tab);
+      return { ...state, ...opened, activeTabId: id };
+    });
+    return returnId;
+  },
+
+  /**
+   * Open a tab with an explicit viewer kind (#49). Used for non-markdown
+   * files — images, read-only text previews, and unsupported binaries.
+   * Same dedupe-by-filePath semantics as openTab().
+   */
+  openFileTab(filePath: string, viewer: TabViewer): string {
+    let returnId = "";
+    _core.update((state) => {
+      const existing = state.tabs.find((t) => t.filePath === filePath);
+      if (existing) {
+        returnId = existing.id;
+        const pane = whichPane(state, existing.id) ?? "left";
+        return {
+          ...state,
+          activeTabId: existing.id,
+          splitState: { ...state.splitState, activePane: pane },
+        };
+      }
+
+      const id = crypto.randomUUID();
+      returnId = id;
+      const tab: Tab = {
+        id,
+        filePath,
+        isDirty: false,
+        scrollPos: 0,
+        cursorPos: 0,
+        lastSaved: Date.now(),
+        lastSavedContent: "",
+        viewer,
+      };
+      const opened = openInActivePane(state, tab);
+      return { ...state, ...opened, activeTabId: id };
+    });
+    return returnId;
+  },
+
+  /**
+   * Open (or focus) the singleton whole-vault graph tab.
+   * Returns the graph tab's ID. Uses a reserved filePath sentinel so the
+   * existing dedupe-by-filePath logic in openTab still applies when called
+   * repeatedly.
+   */
+  openGraphTab(): string {
+    let returnId = "";
+    _core.update((state) => {
+      const existing = state.tabs.find((t) => t.type === "graph");
+      if (existing) {
+        returnId = existing.id;
+        const pane = whichPane(state, existing.id) ?? "left";
+        return {
+          ...state,
+          activeTabId: existing.id,
+          splitState: { ...state.splitState, activePane: pane },
+        };
+      }
+
+      const id = crypto.randomUUID();
+      returnId = id;
+      const tab: Tab = {
+        id,
+        filePath: GRAPH_TAB_PATH,
+        isDirty: false,
+        scrollPos: 0,
+        cursorPos: 0,
+        lastSaved: Date.now(),
+        lastSavedContent: "",
+        type: "graph",
+      };
+      const opened = openInActivePane(state, tab);
+      return { ...state, ...opened, activeTabId: id };
+    });
+    return returnId;
+  },
+
+  /**
+   * Close a tab by ID.
+   * If it was active, activates the left sibling (or right if it was leftmost).
+   * If a split pane becomes empty after close, merges it back to one pane.
+   */
+  closeTab(tabId: string): void {
+    _core.update((state) => {
+      const pane = whichPane(state, tabId);
+      if (pane === null) return state;
+
+      const paneIds = state.splitState[pane];
+      const idx = paneIds.indexOf(tabId);
+      const newPaneIds = paneIds.filter((id) => id !== tabId);
+      const newTabs = state.tabs.filter((t) => t.id !== tabId);
+
+      let newActiveTabId = state.activeTabId;
+      let newSplitState: SplitState;
+
+      const otherPane: "left" | "right" = pane === "left" ? "right" : "left";
+      if (newPaneIds.length === 0 && state.splitState[otherPane].length > 0) {
+        // Source pane empty after close — collapse split: all surviving tabs
+        // end up in left pane, preserving order (left's remainder first, then
+        // right's remainder). Active tab stays if it survived, otherwise
+        // falls through to the merged pane's first tab.
+        const allLeft = state.splitState.left
+          .filter((id) => id !== tabId)
+          .concat(state.splitState.right.filter((id) => id !== tabId));
+
+        newSplitState = { left: allLeft, right: [], activePane: "left" };
+        if (newActiveTabId === tabId) {
+          newActiveTabId = allLeft[0] ?? null;
+        }
+      } else {
+        newSplitState = { ...state.splitState, [pane]: newPaneIds };
+
+        if (state.activeTabId === tabId) {
+          if (idx > 0 && newPaneIds[idx - 1]) {
+            newActiveTabId = newPaneIds[idx - 1] ?? null;
+          } else if (newPaneIds[idx]) {
+            newActiveTabId = newPaneIds[idx] ?? null;
+          } else if (newPaneIds.length > 0) {
+            newActiveTabId = newPaneIds[newPaneIds.length - 1] ?? null;
+          } else {
+            const other = state.splitState[otherPane];
+            newActiveTabId = other.length > 0 ? (other[0] ?? null) : null;
+          }
+        }
+      }
+
+      return {
+        ...state,
+        tabs: newTabs,
+        activeTabId: newActiveTabId,
+        splitState: newSplitState,
+      };
+    });
+  },
+
+  /**
+   * Activate a tab by ID, updating activePane to match the pane containing it.
+   */
+  activateTab(tabId: string): void {
+    _core.update((state) => {
+      const pane = whichPane(state, tabId) ?? state.splitState.activePane;
+      return {
+        ...state,
+        activeTabId: tabId,
+        splitState: { ...state.splitState, activePane: pane },
+      };
+    });
+  },
+
+  /**
+   * Cycle to the next (direction=1) or previous (direction=-1) tab within
+   * the active pane. Wraps around at the ends.
+   */
+  cycleTab(direction: 1 | -1): void {
+    _core.update((state) => {
+      const pane = state.splitState.activePane;
+      const paneIds = state.splitState[pane];
+      if (paneIds.length === 0) return state;
+
+      const currentIdx = state.activeTabId ? paneIds.indexOf(state.activeTabId) : -1;
+      const nextIdx = (currentIdx + direction + paneIds.length) % paneIds.length;
+      return { ...state, activeTabId: paneIds[nextIdx] ?? state.activeTabId };
+    });
+  },
+
+  /**
+   * Set the isDirty flag on a tab (true = unsaved changes, shows dirty dot in tab UI).
+   */
+  setDirty(tabId: string, dirty: boolean): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, isDirty: dirty } : t)),
+    }));
+  },
+
+  /**
+   * Persist scroll and cursor position for a tab so they can be restored on re-activate.
+   */
+  updateScrollPos(tabId: string, scrollPos: number, cursorPos: number): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, scrollPos, cursorPos } : t)),
+    }));
+  },
+
+  /** Persist Reading Mode scroll position (#63). */
+  updateReadingScrollPos(tabId: string, readingScrollPos: number): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, readingScrollPos } : t)),
+    }));
+  },
+
+  /** Set the view mode on a tab (#63). */
+  setViewMode(tabId: string, viewMode: TabViewMode): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, viewMode } : t)),
+    }));
+  },
+
+  /** Toggle between edit / read on a tab; no-op when the tab is missing (#63). */
+  toggleViewMode(tabId: string): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => {
+        if (t.id !== tabId) return t;
+        const next: TabViewMode = (t.viewMode ?? "edit") === "edit" ? "read" : "edit";
+        return { ...t, viewMode: next };
+      }),
+    }));
+  },
+
+  /**
+   * When a file is renamed/moved, update the matching tab's filePath.
+   * Pure metadata mutation — callers that also need to reload the file
+   * from disk must separately invoke tabReloadStore.request().
+   */
+  updateFilePath(oldPath: string, newPath: string): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.filePath === oldPath ? { ...t, filePath: newPath } : t)),
+    }));
+  },
+
+  /**
+   * Close any tab with the given filePath (used when a file is deleted).
+   * Single snapshot + single `_core.update` via closeTab — no redundant
+   * writable emissions.
+   */
+  closeByPath(filePath: string): void {
+    const tab = get(_core).tabs.find((t) => t.filePath === filePath);
+    if (tab) {
+      tabLifecycleStore.closeTab(tab.id);
+    }
+  },
+
+  /**
+   * Read the current active tab (snapshot — not reactive).
+   * Returns null if no tabs are open.
+   */
+  getActiveTab(): Tab | null {
+    const state = get(_core);
+    if (!state.activeTabId) return null;
+    return findTabById(state, state.activeTabId) ?? null;
+  },
+
+  /**
+   * Close every tab and collapse the split. Used when the vault changes at
+   * runtime — tabs reference absolute paths inside the old vault and must not
+   * leak across a switch.
+   */
+  closeAll(): void {
+    _core.set({
+      tabs: [],
+      activeTabId: null,
+      splitState: { left: [], right: [], activePane: "left" },
+    });
+  },
+};

--- a/src/store/tabReloadStore.test.ts
+++ b/src/store/tabReloadStore.test.ts
@@ -1,0 +1,89 @@
+// tabReloadStore tests — covers the reload signal (request/token) and
+// per-tab save-snapshot mutations (setLastSavedContent/setLastSavedHash).
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+import { tabLifecycleStore } from "./tabLifecycleStore";
+import { tabReloadStore } from "./tabReloadStore";
+import { _core, _reset } from "./tabStoreCore";
+
+beforeEach(() => {
+  _reset();
+  tabReloadStore._reset();
+});
+
+describe("tabReloadStore — reload signal", () => {
+  it("request() emits a new token with the given paths", () => {
+    let observed: { token: string; paths: string[] } | null = null;
+    const unsub = tabReloadStore.subscribe((s) => {
+      if (s.pending) observed = s.pending;
+    });
+    tabReloadStore.request(["notes/a.md", "notes/b.md"]);
+    unsub();
+    expect(observed).not.toBeNull();
+    expect(observed!.paths).toEqual(["notes/a.md", "notes/b.md"]);
+    expect(observed!.token).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("request() with an empty array is a no-op", () => {
+    let emissions = 0;
+    const unsub = tabReloadStore.subscribe(() => {
+      emissions += 1;
+    });
+    const initial = emissions; // subscribe-time replay already counted
+    tabReloadStore.request([]);
+    unsub();
+    expect(emissions).toBe(initial);
+  });
+
+  it("two consecutive request() calls produce different tokens", () => {
+    const tokens: string[] = [];
+    const unsub = tabReloadStore.subscribe((s) => {
+      if (s.pending) tokens.push(s.pending.token);
+    });
+    tabReloadStore.request(["a.md"]);
+    tabReloadStore.request(["a.md"]); // same paths, must still re-trigger
+    unsub();
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).not.toBe(tokens[1]);
+  });
+});
+
+describe("tabReloadStore — per-tab save snapshot", () => {
+  it("setLastSavedContent persists the base snapshot for three-way merge", () => {
+    const id = tabLifecycleStore.openTab("/vault/a.md");
+    tabReloadStore.setLastSavedContent(id, "snapshot body");
+    const tab = get(_core).tabs.find((t) => t.id === id);
+    expect(tab?.lastSavedContent).toBe("snapshot body");
+  });
+
+  it("setLastSavedHash records the disk hash on the tab", () => {
+    const id = tabLifecycleStore.openTab("/vault/a.md");
+    tabReloadStore.setLastSavedHash(id, "abc123");
+    const tab = get(_core).tabs.find((t) => t.id === id);
+    expect(tab?.lastSavedHash).toBe("abc123");
+  });
+
+  it("setLastSavedHash(id, null) is distinguishable from never-set (#80)", () => {
+    const id = tabLifecycleStore.openTab("/vault/a.md");
+    const before = get(_core).tabs.find((t) => t.id === id);
+    expect(before?.lastSavedHash).toBeUndefined();
+    tabReloadStore.setLastSavedHash(id, null);
+    const after = get(_core).tabs.find((t) => t.id === id);
+    expect(after?.lastSavedHash).toBeNull();
+    expect(after?.lastSavedHash === undefined).toBe(false);
+  });
+
+  it("save-snapshot mutations are scoped to the given tab", () => {
+    const a = tabLifecycleStore.openTab("/vault/a.md");
+    const b = tabLifecycleStore.openTab("/vault/b.md");
+    tabReloadStore.setLastSavedContent(a, "A body");
+    tabReloadStore.setLastSavedHash(a, "hash-a");
+    const tabA = get(_core).tabs.find((t) => t.id === a);
+    const tabB = get(_core).tabs.find((t) => t.id === b);
+    expect(tabA?.lastSavedContent).toBe("A body");
+    expect(tabA?.lastSavedHash).toBe("hash-a");
+    expect(tabB?.lastSavedContent).toBe("");
+    expect(tabB?.lastSavedHash).toBeUndefined();
+  });
+});

--- a/src/store/tabReloadStore.test.ts
+++ b/src/store/tabReloadStore.test.ts
@@ -1,14 +1,11 @@
-// tabReloadStore tests — covers the reload signal (request/token) and
-// per-tab save-snapshot mutations (setLastSavedContent/setLastSavedHash).
+// tabReloadStore tests — covers only the one-shot reload signal.
+// Per-tab save-snapshot setters (setLastSavedContent/setLastSavedHash)
+// live on tabLifecycleStore; see tabLifecycleStore.test.ts.
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { get } from "svelte/store";
-import { tabLifecycleStore } from "./tabLifecycleStore";
 import { tabReloadStore } from "./tabReloadStore";
-import { _core, _reset } from "./tabStoreCore";
 
 beforeEach(() => {
-  _reset();
   tabReloadStore._reset();
 });
 
@@ -30,7 +27,7 @@ describe("tabReloadStore — reload signal", () => {
     const unsub = tabReloadStore.subscribe(() => {
       emissions += 1;
     });
-    const initial = emissions; // subscribe-time replay already counted
+    const initial = emissions;
     tabReloadStore.request([]);
     unsub();
     expect(emissions).toBe(initial);
@@ -42,48 +39,9 @@ describe("tabReloadStore — reload signal", () => {
       if (s.pending) tokens.push(s.pending.token);
     });
     tabReloadStore.request(["a.md"]);
-    tabReloadStore.request(["a.md"]); // same paths, must still re-trigger
+    tabReloadStore.request(["a.md"]);
     unsub();
     expect(tokens).toHaveLength(2);
     expect(tokens[0]).not.toBe(tokens[1]);
-  });
-});
-
-describe("tabReloadStore — per-tab save snapshot", () => {
-  it("setLastSavedContent persists the base snapshot for three-way merge", () => {
-    const id = tabLifecycleStore.openTab("/vault/a.md");
-    tabReloadStore.setLastSavedContent(id, "snapshot body");
-    const tab = get(_core).tabs.find((t) => t.id === id);
-    expect(tab?.lastSavedContent).toBe("snapshot body");
-  });
-
-  it("setLastSavedHash records the disk hash on the tab", () => {
-    const id = tabLifecycleStore.openTab("/vault/a.md");
-    tabReloadStore.setLastSavedHash(id, "abc123");
-    const tab = get(_core).tabs.find((t) => t.id === id);
-    expect(tab?.lastSavedHash).toBe("abc123");
-  });
-
-  it("setLastSavedHash(id, null) is distinguishable from never-set (#80)", () => {
-    const id = tabLifecycleStore.openTab("/vault/a.md");
-    const before = get(_core).tabs.find((t) => t.id === id);
-    expect(before?.lastSavedHash).toBeUndefined();
-    tabReloadStore.setLastSavedHash(id, null);
-    const after = get(_core).tabs.find((t) => t.id === id);
-    expect(after?.lastSavedHash).toBeNull();
-    expect(after?.lastSavedHash === undefined).toBe(false);
-  });
-
-  it("save-snapshot mutations are scoped to the given tab", () => {
-    const a = tabLifecycleStore.openTab("/vault/a.md");
-    const b = tabLifecycleStore.openTab("/vault/b.md");
-    tabReloadStore.setLastSavedContent(a, "A body");
-    tabReloadStore.setLastSavedHash(a, "hash-a");
-    const tabA = get(_core).tabs.find((t) => t.id === a);
-    const tabB = get(_core).tabs.find((t) => t.id === b);
-    expect(tabA?.lastSavedContent).toBe("A body");
-    expect(tabA?.lastSavedHash).toBe("hash-a");
-    expect(tabB?.lastSavedContent).toBe("");
-    expect(tabB?.lastSavedHash).toBeUndefined();
   });
 });

--- a/src/store/tabReloadStore.ts
+++ b/src/store/tabReloadStore.ts
@@ -1,19 +1,31 @@
-// tabReloadStore — signals EditorPane to reload specific files from disk.
+// tabReloadStore — disk-sync signals and post-save snapshot state (#341).
 //
-// Use case: the backend rewrote one or more files on disk (e.g. rename-cascade
-// rewrites all wiki-link sources). The rename-cascade suppresses the watcher
-// via write_ignore to avoid double-indexing, but that also suppresses any
-// editor merge notification — so open tabs would keep showing the stale content
-// and the next auto-save would silently revert the cascade's work.
+// Two responsibilities:
 //
-// Callers that know they just externally rewrote files call `request(paths)`
-// with the vault-relative paths of affected files. EditorPane subscribes and,
-// for each path whose absolute form matches an open tab, re-reads the file
-// and dispatches a doc-replace transaction to the CM6 view.
+//   1. One-shot reload signal — callers that externally rewrote files on
+//      disk (e.g. rename-cascade) call `request(paths)` with vault-relative
+//      paths. EditorPane subscribes and, for each path whose absolute form
+//      matches an open tab, re-reads the file and dispatches a doc-replace
+//      transaction to the CM6 view. Token-based one-shot pattern mirrors
+//      scrollStore / treeRefreshStore.
 //
-// Pattern mirrors scrollStore / treeRefreshStore: token-based one-shot signal.
+//      Background: the rename-cascade suppresses the watcher via
+//      write_ignore to avoid double-indexing, but that also suppresses any
+//      editor merge notification — so open tabs would keep showing stale
+//      content and the next auto-save would silently revert the cascade's
+//      work.
+//
+//   2. Per-tab save snapshot state — setLastSavedContent writes the base
+//      snapshot used for three-way merge (Plan 05); setLastSavedHash
+//      records the SHA-256 VaultCore wrote so auto-save can verify the
+//      disk hasn't drifted (#80 — previously a global hash leaked across
+//      tabs).
+//
+// These two concerns live together because both react to disk-sync events
+// produced by the save/watcher pipeline.
 
 import { writable } from "svelte/store";
+import { _core } from "./tabStoreCore";
 
 export interface TabReloadRequest {
   /** Opaque token — changes on every request to detect re-subscribe re-triggers. */
@@ -26,14 +38,43 @@ interface TabReloadState {
   pending: TabReloadRequest | null;
 }
 
-const _store = writable<TabReloadState>({ pending: null });
+const _signal = writable<TabReloadState>({ pending: null });
 
 export const tabReloadStore = {
-  subscribe: _store.subscribe,
+  subscribe: _signal.subscribe,
 
   /** Signal that `paths` were externally rewritten and open tabs need reload. */
   request(paths: string[]): void {
     if (paths.length === 0) return;
-    _store.set({ pending: { token: crypto.randomUUID(), paths } });
+    _signal.set({ pending: { token: crypto.randomUUID(), paths } });
+  },
+
+  /**
+   * Update the base snapshot content used for three-way merge (Plan 05).
+   * Called after auto-save completes, so the snapshot tracks what's on disk.
+   */
+  setLastSavedContent(tabId: string, content: string): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedContent: content } : t)),
+    }));
+  },
+
+  /**
+   * Record the SHA-256 hash VaultCore wrote for this tab's last save.
+   * Called by EditorPane after every successful writeFile so the auto-save
+   * merge-check can compare disk hash against the per-tab expected hash
+   * (#80 — global editorStore.lastSavedHash leaked across tabs).
+   */
+  setLastSavedHash(tabId: string, hash: string | null): void {
+    _core.update((state) => ({
+      ...state,
+      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedHash: hash } : t)),
+    }));
+  },
+
+  /** Test helper — clears the one-shot reload signal. */
+  _reset(): void {
+    _signal.set({ pending: null });
   },
 };

--- a/src/store/tabReloadStore.ts
+++ b/src/store/tabReloadStore.ts
@@ -1,31 +1,23 @@
-// tabReloadStore — disk-sync signals and post-save snapshot state (#341).
+// tabReloadStore — one-shot reload signal for externally rewritten files.
 //
-// Two responsibilities:
+// Callers that know they just externally rewrote files on disk (e.g. rename-
+// cascade) call `request(paths)` with the vault-relative paths of affected
+// files. EditorPane subscribes and, for each path whose absolute form matches
+// an open tab, re-reads the file and dispatches a doc-replace transaction to
+// the CM6 view. Token-based one-shot pattern mirrors scrollStore /
+// treeRefreshStore.
 //
-//   1. One-shot reload signal — callers that externally rewrote files on
-//      disk (e.g. rename-cascade) call `request(paths)` with vault-relative
-//      paths. EditorPane subscribes and, for each path whose absolute form
-//      matches an open tab, re-reads the file and dispatches a doc-replace
-//      transaction to the CM6 view. Token-based one-shot pattern mirrors
-//      scrollStore / treeRefreshStore.
+// Background: the rename-cascade suppresses the watcher via write_ignore to
+// avoid double-indexing, but that also suppresses any editor merge
+// notification — so open tabs would keep showing stale content and the next
+// auto-save would silently revert the cascade's work.
 //
-//      Background: the rename-cascade suppresses the watcher via
-//      write_ignore to avoid double-indexing, but that also suppresses any
-//      editor merge notification — so open tabs would keep showing stale
-//      content and the next auto-save would silently revert the cascade's
-//      work.
-//
-//   2. Per-tab save snapshot state — setLastSavedContent writes the base
-//      snapshot used for three-way merge (Plan 05); setLastSavedHash
-//      records the SHA-256 VaultCore wrote so auto-save can verify the
-//      disk hasn't drifted (#80 — previously a global hash leaked across
-//      tabs).
-//
-// These two concerns live together because both react to disk-sync events
-// produced by the save/watcher pipeline.
+// This facade is its own private writable (`_signal`), independent of
+// tabStoreCore. Per-tab save-snapshot mutations (setLastSavedContent /
+// setLastSavedHash) live on tabLifecycleStore alongside the rest of the
+// per-tab metadata — they share the Tab-shape slice of the core store.
 
 import { writable } from "svelte/store";
-import { _core } from "./tabStoreCore";
 
 export interface TabReloadRequest {
   /** Opaque token — changes on every request to detect re-subscribe re-triggers. */
@@ -47,30 +39,6 @@ export const tabReloadStore = {
   request(paths: string[]): void {
     if (paths.length === 0) return;
     _signal.set({ pending: { token: crypto.randomUUID(), paths } });
-  },
-
-  /**
-   * Update the base snapshot content used for three-way merge (Plan 05).
-   * Called after auto-save completes, so the snapshot tracks what's on disk.
-   */
-  setLastSavedContent(tabId: string, content: string): void {
-    _core.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedContent: content } : t)),
-    }));
-  },
-
-  /**
-   * Record the SHA-256 hash VaultCore wrote for this tab's last save.
-   * Called by EditorPane after every successful writeFile so the auto-save
-   * merge-check can compare disk hash against the per-tab expected hash
-   * (#80 — global editorStore.lastSavedHash leaked across tabs).
-   */
-  setLastSavedHash(tabId: string, hash: string | null): void {
-    _core.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedHash: hash } : t)),
-    }));
   },
 
   /** Test helper — clears the one-shot reload signal. */

--- a/src/store/tabStore.test.ts
+++ b/src/store/tabStore.test.ts
@@ -1,13 +1,13 @@
-// tabStore tests — covers all behaviors from 02-03-PLAN.md
-// Test 1: openTab adds a tab and sets it as activeTabId
-// Test 2: openTab with an already-open file path activates the existing tab (no duplicate)
-// Test 3: closeTab removes the tab; if it was active, activates the nearest sibling (left preferred)
-// Test 4: closeTab on the last tab in a split pane closes the pane and merges remaining tabs into one pane
-// Test 5: cycleTab moves activeTabId to the next tab in the same pane (wraps around)
-// Test 6: moveToPane("right") moves the active tab from left to right pane, creating split if right was empty
-// Test 7: setDirty(tabId, true) sets isDirty on the tab; setDirty(tabId, false) clears it
-// Test 8: updateScrollPos(tabId, pos) persists scroll position for tab restore
-// Test 9: initial state has empty tabs array, null activeTabId, splitState with empty right pane
+// tabStore (shim + cross-concern) tests — #341.
+//
+// Facade-specific tests live in tabLifecycleStore.test.ts / tabLayoutStore
+// .test.ts / tabReloadStore.test.ts. This file covers:
+//   1. Cross-concern operations that span multiple facades (closeTab with
+//      split-collapse is the canonical example).
+//   2. Atomicity — subscribers must never observe torn state across a
+//      cross-concern op. Exactly one emission per op on the shared core.
+//   3. Shim surface — tabStore re-exports every method from the three
+//      facades and stays usable by legacy consumers.
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { get } from "svelte/store";
@@ -17,328 +17,152 @@ beforeEach(() => {
   tabStore._reset();
 });
 
-describe("tabStore", () => {
-  describe("Test 9: initial state", () => {
-    it("has empty tabs array, null activeTabId, splitState with empty right pane", () => {
-      const state = get(tabStore);
-      expect(state.tabs).toEqual([]);
-      expect(state.activeTabId).toBeNull();
-      expect(state.splitState.left).toEqual([]);
-      expect(state.splitState.right).toEqual([]);
-      expect(state.splitState.activePane).toBe("left");
-    });
-  });
-
-  describe("Test 1: openTab", () => {
-    it("adds a tab and sets it as activeTabId", () => {
-      const id = tabStore.openTab("/vault/note-a.md");
-      const state = get(tabStore);
-
-      expect(state.tabs).toHaveLength(1);
-      expect(state.tabs[0]!.filePath).toBe("/vault/note-a.md");
-      expect(state.tabs[0]!.id).toBe(id);
-      expect(state.activeTabId).toBe(id);
-      // Tab goes in left pane by default
-      expect(state.splitState.left).toContain(id);
-    });
-
-    it("opening a second file adds another tab", () => {
-      const id1 = tabStore.openTab("/vault/note-a.md");
-      const id2 = tabStore.openTab("/vault/note-b.md");
-      const state = get(tabStore);
-
-      expect(state.tabs).toHaveLength(2);
-      expect(state.activeTabId).toBe(id2);
-      expect(state.splitState.left).toEqual([id1, id2]);
-    });
-  });
-
-  describe("Test 2: openTab with duplicate path", () => {
-    it("activates existing tab and returns its id (no duplicate)", () => {
-      const id1 = tabStore.openTab("/vault/note-a.md");
-      tabStore.openTab("/vault/note-b.md");
-      const id1Again = tabStore.openTab("/vault/note-a.md");
-      const state = get(tabStore);
-
-      expect(state.tabs).toHaveLength(2); // no new tab created
-      expect(id1Again).toBe(id1);
-      expect(state.activeTabId).toBe(id1);
-    });
-  });
-
-  describe("Test 3: closeTab", () => {
-    it("removes the tab from the store", () => {
-      const id = tabStore.openTab("/vault/note-a.md");
-      tabStore.closeTab(id);
-      const state = get(tabStore);
-
-      expect(state.tabs).toHaveLength(0);
-      expect(state.splitState.left).not.toContain(id);
-    });
-
-    it("if active, activates the left sibling (preferred)", () => {
+describe("tabStore shim — cross-concern behavior", () => {
+  describe("closeTab merges split pane when pane becomes empty", () => {
+    it("closing the only tab in the right pane collapses split to left-only", () => {
       const id1 = tabStore.openTab("/vault/a.md");
       const id2 = tabStore.openTab("/vault/b.md");
-      const id3 = tabStore.openTab("/vault/c.md");
-      // id3 is currently active; close it => should activate id2
-      tabStore.closeTab(id3);
-
-      expect(get(tabStore).activeTabId).toBe(id2);
-    });
-
-    it("falls back to right sibling when closing leftmost active tab", () => {
-      const id1 = tabStore.openTab("/vault/a.md");
-      const id2 = tabStore.openTab("/vault/b.md");
-      tabStore.activateTab(id1);
-      tabStore.closeTab(id1);
-
-      expect(get(tabStore).activeTabId).toBe(id2);
-    });
-
-    it("sets activeTabId to null when last tab is closed", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.closeTab(id);
-
-      expect(get(tabStore).activeTabId).toBeNull();
-    });
-  });
-
-  describe("Test 4: closeTab merges split pane when last tab in pane is closed", () => {
-    it("closing last tab in right pane collapses split to left pane only", () => {
-      const id1 = tabStore.openTab("/vault/a.md");
-      const id2 = tabStore.openTab("/vault/b.md");
-      // Move id2 to right pane to create split
       tabStore.activateTab(id2);
       tabStore.moveToPane("right");
-
-      // Now close the only tab in the right pane (id2)
       tabStore.activateTab(id2);
       tabStore.closeTab(id2);
       const state = get(tabStore);
-
       expect(state.splitState.right).toEqual([]);
       expect(state.splitState.activePane).toBe("left");
       expect(state.tabs.find((t) => t.id === id2)).toBeUndefined();
+      expect(state.splitState.left).toEqual([id1]);
     });
-  });
 
-  describe("Test 5: cycleTab", () => {
-    it("cycles forward through tabs in same pane (wraps around)", () => {
+    it("closing active tab in right pane with sibling leaves right pane intact", () => {
       const id1 = tabStore.openTab("/vault/a.md");
       const id2 = tabStore.openTab("/vault/b.md");
       const id3 = tabStore.openTab("/vault/c.md");
-      tabStore.activateTab(id1);
-
-      tabStore.cycleTab(1);
-      expect(get(tabStore).activeTabId).toBe(id2);
-
-      tabStore.cycleTab(1);
-      expect(get(tabStore).activeTabId).toBe(id3);
-
-      // Wrap around
-      tabStore.cycleTab(1);
-      expect(get(tabStore).activeTabId).toBe(id1);
-    });
-
-    it("cycles backward through tabs (wraps around)", () => {
-      const id1 = tabStore.openTab("/vault/a.md");
-      const id2 = tabStore.openTab("/vault/b.md");
-      const id3 = tabStore.openTab("/vault/c.md");
+      tabStore.activateTab(id2);
+      tabStore.moveToPane("right");
       tabStore.activateTab(id3);
-
-      tabStore.cycleTab(-1);
-      expect(get(tabStore).activeTabId).toBe(id2);
-
-      // Wrap backward
-      tabStore.activateTab(id1);
-      tabStore.cycleTab(-1);
-      expect(get(tabStore).activeTabId).toBe(id3);
+      tabStore.moveToPane("right"); // right pane: [id2, id3]
+      tabStore.closeTab(id2);
+      const state = get(tabStore);
+      expect(state.splitState.right).toEqual([id3]);
+      expect(state.splitState.left).toEqual([id1]);
     });
-  });
 
-  describe("Test 6: moveToPane", () => {
-    it("moves active tab to right pane, creating split if empty", () => {
+    it("closing only tab in left pane collapses split; right contents move into left", () => {
       const id1 = tabStore.openTab("/vault/a.md");
       const id2 = tabStore.openTab("/vault/b.md");
       tabStore.activateTab(id2);
       tabStore.moveToPane("right");
-      const state = get(tabStore);
-
-      expect(state.splitState.left).toContain(id1);
-      expect(state.splitState.left).not.toContain(id2);
-      expect(state.splitState.right).toContain(id2);
-    });
-
-    it("moving to current pane does nothing", () => {
-      const id1 = tabStore.openTab("/vault/a.md");
-      tabStore.moveToPane("left"); // already in left pane
-      const state = get(tabStore);
-
-      expect(state.splitState.left).toContain(id1);
-      expect(state.splitState.right).toEqual([]);
-    });
-
-    it("moving from source pane that becomes empty closes the split", () => {
-      const id1 = tabStore.openTab("/vault/a.md");
-      // Move to right to create split
-      tabStore.moveToPane("right");
-      // Now move back to left; right pane becomes empty
-      tabStore.moveToPane("left");
-      const state = get(tabStore);
-
-      expect(state.splitState.right).toEqual([]);
-      expect(state.splitState.left).toContain(id1);
-    });
-  });
-
-  describe("Test 7: setDirty", () => {
-    it("setDirty(tabId, true) sets isDirty to true", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.setDirty(id, true);
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.isDirty).toBe(true);
-    });
-
-    it("setDirty(tabId, false) clears isDirty", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.setDirty(id, true);
-      tabStore.setDirty(id, false);
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.isDirty).toBe(false);
-    });
-  });
-
-  describe("Test 8: updateScrollPos", () => {
-    it("persists scrollPos and cursorPos for a tab", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.updateScrollPos(id, 42, 100);
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.scrollPos).toBe(42);
-      expect(tab?.cursorPos).toBe(100);
-    });
-  });
-
-  describe("updateFilePath", () => {
-    it("updates the filePath of a tab when renamed", () => {
-      const id = tabStore.openTab("/vault/old-name.md");
-      tabStore.updateFilePath("/vault/old-name.md", "/vault/new-name.md");
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.filePath).toBe("/vault/new-name.md");
-    });
-
-    it("does nothing if oldPath does not match any tab", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.updateFilePath("/vault/nonexistent.md", "/vault/other.md");
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.filePath).toBe("/vault/a.md");
-    });
-  });
-
-  describe("closeByPath", () => {
-    it("closes any tab with matching filePath", () => {
-      const id1 = tabStore.openTab("/vault/a.md");
-      const id2 = tabStore.openTab("/vault/b.md");
-      tabStore.closeByPath("/vault/a.md");
-      const state = get(tabStore);
-
-      expect(state.tabs.find((t) => t.id === id1)).toBeUndefined();
-      expect(state.tabs.find((t) => t.id === id2)).toBeDefined();
-    });
-  });
-
-  describe("openGraphTab", () => {
-    it("creates a singleton graph tab and activates it", () => {
-      const id = tabStore.openGraphTab();
-      const state = get(tabStore);
-      expect(state.tabs).toHaveLength(1);
-      const tab = state.tabs.find((t) => t.id === id);
-      expect(tab?.type).toBe("graph");
-      expect(tab?.filePath).toBe("vault://graph");
-      expect(state.activeTabId).toBe(id);
-    });
-
-    it("focuses the existing graph tab when called twice (no duplicate)", () => {
-      const id1 = tabStore.openGraphTab();
-      tabStore.openTab("/vault/a.md");
-      const id2 = tabStore.openGraphTab();
-      const state = get(tabStore);
-      expect(id2).toBe(id1);
-      expect(state.tabs.filter((t) => t.type === "graph")).toHaveLength(1);
-      expect(state.activeTabId).toBe(id1);
-    });
-
-    it("graph tab can be closed like any other tab", () => {
-      tabStore.openTab("/vault/a.md");
-      const gid = tabStore.openGraphTab();
-      tabStore.closeTab(gid);
-      const state = get(tabStore);
-      expect(state.tabs.find((t) => t.type === "graph")).toBeUndefined();
-    });
-
-    it("cycleTab traverses graph + file tabs uniformly", () => {
-      const a = tabStore.openTab("/vault/a.md");
-      const gid = tabStore.openGraphTab();
-      tabStore.activateTab(a);
-      tabStore.cycleTab(1);
-      expect(get(tabStore).activeTabId).toBe(gid);
-    });
-
-    it("file tabs default to type undefined (backwards-compatible)", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.type).toBeUndefined();
-    });
-  });
-
-  describe("activateTab", () => {
-    it("sets activeTabId and switches activePane", () => {
-      const id1 = tabStore.openTab("/vault/a.md");
-      const id2 = tabStore.openTab("/vault/b.md");
-      tabStore.activateTab(id2);
-      tabStore.moveToPane("right");
-      // Now id1 is in left, id2 is in right; activate id1
       tabStore.activateTab(id1);
+      tabStore.closeTab(id1);
       const state = get(tabStore);
-
-      expect(state.activeTabId).toBe(id1);
+      expect(state.splitState.right).toEqual([]);
+      expect(state.splitState.left).toEqual([id2]);
       expect(state.splitState.activePane).toBe("left");
+      expect(state.activeTabId).toBe(id2);
     });
   });
+});
 
-  describe("Issue #63: Reading Mode per-tab view mode", () => {
-    it("new tabs default viewMode to undefined (implicitly 'edit')", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.viewMode).toBeUndefined();
-    });
+describe("tabStore shim — atomicity (exactly one emission per op)", () => {
+  // Every cross-concern method must perform a single `_core.update(...)`.
+  // Multiple updates produce torn intermediate states — subscribers could
+  // observe `tabs` updated before `splitState.left`, or the new `activeTabId`
+  // pointing at a tab that isn't yet in any pane. Asserting emission count
+  // is the tight regression net.
 
-    it("setViewMode('read') flips the tab to Reading Mode", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.setViewMode(id, "read");
-      const tab = get(tabStore).tabs.find((t) => t.id === id);
-      expect(tab?.viewMode).toBe("read");
+  function countEmissionsDuring(fn: () => void): number {
+    let count = -1; // discount the subscribe-time replay
+    const unsub = tabStore.subscribe(() => {
+      count += 1;
     });
+    fn();
+    unsub();
+    return count;
+  }
 
-    it("toggleViewMode flips between edit and read, treating undefined as edit", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.toggleViewMode(id);
-      expect(get(tabStore).tabs.find((t) => t.id === id)?.viewMode).toBe("read");
-      tabStore.toggleViewMode(id);
-      expect(get(tabStore).tabs.find((t) => t.id === id)?.viewMode).toBe("edit");
+  it("openTab emits exactly once", () => {
+    const emissions = countEmissionsDuring(() => {
+      tabStore.openTab("/vault/a.md");
     });
+    expect(emissions).toBe(1);
+  });
 
-    it("toggleViewMode is scoped to the given tab id", () => {
-      const a = tabStore.openTab("/vault/a.md");
-      const b = tabStore.openTab("/vault/b.md");
-      tabStore.toggleViewMode(a);
-      expect(get(tabStore).tabs.find((t) => t.id === a)?.viewMode).toBe("read");
-      expect(get(tabStore).tabs.find((t) => t.id === b)?.viewMode).toBeUndefined();
+  it("closeTab with merge-collapse emits exactly once", () => {
+    tabStore.openTab("/vault/a.md");
+    const id2 = tabStore.openTab("/vault/b.md");
+    tabStore.activateTab(id2);
+    tabStore.moveToPane("right");
+    tabStore.activateTab(id2);
+    const emissions = countEmissionsDuring(() => {
+      tabStore.closeTab(id2);
     });
+    expect(emissions).toBe(1);
+  });
 
-    it("updateReadingScrollPos persists the reader's scroll position", () => {
-      const id = tabStore.openTab("/vault/a.md");
-      tabStore.updateReadingScrollPos(id, 420);
-      expect(get(tabStore).tabs.find((t) => t.id === id)?.readingScrollPos).toBe(420);
+  it("moveToPane emits exactly once", () => {
+    tabStore.openTab("/vault/a.md");
+    const id2 = tabStore.openTab("/vault/b.md");
+    tabStore.activateTab(id2);
+    const emissions = countEmissionsDuring(() => {
+      tabStore.moveToPane("right");
     });
+    expect(emissions).toBe(1);
+  });
+
+  it("activateTab emits exactly once", () => {
+    const id1 = tabStore.openTab("/vault/a.md");
+    tabStore.openTab("/vault/b.md");
+    const emissions = countEmissionsDuring(() => {
+      tabStore.activateTab(id1);
+    });
+    expect(emissions).toBe(1);
+  });
+
+  it("closeByPath emits exactly once when a matching tab exists", () => {
+    tabStore.openTab("/vault/a.md");
+    tabStore.openTab("/vault/b.md");
+    const emissions = countEmissionsDuring(() => {
+      tabStore.closeByPath("/vault/a.md");
+    });
+    expect(emissions).toBe(1);
+  });
+
+  it("closeByPath is silent when no tab matches the path", () => {
+    tabStore.openTab("/vault/a.md");
+    const emissions = countEmissionsDuring(() => {
+      tabStore.closeByPath("/vault/missing.md");
+    });
+    expect(emissions).toBe(0);
+  });
+});
+
+describe("tabStore shim — surface preservation", () => {
+  it("exposes every legacy method via the shim", () => {
+    const methods = [
+      "openTab",
+      "openFileTab",
+      "openGraphTab",
+      "closeTab",
+      "closeAll",
+      "closeByPath",
+      "activateTab",
+      "cycleTab",
+      "getActiveTab",
+      "setDirty",
+      "setViewMode",
+      "toggleViewMode",
+      "updateScrollPos",
+      "updateReadingScrollPos",
+      "updateFilePath",
+      "moveToPane",
+      "_reorderPane",
+      "setLastSavedContent",
+      "setLastSavedHash",
+      "_reset",
+    ] as const;
+    for (const name of methods) {
+      expect(typeof (tabStore as Record<string, unknown>)[name]).toBe("function");
+    }
+    expect(typeof tabStore.subscribe).toBe("function");
   });
 });

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -1,532 +1,60 @@
-// tabStore — classic Svelte `writable` store per D-06 / RC-01.
-// Manages multi-tab layout and split-view state for Plan 03 (EDIT-05, EDIT-06).
-// editorStore continues to handle per-active-tab CM6 content and hash state.
+// tabStore — compatibility shim over the three facades introduced by #341.
+//
+// New code should import from the specific facade for the concern it touches:
+//   • tabLifecycleStore — open/close/activate/cycle/per-tab metadata
+//   • tabLayoutStore    — moveToPane / reorderPane
+//   • tabReloadStore    — reload request + save snapshot state
+//
+// This shim exists to keep the existing 38+ consumers of `tabStore` working
+// unchanged; it does not add any API beyond what those consumers already use.
+//
+// The `_reorderPane` alias preserves the pre-refactor method name for
+// TabBar.svelte; new callers should use tabLayoutStore.reorderPane directly.
 
-import { writable } from "svelte/store";
+import { _core, _reset } from "./tabStoreCore";
+import { tabLifecycleStore } from "./tabLifecycleStore";
+import { tabLayoutStore } from "./tabLayoutStore";
+import { tabReloadStore } from "./tabReloadStore";
 
-/**
- * Tab `type` discriminant — "file" is the default (normal markdown tab);
- * "graph" is the whole-vault graph view (issue #32). Graph tabs store a
- * sentinel filePath so any existing code paths that look at filePath
- * (e.g. absolute-path matching, sidebar sync) keep working without a
- * widespread refactor.
- */
-export type TabType = "file" | "graph";
-
-/**
- * Non-markdown file previews (#49). `viewer` selects which UI branch
- * EditorPane renders. Omitted on markdown tabs for backwards compatibility
- * with existing callers that never set this field.
- */
-export type TabViewer = "markdown" | "image" | "text" | "unsupported" | "canvas";
-
-/**
- * Reading Mode vs Edit Mode (#63). Persisted per-tab; only meaningful for
- * markdown tabs (image / unsupported previews ignore this flag). Defaults
- * to "edit" when omitted so existing tabs remain editable.
- */
-export type TabViewMode = "edit" | "read";
-
-/** Sentinel filePath used by the singleton graph tab. */
-export const GRAPH_TAB_PATH = "vault://graph";
-
-export interface Tab {
-  id: string;
-  filePath: string;
-  isDirty: boolean;
-  scrollPos: number;
-  cursorPos: number;
-  lastSaved: number;
-  lastSavedContent: string;  // base snapshot for three-way merge (Plan 05)
-  /**
-   * SHA-256 of the last content VaultCore wrote to disk for this tab.
-   * Per-tab so switching between tabs doesn't leak another tab's hash into
-   * the auto-save merge check (#80). `null` when the tab has never been
-   * saved in this session — the first auto-save skips the hash-verify
-   * merge branch and takes the direct-write path.
-   */
-  lastSavedHash?: string | null;
-  /** Tab kind — "file" when omitted. */
-  type?: TabType;
-  /**
-   * Viewer used to render the tab (#49). Omitted on existing markdown tabs
-   * so previous callers continue to work unchanged. "image" / "text" /
-   * "unsupported" are set by openFileTab() when opening non-markdown files.
-   */
-  viewer?: TabViewer;
-  /**
-   * Reading Mode toggle (#63). "edit" = CM6 editor with live preview,
-   * "read" = rendered HTML. Omitted tabs behave as "edit".
-   */
-  viewMode?: TabViewMode;
-  /**
-   * Scroll position used by Reading Mode (#63). Tracked separately from
-   * `scrollPos` so switching modes can restore each view's last position
-   * without clobbering the other.
-   */
-  readingScrollPos?: number;
-}
-
-export interface SplitState {
-  left: string[];  // Tab IDs in left pane
-  right: string[]; // Tab IDs in right pane (empty = no split)
-  activePane: "left" | "right";
-}
-
-export interface TabStoreState {
-  tabs: Tab[];
-  activeTabId: string | null;
-  splitState: SplitState;
-}
-
-const initial: TabStoreState = {
-  tabs: [],
-  activeTabId: null,
-  splitState: { left: [], right: [], activePane: "left" },
-};
-
-function makeInitial(): TabStoreState {
-  return {
-    tabs: [],
-    activeTabId: null,
-    splitState: { left: [], right: [], activePane: "left" },
-  };
-}
-
-const _store = writable<TabStoreState>(makeInitial());
-
-function findTabById(state: TabStoreState, id: string): Tab | undefined {
-  return state.tabs.find((t) => t.id === id);
-}
-
-function whichPane(state: TabStoreState, tabId: string): "left" | "right" | null {
-  if (state.splitState.left.includes(tabId)) return "left";
-  if (state.splitState.right.includes(tabId)) return "right";
-  return null;
-}
+export {
+  GRAPH_TAB_PATH,
+  type SplitState,
+  type Tab,
+  type TabStoreState,
+  type TabType,
+  type TabViewer,
+  type TabViewMode,
+} from "./tabStoreCore";
 
 export const tabStore = {
-  subscribe: _store.subscribe,
+  subscribe: _core.subscribe,
 
-  /**
-   * Open a tab for the given file path.
-   * If a tab with the same path already exists, activate it (no duplicate).
-   * Otherwise, create a new tab in the currently active pane.
-   * Returns the tab ID.
-   */
-  openTab(filePath: string): string {
-    let returnId = "";
-    _store.update((state) => {
-      // Check for existing tab with same filePath
-      const existing = state.tabs.find((t) => t.filePath === filePath);
-      if (existing) {
-        returnId = existing.id;
-        const pane = whichPane(state, existing.id) ?? "left";
-        return {
-          ...state,
-          activeTabId: existing.id,
-          splitState: { ...state.splitState, activePane: pane },
-        };
-      }
+  // Lifecycle
+  openTab: tabLifecycleStore.openTab,
+  openFileTab: tabLifecycleStore.openFileTab,
+  openGraphTab: tabLifecycleStore.openGraphTab,
+  closeTab: tabLifecycleStore.closeTab,
+  closeAll: tabLifecycleStore.closeAll,
+  closeByPath: tabLifecycleStore.closeByPath,
+  activateTab: tabLifecycleStore.activateTab,
+  cycleTab: tabLifecycleStore.cycleTab,
+  getActiveTab: tabLifecycleStore.getActiveTab,
+  setDirty: tabLifecycleStore.setDirty,
+  setViewMode: tabLifecycleStore.setViewMode,
+  toggleViewMode: tabLifecycleStore.toggleViewMode,
+  updateScrollPos: tabLifecycleStore.updateScrollPos,
+  updateReadingScrollPos: tabLifecycleStore.updateReadingScrollPos,
+  updateFilePath: tabLifecycleStore.updateFilePath,
 
-      // Create new tab
-      const id = crypto.randomUUID();
-      returnId = id;
-      const tab: Tab = {
-        id,
-        filePath,
-        isDirty: false,
-        scrollPos: 0,
-        cursorPos: 0,
-        lastSaved: Date.now(),
-        lastSavedContent: "",
-      };
+  // Layout
+  moveToPane: tabLayoutStore.moveToPane,
+  /** Preserved alias — new callers: use tabLayoutStore.reorderPane. */
+  _reorderPane: tabLayoutStore.reorderPane,
 
-      const activePane = state.splitState.activePane;
-      const newPaneIds = [...state.splitState[activePane], id];
-      return {
-        ...state,
-        tabs: [...state.tabs, tab],
-        activeTabId: id,
-        splitState: {
-          ...state.splitState,
-          [activePane]: newPaneIds,
-        },
-      };
-    });
-    return returnId;
-  },
+  // Reload / save snapshot
+  setLastSavedContent: tabReloadStore.setLastSavedContent,
+  setLastSavedHash: tabReloadStore.setLastSavedHash,
 
-  /**
-   * Open a tab with an explicit viewer kind (#49). Used for non-markdown
-   * files — images, read-only text previews, and unsupported binaries.
-   * Same dedupe-by-filePath semantics as openTab().
-   */
-  openFileTab(filePath: string, viewer: TabViewer): string {
-    let returnId = "";
-    _store.update((state) => {
-      const existing = state.tabs.find((t) => t.filePath === filePath);
-      if (existing) {
-        returnId = existing.id;
-        const pane = whichPane(state, existing.id) ?? "left";
-        return {
-          ...state,
-          activeTabId: existing.id,
-          splitState: { ...state.splitState, activePane: pane },
-        };
-      }
-
-      const id = crypto.randomUUID();
-      returnId = id;
-      const tab: Tab = {
-        id,
-        filePath,
-        isDirty: false,
-        scrollPos: 0,
-        cursorPos: 0,
-        lastSaved: Date.now(),
-        lastSavedContent: "",
-        viewer,
-      };
-      const activePane = state.splitState.activePane;
-      const newPaneIds = [...state.splitState[activePane], id];
-      return {
-        ...state,
-        tabs: [...state.tabs, tab],
-        activeTabId: id,
-        splitState: {
-          ...state.splitState,
-          [activePane]: newPaneIds,
-        },
-      };
-    });
-    return returnId;
-  },
-
-  /**
-   * Open (or focus) the singleton whole-vault graph tab.
-   * Returns the graph tab's ID. Uses a reserved filePath sentinel so the
-   * existing dedupe-by-filePath logic in openTab still applies when called
-   * repeatedly.
-   */
-  openGraphTab(): string {
-    let returnId = "";
-    _store.update((state) => {
-      const existing = state.tabs.find((t) => t.type === "graph");
-      if (existing) {
-        returnId = existing.id;
-        const pane = whichPane(state, existing.id) ?? "left";
-        return {
-          ...state,
-          activeTabId: existing.id,
-          splitState: { ...state.splitState, activePane: pane },
-        };
-      }
-
-      const id = crypto.randomUUID();
-      returnId = id;
-      const tab: Tab = {
-        id,
-        filePath: GRAPH_TAB_PATH,
-        isDirty: false,
-        scrollPos: 0,
-        cursorPos: 0,
-        lastSaved: Date.now(),
-        lastSavedContent: "",
-        type: "graph",
-      };
-      const activePane = state.splitState.activePane;
-      const newPaneIds = [...state.splitState[activePane], id];
-      return {
-        ...state,
-        tabs: [...state.tabs, tab],
-        activeTabId: id,
-        splitState: {
-          ...state.splitState,
-          [activePane]: newPaneIds,
-        },
-      };
-    });
-    return returnId;
-  },
-
-  /**
-   * Close a tab by ID.
-   * If it was active, activates the left sibling (or right if it was leftmost).
-   * If a split pane becomes empty after close, merges it back to one pane.
-   */
-  closeTab(tabId: string): void {
-    _store.update((state) => {
-      const pane = whichPane(state, tabId);
-      if (pane === null) return state; // tab not found
-
-      const paneIds = state.splitState[pane];
-      const idx = paneIds.indexOf(tabId);
-      const newPaneIds = paneIds.filter((id) => id !== tabId);
-      const newTabs = state.tabs.filter((t) => t.id !== tabId);
-
-      // Determine new active tab
-      let newActiveTabId = state.activeTabId;
-      let newSplitState: SplitState;
-
-      // Handle pane becoming empty
-      const otherPane: "left" | "right" = pane === "left" ? "right" : "left";
-      if (newPaneIds.length === 0 && state.splitState[otherPane].length > 0) {
-        // Merge remaining tabs into left pane
-        const mergedLeft = pane === "left"
-          ? state.splitState[otherPane]
-          : newPaneIds.concat(state.splitState.right.filter((id) => id !== tabId));
-
-        const allLeft = state.splitState.left
-          .filter((id) => id !== tabId)
-          .concat(state.splitState.right.filter((id) => id !== tabId));
-
-        newSplitState = { left: allLeft, right: [], activePane: "left" };
-        // Active tab: keep current or pick first from merged
-        if (newActiveTabId === tabId) {
-          newActiveTabId = allLeft[0] ?? null;
-        }
-      } else {
-        newSplitState = { ...state.splitState, [pane]: newPaneIds };
-
-        if (state.activeTabId === tabId) {
-          // Prefer left sibling, then right sibling
-          if (idx > 0 && newPaneIds[idx - 1]) {
-            newActiveTabId = newPaneIds[idx - 1] ?? null;
-          } else if (newPaneIds[idx]) {
-            newActiveTabId = newPaneIds[idx] ?? null;
-          } else if (newPaneIds.length > 0) {
-            newActiveTabId = newPaneIds[newPaneIds.length - 1] ?? null;
-          } else {
-            const other = state.splitState[otherPane];
-            newActiveTabId = other.length > 0 ? (other[0] ?? null) : null;
-          }
-        }
-      }
-
-      return {
-        ...state,
-        tabs: newTabs,
-        activeTabId: newActiveTabId,
-        splitState: newSplitState,
-      };
-    });
-  },
-
-  /**
-   * Activate a tab by ID, updating activePane to match the pane containing it.
-   */
-  activateTab(tabId: string): void {
-    _store.update((state) => {
-      const pane = whichPane(state, tabId) ?? state.splitState.activePane;
-      return {
-        ...state,
-        activeTabId: tabId,
-        splitState: { ...state.splitState, activePane: pane },
-      };
-    });
-  },
-
-  /**
-   * Cycle to the next (direction=1) or previous (direction=-1) tab within
-   * the active pane. Wraps around at the ends.
-   */
-  cycleTab(direction: 1 | -1): void {
-    _store.update((state) => {
-      const pane = state.splitState.activePane;
-      const paneIds = state.splitState[pane];
-      if (paneIds.length === 0) return state;
-
-      const currentIdx = state.activeTabId ? paneIds.indexOf(state.activeTabId) : -1;
-      const nextIdx = (currentIdx + direction + paneIds.length) % paneIds.length;
-      return { ...state, activeTabId: paneIds[nextIdx] ?? state.activeTabId };
-    });
-  },
-
-  /**
-   * Move the currently active tab to the specified pane.
-   * Creates a split if the target pane was empty.
-   * If the source pane becomes empty, closes that pane (merge back to one pane).
-   */
-  moveToPane(targetPane: "left" | "right"): void {
-    _store.update((state) => {
-      const activeTabId = state.activeTabId;
-      if (!activeTabId) return state;
-
-      const sourcePane = whichPane(state, activeTabId);
-      if (sourcePane === null) return state;
-      if (sourcePane === targetPane) return state; // already there
-
-      const newSourceIds = state.splitState[sourcePane].filter((id) => id !== activeTabId);
-      const newTargetIds = [...state.splitState[targetPane], activeTabId];
-
-      let newSplitState: SplitState;
-      if (newSourceIds.length === 0) {
-        // Source pane is now empty — collapse split to one pane (always left)
-        // All tabs end up in left pane
-        const leftIds = targetPane === "left" ? newTargetIds : newTargetIds;
-        newSplitState = {
-          left: leftIds,
-          right: [],
-          activePane: "left",
-        };
-      } else {
-        newSplitState = {
-          ...state.splitState,
-          [sourcePane]: newSourceIds,
-          [targetPane]: newTargetIds,
-          activePane: targetPane,
-        };
-      }
-
-      return {
-        ...state,
-        splitState: newSplitState,
-      };
-    });
-  },
-
-  /**
-   * Set the isDirty flag on a tab (true = unsaved changes, shows dirty dot in tab UI).
-   */
-  setDirty(tabId: string, dirty: boolean): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, isDirty: dirty } : t)),
-    }));
-  },
-
-  /**
-   * Persist scroll and cursor position for a tab so they can be restored on re-activate.
-   */
-  updateScrollPos(tabId: string, scrollPos: number, cursorPos: number): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, scrollPos, cursorPos } : t)),
-    }));
-  },
-
-  /** Persist Reading Mode scroll position (#63). */
-  updateReadingScrollPos(tabId: string, readingScrollPos: number): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, readingScrollPos } : t)),
-    }));
-  },
-
-  /** Set the view mode on a tab (#63). */
-  setViewMode(tabId: string, viewMode: TabViewMode): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, viewMode } : t)),
-    }));
-  },
-
-  /** Toggle between edit / read on a tab; no-op when the tab is missing (#63). */
-  toggleViewMode(tabId: string): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => {
-        if (t.id !== tabId) return t;
-        const next: TabViewMode = (t.viewMode ?? "edit") === "edit" ? "read" : "edit";
-        return { ...t, viewMode: next };
-      }),
-    }));
-  },
-
-  /**
-   * When a file is renamed/moved, update the matching tab's filePath.
-   */
-  updateFilePath(oldPath: string, newPath: string): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.filePath === oldPath ? { ...t, filePath: newPath } : t)),
-    }));
-  },
-
-  /**
-   * Close any tab with the given filePath (used when a file is deleted).
-   */
-  closeByPath(filePath: string): void {
-    _store.update((state) => {
-      const tab = state.tabs.find((t) => t.filePath === filePath);
-      if (!tab) return state;
-      // Reuse closeTab logic via internal state mutation
-      return state;
-    });
-    // Get current state, find tab, then closeTab
-    let tabId: string | undefined;
-    const unsub = _store.subscribe((state) => {
-      tabId = state.tabs.find((t) => t.filePath === filePath)?.id;
-    });
-    unsub();
-    if (tabId) {
-      tabStore.closeTab(tabId);
-    }
-  },
-
-  /**
-   * Read the current active tab (snapshot — not reactive).
-   * Returns null if no tabs are open.
-   */
-  getActiveTab(): Tab | null {
-    let result: Tab | null = null;
-    const unsub = _store.subscribe((state) => {
-      result = state.activeTabId
-        ? (state.tabs.find((t) => t.id === state.activeTabId) ?? null)
-        : null;
-    });
-    unsub();
-    return result;
-  },
-
-  /**
-   * Update the base snapshot content used for three-way merge (Plan 05).
-   * Called after auto-save completes, so the snapshot tracks what's on disk.
-   */
-  setLastSavedContent(tabId: string, content: string): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedContent: content } : t)),
-    }));
-  },
-
-  /**
-   * Record the SHA-256 hash VaultCore wrote for this tab's last save.
-   * Called by EditorPane after every successful writeFile so the auto-save
-   * merge-check can compare disk hash against the per-tab expected hash
-   * (#80 — global editorStore.lastSavedHash leaked across tabs).
-   */
-  setLastSavedHash(tabId: string, hash: string | null): void {
-    _store.update((state) => ({
-      ...state,
-      tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, lastSavedHash: hash } : t)),
-    }));
-  },
-
-  /**
-   * Close every tab and collapse the split. Used when the vault changes at
-   * runtime — tabs reference absolute paths inside the old vault and must not
-   * leak across a switch.
-   */
-  closeAll(): void {
-    _store.set(makeInitial());
-  },
-
-  /**
-   * Reorder the tab IDs in a specific pane (used by drag-to-reorder in TabBar).
-   */
-  _reorderPane(pane: "left" | "right", newIds: string[]): void {
-    _store.update((state) => ({
-      ...state,
-      splitState: { ...state.splitState, [pane]: newIds },
-    }));
-  },
-
-  /**
-   * Test helper — resets to initial state.
-   */
-  _reset(): void {
-    _store.set(makeInitial());
-  },
+  // Test helper
+  _reset,
 };

--- a/src/store/tabStore.ts
+++ b/src/store/tabStore.ts
@@ -1,9 +1,11 @@
 // tabStore — compatibility shim over the three facades introduced by #341.
 //
 // New code should import from the specific facade for the concern it touches:
-//   • tabLifecycleStore — open/close/activate/cycle/per-tab metadata
-//   • tabLayoutStore    — moveToPane / reorderPane
-//   • tabReloadStore    — reload request + save snapshot state
+//   • tabLifecycleStore — Tab[] slice (open/close/activate/cycle + per-tab
+//     metadata including save snapshot state)
+//   • tabLayoutStore    — SplitState slice (moveToPane / reorderPane)
+//   • tabReloadStore    — disk-sync one-shot reload signal (independent
+//     private writable; own .subscribe)
 //
 // This shim exists to keep the existing 38+ consumers of `tabStore` working
 // unchanged; it does not add any API beyond what those consumers already use.
@@ -11,7 +13,7 @@
 // The `_reorderPane` alias preserves the pre-refactor method name for
 // TabBar.svelte; new callers should use tabLayoutStore.reorderPane directly.
 
-import { _core, _reset } from "./tabStoreCore";
+import { _core, _reset as _resetCore } from "./tabStoreCore";
 import { tabLifecycleStore } from "./tabLifecycleStore";
 import { tabLayoutStore } from "./tabLayoutStore";
 import { tabReloadStore } from "./tabReloadStore";
@@ -45,16 +47,21 @@ export const tabStore = {
   updateScrollPos: tabLifecycleStore.updateScrollPos,
   updateReadingScrollPos: tabLifecycleStore.updateReadingScrollPos,
   updateFilePath: tabLifecycleStore.updateFilePath,
+  setLastSavedContent: tabLifecycleStore.setLastSavedContent,
+  setLastSavedHash: tabLifecycleStore.setLastSavedHash,
 
   // Layout
   moveToPane: tabLayoutStore.moveToPane,
   /** Preserved alias — new callers: use tabLayoutStore.reorderPane. */
   _reorderPane: tabLayoutStore.reorderPane,
 
-  // Reload / save snapshot
-  setLastSavedContent: tabReloadStore.setLastSavedContent,
-  setLastSavedHash: tabReloadStore.setLastSavedHash,
-
-  // Test helper
-  _reset,
+  /**
+   * Full reset: clears both the shared core (tabs + split) and the
+   * disk-sync reload signal. Tests that need only the core reset can
+   * import `_reset` from tabStoreCore directly.
+   */
+  _reset(): void {
+    _resetCore();
+    tabReloadStore._reset();
+  },
 };

--- a/src/store/tabStoreCore.ts
+++ b/src/store/tabStoreCore.ts
@@ -1,11 +1,16 @@
 // tabStoreCore — shared writable backing the three tab facades (#341).
 //
-// Decision rule for where a new method belongs:
-//   • tabLifecycleStore — tab identity (open/close/activate/cycle) and
-//     per-tab metadata (dirty flag, view mode, scroll positions, rename).
-//   • tabLayoutStore    — pane arrangement (moveToPane, reorderPane).
-//   • tabReloadStore    — disk-sync signals and post-save snapshot state
-//     (lastSavedContent, lastSavedHash, request-reload token).
+// Decision rule for where a new method belongs — split by data shape,
+// not by causal origin. A setter belongs to the facade that owns the
+// slice of state it mutates:
+//   • tabLifecycleStore — anything that reads/writes the Tab[] slice
+//     (open/close/activate/cycle + every per-tab field: isDirty,
+//     viewMode, scrollPos, lastSavedContent, lastSavedHash, ...).
+//   • tabLayoutStore    — anything that reads/writes the SplitState slice
+//     (moveToPane, reorderPane).
+//   • tabReloadStore    — disk-sync signal that does NOT live in the
+//     shared core; it has its own private writable for the one-shot
+//     reload token dispatched by the rename-cascade path.
 //
 // The three facades share one private writable here. Every cross-concern
 // mutation (e.g. closeTab touches tabs + splitState + activeTabId) lives in

--- a/src/store/tabStoreCore.ts
+++ b/src/store/tabStoreCore.ts
@@ -1,0 +1,125 @@
+// tabStoreCore — shared writable backing the three tab facades (#341).
+//
+// Decision rule for where a new method belongs:
+//   • tabLifecycleStore — tab identity (open/close/activate/cycle) and
+//     per-tab metadata (dirty flag, view mode, scroll positions, rename).
+//   • tabLayoutStore    — pane arrangement (moveToPane, reorderPane).
+//   • tabReloadStore    — disk-sync signals and post-save snapshot state
+//     (lastSavedContent, lastSavedHash, request-reload token).
+//
+// The three facades share one private writable here. Every cross-concern
+// mutation (e.g. closeTab touches tabs + splitState + activeTabId) lives in
+// exactly one facade method and performs a single `_core.update(...)` so
+// subscribers never observe a torn intermediate state. The atomicity tests
+// in tabStore.test.ts assert exactly-one emission per cross-concern op.
+//
+// tabStore.ts remains as a thin compatibility shim re-exporting the full
+// method surface for existing consumers.
+//
+// Classic Svelte `writable` per D-06 / RC-01.
+import { writable } from "svelte/store";
+
+/**
+ * Tab `type` discriminant — "file" is the default (normal markdown tab);
+ * "graph" is the whole-vault graph view (issue #32). Graph tabs store a
+ * sentinel filePath so any existing code paths that look at filePath
+ * (e.g. absolute-path matching, sidebar sync) keep working without a
+ * widespread refactor.
+ */
+export type TabType = "file" | "graph";
+
+/**
+ * Non-markdown file previews (#49). `viewer` selects which UI branch
+ * EditorPane renders. Omitted on markdown tabs for backwards compatibility
+ * with existing callers that never set this field.
+ */
+export type TabViewer = "markdown" | "image" | "text" | "unsupported" | "canvas";
+
+/**
+ * Reading Mode vs Edit Mode (#63). Persisted per-tab; only meaningful for
+ * markdown tabs (image / unsupported previews ignore this flag). Defaults
+ * to "edit" when omitted so existing tabs remain editable.
+ */
+export type TabViewMode = "edit" | "read";
+
+/** Sentinel filePath used by the singleton graph tab. */
+export const GRAPH_TAB_PATH = "vault://graph";
+
+export interface Tab {
+  id: string;
+  filePath: string;
+  isDirty: boolean;
+  scrollPos: number;
+  cursorPos: number;
+  lastSaved: number;
+  lastSavedContent: string;  // base snapshot for three-way merge (Plan 05)
+  /**
+   * SHA-256 of the last content VaultCore wrote to disk for this tab.
+   * Per-tab so switching between tabs doesn't leak another tab's hash into
+   * the auto-save merge check (#80). `null` when the tab has never been
+   * saved in this session — the first auto-save skips the hash-verify
+   * merge branch and takes the direct-write path.
+   */
+  lastSavedHash?: string | null;
+  /** Tab kind — "file" when omitted. */
+  type?: TabType;
+  /**
+   * Viewer used to render the tab (#49). Omitted on existing markdown tabs
+   * so previous callers continue to work unchanged. "image" / "text" /
+   * "unsupported" are set by openFileTab() when opening non-markdown files.
+   */
+  viewer?: TabViewer;
+  /**
+   * Reading Mode toggle (#63). "edit" = CM6 editor with live preview,
+   * "read" = rendered HTML. Omitted tabs behave as "edit".
+   */
+  viewMode?: TabViewMode;
+  /**
+   * Scroll position used by Reading Mode (#63). Tracked separately from
+   * `scrollPos` so switching modes can restore each view's last position
+   * without clobbering the other.
+   */
+  readingScrollPos?: number;
+}
+
+export interface SplitState {
+  left: string[];  // Tab IDs in left pane
+  right: string[]; // Tab IDs in right pane (empty = no split)
+  activePane: "left" | "right";
+}
+
+export interface TabStoreState {
+  tabs: Tab[];
+  activeTabId: string | null;
+  splitState: SplitState;
+}
+
+export function makeInitial(): TabStoreState {
+  return {
+    tabs: [],
+    activeTabId: null,
+    splitState: { left: [], right: [], activePane: "left" },
+  };
+}
+
+/**
+ * Shared private writable. Facades import this and call `.update`/`.set`
+ * directly — consumers should never see this symbol, they subscribe via
+ * the facade's `.subscribe`.
+ */
+export const _core = writable<TabStoreState>(makeInitial());
+
+export function findTabById(state: TabStoreState, id: string): Tab | undefined {
+  return state.tabs.find((t) => t.id === id);
+}
+
+export function whichPane(state: TabStoreState, tabId: string): "left" | "right" | null {
+  if (state.splitState.left.includes(tabId)) return "left";
+  if (state.splitState.right.includes(tabId)) return "right";
+  return null;
+}
+
+/** Reset the shared writable to its initial empty state. Test helper. */
+export function _reset(): void {
+  _core.set(makeInitial());
+}


### PR DESCRIPTION
Closes #341.

## Summary

`src/store/tabStore.ts` (532 lines) mixed three concerns — tab identity,
pane layout, and disk-sync — in one writable. The file was hard to
reason about, hard to test in isolation, and regressions in one concern
routinely slipped through review because of cross-concern coupling.

This PR decomposes the store into a **shared private writable + three
scoped facades**, keeps a thin `tabStore.ts` shim for the 47 existing
consumers, and folds in two small Boy Scout cleanups.

## Architecture

```
tabStoreCore.ts       ← private `writable<TabStoreState>` + types
  ├─ tabLifecycleStore — open/close/activate/cycle + per-tab metadata
  ├─ tabLayoutStore    — moveToPane + reorderPane
  └─ tabReloadStore    — reload signal + per-tab save snapshot
tabStore.ts           ← compatibility shim, re-exports the full surface
```

The three facades share the single writable in `tabStoreCore`. Every
cross-concern method (e.g. `closeTab` touches tabs + splitState +
activeTabId) performs **exactly one** `_core.update(...)` — so
subscribers never observe a torn intermediate state. The atomicity
invariant is enforced by emission-counter tests in `tabStore.test.ts`.

Decision rule (documented at the top of `tabStoreCore.ts`):
- **Lifecycle** — tab identity + per-tab metadata
- **Layout** — pane arrangement
- **Reload** — disk-sync signals + post-save snapshot state

## Why single core instead of three separate stores?

Splitting the state across three writables would force cross-concern
methods (`closeTab`, `openTab`, `moveToPane`) to emit 2-3 times,
producing observable torn states (e.g. a subscriber could see `tabs`
updated before `splitState.left`, or the new `activeTabId` pointing at
a tab that isn't yet in any pane). That's the exact class of race bug
this refactor is trying to eliminate.

## What didn't change

- Zero behavior change for any consumer.
- `tabStore.ts` keeps its full legacy method surface via re-exports.
- Existing 47 consumers stay on the old import path.
- The `_reorderPane` alias is preserved for TabBar's drag handler;
  new code should use `tabLayoutStore.reorderPane`.

## Boy Scout

Folded in (second commit, clean separation for review):
- `EditorPane.handleWikiLinkClick` — replaced subscribe/unsub
  snapshot with `get(vaultStore).currentPath`.
- `EditorPane.unsubTabReload` — same rewrite.
- `VaultLayout.closeActiveTab` — symmetry fix using `getActiveTab()`.
- `closeByPath` / `getActiveTab` on the lifecycle facade now use
  `get()` (eliminates the dead `_store.update(() => state)` no-op
  the legacy `closeByPath` previously fired).

Noted for follow-up (not fixed here — out of scope):
- `GraphView.svelte` has three separate `tabStore.subscribe` blocks
  that only react to identity changes — candidates for a derived
  slice after this lands.
- `updateFilePath` takes untyped strings; branded `AbsPath` /
  `VaultRelPath` would be cleaner but is a separate discussion.
- An ESLint `no-restricted-imports` rule steering new code away
  from `./tabStore` would make the shim a soft-deprecation; defer.

## Test plan

- [x] `npx vitest run src/store/` — 53/53 pass
- [x] `npx vitest run` across store/components/lib — 1087/1088 pass
      (one flaky perf budget test unrelated to this refactor: 502ms
      vs. 500ms jsdom bound in `largeFile.test.ts`, passes on rerun)
- [x] `npx tsc --noEmit` — clean
- [ ] UAT — open/close/cycle tabs, split/merge panes, reload after
      external rename, toggle reading mode, verify no visible
      regressions at 100k-note vault

### Pin-before-refactor tests added

Nails current behavior before decomposing:
- `closeTab` of active tab in right pane merges into left (mirror of
  the pre-existing right-closed test).
- `closeTab` of only tab in left pane collapses split.
- `reorderPane` (previously untested despite being live via TabBar).
- `setLastSavedHash(id, null)` is distinguishable from never-set (#80).
- `tabReloadStore.request` emits a fresh token on repeat calls.

### Atomicity regression net

Asserts **exactly one emission** on the shared core for every cross-
concern op: `openTab`, `closeTab` (with merge-collapse), `moveToPane`,
`activateTab`, `closeByPath` (and 0 emissions for `closeByPath` on a
miss). This is the tight guard against anyone accidentally splitting
a cross-concern method into multiple `_core.update` calls.

## Files

Added:
- `src/store/tabStoreCore.ts`
- `src/store/tabLifecycleStore.ts`
- `src/store/tabLifecycleStore.test.ts`
- `src/store/tabLayoutStore.ts`
- `src/store/tabLayoutStore.test.ts`
- `src/store/tabReloadStore.test.ts`

Modified:
- `src/store/tabStore.ts` — now a ~55-line shim
- `src/store/tabStore.test.ts` — narrowed to cross-concern + atomicity
- `src/store/tabReloadStore.ts` — grew two methods + `_reset` helper
- `src/components/Editor/EditorPane.svelte` — Boy Scout `get()` rewrites
- `src/components/Layout/VaultLayout.svelte` — Boy Scout symmetry fix