### PR TITLE
fix(encryption): close tabs inside a folder when it is locked (#351)

### DIFF
--- a/src-tauri/src/commands/encryption.rs
+++ b/src-tauri/src/commands/encryption.rs
@@ -40,22 +40,18 @@ const PROGRESS_EMIT_THRESHOLD: usize = 16;
 /// so the frontend never handles KDF material. Used by
 /// `list_encrypted_folders` and the `vault://encrypted_folders_changed`
 /// event payload.
+///
+/// #351: `locked` reflects the in-memory registry state at list time
+/// (NOT persisted in the manifest). The frontend diffs this field
+/// across refreshes to detect unlocked → locked transitions and close
+/// any open tabs that sit inside a now-locked root.
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct EncryptedFolderView {
     pub path: String,
     pub created_at: String,
     pub state: FolderState,
-}
-
-impl From<&EncryptedFolderMeta> for EncryptedFolderView {
-    fn from(m: &EncryptedFolderMeta) -> Self {
-        Self {
-            path: m.path.clone(),
-            created_at: m.created_at.clone(),
-            state: m.state,
-        }
-    }
+    pub locked: bool,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -361,7 +357,29 @@ pub async fn list_encrypted_folders(
 ) -> Result<Vec<EncryptedFolderView>, VaultError> {
     let root = vault_root(&state)?;
     let metas = read_manifest(&root)?;
-    Ok(metas.iter().map(EncryptedFolderView::from).collect())
+    Ok(metas
+        .iter()
+        .map(|m| {
+            // #351: derive `locked` from the in-memory registry. A
+            // manifest entry whose folder cannot be canonicalized
+            // (renamed outside the app, orphaned entry) is reported
+            // as locked — the conservative default matches
+            // `reload_manifest_and_lock_all` which also skips-as-locked
+            // rather than opening a plaintext read window.
+            let locked = match std::fs::canonicalize(root.join(&m.path)) {
+                Ok(canon) => state
+                    .locked_paths
+                    .is_locked(&CanonicalPath::assume_canonical(canon)),
+                Err(_) => true,
+            };
+            EncryptedFolderView {
+                path: m.path.clone(),
+                created_at: m.created_at.clone(),
+                state: m.state,
+                locked,
+            }
+        })
+        .collect())
 }
 
 // ── integration hook used by open_vault ──────────────────────────────────────

--- a/src-tauri/src/commands/encryption.rs
+++ b/src-tauri/src/commands/encryption.rs
@@ -362,15 +362,30 @@ pub async fn list_encrypted_folders(
         .map(|m| {
             // #351: derive `locked` from the in-memory registry. A
             // manifest entry whose folder cannot be canonicalized
-            // (renamed outside the app, orphaned entry) is reported
-            // as locked — the conservative default matches
-            // `reload_manifest_and_lock_all` which also skips-as-locked
-            // rather than opening a plaintext read window.
-            let locked = match std::fs::canonicalize(root.join(&m.path)) {
+            // (renamed outside the app, orphaned entry, transient FS
+            // failure on a networked / unmounted share) reports as
+            // locked — the conservative default matches
+            // `reload_manifest_and_lock_all`, which also skips-as-locked
+            // rather than opening a plaintext read window. Log so the
+            // failure is observable when it happens; the fallback keeps
+            // the UI behavior safe but masks the root cause otherwise.
+            // Blocking `canonicalize` is acceptable here because the
+            // manifest holds < 10 entries in practice and the other
+            // encryption entry points (`lock_folder`,
+            // `reload_manifest_and_lock_all`) already canonicalize in
+            // this same pattern.
+            let abs = root.join(&m.path);
+            let locked = match std::fs::canonicalize(&abs) {
                 Ok(canon) => state
                     .locked_paths
                     .is_locked(&CanonicalPath::assume_canonical(canon)),
-                Err(_) => true,
+                Err(e) => {
+                    log::warn!(
+                        "list_encrypted_folders: canonicalize {} failed: {e} — reporting locked",
+                        abs.display()
+                    );
+                    true
+                }
             };
             EncryptedFolderView {
                 path: m.path.clone(),

--- a/src/store/__tests__/encryptedFoldersStore.test.ts
+++ b/src/store/__tests__/encryptedFoldersStore.test.ts
@@ -5,6 +5,10 @@
 // and driven by the `vault://encrypted_folders_changed` event. We
 // cover: init populates, reset clears, and the synthetic test setter
 // works as expected.
+//
+// #351 adds: on refresh, detect unlocked→locked transitions (diff the
+// `locked` flag across snapshots) and close any open tabs whose file
+// path falls under the newly-locked root.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { get } from "svelte/store";
@@ -31,16 +35,21 @@ import {
   initEncryptedFoldersStore,
   resetEncryptedFoldersStore,
 } from "../encryptedFoldersStore";
+import { tabLifecycleStore } from "../tabLifecycleStore";
+import { _reset as _resetTabs } from "../tabStoreCore";
+import { vaultStore } from "../vaultStore";
 
 describe("encryptedFoldersStore", () => {
   beforeEach(() => {
     listEncryptedFoldersMock.mockReset();
     listenEncryptedFoldersChangedMock.mockClear();
     resetEncryptedFoldersStore();
+    _resetTabs();
   });
 
   afterEach(() => {
     resetEncryptedFoldersStore();
+    _resetTabs();
   });
 
   it("starts empty and not-ready", () => {
@@ -51,8 +60,8 @@ describe("encryptedFoldersStore", () => {
 
   it("populates after initEncryptedFoldersStore() resolves", async () => {
     listEncryptedFoldersMock.mockResolvedValue([
-      { path: "secret", createdAt: "2026-04-23T00:00:00Z", state: "encrypted" },
-      { path: "journal", createdAt: "2026-04-23T00:00:00Z", state: "encrypted" },
+      { path: "secret", createdAt: "2026-04-23T00:00:00Z", state: "encrypted", locked: true },
+      { path: "journal", createdAt: "2026-04-23T00:00:00Z", state: "encrypted", locked: true },
     ]);
     await initEncryptedFoldersStore();
     expect(get(encryptedFolders)).toHaveLength(2);
@@ -86,7 +95,7 @@ describe("encryptedFoldersStore", () => {
 
   it("resetEncryptedFoldersStore clears state", () => {
     _setEncryptedFoldersForTest([
-      { path: "x", createdAt: "t", state: "encrypted" },
+      { path: "x", createdAt: "t", state: "encrypted", locked: true },
     ]);
     expect(get(encryptedFolders)).toHaveLength(1);
     resetEncryptedFoldersStore();
@@ -101,5 +110,140 @@ describe("encryptedFoldersStore", () => {
     // again.
     expect(get(encryptedFoldersReady)).toBe(false);
     expect(get(encryptedFolders)).toEqual([]);
+  });
+
+  // #351 — tab-close on folder lock.
+  describe("#351 tab closure on lock transition", () => {
+    /**
+     * Seed vaultStore with a root and return a fake unlisten capturing
+     * the event handler so we can drive it synchronously in tests.
+     */
+    function captureEventHandler(): { fire: () => Promise<void> } {
+      let captured: (() => void) | null = null;
+      listenEncryptedFoldersChangedMock.mockImplementationOnce(
+        async (h: () => void) => {
+          captured = h;
+          return () => {};
+        },
+      );
+      return {
+        fire: async () => {
+          if (!captured) throw new Error("handler not yet registered");
+          captured();
+          // Event handler kicks off async work — let the microtask queue drain.
+          await Promise.resolve();
+          await Promise.resolve();
+          await Promise.resolve();
+        },
+      };
+    }
+
+    function setVaultRoot(root: string): void {
+      vaultStore.setReady({ currentPath: root, fileList: [], fileCount: 0 });
+    }
+
+    it("does NOT close tabs on initial populate, even if folders are locked", async () => {
+      // A persisted-session scenario: the user had `/vault/secret/a.md`
+      // open when the app was quit; on re-open the manifest says `secret`
+      // is locked (new sessions always start locked per #345). The store
+      // must seed its previous-locked snapshot WITHOUT diffing against
+      // an empty set — otherwise every initial locked root would close
+      // its open tabs on vault open.
+      setVaultRoot("/vault");
+      tabLifecycleStore.openTab("/vault/secret/a.md");
+      listEncryptedFoldersMock.mockResolvedValue([
+        { path: "secret", createdAt: "t", state: "encrypted", locked: true },
+      ]);
+      await initEncryptedFoldersStore();
+      expect(get(tabLifecycleStore).tabs).toHaveLength(1);
+    });
+
+    it("closes tabs under a folder that transitions unlocked → locked", async () => {
+      setVaultRoot("/vault");
+      tabLifecycleStore.openTab("/vault/secret/a.md");
+      tabLifecycleStore.openTab("/vault/secret/sub/b.md");
+      const keep = tabLifecycleStore.openTab("/vault/other/c.md");
+      // Initial snapshot: `secret` is unlocked.
+      const { fire } = captureEventHandler();
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "secret", createdAt: "t", state: "encrypted", locked: false },
+      ]);
+      await initEncryptedFoldersStore();
+      expect(get(tabLifecycleStore).tabs).toHaveLength(3);
+      // Next refresh: `secret` is now locked.
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "secret", createdAt: "t", state: "encrypted", locked: true },
+      ]);
+      await fire();
+      const state = get(tabLifecycleStore);
+      expect(state.tabs.map((t) => t.id)).toEqual([keep]);
+    });
+
+    it("leaves tabs alone when a folder transitions locked → unlocked", async () => {
+      setVaultRoot("/vault");
+      // First snapshot: locked. Tabs should not close (seeded previous).
+      const { fire } = captureEventHandler();
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "secret", createdAt: "t", state: "encrypted", locked: true },
+      ]);
+      await initEncryptedFoldersStore();
+      tabLifecycleStore.openTab("/vault/other/a.md");
+      // User unlocks; new refresh shows locked=false. Nothing to close.
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "secret", createdAt: "t", state: "encrypted", locked: false },
+      ]);
+      await fire();
+      expect(get(tabLifecycleStore).tabs).toHaveLength(1);
+    });
+
+    it("closes only tabs under the newly-locked folder, not under already-locked ones", async () => {
+      setVaultRoot("/vault");
+      tabLifecycleStore.openTab("/vault/journal/x.md");
+      tabLifecycleStore.openTab("/vault/secret/y.md");
+      // Initial snapshot: journal locked, secret unlocked.
+      const { fire } = captureEventHandler();
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "journal", createdAt: "t", state: "encrypted", locked: true },
+        { path: "secret", createdAt: "t", state: "encrypted", locked: false },
+      ]);
+      await initEncryptedFoldersStore();
+      // After seed: both tabs still open (journal tab was already there
+      // when we seeded; we do not retroactively close on seed).
+      expect(get(tabLifecycleStore).tabs).toHaveLength(2);
+      // Lock secret. Journal stays locked — should NOT re-trigger close.
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "journal", createdAt: "t", state: "encrypted", locked: true },
+        { path: "secret", createdAt: "t", state: "encrypted", locked: true },
+      ]);
+      await fire();
+      const state = get(tabLifecycleStore);
+      const paths = state.tabs.map((t) => t.filePath);
+      // journal/x.md survives (still open from before — it was never re-locked
+      // in our tracked deltas); secret/y.md is closed.
+      expect(paths).toContain("/vault/journal/x.md");
+      expect(paths).not.toContain("/vault/secret/y.md");
+    });
+
+    it("leaves previous snapshot unchanged when the refresh IPC fails", async () => {
+      setVaultRoot("/vault");
+      tabLifecycleStore.openTab("/vault/secret/a.md");
+      // Seed: unlocked.
+      const { fire } = captureEventHandler();
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "secret", createdAt: "t", state: "encrypted", locked: false },
+      ]);
+      await initEncryptedFoldersStore();
+      // Transient failure — don't mutate previous set, don't close tabs.
+      listEncryptedFoldersMock.mockRejectedValueOnce(new Error("boom"));
+      await fire();
+      expect(get(tabLifecycleStore).tabs).toHaveLength(1);
+      // Recovery: next successful refresh still sees the unlocked→locked
+      // delta and closes the tab.
+      listEncryptedFoldersMock.mockResolvedValueOnce([
+        { path: "secret", createdAt: "t", state: "encrypted", locked: true },
+      ]);
+      await fire();
+      expect(get(tabLifecycleStore).tabs).toHaveLength(0);
+    });
   });
 });

--- a/src/store/encryptedFoldersStore.ts
+++ b/src/store/encryptedFoldersStore.ts
@@ -17,12 +17,23 @@
 //   convenience `lockedPaths: Set<string>` of vault-relative paths
 //   that the sidebar and command palette can consult without doing
 //   their own filtering.
+//
+// #351: the store also owns the "close tabs on lock" side effect.
+// Each refresh tracks which roots were locked last time; when a root
+// transitions unlocked → locked (or appears freshly locked after an
+// `encrypt_folder`), every open tab whose absolute path sits under
+// that root is closed via `tabLifecycleStore.closeUnderPath`. The
+// initial populate seeds the previous-locked snapshot without closing
+// anything so that tabs restored from a persisted session are not
+// retroactively evicted on vault open.
 
-import { writable, derived, type Readable } from "svelte/store";
+import { writable, derived, get, type Readable } from "svelte/store";
 
 import { listEncryptedFolders } from "../ipc/commands";
 import { listenEncryptedFoldersChanged } from "../ipc/events";
 import { treeRefreshStore } from "./treeRefreshStore";
+import { tabLifecycleStore } from "./tabLifecycleStore";
+import { vaultStore } from "./vaultStore";
 import type { EncryptedFolderView } from "../types/encryption";
 
 interface StoreState {
@@ -35,6 +46,36 @@ const internal = writable<StoreState>({ entries: [], ready: false });
 
 let unlisten: (() => void) | null = null;
 
+/**
+ * #351: vault-relative paths that were reported as `locked: true` in
+ * the most recent successful refresh. Drives the unlocked → locked
+ * diff that triggers `tabLifecycleStore.closeUnderPath`. Lives at
+ * module scope alongside `unlisten` — same lifecycle, cleared by
+ * `resetEncryptedFoldersStore`.
+ */
+let previousLockedRelPaths = new Set<string>();
+
+/**
+ * #351: skip the close-tabs side effect on the very first refresh
+ * after `initEncryptedFoldersStore`. A persisted-session scenario
+ * (vault closed with tabs open inside an encrypted root; re-opened
+ * later — the manifest always reports locked=true on cold start)
+ * would otherwise close those tabs on every vault open. Seeding
+ * once at init means the diff only fires on real transitions.
+ */
+let seeded = false;
+
+/**
+ * #351: serialize overlapping refreshes so the locked-path diff is
+ * well-defined. Two `encrypted_folders_changed` events can arrive in
+ * quick succession (e.g., auto-lock timers for two folders firing
+ * within a few ms); without a chain guard the two async refreshes
+ * both read-then-write `previousLockedRelPaths` against different
+ * snapshots and one transition can be lost. The chain ensures each
+ * refresh runs to completion before the next starts.
+ */
+let refreshChain: Promise<void> = Promise.resolve();
+
 /** Read-only view of the raw manifest entries (salt stripped). */
 export const encryptedFolders: Readable<EncryptedFolderView[]> = derived(
   internal,
@@ -44,10 +85,10 @@ export const encryptedFolders: Readable<EncryptedFolderView[]> = derived(
 /**
  * Precomputed set of **vault-relative, forward-slash** paths whose
  * entry is tracked in the manifest. Does NOT distinguish locked vs
- * unlocked — that signal lives on `DirEntry.encryption` straight from
- * the backend. Callers that hold absolute paths must normalize first
- * (strip the vault prefix) before checking membership — see the
- * helper in `openFileAsTab.ts`.
+ * unlocked — use `EncryptedFolderView.locked` or consult
+ * `DirEntry.encryption` for that signal. Callers that hold absolute
+ * paths must normalize first (strip the vault prefix) before checking
+ * membership — see the helper in `openFileAsTab.ts`.
  */
 export const encryptedPaths: Readable<Set<string>> = derived(
   internal,
@@ -60,17 +101,64 @@ export const encryptedFoldersReady: Readable<boolean> = derived(
   ($s) => $s.ready,
 );
 
+/**
+ * Compare `entries` against the previous locked-paths snapshot and
+ * close tabs for every root that has newly transitioned into the
+ * locked state. The first call after init only seeds the snapshot;
+ * subsequent calls emit close events.
+ *
+ * Absolute path reconstruction mirrors `openFileAsTab.ts::findLockingRoot`:
+ * take the vault root from `vaultStore.currentPath`, strip any trailing
+ * separators, and join with the manifest's vault-relative path using
+ * a forward slash. This is the same code path the tab originally used
+ * when it was opened, so prefix matching against `tab.filePath` works
+ * without an extra canonicalization round-trip.
+ */
+function reconcileLockedTabs(entries: EncryptedFolderView[]): void {
+  const currentLocked = new Set(
+    entries.filter((e) => e.locked).map((e) => e.path),
+  );
+  if (!seeded) {
+    previousLockedRelPaths = currentLocked;
+    seeded = true;
+    return;
+  }
+  const newlyLocked: string[] = [];
+  for (const rel of currentLocked) {
+    if (!previousLockedRelPaths.has(rel)) newlyLocked.push(rel);
+  }
+  previousLockedRelPaths = currentLocked;
+  if (newlyLocked.length === 0) return;
+
+  const vaultRoot = get(vaultStore).currentPath;
+  if (!vaultRoot) return;
+  const normalizedVault = vaultRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+  for (const rel of newlyLocked) {
+    const abs = `${normalizedVault}/${rel}`;
+    tabLifecycleStore.closeUnderPath(abs);
+  }
+}
+
 async function refresh(): Promise<void> {
   try {
     const entries = await listEncryptedFolders();
     internal.set({ entries, ready: true });
+    reconcileLockedTabs(entries);
   } catch (e) {
     // Don't throw on refresh — transient IPC failure keeps the last
     // known state; the next `encrypted_folders_changed` event will
-    // re-try. Log so bugs are observable in dev.
+    // re-try. `previousLockedRelPaths` is intentionally NOT mutated
+    // so the next successful refresh still observes the pending
+    // unlocked → locked deltas. Log so bugs are observable in dev.
     // eslint-disable-next-line no-console
     console.warn("encryptedFoldersStore refresh failed", e);
   }
+}
+
+/** Chain a refresh onto the in-flight one so concurrent events serialize. */
+function scheduleRefresh(): Promise<void> {
+  refreshChain = refreshChain.then(refresh, refresh);
+  return refreshChain;
 }
 
 /**
@@ -88,17 +176,22 @@ export async function initEncryptedFoldersStore(): Promise<void> {
     } catch { /* swallow */ }
     unlisten = null;
   }
-  await refresh();
+  // Reset the lock-diff state on every init so a vault switch does not
+  // leak the previous vault's locked-paths snapshot into the new vault.
+  previousLockedRelPaths = new Set();
+  seeded = false;
+  await scheduleRefresh();
   try {
     unlisten = await listenEncryptedFoldersChanged(() => {
-      void refresh();
-      // #345: the sidebar's `DirEntry.encryption` is cached via the
-      // tree model built from `list_directory`. Encrypt / unlock /
-      // lock mutate that field on the backend but the cached tree
-      // still shows the old state until we force a re-fetch. A
-      // treeRefreshStore pulse here makes the unlock actually
-      // reveal children and the lock actually re-hide them.
-      treeRefreshStore.requestRefresh();
+      void scheduleRefresh().then(() => {
+        // #345: the sidebar's `DirEntry.encryption` is cached via the
+        // tree model built from `list_directory`. Encrypt / unlock /
+        // lock mutate that field on the backend but the cached tree
+        // still shows the old state until we force a re-fetch. A
+        // treeRefreshStore pulse here makes the unlock actually
+        // reveal children and the lock actually re-hide them.
+        treeRefreshStore.requestRefresh();
+      });
     });
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -114,6 +207,8 @@ export function resetEncryptedFoldersStore(): void {
     unlisten = null;
   }
   internal.set({ entries: [], ready: false });
+  previousLockedRelPaths = new Set();
+  seeded = false;
 }
 
 /** Test-only: manually push state. Do not use in production code. */

--- a/src/store/encryptedFoldersStore.ts
+++ b/src/store/encryptedFoldersStore.ts
@@ -157,7 +157,9 @@ async function refresh(): Promise<void> {
 
 /** Chain a refresh onto the in-flight one so concurrent events serialize. */
 function scheduleRefresh(): Promise<void> {
-  refreshChain = refreshChain.then(refresh, refresh);
+  // `refresh` catches its own errors internally — the chain never rejects,
+  // so no second handler is needed.
+  refreshChain = refreshChain.then(refresh);
   return refreshChain;
 }
 
@@ -178,8 +180,13 @@ export async function initEncryptedFoldersStore(): Promise<void> {
   }
   // Reset the lock-diff state on every init so a vault switch does not
   // leak the previous vault's locked-paths snapshot into the new vault.
+  // Also reset `refreshChain` — any in-flight refresh tail from the old
+  // vault would otherwise drain AFTER `seeded` was cleared and seed
+  // `previousLockedRelPaths` with stale old-vault paths, causing
+  // spurious or missed close events on the new vault's first real diff.
   previousLockedRelPaths = new Set();
   seeded = false;
+  refreshChain = Promise.resolve();
   await scheduleRefresh();
   try {
     unlisten = await listenEncryptedFoldersChanged(() => {

--- a/src/store/tabLifecycleStore.test.ts
+++ b/src/store/tabLifecycleStore.test.ts
@@ -178,6 +178,121 @@ describe("tabLifecycleStore", () => {
     });
   });
 
+  // #351 — when an encrypted folder is locked, every open tab whose file
+  // lives under that folder must close. Plaintext buffers are released as
+  // the tab's EditorPane unmounts, which satisfies the acceptance criterion
+  // of not leaving decrypted content visible or editable.
+  describe("closeUnderPath", () => {
+    it("closes a tab whose filePath exactly matches the folder path", () => {
+      // Edge case: a file tab whose path happens to equal the folder arg.
+      // Shouldn't happen in practice (a locked folder is a directory), but
+      // the prefix check must not silently miss it.
+      const id = tabLifecycleStore.openTab("/vault/secret");
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      expect(get(tabLifecycleStore).tabs.find((t) => t.id === id)).toBeUndefined();
+    });
+
+    it("closes child-file tabs under the folder", () => {
+      const id1 = tabLifecycleStore.openTab("/vault/secret/a.md");
+      const id2 = tabLifecycleStore.openTab("/vault/secret/sub/b.md");
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs.find((t) => t.id === id1)).toBeUndefined();
+      expect(state.tabs.find((t) => t.id === id2)).toBeUndefined();
+      expect(state.tabs).toHaveLength(0);
+    });
+
+    it("does NOT close siblings with a shared string prefix", () => {
+      // `/vault/secret` is locked; `/vault/secretplans/*` must stay open.
+      // String-startsWith alone would incorrectly match this — the check
+      // must insist on a path separator boundary.
+      tabLifecycleStore.openTab("/vault/secret/a.md");
+      const keep = tabLifecycleStore.openTab("/vault/secretplans/note.md");
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(1);
+      expect(state.tabs[0]!.id).toBe(keep);
+    });
+
+    it("leaves unrelated tabs alone", () => {
+      tabLifecycleStore.openTab("/vault/secret/a.md");
+      const keep = tabLifecycleStore.openTab("/vault/other/b.md");
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(1);
+      expect(state.tabs[0]!.id).toBe(keep);
+    });
+
+    it("does not touch the graph tab", () => {
+      tabLifecycleStore.openTab("/vault/secret/a.md");
+      const graphId = tabLifecycleStore.openGraphTab();
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(1);
+      expect(state.tabs[0]!.id).toBe(graphId);
+      expect(state.tabs[0]!.type).toBe("graph");
+    });
+
+    it("is a no-op when no tab falls under the path", () => {
+      const id = tabLifecycleStore.openTab("/vault/other/a.md");
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(1);
+      expect(state.tabs[0]!.id).toBe(id);
+    });
+
+    it("reassigns activeTabId to a surviving tab when the active tab is closed", () => {
+      const keep = tabLifecycleStore.openTab("/vault/other/a.md");
+      const active = tabLifecycleStore.openTab("/vault/secret/x.md");
+      tabLifecycleStore.activateTab(active);
+      expect(get(tabLifecycleStore).activeTabId).toBe(active);
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs.map((t) => t.id)).toEqual([keep]);
+      expect(state.activeTabId).toBe(keep);
+    });
+
+    it("sets activeTabId to null when every surviving tab is closed", () => {
+      const a = tabLifecycleStore.openTab("/vault/secret/a.md");
+      tabLifecycleStore.openTab("/vault/secret/b.md");
+      tabLifecycleStore.activateTab(a);
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(0);
+      expect(state.activeTabId).toBeNull();
+    });
+
+    it("collapses the split when the right pane is fully consumed", () => {
+      const left = tabLifecycleStore.openTab("/vault/plain.md");
+      const r1 = tabLifecycleStore.openTab("/vault/secret/a.md");
+      const r2 = tabLifecycleStore.openTab("/vault/secret/b.md");
+      // Manually stage a split — both victims live in the right pane.
+      _core.update((s) => ({
+        ...s,
+        splitState: { left: [left], right: [r1, r2], activePane: "right" },
+        activeTabId: r1,
+      }));
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs.map((t) => t.id)).toEqual([left]);
+      expect(state.splitState.left).toEqual([left]);
+      expect(state.splitState.right).toEqual([]);
+      expect(state.splitState.activePane).toBe("left");
+      expect(state.activeTabId).toBe(left);
+    });
+
+    it("tolerates Windows-style backslash separators in tab paths", () => {
+      // Tauri on Windows returns paths with `\\` separators; the prefix
+      // check must compare them in a separator-agnostic way.
+      tabLifecycleStore.openTab("C:\\vault\\secret\\a.md");
+      const keep = tabLifecycleStore.openTab("C:\\vault\\other\\b.md");
+      tabLifecycleStore.closeUnderPath("C:\\vault\\secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs).toHaveLength(1);
+      expect(state.tabs[0]!.id).toBe(keep);
+    });
+  });
+
   describe("openGraphTab", () => {
     it("creates a singleton graph tab and activates it", () => {
       const id = tabLifecycleStore.openGraphTab();

--- a/src/store/tabLifecycleStore.test.ts
+++ b/src/store/tabLifecycleStore.test.ts
@@ -281,6 +281,27 @@ describe("tabLifecycleStore", () => {
       expect(state.activeTabId).toBe(left);
     });
 
+    it("collapses the split when the left pane is fully consumed", () => {
+      // Mirror of the right-pane-consumed case — survivors live in the
+      // right pane, so the collapse must move them into the now-sole
+      // left pane and flip activePane to "left".
+      const l1 = tabLifecycleStore.openTab("/vault/secret/a.md");
+      const l2 = tabLifecycleStore.openTab("/vault/secret/b.md");
+      const right = tabLifecycleStore.openTab("/vault/plain.md");
+      _core.update((s) => ({
+        ...s,
+        splitState: { left: [l1, l2], right: [right], activePane: "left" },
+        activeTabId: l1,
+      }));
+      tabLifecycleStore.closeUnderPath("/vault/secret");
+      const state = get(tabLifecycleStore);
+      expect(state.tabs.map((t) => t.id)).toEqual([right]);
+      expect(state.splitState.left).toEqual([right]);
+      expect(state.splitState.right).toEqual([]);
+      expect(state.splitState.activePane).toBe("left");
+      expect(state.activeTabId).toBe(right);
+    });
+
     it("tolerates Windows-style backslash separators in tab paths", () => {
       // Tauri on Windows returns paths with `\\` separators; the prefix
       // check must compare them in a separator-agnostic way.

--- a/src/store/tabLifecycleStore.ts
+++ b/src/store/tabLifecycleStore.ts
@@ -349,8 +349,13 @@ export const tabLifecycleStore = {
       }
 
       // Collapse the split when a pane becomes empty, mirroring closeTab.
+      // When every tab dies, reset activePane to "left" to match closeAll
+      // and the generic closeTab's zero-tab fallback — otherwise a stale
+      // "right" activePane pointer would outlive the pane itself.
       let newSplitState: SplitState;
-      if (newLeft.length === 0 && newRight.length > 0) {
+      if (newLeft.length === 0 && newRight.length === 0) {
+        newSplitState = { left: [], right: [], activePane: "left" };
+      } else if (newLeft.length === 0 && newRight.length > 0) {
         newSplitState = { left: newRight, right: [], activePane: "left" };
       } else if (newRight.length === 0 && newLeft.length > 0) {
         newSplitState = {

--- a/src/store/tabLifecycleStore.ts
+++ b/src/store/tabLifecycleStore.ts
@@ -300,6 +300,82 @@ export const tabLifecycleStore = {
   },
 
   /**
+   * #351: close every tab whose filePath sits at or under `folderAbsPath`.
+   * Used by the encrypted-folders lock flow — when a folder transitions
+   * to locked, any open tab inside that subtree must close so the
+   * decrypted plaintext buffer is released along with the EditorPane
+   * tear-down.
+   *
+   * The check normalizes to forward slashes (Windows tolerance) and
+   * requires a separator boundary after the folder path — so
+   * `/vault/secret` does NOT match `/vault/secretplans/note.md`.
+   *
+   * Graph and other non-filesystem tabs (`vault://` sentinels) never
+   * match because their pseudo-paths do not share the folder prefix.
+   *
+   * Atomicity: single `_core.update` — one store emission regardless of
+   * how many tabs are closed. Active-tab fallback prefers the tab
+   * immediately to the left of the first victim; if nothing survives
+   * in either pane, activeTabId becomes null. Splits collapse to the
+   * left pane when one pane is fully consumed, matching `closeTab`.
+   */
+  closeUnderPath(folderAbsPath: string): void {
+    const normSep = (p: string): string => p.replace(/\\/g, "/");
+    const folder = normSep(folderAbsPath).replace(/\/+$/, "");
+    _core.update((state) => {
+      const victims = new Set(
+        state.tabs
+          .filter((t) => {
+            const tp = normSep(t.filePath);
+            return tp === folder || tp.startsWith(folder + "/");
+          })
+          .map((t) => t.id),
+      );
+      if (victims.size === 0) return state;
+
+      const newTabs = state.tabs.filter((t) => !victims.has(t.id));
+      const filterPane = (ids: string[]): string[] => ids.filter((id) => !victims.has(id));
+      const newLeft = filterPane(state.splitState.left);
+      const newRight = filterPane(state.splitState.right);
+
+      // Pick new active: keep current if it survived, else first tab in
+      // the active pane, else first tab anywhere, else null.
+      let newActiveTabId = state.activeTabId;
+      if (newActiveTabId === null || victims.has(newActiveTabId)) {
+        const preferred =
+          state.splitState.activePane === "left" ? newLeft : newRight;
+        newActiveTabId =
+          preferred[0] ?? newLeft[0] ?? newRight[0] ?? null;
+      }
+
+      // Collapse the split when a pane becomes empty, mirroring closeTab.
+      let newSplitState: SplitState;
+      if (newLeft.length === 0 && newRight.length > 0) {
+        newSplitState = { left: newRight, right: [], activePane: "left" };
+      } else if (newRight.length === 0 && newLeft.length > 0) {
+        newSplitState = {
+          left: newLeft,
+          right: [],
+          activePane: "left",
+        };
+      } else {
+        newSplitState = {
+          left: newLeft,
+          right: newRight,
+          activePane: state.splitState.activePane,
+        };
+      }
+
+      return {
+        ...state,
+        tabs: newTabs,
+        activeTabId: newActiveTabId,
+        splitState: newSplitState,
+      };
+    });
+  },
+
+  /**
    * Read the current active tab (snapshot — not reactive).
    * Returns null if no tabs are open.
    */

--- a/src/types/encryption.ts
+++ b/src/types/encryption.ts
@@ -16,6 +16,14 @@ export interface EncryptedFolderView {
    * lets the user recover it.
    */
   state: EncryptedFolderState;
+  /**
+   * #351 — whether this root is currently locked in the running
+   * session. Derived from the in-memory `locked_paths` registry at
+   * list time; not persisted in the manifest. The frontend diffs
+   * this across refreshes to detect unlocked → locked transitions
+   * and close any open tabs that sit inside a now-locked root.
+   */
+  locked: boolean;
 }
 
 /** Progress payload for the `vault://encrypt_progress` event. */


### PR DESCRIPTION
Closes #351.

## Summary

Locking an encrypted folder used to leave any open tabs from inside that folder visible and editable, defeating the guarantee of the lock. This PR closes every tab whose path sits under a newly-locked root on all three lock paths (manual, auto-lock timer, app-quit) via a single frontend listener on `vault://encrypted_folders_changed`.

- Backend: extend `EncryptedFolderView` with a `locked: bool` derived from the in-memory registry at list time. Orphaned manifest entries (canonicalize fails) report `locked: true` as the conservative default.
- `tabLifecycleStore.closeUnderPath(folderAbsPath)` closes every matching tab in a single `_core.update` (no torn state). Prefix match requires a separator boundary — `/vault/secret` does not match `/vault/secretplans`. Windows `\\` separators are normalized.
- `encryptedFoldersStore` diffs the `locked` field across refreshes and calls `closeUnderPath` for every unlocked → locked transition. Refreshes are serialized through a promise chain so overlapping lock events cannot drop a transition. The first refresh after init only seeds the snapshot, so a cold-start vault open with tabs restored inside an encrypted root does not retroactively close them.

## Design notes / scope

- **Path boundary.** Paths stay vault-relative across the IPC; the frontend reconstructs absolute paths via `vaultStore.currentPath`, mirroring the existing `openFileAsTab.ts::findLockingRoot` pattern. No new IPC command was needed — just a new field on the existing `list_encrypted_folders` response.
- **Dirty-tab flush before close.** Out of scope. There is no current `forceSave` API (the tab store has no access to live CodeMirror views; auto-save is per-EditorPane, 2s idle debounce). Unsaved keystrokes within the ≤ 2s debounce window fall inside VaultCore's spec-accepted crash-recovery budget.
- **Plaintext buffer clearing.** When a tab closes, its EditorPane unmounts and the CodeMirror state is released. That is what satisfies the acceptance criterion — no separate wipe step is needed.

## Test plan

- [x] `pnpm exec vitest run src/store/tabLifecycleStore.test.ts src/store/__tests__/encryptedFoldersStore.test.ts` — 56 pass
- [x] `pnpm exec vitest run src/store/tabStore.test.ts src/store/tabLayoutStore.test.ts src/store/tabReloadStore.test.ts src/lib/__tests__/openFileAsTab.test.ts src/store/__tests__/autoLockStore.test.ts` — 34 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `cargo test --lib encryption` — 41 pass
- [x] `cargo build --lib` — clean
- [ ] Manual UAT: open a note inside an encrypted folder, lock via sidebar → tab closes. Repeat via auto-lock timer and app-quit paths.

New coverage specifically for #351:

- `closeUnderPath`: exact match, nested children, prefix collision (`secret` vs `secretplans`), graph-tab untouched, no-op, active-tab reassignment, empty-result null active, split-pane collapse, Windows separator tolerance.
- `encryptedFoldersStore`: initial populate never closes tabs, unlocked → locked closes matching tabs only, locked → unlocked is a no-op, refresh-IPC failure preserves the previous snapshot so the next success still emits the close.