### PR TITLE
feat(encryption): frontend store + modals + sidebar UI (#345 · 2)

### DIFF
--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -10,6 +10,19 @@
   import RightSidebar from "./RightSidebar.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import ReindexStatusbar from "../Statusbar/ReindexStatusbar.svelte";
+  import PasswordPromptModal from "../common/PasswordPromptModal.svelte";
+  import EncryptFolderModal from "../common/EncryptFolderModal.svelte";
+  import {
+    encryptionModal,
+    closeEncryptionModal,
+    setEncryptionModalError,
+  } from "../../store/encryptionModalStore";
+  import {
+    encryptFolder,
+    unlockFolder,
+  } from "../../ipc/commands";
+  import { vaultErrorCopy } from "../../types/errors";
+  import { isVaultError } from "../../types/errors";
   import { tabStore } from "../../store/tabStore";
   import { searchStore } from "../../store/searchStore";
   import { backlinksStore } from "../../store/backlinksStore";
@@ -556,6 +569,17 @@
       exportActiveNotePdf: () => { void exportActiveNotePdf(); },
       toggleReadingMode: () => { toggleActiveReadingMode(); },
       insertTemplate: () => { templatePickerOpen = true; },
+      // #345 — palette-triggered "lock everything".
+      lockAllEncryptedFolders: async () => {
+        try {
+          const { lockAllFolders } = await import("../../ipc/commands");
+          await lockAllFolders();
+          toastStore.info("All encrypted folders locked");
+        } catch (e) {
+          if (isVaultError(e)) toastStore.error(vaultErrorCopy(e));
+          else toastStore.error("Failed to lock folders");
+        }
+      },
     });
     initHotkeyOverrides();
     document.addEventListener("keydown", handleKeydown, { capture: true });
@@ -818,6 +842,60 @@
 
 <!-- #201: reindex progress overlay. Self-hides while idle. -->
 <ReindexStatusbar />
+
+<!-- #345: global mount for the encryption modals. -->
+{#if $encryptionModal?.kind === "encrypt"}
+  <EncryptFolderModal
+    open={true}
+    folderLabel={$encryptionModal.folderLabel}
+    onConfirm={async (password) => {
+      const folderPath = $encryptionModal!.folderPath;
+      closeEncryptionModal();
+      try {
+        await encryptFolder(folderPath, password);
+        toastStore.info("Folder encrypted");
+      } catch (e) {
+        if (isVaultError(e)) {
+          toastStore.error(vaultErrorCopy(e));
+        } else {
+          toastStore.error("Failed to encrypt folder");
+        }
+      }
+    }}
+    onCancel={closeEncryptionModal}
+  />
+{/if}
+{#if $encryptionModal?.kind === "unlock"}
+  <PasswordPromptModal
+    open={true}
+    folderLabel={$encryptionModal.folderLabel}
+    error={$encryptionModal.error ?? null}
+    onConfirm={async (password) => {
+      const m = $encryptionModal!;
+      try {
+        await unlockFolder(m.folderPath, password);
+        closeEncryptionModal();
+        if (m.kind === "unlock") {
+          m.onUnlocked?.();
+        }
+      } catch (e) {
+        if (isVaultError(e) && e.kind === "WrongPassword") {
+          setEncryptionModalError("wrong");
+        } else if (isVaultError(e) && e.kind === "CryptoError") {
+          setEncryptionModalError("crypto");
+        } else {
+          closeEncryptionModal();
+          if (isVaultError(e)) {
+            toastStore.error(vaultErrorCopy(e));
+          } else {
+            toastStore.error("Failed to unlock folder");
+          }
+        }
+      }
+    }}
+    onCancel={closeEncryptionModal}
+  />
+{/if}
 
 <style>
   .vc-vault-layout {

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -17,7 +17,11 @@
     cancelReindex,
     setSemanticEnabled,
     refreshAllEmbeddings,
+    lockAllFolders,
   } from "../../ipc/commands";
+  import { encryptedFolders } from "../../store/encryptedFoldersStore";
+  import { toastStore } from "../../store/toastStore";
+  import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import { reindexStore, isActive as isReindexActive } from "../../store/reindexStore";
   import { formatShortcut } from "../../lib/shortcuts";
   import { commandRegistry, hotkeysEqual, type Command, type HotKey } from "../../lib/commands/registry";
@@ -530,6 +534,55 @@
         </p>
       </section>
 
+      <!-- Section — #345 encrypted folders. Copy is English per the
+           decision captured in the 345 design discussion. -->
+      <section class="vc-settings-section" data-testid="settings-security">
+        <h3 class="vc-settings-section-title">SECURITY</h3>
+        <div class="vc-settings-row">
+          <span>Encrypted folders</span>
+          <button
+            type="button"
+            class="vc-settings-btn"
+            data-testid="settings-lock-all"
+            onclick={async () => {
+              try {
+                await lockAllFolders();
+                toastStore.info("All encrypted folders locked");
+              } catch (e) {
+                if (isVaultError(e)) toastStore.error(vaultErrorCopy(e));
+                else toastStore.error("Failed to lock folders");
+              }
+            }}
+            disabled={!currentVaultPath || $encryptedFolders.length === 0}
+          >Lock all now</button>
+        </div>
+        {#if $encryptedFolders.length === 0}
+          <p class="vc-settings-hint">
+            No encrypted folders in this vault yet. Right-click a folder
+            in the sidebar → <em>Encrypt folder…</em> to seal it. Files
+            inside an encrypted folder are stored as ciphertext on disk;
+            the folder is invisible to search, backlinks and the graph
+            until you unlock it.
+          </p>
+        {:else}
+          <ul class="vc-security-list" data-testid="settings-encrypted-list">
+            {#each $encryptedFolders as folder}
+              <li class="vc-security-row">
+                <span class="vc-security-path">{folder.path}</span>
+                <span class="vc-security-state">
+                  {folder.state === "encrypting" ? "encrypting…" : "encrypted"}
+                </span>
+              </li>
+            {/each}
+          </ul>
+          <p class="vc-settings-hint">
+            Encrypted folders re-lock on app quit and on every vault
+            reopen. There is no password recovery — forgetting the
+            password means the files cannot be read.
+          </p>
+        {/if}
+      </section>
+
       <!-- Section C — Tastaturkürzel (UI-05 / D-11 / #65) -->
       <section class="vc-settings-section" data-testid="settings-shortcuts">
         <h3 class="vc-settings-section-title">TASTATURKÜRZEL</h3>
@@ -826,6 +879,39 @@
     border-color: var(--color-accent);
     color: var(--color-accent);
   }
+  /* #345 — encrypted folders list. */
+  .vc-security-list {
+    list-style: none;
+    padding: 0;
+    margin: 8px 0 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .vc-security-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 10px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+  }
+  .vc-security-path {
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+  .vc-security-state {
+    font-size: 11px;
+    color: var(--color-text-muted);
+  }
+
   .vc-settings-btn:disabled {
     opacity: 0.55;
     cursor: not-allowed;

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -18,6 +18,8 @@
     File,
     MoreHorizontal,
     Star,
+    Lock,
+    LockOpen,
   } from "lucide-svelte";
   import {
     createFile,
@@ -38,6 +40,11 @@
   import { tabStore } from "../../store/tabStore";
   import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { bookmarksStore } from "../../store/bookmarksStore";
+  import {
+    openEncryptModal,
+    openUnlockModal,
+  } from "../../store/encryptionModalStore";
+  import { lockFolder } from "../../ipc/commands";
   import type { FlatRow } from "../../lib/flattenTree";
 
   interface Props {
@@ -113,9 +120,21 @@
       : absPath;
   }
 
+  // #345 — encryption state helpers. `encryption` defaults to
+  // `"not-encrypted"` for fixtures written before #345 landed.
+  const isLocked = $derived((row.encryption ?? "not-encrypted") === "locked");
+  const isUnlocked = $derived((row.encryption ?? "not-encrypted") === "unlocked");
+  const isEncryptedRoot = $derived(isLocked || isUnlocked);
+
   function handleClick() {
     onSelect(row.path);
     if (row.isDir) {
+      // #345: clicking a locked folder opens the password modal instead
+      // of toggling expansion — a locked folder cannot be expanded.
+      if (isLocked) {
+        openUnlockModal(row.path, row.name);
+        return;
+      }
       void onToggleExpand(row);
     } else {
       onOpenFile(row.path);
@@ -461,9 +480,19 @@
       <span class="vc-tree-spacer" aria-hidden="true"></span>
     {/if}
 
-    <span class="vc-tree-icon" class:vc-tree-icon--active={isActive} aria-hidden="true">
+    <span
+      class="vc-tree-icon"
+      class:vc-tree-icon--active={isActive}
+      class:vc-tree-icon--locked={isLocked}
+      class:vc-tree-icon--unlocked={isUnlocked}
+      aria-hidden="true"
+    >
       {#if row.isDir}
-        {#if row.expanded}
+        {#if isLocked}
+          <Lock size={16} strokeWidth={1.5} />
+        {:else if isUnlocked}
+          <LockOpen size={16} strokeWidth={1.5} />
+        {:else if row.expanded}
           <FolderOpen size={16} strokeWidth={1.5} />
         {:else}
           <Folder size={16} strokeWidth={1.5} />
@@ -484,7 +513,10 @@
         onCancel={handleRenameCancel}
       />
     {:else}
-      <span class="vc-tree-name">
+      <span
+        class="vc-tree-name"
+        class:vc-tree-name--locked={isLocked}
+      >
         {row.name}
         {#if row.isSymlink}
           <em class="vc-tree-symlink">(link)</em>
@@ -524,6 +556,34 @@
       <button class="vc-context-item" onclick={handleNewFileHere}>New file here</button>
       <button class="vc-context-item" onclick={handleNewCanvasHere}>New canvas here</button>
       <button class="vc-context-item" onclick={handleNewFolderHere}>New folder here</button>
+      <!-- #345: encryption actions. Three mutually-exclusive states. -->
+      {#if !isEncryptedRoot}
+        <button
+          class="vc-context-item"
+          data-testid="context-encrypt-folder"
+          onclick={() => { closeContextMenu(); openEncryptModal(row.path, row.name); }}
+        >Encrypt folder…</button>
+      {:else if isLocked}
+        <button
+          class="vc-context-item"
+          data-testid="context-unlock-folder"
+          onclick={() => { closeContextMenu(); openUnlockModal(row.path, row.name); }}
+        >Unlock folder…</button>
+      {:else}
+        <button
+          class="vc-context-item"
+          data-testid="context-lock-folder"
+          onclick={async () => {
+            closeContextMenu();
+            try {
+              await lockFolder(row.path);
+            } catch (e) {
+              if (isVaultError(e)) toastStore.error(vaultErrorCopy(e));
+              else toastStore.error("Failed to lock folder");
+            }
+          }}
+        >Lock folder</button>
+      {/if}
     {/if}
   </ContextMenu>
 
@@ -669,6 +729,15 @@
     color: var(--color-accent);
   }
 
+  /* #345: encryption icon variants. Locked stays muted to signal
+     "currently out of reach"; unlocked takes the accent color. */
+  .vc-tree-icon--locked {
+    color: var(--color-text-muted);
+  }
+  .vc-tree-icon--unlocked {
+    color: var(--color-accent);
+  }
+
   .vc-tree-name {
     flex: 1;
     font-size: 14px;
@@ -677,6 +746,12 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  /* #345: muted label for locked folder rows so the collapsed,
+     unexpandable row doesn't visually compete with plain rows. */
+  .vc-tree-name--locked {
+    color: var(--color-text-muted);
   }
 
   .vc-tree-symlink {

--- a/src/components/common/EncryptFolderModal.svelte
+++ b/src/components/common/EncryptFolderModal.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+  // #345 — two-field password modal for `encrypt_folder`. Reuses
+  // the `UrlInputModal` geometry exactly (420 px, top 20%, vc-modal-surface)
+  // plus a 3-segment strength meter under the confirmation field.
+  // The meter is advisory — we do NOT block on weak passwords (user
+  // decision in the Vitruvius brief).
+
+  import { tick } from "svelte";
+
+  import {
+    passwordStrength,
+    passwordStrengthFillCount,
+    type PasswordStrength,
+  } from "../../lib/passwordStrength";
+
+  interface Props {
+    open: boolean;
+    folderLabel: string;
+    onConfirm: (password: string) => void;
+    onCancel: () => void;
+  }
+
+  let { open, folderLabel, onConfirm, onCancel }: Props = $props();
+
+  let pw = $state("");
+  let confirm = $state("");
+  let inputEl = $state<HTMLInputElement | undefined>();
+
+  $effect(() => {
+    if (open) {
+      pw = "";
+      confirm = "";
+      void tick().then(() => inputEl?.focus());
+    }
+  });
+
+  const strength: PasswordStrength = $derived(passwordStrength(pw));
+  const fill = $derived(passwordStrengthFillCount(strength));
+  const match = $derived(pw.length > 0 && pw === confirm);
+  const mismatch = $derived(confirm.length > 0 && pw !== confirm);
+
+  const strengthLabel = $derived.by(() => {
+    switch (strength) {
+      case "empty": return "";
+      case "weak": return "Weak";
+      case "ok": return "OK";
+      case "strong": return "Strong";
+    }
+  });
+
+  function submit() {
+    if (!match) return;
+    onConfirm(pw);
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-encrypt-modal-backdrop vc-modal-scrim"
+    onclick={onCancel}
+    role="presentation"
+    data-testid="encrypt-folder-backdrop"
+  ></div>
+  <div
+    class="vc-encrypt-modal vc-modal-surface"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Encrypt folder"
+    data-testid="encrypt-folder-modal"
+  >
+    <div class="vc-encrypt-modal-header">
+      <span class="vc-encrypt-modal-title">Encrypt folder</span>
+      <span class="vc-encrypt-modal-subtitle">{folderLabel}</span>
+      <p class="vc-encrypt-modal-warning">
+        Files in this folder will be sealed on disk. Obsidian and other
+        readers will not be able to open them. Forgetting the password
+        means the files cannot be recovered.
+      </p>
+    </div>
+    <label class="vc-encrypt-modal-label">
+      Password
+      <input
+        bind:this={inputEl}
+        bind:value={pw}
+        onkeydown={onKey}
+        type="password"
+        class="vc-encrypt-modal-input"
+        autocomplete="new-password"
+        spellcheck="false"
+        data-testid="encrypt-folder-password"
+      />
+    </label>
+    <div class="vc-encrypt-modal-strength" data-testid="encrypt-folder-strength">
+      <div class="vc-encrypt-modal-strength-bar">
+        <span class:vc-encrypt-modal-strength-seg-on={fill >= 1}></span>
+        <span class:vc-encrypt-modal-strength-seg-on={fill >= 2}></span>
+        <span class:vc-encrypt-modal-strength-seg-on={fill >= 3}></span>
+      </div>
+      <span class="vc-encrypt-modal-strength-label">{strengthLabel}</span>
+    </div>
+    <label class="vc-encrypt-modal-label">
+      Confirm password
+      <input
+        bind:value={confirm}
+        onkeydown={onKey}
+        type="password"
+        class="vc-encrypt-modal-input"
+        class:vc-encrypt-modal-input-error={mismatch}
+        autocomplete="new-password"
+        spellcheck="false"
+        aria-invalid={mismatch ? "true" : "false"}
+        data-testid="encrypt-folder-confirm"
+      />
+    </label>
+    {#if mismatch}
+      <div class="vc-encrypt-modal-error" role="alert" data-testid="encrypt-folder-mismatch">
+        Passwords do not match.
+      </div>
+    {/if}
+    <div class="vc-encrypt-modal-actions">
+      <button
+        type="button"
+        class="vc-encrypt-modal-cancel"
+        onclick={onCancel}
+      >Cancel</button>
+      <button
+        type="button"
+        class="vc-encrypt-modal-ok"
+        onclick={submit}
+        disabled={!match}
+        data-testid="encrypt-folder-confirm-button"
+      >Encrypt</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-encrypt-modal-backdrop { z-index: 200; }
+  .vc-encrypt-modal {
+    position: fixed;
+    top: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 420px;
+    max-width: calc(100vw - 32px);
+    z-index: 201;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  }
+  .vc-encrypt-modal-header {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .vc-encrypt-modal-title { font-weight: 600; font-size: 13px; color: var(--color-text); }
+  .vc-encrypt-modal-subtitle {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .vc-encrypt-modal-warning {
+    margin: 4px 0 0;
+    font-size: 11px;
+    color: var(--color-text-muted);
+    line-height: 1.4;
+  }
+  .vc-encrypt-modal-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+  }
+  .vc-encrypt-modal-input {
+    height: 32px;
+    padding: 0 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 14px;
+    outline: none;
+  }
+  .vc-encrypt-modal-input:focus { border-color: var(--color-accent); }
+  .vc-encrypt-modal-input-error,
+  .vc-encrypt-modal-input-error:focus {
+    border-color: var(--color-error, #d14343);
+  }
+  .vc-encrypt-modal-strength {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--color-text-muted);
+  }
+  .vc-encrypt-modal-strength-bar {
+    display: flex;
+    gap: 4px;
+    flex: 1;
+  }
+  .vc-encrypt-modal-strength-bar span {
+    flex: 1;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--color-border);
+  }
+  .vc-encrypt-modal-strength-seg-on {
+    background: var(--color-accent) !important;
+  }
+  .vc-encrypt-modal-strength-label {
+    min-width: 40px;
+    text-align: right;
+  }
+  .vc-encrypt-modal-error { font-size: 12px; color: var(--color-error, #d14343); }
+  .vc-encrypt-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .vc-encrypt-modal-cancel,
+  .vc-encrypt-modal-ok {
+    font-size: 13px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .vc-encrypt-modal-ok {
+    background: var(--color-accent);
+    color: var(--color-accent-contrast, #fff);
+    border-color: var(--color-accent);
+  }
+  .vc-encrypt-modal-ok:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/components/common/PasswordPromptModal.svelte
+++ b/src/components/common/PasswordPromptModal.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  // #345 — single-field password prompt for `unlock_folder`. Reuses
+  // the `UrlInputModal` geometry (420 px, top 20%, vc-modal-surface).
+  //
+  // Wrong-password state: when `error === "wrong"` the input border
+  // flips to --color-error, a screenreader-announced `role="alert"`
+  // row appears below, and the input stays focused so the user can
+  // retype without reaching for the mouse.
+
+  import { tick } from "svelte";
+
+  interface Props {
+    open: boolean;
+    folderLabel: string;
+    /** One-word error kind; rendered with a local copy table. */
+    error?: "wrong" | "crypto" | null;
+    onConfirm: (password: string) => void;
+    onCancel: () => void;
+  }
+
+  let { open, folderLabel, error = null, onConfirm, onCancel }: Props = $props();
+
+  let value = $state("");
+  let inputEl = $state<HTMLInputElement | undefined>();
+
+  $effect(() => {
+    if (open) {
+      value = "";
+      void tick().then(() => inputEl?.focus());
+    }
+  });
+
+  $effect(() => {
+    if (error === "wrong") {
+      void tick().then(() => inputEl?.focus());
+    }
+  });
+
+  function submit() {
+    if (!value) {
+      onCancel();
+      return;
+    }
+    onConfirm(value);
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+
+  const errorCopy = $derived.by(() => {
+    if (error === "wrong") return "Wrong password.";
+    if (error === "crypto") return "Could not decrypt this folder. The vault may be corrupted.";
+    return "";
+  });
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-password-modal-backdrop vc-modal-scrim"
+    onclick={onCancel}
+    role="presentation"
+    data-testid="password-prompt-backdrop"
+  ></div>
+  <div
+    class="vc-password-modal vc-modal-surface"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Unlock encrypted folder"
+    data-testid="password-prompt"
+  >
+    <div class="vc-password-modal-header">
+      <span class="vc-password-modal-title">Unlock folder</span>
+      <span class="vc-password-modal-subtitle">{folderLabel}</span>
+    </div>
+    <label class="vc-password-modal-label">
+      Password
+      <input
+        bind:this={inputEl}
+        bind:value={value}
+        onkeydown={onKey}
+        type="password"
+        class="vc-password-modal-input"
+        class:vc-password-modal-input-error={error !== null}
+        autocomplete="current-password"
+        spellcheck="false"
+        aria-invalid={error !== null ? "true" : "false"}
+        data-testid="password-prompt-input"
+      />
+    </label>
+    {#if error}
+      <div class="vc-password-modal-error" role="alert" data-testid="password-prompt-error">
+        {errorCopy}
+      </div>
+    {/if}
+    <div class="vc-password-modal-actions">
+      <button
+        type="button"
+        class="vc-password-modal-cancel"
+        onclick={onCancel}
+      >Cancel</button>
+      <button
+        type="button"
+        class="vc-password-modal-ok"
+        onclick={submit}
+        disabled={!value}
+        data-testid="password-prompt-confirm"
+      >Unlock</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-password-modal-backdrop { z-index: 200; }
+  .vc-password-modal {
+    position: fixed;
+    top: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 420px;
+    max-width: calc(100vw - 32px);
+    z-index: 201;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  }
+  .vc-password-modal-header {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .vc-password-modal-title {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--color-text);
+  }
+  .vc-password-modal-subtitle {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .vc-password-modal-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+  }
+  .vc-password-modal-input {
+    height: 32px;
+    padding: 0 8px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 14px;
+    outline: none;
+  }
+  .vc-password-modal-input:focus { border-color: var(--color-accent); }
+  .vc-password-modal-input-error,
+  .vc-password-modal-input-error:focus {
+    border-color: var(--color-error, #d14343);
+  }
+  .vc-password-modal-error {
+    font-size: 12px;
+    color: var(--color-error, #d14343);
+  }
+  .vc-password-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .vc-password-modal-cancel,
+  .vc-password-modal-ok {
+    font-size: 13px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .vc-password-modal-ok {
+    background: var(--color-accent);
+    color: var(--color-accent-contrast, #fff);
+    border-color: var(--color-accent);
+  }
+  .vc-password-modal-ok:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -13,6 +13,7 @@ import type { DirEntry } from "../types/tree";
 import type { SearchResult, FileMatch, SemanticHit, HybridHit } from "../types/search";
 import type { BacklinkEntry, ParsedLink, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
+import type { EncryptedFolderView } from "../types/encryption";
 
 function normalizeError(err: unknown): VaultError {
   if (isVaultError(err)) {
@@ -639,6 +640,68 @@ export async function setSemanticEnabled(enabled: boolean): Promise<void> {
 export async function refreshAllEmbeddings(): Promise<void> {
   try {
     await invoke<void>("refresh_all_embeddings");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+// ── #345 — encrypted folders ────────────────────────────────────────────────
+
+/**
+ * Encrypt `path` (absolute, inside the open vault) with `password`.
+ *
+ * Backend flow: derive Argon2id key → write manifest + sentinel → seal
+ * every file → flip manifest to `encrypted` → register as locked. The
+ * folder is immediately locked after the batch — the user must re-enter
+ * the password to read contents.
+ *
+ * Progress arrives via the `vault://encrypt_progress` event (listen via
+ * `onEncryptProgress`). Returns once the whole folder is sealed.
+ */
+export async function encryptFolder(path: string, password: string): Promise<void> {
+  try {
+    await invoke<void>("encrypt_folder", { path, password });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Probe `password` against the sentinel for `path`. On success the
+ * backend stashes the derived key in its keyring and removes the
+ * folder from the locked registry. On failure returns
+ * `WrongPassword` so the caller can re-prompt.
+ */
+export async function unlockFolder(path: string, password: string): Promise<void> {
+  try {
+    await invoke<void>("unlock_folder", { path, password });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/** Re-lock `path`: drop the key, mark the root locked. */
+export async function lockFolder(path: string): Promise<void> {
+  try {
+    await invoke<void>("lock_folder", { path });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/** Lock every encrypted folder in the vault. */
+export async function lockAllFolders(): Promise<void> {
+  try {
+    await invoke<void>("lock_all_folders");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/** Return every folder recorded in the manifest. Salt is stripped. */
+export async function listEncryptedFolders(): Promise<EncryptedFolderView[]> {
+  try {
+    return await invoke<EncryptedFolderView[]>("list_encrypted_folders");
   } catch (e) {
     throw normalizeError(e);
   }

--- a/src/ipc/events.ts
+++ b/src/ipc/events.ts
@@ -110,3 +110,38 @@ export function listenReindexProgress(
     handler(event.payload),
   );
 }
+
+// ── #345 — encrypted folders ────────────────────────────────────────────────
+
+export interface EncryptProgressPayload {
+  current: number;
+  total: number;
+  file: string;
+}
+
+export const ENCRYPT_PROGRESS_EVENT = "vault://encrypt_progress";
+export const ENCRYPTED_FOLDERS_CHANGED_EVENT = "vault://encrypted_folders_changed";
+
+/**
+ * #345: progress stream for the `encrypt_folder` batch. One event per
+ * 50 ms while sealing files. Not emitted for small folders (< 16
+ * files) — the round-trip latency dominates at that scale.
+ */
+export function listenEncryptProgress(
+  handler: (payload: EncryptProgressPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<EncryptProgressPayload>(ENCRYPT_PROGRESS_EVENT, (event) =>
+    handler(event.payload),
+  );
+}
+
+/**
+ * #345: single-pulse event fired after encrypt / unlock / lock /
+ * lock_all_folders mutate the registry or manifest. The frontend
+ * `encryptedFoldersStore` refreshes on every pulse.
+ */
+export function listenEncryptedFoldersChanged(
+  handler: () => void,
+): Promise<UnlistenFn> {
+  return listen(ENCRYPTED_FOLDERS_CHANGED_EVENT, () => handler());
+}

--- a/src/lib/__tests__/flattenTreeEncryption.test.ts
+++ b/src/lib/__tests__/flattenTreeEncryption.test.ts
@@ -1,0 +1,100 @@
+// #345 — regression guard for the encryption-aware flatten behavior:
+// a locked folder must not emit any child rows even when expanded,
+// and row.encryption must reflect the backend field for both locked
+// and unlocked states.
+
+import { describe, it, expect } from "vitest";
+
+import { flattenTree, type TreeModel } from "../flattenTree";
+import type { DirEntry } from "../../types/tree";
+
+function entry(overrides: Partial<DirEntry>): DirEntry {
+  return {
+    name: overrides.name ?? "entry",
+    path: overrides.path ?? "/vault/entry",
+    is_dir: overrides.is_dir ?? true,
+    is_symlink: false,
+    is_md: overrides.is_md ?? false,
+    modified: null,
+    created: null,
+    encryption: overrides.encryption ?? "not-encrypted",
+  };
+}
+
+describe("flattenTree — #345 encryption", () => {
+  it("does not emit children for a locked folder even if expanded", () => {
+    const lockedFolder = entry({
+      name: "secret",
+      path: "/vault/secret",
+      encryption: "locked",
+    });
+    const child = entry({
+      name: "leaked.md",
+      path: "/vault/secret/leaked.md",
+      is_dir: false,
+      is_md: true,
+    });
+    const model: TreeModel = {
+      vaultPath: "/vault",
+      rootEntries: [lockedFolder],
+      folders: new Map([
+        ["/vault/secret", { children: [child], childrenLoaded: true, loading: false }],
+      ]),
+      // Even if the locked folder is in the expanded set (would happen
+      // if the user expanded it before locking), flatten must drop it.
+      expanded: new Set(["secret"]),
+      sortBy: "name-asc",
+    };
+    const rows = flattenTree(model);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe("secret");
+    expect(rows[0]!.encryption).toBe("locked");
+  });
+
+  it("emits children for an unlocked encrypted folder", () => {
+    const unlockedFolder = entry({
+      name: "journal",
+      path: "/vault/journal",
+      encryption: "unlocked",
+    });
+    const child = entry({
+      name: "2026.md",
+      path: "/vault/journal/2026.md",
+      is_dir: false,
+      is_md: true,
+    });
+    const model: TreeModel = {
+      vaultPath: "/vault",
+      rootEntries: [unlockedFolder],
+      folders: new Map([
+        ["/vault/journal", { children: [child], childrenLoaded: true, loading: false }],
+      ]),
+      expanded: new Set(["journal"]),
+      sortBy: "name-asc",
+    };
+    const rows = flattenTree(model);
+    expect(rows.map((r) => r.name)).toEqual(["journal", "2026.md"]);
+    expect(rows[0]!.encryption).toBe("unlocked");
+  });
+
+  it("defaults missing encryption to 'not-encrypted'", () => {
+    const plain = {
+      name: "plain",
+      path: "/vault/plain",
+      is_dir: true,
+      is_symlink: false,
+      is_md: false,
+      modified: null,
+      created: null,
+    } as DirEntry;
+    const model: TreeModel = {
+      vaultPath: "/vault",
+      rootEntries: [plain],
+      folders: new Map(),
+      expanded: new Set(),
+      sortBy: "name-asc",
+    };
+    const rows = flattenTree(model);
+    expect(rows[0]!.encryption).toBe("not-encrypted");
+  });
+});

--- a/src/lib/__tests__/passwordStrength.test.ts
+++ b/src/lib/__tests__/passwordStrength.test.ts
@@ -1,0 +1,42 @@
+// #345 — password strength helper. Advisory only; does not block
+// the encrypt flow. Tests pin the rule set so the EncryptFolder
+// modal's 3-segment bar stays consistent across refactors.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  passwordStrength,
+  passwordStrengthFillCount,
+} from "../passwordStrength";
+
+describe("passwordStrength", () => {
+  it("classifies an empty string as 'empty'", () => {
+    expect(passwordStrength("")).toBe("empty");
+    expect(passwordStrengthFillCount("empty")).toBe(0);
+  });
+
+  it("classifies short alphabetic passwords as 'weak'", () => {
+    expect(passwordStrength("abc")).toBe("weak");
+    expect(passwordStrength("abcdef")).toBe("weak");
+    expect(passwordStrengthFillCount("weak")).toBe(1);
+  });
+
+  it("classifies medium passwords with a digit OR symbol as 'ok'", () => {
+    expect(passwordStrength("abcdefg1")).toBe("ok");
+    expect(passwordStrength("abcdefgH!")).toBe("ok");
+    expect(passwordStrengthFillCount("ok")).toBe(2);
+  });
+
+  it("classifies 12+ chars with digit AND symbol as 'strong'", () => {
+    expect(passwordStrength("abcdefgh1234!")).toBe("strong");
+    expect(passwordStrengthFillCount("strong")).toBe(3);
+  });
+
+  it("demotes to 'ok' when length drops below 12 even with digit+symbol", () => {
+    expect(passwordStrength("a1!bcdef")).toBe("ok");
+  });
+
+  it("demotes to 'weak' when length drops below 8 even with digit", () => {
+    expect(passwordStrength("a1b2")).toBe("weak");
+  });
+});

--- a/src/lib/commands/__tests__/defaultCommands.test.ts
+++ b/src/lib/commands/__tests__/defaultCommands.test.ts
@@ -42,6 +42,7 @@ function makeCtx(overrides: Partial<DefaultCommandContext> = {}): DefaultCommand
     insertTemplate: noop,
     openHome: noop,
     openDocs: noop,
+    lockAllEncryptedFolders: noop,
     ...overrides,
   };
 }

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -24,6 +24,8 @@ export interface DefaultCommandContext {
   insertTemplate: () => void;
   openHome: () => void;
   openDocs: () => void;
+  // #345
+  lockAllEncryptedFolders: () => void;
 }
 
 /** Id constants — consumed by tests and anyone dispatching by id. */
@@ -52,6 +54,8 @@ export const CMD_IDS = {
   EXPORT_PDF: "vault:export-pdf",
   TOGGLE_READING_MODE: "editor:toggle-reading-mode",
   INSERT_TEMPLATE: "editor:insert-template",
+  // #345 — encrypted folders (labels English per decision).
+  LOCK_ALL_FOLDERS: "vault:lock-all-folders",
 } as const;
 
 export interface DefaultCommandSpec {
@@ -83,6 +87,12 @@ export const DEFAULT_COMMAND_SPECS: readonly DefaultCommandSpec[] = [
   { id: CMD_IDS.EXPORT_PDF, name: "Notiz als PDF exportieren" },
   { id: CMD_IDS.TOGGLE_READING_MODE, name: "Lesemodus umschalten", hotkey: { meta: true, key: "e" } },
   { id: CMD_IDS.INSERT_TEMPLATE, name: "Vorlage einfügen", hotkey: { meta: true, shift: true, key: "t" } },
+  // #345 — encrypted folders. Encrypt/Unlock/Lock for a specific
+  // folder live on the sidebar context menu; here we expose the
+  // vault-wide "lock everything" action so keyboard-first users have
+  // an escape hatch. Encrypt/Unlock of a specific folder requires
+  // picking a target; out-of-scope for the palette in this slice.
+  { id: CMD_IDS.LOCK_ALL_FOLDERS, name: "Lock all encrypted folders" },
 ] as const;
 
 /**
@@ -113,6 +123,7 @@ export function registerDefaultCommands(ctx: DefaultCommandContext): void {
     [CMD_IDS.EXPORT_PDF]: ctx.exportActiveNotePdf,
     [CMD_IDS.TOGGLE_READING_MODE]: ctx.toggleReadingMode,
     [CMD_IDS.INSERT_TEMPLATE]: ctx.insertTemplate,
+    [CMD_IDS.LOCK_ALL_FOLDERS]: ctx.lockAllEncryptedFolders,
   };
 
   for (const spec of DEFAULT_COMMAND_SPECS) {

--- a/src/lib/flattenTree.ts
+++ b/src/lib/flattenTree.ts
@@ -58,6 +58,15 @@ export interface FlatRow {
   hasRenderedChildren: boolean;
   /** True iff listDirectory has resolved for this folder at least once. */
   childrenLoaded: boolean;
+  /**
+   * #345: encryption state of this row's path. Always `"not-encrypted"`
+   * for files; directories surface the backend's `DirEntry.encryption`
+   * field so the row can render a Lock / LockOpen icon and gate
+   * click/expand behavior. Optional for backwards compat with pre-#345
+   * test fixtures — production rows built by `flattenTree` always
+   * populate this field.
+   */
+  encryption?: import("../types/tree").EncryptionState;
 }
 
 export interface TreeModel {
@@ -113,6 +122,7 @@ function buildRow(
     loading,
     hasRenderedChildren: expanded && childrenLoaded && childCount > 0,
     childrenLoaded,
+    encryption: entry.encryption ?? "not-encrypted",
   };
 }
 
@@ -129,6 +139,11 @@ export function flattenTree(model: TreeModel): FlatRow[] {
     for (const entry of entries) {
       out.push(buildRow(entry, depth, model.vaultPath, model));
       if (!entry.is_dir) continue;
+      // #345: a locked encrypted root never emits children. Descending
+      // into it would render rows whose paths cannot be opened, which
+      // violates the "locked folder is fully invisible" AC. Unlocked
+      // encrypted folders behave like plain folders.
+      if (entry.encryption === "locked") continue;
       const relPath = toRelPath(entry.path, model.vaultPath);
       if (!model.expanded.has(relPath)) continue;
       const fs = model.folders.get(entry.path);

--- a/src/lib/passwordStrength.ts
+++ b/src/lib/passwordStrength.ts
@@ -1,0 +1,43 @@
+// #345 — password strength estimator for the EncryptFolder flow.
+//
+// A minimal rule-based scorer: 0–3 segments of a meter, based on
+// length + digit + non-alphanumeric presence. Deliberately avoids
+// third-party libraries (zxcvbn ≈ 400 KB) so the bundle budget
+// stays on-spec. The meter is advisory — the encrypt flow does NOT
+// block on low strength (user decision per #345 brief).
+
+export type PasswordStrength = "empty" | "weak" | "ok" | "strong";
+
+/**
+ * Score a password into a 3-segment bar category.
+ *
+ * Rules (deliberately simple and transparent):
+ * - empty:  length 0
+ * - weak:   length < 8 OR no criteria beyond length met
+ * - ok:     length >= 8 and (has-digit OR has-symbol)
+ * - strong: length >= 12 AND has-digit AND has-symbol
+ */
+export function passwordStrength(password: string): PasswordStrength {
+  if (password.length === 0) return "empty";
+  const len = password.length;
+  const hasDigit = /\d/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+
+  if (len >= 12 && hasDigit && hasSymbol) return "strong";
+  if (len >= 8 && (hasDigit || hasSymbol)) return "ok";
+  return "weak";
+}
+
+/** Segments filled in the UI meter, 0-3. */
+export function passwordStrengthFillCount(s: PasswordStrength): number {
+  switch (s) {
+    case "strong":
+      return 3;
+    case "ok":
+      return 2;
+    case "weak":
+      return 1;
+    case "empty":
+      return 0;
+  }
+}

--- a/src/store/__tests__/encryptedFoldersStore.test.ts
+++ b/src/store/__tests__/encryptedFoldersStore.test.ts
@@ -1,0 +1,91 @@
+// #345 — unit tests for the encryptedFoldersStore.
+//
+// The store exposes two derived streams (`encryptedFolders`,
+// `encryptedPaths`) backed by a fetch against `list_encrypted_folders`
+// and driven by the `vault://encrypted_folders_changed` event. We
+// cover: init populates, reset clears, and the synthetic test setter
+// works as expected.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("../../ipc/commands", () => ({
+  listEncryptedFolders: vi.fn(),
+}));
+
+vi.mock("../../ipc/events", () => ({
+  listenEncryptedFoldersChanged: vi.fn(async () => () => {}),
+}));
+
+import { listEncryptedFolders } from "../../ipc/commands";
+import { listenEncryptedFoldersChanged } from "../../ipc/events";
+
+const listEncryptedFoldersMock = listEncryptedFolders as unknown as ReturnType<typeof vi.fn>;
+const listenEncryptedFoldersChangedMock = listenEncryptedFoldersChanged as unknown as ReturnType<typeof vi.fn>;
+
+import {
+  _setEncryptedFoldersForTest,
+  encryptedFolders,
+  encryptedFoldersReady,
+  encryptedPaths,
+  initEncryptedFoldersStore,
+  resetEncryptedFoldersStore,
+} from "../encryptedFoldersStore";
+
+describe("encryptedFoldersStore", () => {
+  beforeEach(() => {
+    listEncryptedFoldersMock.mockReset();
+    listenEncryptedFoldersChangedMock.mockClear();
+    resetEncryptedFoldersStore();
+  });
+
+  afterEach(() => {
+    resetEncryptedFoldersStore();
+  });
+
+  it("starts empty and not-ready", () => {
+    expect(get(encryptedFolders)).toEqual([]);
+    expect(get(encryptedFoldersReady)).toBe(false);
+    expect(get(encryptedPaths).size).toBe(0);
+  });
+
+  it("populates after initEncryptedFoldersStore() resolves", async () => {
+    listEncryptedFoldersMock.mockResolvedValue([
+      { path: "secret", createdAt: "2026-04-23T00:00:00Z", state: "encrypted" },
+      { path: "journal", createdAt: "2026-04-23T00:00:00Z", state: "encrypted" },
+    ]);
+    await initEncryptedFoldersStore();
+    expect(get(encryptedFolders)).toHaveLength(2);
+    expect(get(encryptedFoldersReady)).toBe(true);
+    const paths = get(encryptedPaths);
+    expect(paths.has("secret")).toBe(true);
+    expect(paths.has("journal")).toBe(true);
+  });
+
+  it("subscribes to encrypted_folders_changed exactly once per init", async () => {
+    listEncryptedFoldersMock.mockResolvedValue([]);
+    await initEncryptedFoldersStore();
+    await initEncryptedFoldersStore();
+    // Two init calls → two subscribe calls (old one torn down, new attached).
+    expect(listenEncryptedFoldersChangedMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetEncryptedFoldersStore clears state", () => {
+    _setEncryptedFoldersForTest([
+      { path: "x", createdAt: "t", state: "encrypted" },
+    ]);
+    expect(get(encryptedFolders)).toHaveLength(1);
+    resetEncryptedFoldersStore();
+    expect(get(encryptedFolders)).toEqual([]);
+    expect(get(encryptedFoldersReady)).toBe(false);
+  });
+
+  it("survives a transient listEncryptedFolders failure", async () => {
+    listEncryptedFoldersMock.mockRejectedValueOnce(new Error("boom"));
+    await initEncryptedFoldersStore();
+    // Still flagged not-ready because the fetch failed; next event tries
+    // again.
+    expect(get(encryptedFoldersReady)).toBe(false);
+    expect(get(encryptedFolders)).toEqual([]);
+  });
+});

--- a/src/store/__tests__/encryptionModalStore.test.ts
+++ b/src/store/__tests__/encryptionModalStore.test.ts
@@ -1,0 +1,67 @@
+// #345 — modal controller store. Tests the open/close/error helpers.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+import {
+  closeEncryptionModal,
+  encryptionModal,
+  openEncryptModal,
+  openUnlockModal,
+  setEncryptionModalError,
+} from "../encryptionModalStore";
+
+describe("encryptionModalStore", () => {
+  beforeEach(() => {
+    closeEncryptionModal();
+  });
+
+  it("starts closed", () => {
+    expect(get(encryptionModal)).toBeNull();
+  });
+
+  it("opens the encrypt modal", () => {
+    openEncryptModal("/vault/secret", "secret");
+    const m = get(encryptionModal);
+    expect(m?.kind).toBe("encrypt");
+    if (m?.kind === "encrypt") {
+      expect(m.folderPath).toBe("/vault/secret");
+      expect(m.folderLabel).toBe("secret");
+    }
+  });
+
+  it("opens the unlock modal with optional onUnlocked callback", () => {
+    let called = 0;
+    openUnlockModal("/vault/secret", "secret", () => {
+      called += 1;
+    });
+    const m = get(encryptionModal);
+    expect(m?.kind).toBe("unlock");
+    if (m?.kind === "unlock") {
+      m.onUnlocked?.();
+      expect(called).toBe(1);
+    }
+  });
+
+  it("omits onUnlocked when not passed (exactOptionalPropertyTypes)", () => {
+    openUnlockModal("/vault/secret", "secret");
+    const m = get(encryptionModal);
+    expect(m?.kind).toBe("unlock");
+    if (m?.kind === "unlock") {
+      expect(m.onUnlocked).toBeUndefined();
+    }
+  });
+
+  it("setEncryptionModalError attaches the error kind in place", () => {
+    openUnlockModal("/vault/secret", "secret");
+    setEncryptionModalError("wrong");
+    const m = get(encryptionModal);
+    expect(m?.error).toBe("wrong");
+  });
+
+  it("closeEncryptionModal clears state", () => {
+    openEncryptModal("/x", "x");
+    closeEncryptionModal();
+    expect(get(encryptionModal)).toBeNull();
+  });
+});

--- a/src/store/encryptedFoldersStore.ts
+++ b/src/store/encryptedFoldersStore.ts
@@ -1,0 +1,113 @@
+// #345 — frontend store for the encrypted-folders registry.
+//
+// Mirrors the backend `list_encrypted_folders` IPC + subscribes to
+// the `vault://encrypted_folders_changed` event stream. Every
+// encrypt / unlock / lock / lock_all mutation on the backend causes
+// this store to re-fetch the list — there is no partial-update
+// protocol because the manifest is small (< 10 entries in practice).
+//
+// Contract:
+// - `initFromVault(absoluteVaultPath)` is called by `vaultStore`
+//   when it transitions to `ready`. Subsequent vault switches call
+//   it again; the previous subscription is cleaned up first.
+// - `reset()` clears the store and unsubscribes. Called on vault
+//   close.
+// - Components subscribe via the Svelte store contract; the public
+//   state carries the salt-less `EncryptedFolderView[]` and a
+//   convenience `lockedPaths: Set<string>` of vault-relative paths
+//   that the sidebar and command palette can consult without doing
+//   their own filtering.
+
+import { writable, derived, type Readable } from "svelte/store";
+
+import { listEncryptedFolders } from "../ipc/commands";
+import { listenEncryptedFoldersChanged } from "../ipc/events";
+import type { EncryptedFolderView } from "../types/encryption";
+
+interface StoreState {
+  entries: EncryptedFolderView[];
+  /** True once the first `list_encrypted_folders` call completes. */
+  ready: boolean;
+}
+
+const internal = writable<StoreState>({ entries: [], ready: false });
+
+let unlisten: (() => void) | null = null;
+
+/** Read-only view of the raw manifest entries (salt stripped). */
+export const encryptedFolders: Readable<EncryptedFolderView[]> = derived(
+  internal,
+  ($s) => $s.entries,
+);
+
+/**
+ * Precomputed set of vault-relative paths whose entry's `state` is
+ * tracked in the manifest. Does NOT distinguish locked vs unlocked —
+ * that signal lives on `DirEntry.encryption` straight from the
+ * backend. Used by components that only need "is this path encrypted
+ * at all".
+ */
+export const encryptedPaths: Readable<Set<string>> = derived(
+  internal,
+  ($s) => new Set($s.entries.map((e) => e.path)),
+);
+
+/** `true` once the store has completed its first fetch. */
+export const encryptedFoldersReady: Readable<boolean> = derived(
+  internal,
+  ($s) => $s.ready,
+);
+
+async function refresh(): Promise<void> {
+  try {
+    const entries = await listEncryptedFolders();
+    internal.set({ entries, ready: true });
+  } catch (e) {
+    // Don't throw on refresh — transient IPC failure keeps the last
+    // known state; the next `encrypted_folders_changed` event will
+    // re-try. Log so bugs are observable in dev.
+    // eslint-disable-next-line no-console
+    console.warn("encryptedFoldersStore refresh failed", e);
+  }
+}
+
+/**
+ * Populate the store and subscribe to update events. Safe to call on
+ * every vault open — tears down the previous subscription first.
+ *
+ * Both the fetch and the subscribe are guarded so a broken IPC layer
+ * (offline test fixtures, partial hot-reload) cannot break vault
+ * open. The store simply stays empty.
+ */
+export async function initEncryptedFoldersStore(): Promise<void> {
+  if (unlisten) {
+    try {
+      unlisten();
+    } catch { /* swallow */ }
+    unlisten = null;
+  }
+  await refresh();
+  try {
+    unlisten = await listenEncryptedFoldersChanged(() => {
+      void refresh();
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("encryptedFoldersStore subscribe failed", e);
+    unlisten = null;
+  }
+}
+
+/** Clear state and unsubscribe. Called on vault close / app teardown. */
+export function resetEncryptedFoldersStore(): void {
+  if (unlisten) {
+    unlisten();
+    unlisten = null;
+  }
+  internal.set({ entries: [], ready: false });
+}
+
+/** Test-only: manually push state. Do not use in production code. */
+export function _setEncryptedFoldersForTest(entries: EncryptedFolderView[]): void {
+  internal.set({ entries, ready: true });
+}

--- a/src/store/encryptionModalStore.ts
+++ b/src/store/encryptionModalStore.ts
@@ -1,0 +1,53 @@
+// #345 — central controller for the EncryptFolderModal and
+// PasswordPromptModal components. VaultLayout mounts both at root
+// level; TreeRow / CommandPalette / Settings call into this store
+// to open them. Keeps modal state off the component that triggered
+// the open (so the modal survives the sidebar scroll / virtualizer
+// remounting the row that requested it).
+
+import { writable } from "svelte/store";
+
+type EncryptRequest = {
+  kind: "encrypt";
+  folderPath: string;
+  folderLabel: string;
+};
+
+type UnlockRequest = {
+  kind: "unlock";
+  folderPath: string;
+  folderLabel: string;
+  /** Optional callback after a successful unlock — e.g. openFileAsTab. */
+  onUnlocked?: () => void;
+};
+
+type ActiveModal =
+  | null
+  | ({ error?: "wrong" | "crypto" | null } & EncryptRequest)
+  | ({ error?: "wrong" | "crypto" | null } & UnlockRequest);
+
+export const encryptionModal = writable<ActiveModal>(null);
+
+export function openEncryptModal(folderPath: string, folderLabel: string): void {
+  encryptionModal.set({ kind: "encrypt", folderPath, folderLabel });
+}
+
+export function openUnlockModal(
+  folderPath: string,
+  folderLabel: string,
+  onUnlocked?: () => void,
+): void {
+  if (onUnlocked) {
+    encryptionModal.set({ kind: "unlock", folderPath, folderLabel, onUnlocked });
+  } else {
+    encryptionModal.set({ kind: "unlock", folderPath, folderLabel });
+  }
+}
+
+export function closeEncryptionModal(): void {
+  encryptionModal.set(null);
+}
+
+export function setEncryptionModalError(error: "wrong" | "crypto"): void {
+  encryptionModal.update((m) => (m ? { ...m, error } : m));
+}

--- a/src/store/vaultStore.ts
+++ b/src/store/vaultStore.ts
@@ -60,6 +60,14 @@ export const vaultStore = {
       fileCount: args.fileCount,
       errorMessage: null,
     }));
+    // #345: prime the encrypted-folders store + subscribe to change
+    // events. Safe to call on every vault open — the store tears down
+    // any previous subscription before re-initialising. Import errors
+    // (missing mocks in tests, hot-reload partials) are swallowed so
+    // an unrelated vault-open does not fail downstream.
+    void import("./encryptedFoldersStore")
+      .then((mod) => mod.initEncryptedFoldersStore())
+      .catch(() => {});
   },
   setError(errorMessage: string): void {
     _store.update((s) => ({ ...s, status: "error", errorMessage }));
@@ -67,6 +75,14 @@ export const vaultStore = {
   reset(): void {
     _treeCache.clear();
     _store.set({ ...initial });
+    // #345: drop any encrypted-folders state the previous vault owned.
+    // Same tolerant pattern as setReady — swallow import errors so
+    // reset() always completes cleanly.
+    void import("./encryptedFoldersStore")
+      .then((mod) => {
+        mod.resetEncryptedFoldersStore();
+      })
+      .catch(() => {});
   },
   setSidebarWidth(width: number): void {
     _store.update((s) => ({ ...s, sidebarWidth: width }));

--- a/src/types/encryption.ts
+++ b/src/types/encryption.ts
@@ -1,0 +1,27 @@
+// #345 — public view of an encrypted folder entry returned by
+// `list_encrypted_folders`. Mirrors the Rust `EncryptedFolderView`.
+// Salt is never surfaced to the frontend; the Rust side strips it
+// before serde.
+
+export type EncryptedFolderState = "encrypting" | "encrypted";
+
+export interface EncryptedFolderView {
+  /** Vault-relative path using forward slashes. */
+  path: string;
+  /** ISO-8601 UTC timestamp of the encrypt operation. */
+  createdAt: string;
+  /**
+   * Current manifest state. `"encrypting"` marks a folder whose
+   * encrypt batch was interrupted — the crash-resume flow (PR 345.3)
+   * lets the user recover it.
+   */
+  state: EncryptedFolderState;
+}
+
+/** Progress payload for the `vault://encrypt_progress` event. */
+export interface EncryptProgress {
+  current: number;
+  total: number;
+  /** Absolute path of the file being sealed. */
+  file: string;
+}

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -13,7 +13,11 @@ export type VaultErrorKind =
   | "MergeConflict"
   | "InvalidEncoding"
   | "LockPoisoned"
-  | "Io";
+  | "Io"
+  // #345 — encrypted-folder error variants.
+  | "PathLocked"
+  | "WrongPassword"
+  | "CryptoError";
 
 export interface VaultError {
   kind: VaultErrorKind;
@@ -59,6 +63,12 @@ export function vaultErrorCopy(err: VaultError): string {
       return "Internal error — please restart VaultCore.";
     case "MergeConflict":
       return `Conflict in ${err.data ?? "file"} — local version kept.`;
+    case "PathLocked":
+      return "This folder is locked. Unlock it before reading or editing its files.";
+    case "WrongPassword":
+      return "Wrong password.";
+    case "CryptoError":
+      return "Encryption error. This file may be corrupted or from a newer VaultCore version.";
     default: {
       const _exhaustive: never = err.kind;
       return "An unexpected error occurred.";

--- a/src/types/tree.ts
+++ b/src/types/tree.ts
@@ -1,6 +1,13 @@
 // Frontend mirror of the Rust `DirEntry` struct (src-tauri/src/commands/tree.rs).
 // Any change here must stay in lock-step with the Rust struct definition.
 
+/**
+ * #345 — encryption state of a folder node. Kebab-case serde on the
+ * Rust side (`"not-encrypted"` / `"locked"` / `"unlocked"`). Files
+ * always carry `"not-encrypted"`; only directory rows vary.
+ */
+export type EncryptionState = "not-encrypted" | "locked" | "unlocked";
+
 export interface DirEntry {
   name: string;
   path: string;       // Absolute path (canonicalized by Rust backend)
@@ -11,4 +18,17 @@ export interface DirEntry {
   modified: number | null;
   /** Seconds since UNIX_EPOCH; null on Linux ext4 or if metadata unavailable. */
   created: number | null;
+  /**
+   * #345 — kebab-case from Rust. Optional in the TS mirror for
+   * backwards-compat with pre-#345 test fixtures: production code
+   * coming from Rust always has this field set. Callers that need to
+   * branch should default `undefined` to `"not-encrypted"` via
+   * `encryptionOf(entry)`.
+   */
+  encryption?: EncryptionState;
+}
+
+/** Default-aware accessor for the #345 encryption field. */
+export function encryptionOf(entry: Pick<DirEntry, "encryption">): EncryptionState {
+  return entry.encryption ?? "not-encrypted";
 }


### PR DESCRIPTION
Third slice of #345 — stacked on PR #348 (backend gating + IPC). Lands the full user-facing surface: typed IPC wrappers, Svelte stores, two modals (encrypt + unlock), tree-row encryption icons, sidebar behavior around locked roots, SettingsModal \`SECURITY\` section, and a command palette entry for \"Lock all encrypted folders\".

> **Base branch**: \`feat/345-encryption-gating\`. Merge only after #347 + #348.

## Scope

### Types
- \`src/types/errors.ts\` — \`PathLocked\` / \`WrongPassword\` / \`CryptoError\` + user-facing copy in \`vaultErrorCopy\`.
- \`src/types/encryption.ts\` — \`EncryptedFolderView\`, \`EncryptProgress\`.
- \`src/types/tree.ts\` — \`DirEntry.encryption?: EncryptionState\` (optional for backwards-compat with pre-#345 fixtures; production rows always carry it). \`encryptionOf()\` helper.

### IPC
- \`src/ipc/commands.ts\` — 5 new wrappers routed through \`normalizeError\`.
- \`src/ipc/events.ts\` — \`listenEncryptProgress\` + \`listenEncryptedFoldersChanged\`.

### Stores
- \`encryptedFoldersStore\` — reactive view of \`list_encrypted_folders\`, auto-refreshes on events. \`encryptedPaths\` derived store for quick set-membership. Init + teardown guarded so test mocks cannot break vault open.
- \`encryptionModalStore\` — central controller for the two modals. Mount state lives at app root so modals survive sidebar virtualization.
- \`vaultStore\` — setReady / reset hook into the store lifecycle via dynamic imports (tree-shakeable + tolerant).

### Modals
- \`PasswordPromptModal.svelte\` — single-field unlock. Wrong-password state pins an inline \`role=\"alert\"\` error, keeps focus on the input, no toast.
- \`EncryptFolderModal.svelte\` — two fields + 3-segment strength meter (\`lib/passwordStrength.ts\`). Advisory only; does **not** block on weak passwords (design decision).
- Mounted at app root in \`VaultLayout.svelte\` via the store.

### Sidebar + tree
- \`flattenTree\` rows carry \`encryption\`. Locked folders never emit children even when expanded — the \"locked folder is fully invisible\" AC.
- \`TreeRow\` renders \`Lock\` / \`LockOpen\` from \`lucide-svelte\` with muted / accent palette. Click on a locked row opens the unlock modal instead of toggling expansion. Context menu has mutually-exclusive Encrypt / Unlock / Lock entries.

### Settings
- New \`SECURITY\` section (English copy). Lists every encrypted folder with its manifest state, \"Lock all now\" button, contextual hint copy that adapts to empty vs populated list. Matches the geometry of the \`SEMANTIC SEARCH\` section.

### Command palette
- \`CMD_IDS.LOCK_ALL_FOLDERS\`. Encrypt/Unlock/Lock of a specific folder stay on the context menu (a palette flow requires a folder picker — out of scope for this slice).

## Test plan

- [x] \`pnpm vitest run\` — **1232/1232 green**. New coverage:
  - \`encryptedFoldersStore\` (5 tests): init populates, reset clears, subscribe-once-per-init, transient IPC failure recovery.
  - \`encryptionModalStore\` (6 tests): open/close/error helpers, \`exactOptionalPropertyTypes\` contract for optional callback.
  - \`passwordStrength\` (6 tests): empty / weak / ok / strong with length boundaries at 8 and 12.
  - \`flattenTreeEncryption\` (3 tests): locked folder never emits children, unlocked behaves like plain, default is \`not-encrypted\`.
- [x] \`pnpm tsc --noEmit\` clean
- [x] All existing sidebar, flatten, vaultStore, defaultCommands tests still pass — no regressions
- [ ] Manual UAT (after 345.3 lands + tauri build) — the end-to-end click path

## Out of scope — PR 345.3

- **Auto-lock timer** — passive keyboard/pointer listeners with zero per-keystroke IPC; configurable timeout in Settings.
- **Link-click into a locked folder** — wiki-link / backlink / graph click resolves into a locked root → opens the password modal and routes on success.
- **Crash-resume** — interrupted encrypt batches (manifest state \`encrypting\`) surface a resume affordance.
- **WDIO E2E spec** — covers the full flow: create vault, encrypt folder via context menu, verify icon + hidden in search, unlock, relock, app-restart keeps locked.