### PR TITLE
fix(encryption): unlock opens folder immediately without second click (#355)

### DIFF
--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -743,6 +743,7 @@
             {onSelect}
             {onOpenFile}
             onToggleExpand={(r) => onToggleExpand(r)}
+            onEnsureExpanded={(r) => setExpanded(r.relPath, r.path, true)}
             onRefreshFolder={refreshFolder}
             onPathChanged={handlePathChanged}
             {onRenameStateChange}

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -54,6 +54,13 @@
     onSelect: (path: string) => void;
     onOpenFile: (path: string) => void;
     onToggleExpand: (row: FlatRow) => void | Promise<void>;
+    /**
+     * Guaranteed-expand (idempotent). Use when the caller needs the
+     * folder open regardless of its current expanded state — e.g. after
+     * unlock, or after creating a child, where a plain toggle would
+     * collapse an already-expanded folder.
+     */
+    onEnsureExpanded: (row: FlatRow) => void | Promise<void>;
     /** Tell the Sidebar the child list for this folder needs re-fetching. */
     onRefreshFolder: (folderPath: string) => void | Promise<void>;
     onPathChanged: (oldPath: string, newPath: string) => void;
@@ -67,6 +74,7 @@
     onSelect,
     onOpenFile,
     onToggleExpand,
+    onEnsureExpanded,
     onRefreshFolder,
     onPathChanged,
     onRenameStateChange,
@@ -132,18 +140,13 @@
     if (row.isDir) {
       // #345: clicking a locked folder opens the password modal
       // instead of toggling expansion. On successful unlock we
-      // schedule the expand via onUnlocked — the tree refresh that
-      // fires from `encrypted_folders_changed` rebuilds this row
-      // with `encryption: "unlocked"`, and the expand we trigger
-      // here then descends into the now-visible children without
-      // requiring a second click.
+      // ensure-expand — a plain toggle would *collapse* the folder
+      // if it happened to be in `treeState.expanded` from before it
+      // was locked (locking doesn't prune the expanded set), forcing
+      // a second click to re-open it.
       if (isLocked) {
         openUnlockModal(row.path, row.name, async () => {
-          // The store swap + tree refresh run asynchronously after
-          // the unlock event; yield the microtask queue so the
-          // refreshed row is the one we toggle.
-          await Promise.resolve();
-          await onToggleExpand(row);
+          await onEnsureExpanded(row);
         });
         return;
       }

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -56,9 +56,12 @@
     onToggleExpand: (row: FlatRow) => void | Promise<void>;
     /**
      * Guaranteed-expand (idempotent). Use when the caller needs the
-     * folder open regardless of its current expanded state — e.g. after
-     * unlock, or after creating a child, where a plain toggle would
-     * collapse an already-expanded folder.
+     * folder open regardless of its current expanded state. A plain
+     * `onToggleExpand` reads `treeState.expanded` and flips it, so
+     * calling it on an already-expanded folder collapses it — wrong
+     * for any flow whose intent is "make sure this folder is open"
+     * (unlock success; "New file/folder here" context menu entries
+     * that should leave the containing folder expanded).
      */
     onEnsureExpanded: (row: FlatRow) => void | Promise<void>;
     /** Tell the Sidebar the child list for this folder needs re-fetching. */
@@ -138,14 +141,24 @@
   function handleClick() {
     onSelect(row.path);
     if (row.isDir) {
-      // #345: clicking a locked folder opens the password modal
-      // instead of toggling expansion. On successful unlock we
-      // ensure-expand — a plain toggle would *collapse* the folder
-      // if it happened to be in `treeState.expanded` from before it
-      // was locked (locking doesn't prune the expanded set), forcing
-      // a second click to re-open it.
+      // #355: clicking a locked folder opens the password modal
+      // instead of toggling expansion. On successful unlock we:
+      //   1. Re-fetch the parent listing so the cached DirEntry for
+      //      this folder flips from `encryption: "locked"` to
+      //      `"unlocked"`. Without this step, flattenTree's
+      //      `if (entry.encryption === "locked") continue` would
+      //      skip children of an otherwise-expanded folder until
+      //      the async `encrypted_folders_changed` pulse lands —
+      //      yielding a brief "expanded but empty" flash.
+      //   2. Ensure-expand (idempotent). A plain toggle would
+      //      *collapse* a folder whose relPath is still in
+      //      `treeState.expanded` from before it was locked
+      //      (locking does not prune the expanded set), forcing
+      //      a second click to re-open it.
       if (isLocked) {
         openUnlockModal(row.path, row.name, async () => {
+          const parent = parentOf(row.path) ?? getVaultRoot();
+          if (parent) await onRefreshFolder(parent);
           await onEnsureExpanded(row);
         });
         return;
@@ -299,7 +312,7 @@
     closeContextMenu();
     try {
       const newPath = await createFile(row.path, "");
-      await onToggleExpand({ ...row, expanded: false });
+      await onEnsureExpanded(row);
       await onRefreshFolder(row.path);
       tabStore.openTab(newPath);
     } catch (e) {
@@ -313,7 +326,7 @@
     try {
       const newPath = await createFile(row.path, "Untitled.canvas");
       await writeFile(newPath, serializeCanvas(emptyCanvas()));
-      await onToggleExpand({ ...row, expanded: false });
+      await onEnsureExpanded(row);
       await onRefreshFolder(row.path);
       tabStore.openFileTab(newPath, "canvas");
     } catch (e) {
@@ -326,7 +339,7 @@
     closeContextMenu();
     try {
       await createFolder(row.path, "");
-      await onToggleExpand({ ...row, expanded: false });
+      await onEnsureExpanded(row);
       await onRefreshFolder(row.path);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -303,17 +303,22 @@
   }
 
   function parentOf(absPath: string): string | null {
-    const i = absPath.lastIndexOf("/");
-    if (i <= 0) return null;
-    return absPath.slice(0, i);
+    // Backend paths (`DirEntry.path` via `to_string_lossy` in `tree.rs`)
+    // carry native separators — backslashes on Windows, forward slashes
+    // elsewhere. Accept both so a top-level folder like `C:\Vault\secret`
+    // still resolves to its parent instead of silently returning `null`
+    // and skipping the post-unlock parent refresh on Windows.
+    const lastSep = Math.max(absPath.lastIndexOf("/"), absPath.lastIndexOf("\\"));
+    if (lastSep <= 0) return null;
+    return absPath.slice(0, lastSep);
   }
 
   async function handleNewFileHere() {
     closeContextMenu();
     try {
       const newPath = await createFile(row.path, "");
-      await onEnsureExpanded(row);
       await onRefreshFolder(row.path);
+      await onEnsureExpanded(row);
       tabStore.openTab(newPath);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
@@ -326,8 +331,8 @@
     try {
       const newPath = await createFile(row.path, "Untitled.canvas");
       await writeFile(newPath, serializeCanvas(emptyCanvas()));
-      await onEnsureExpanded(row);
       await onRefreshFolder(row.path);
+      await onEnsureExpanded(row);
       tabStore.openFileTab(newPath, "canvas");
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
@@ -339,8 +344,8 @@
     closeContextMenu();
     try {
       await createFolder(row.path, "");
-      await onEnsureExpanded(row);
       await onRefreshFolder(row.path);
+      await onEnsureExpanded(row);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });

--- a/src/components/Sidebar/__tests__/SidebarUnlockKeepsExpanded.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarUnlockKeepsExpanded.test.ts
@@ -1,0 +1,172 @@
+// Regression for #355 — the Sidebar-level invariant: when a folder's
+// relPath is already in `treeState.expanded` (because the user
+// expanded it before locking), clicking the folder → entering the
+// password → unlock-success must keep it expanded. A prior version
+// of TreeRow called `onToggleExpand` from the unlock callback, which
+// flipped the expanded set and collapsed the folder.
+//
+// The pure wiring test in TreeRowUnlockExpand.test.ts asserts that
+// the unlock callback targets `onEnsureExpanded` (not toggle). This
+// test validates the next layer down: that the Sidebar's
+// `onEnsureExpanded` prop is wired to an idempotent helper and does
+// not collapse an already-expanded relPath.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+  lockFolder: vi.fn(),
+  unlockFolder: vi.fn(),
+  listEncryptedFolders: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenEncryptedFoldersChanged: vi.fn().mockResolvedValue(() => {}),
+}));
+
+const openUnlockModal = vi.fn<
+  [string, string, (() => void | Promise<void>)?],
+  void
+>();
+
+vi.mock("../../../store/encryptionModalStore", () => ({
+  openEncryptModal: vi.fn(),
+  openUnlockModal: (path: string, label: string, cb?: () => void | Promise<void>) => {
+    openUnlockModal(path, label, cb);
+  },
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { loadTreeState, saveTreeState } from "../../../lib/treeState";
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+const VAULT = "/tmp/test-vault";
+
+function lockedDir(name: string, path: string): DirEntry {
+  return {
+    name, path,
+    is_dir: true, is_symlink: false, is_md: false,
+    modified: null, created: null,
+    encryption: "locked",
+  };
+}
+function unlockedDir(name: string, path: string): DirEntry {
+  return {
+    name, path,
+    is_dir: true, is_symlink: false, is_md: false,
+    modified: null, created: null,
+    encryption: "unlocked",
+  };
+}
+function md(name: string, path: string): DirEntry {
+  return { name, path, is_dir: false, is_symlink: false, is_md: true, modified: null, created: null };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+describe("Sidebar unlock keeps folder expanded (#355)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    openUnlockModal.mockClear();
+    vi.clearAllMocks();
+  });
+
+  it("unlock callback does not collapse a folder whose relPath was already in treeState.expanded", async () => {
+    // Pre-seed the persisted tree state so "secret" is already in
+    // `expanded` at mount — simulating the scenario where the user
+    // expanded the folder before locking it.
+    await saveTreeState(VAULT, { sortBy: "name", expanded: ["secret"] });
+
+    const secret = lockedDir("secret", `${VAULT}/secret`);
+    const secretUnlocked = unlockedDir("secret", `${VAULT}/secret`);
+    const child = md("note.md", `${VAULT}/secret/note.md`);
+
+    let unlockDone = false;
+    (listDirectory as any).mockImplementation(async (path: string) => {
+      if (path === VAULT) return [unlockDone ? secretUnlocked : secret];
+      if (path === secret.path) return [child];
+      return [];
+    });
+
+    render(Sidebar, { props: makeProps() });
+
+    // Drain initial mount + load.
+    for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
+
+    // Click the locked folder → opens the unlock modal (not toggle).
+    const el = document.querySelector(
+      `.vc-tree-row[data-path="${secret.path}"]`,
+    ) as HTMLElement | null;
+    // Row selector: some renderers set data-path, others don't — fall back
+    // to text match as a safety net.
+    const row = el ?? Array.from(document.querySelectorAll(".vc-tree-row"))
+      .find((n) => n.textContent?.includes("secret")) as HTMLElement | undefined;
+    expect(row, "locked folder row rendered").toBeTruthy();
+    (row as HTMLElement).click();
+
+    for (let i = 0; i < 5; i += 1) { await Promise.resolve(); await tick(); }
+
+    expect(openUnlockModal).toHaveBeenCalledTimes(1);
+    const callback = openUnlockModal.mock.calls[0][2];
+    expect(callback).toBeTypeOf("function");
+
+    // Simulate successful unlock on the backend: the parent listing now
+    // returns the folder with encryption: "unlocked".
+    unlockDone = true;
+    await callback!();
+
+    for (let i = 0; i < 30; i += 1) { await Promise.resolve(); await tick(); }
+
+    // The invariant: "secret" must still be in persisted expanded set
+    // (not collapsed by a stale toggle) AND the child must have been
+    // loaded (children fetched by the ensure-expand path).
+    const persisted = await loadTreeState(VAULT);
+    expect(persisted.expanded).toContain("secret");
+
+    const callsForSecret = (listDirectory as any).mock.calls
+      .filter((c: [string]) => c[0] === secret.path);
+    expect(callsForSecret.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Sidebar/__tests__/SidebarUnlockKeepsExpanded.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarUnlockKeepsExpanded.test.ts
@@ -136,15 +136,10 @@ describe("Sidebar unlock keeps folder expanded (#355)", () => {
     for (let i = 0; i < 15; i += 1) { await Promise.resolve(); await tick(); }
 
     // Click the locked folder → opens the unlock modal (not toggle).
-    const el = document.querySelector(
-      `.vc-tree-row[data-path="${secret.path}"]`,
-    ) as HTMLElement | null;
-    // Row selector: some renderers set data-path, others don't — fall back
-    // to text match as a safety net.
-    const row = el ?? Array.from(document.querySelectorAll(".vc-tree-row"))
+    const row = Array.from(document.querySelectorAll(".vc-tree-row"))
       .find((n) => n.textContent?.includes("secret")) as HTMLElement | undefined;
     expect(row, "locked folder row rendered").toBeTruthy();
-    (row as HTMLElement).click();
+    row!.click();
 
     for (let i = 0; i < 5; i += 1) { await Promise.resolve(); await tick(); }
 

--- a/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
@@ -49,6 +49,7 @@ function makeProps(row: FlatRow) {
     onSelect: vi.fn(),
     onOpenFile: vi.fn(),
     onToggleExpand: vi.fn(),
+    onEnsureExpanded: vi.fn(),
     onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
   };

--- a/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
@@ -64,6 +64,7 @@ function makeProps(row: FlatRow) {
     onSelect: vi.fn(),
     onOpenFile: vi.fn(),
     onToggleExpand: vi.fn(),
+    onEnsureExpanded: vi.fn(),
     onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
   };

--- a/src/components/Sidebar/__tests__/TreeRowUnlockExpand.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRowUnlockExpand.test.ts
@@ -1,0 +1,124 @@
+// Regression: clicking a locked folder opens the password modal, and on
+// successful unlock the folder must open *immediately* — a second click
+// must not be required.
+//
+// The bug: `handleClick` used to call `onToggleExpand(row)` from the unlock
+// callback. Because locking does not prune `treeState.expanded`, a folder
+// that was expanded before being locked stayed in the expanded set while
+// locked; toggling after unlock therefore *collapsed* the folder. The fix
+// routes the unlock-success path through `onEnsureExpanded`, an idempotent
+// guaranteed-expand that the Sidebar maps to `setExpanded(..., true)`.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  renameFile: vi.fn(),
+  lockFolder: vi.fn(),
+  unlockFolder: vi.fn(),
+}));
+
+const openUnlockModal = vi.fn<
+  [string, string, (() => void | Promise<void>)?],
+  void
+>();
+
+vi.mock("../../../store/encryptionModalStore", () => ({
+  openEncryptModal: vi.fn(),
+  openUnlockModal: (path: string, label: string, cb?: () => void | Promise<void>) => {
+    openUnlockModal(path, label, cb);
+  },
+}));
+
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import TreeRow from "../TreeRow.svelte";
+import type { FlatRow } from "../../../lib/flattenTree";
+
+const VAULT = "/tmp/test-vault";
+
+function lockedFolderRow(overrides: Partial<FlatRow> = {}): FlatRow {
+  return {
+    path: `${VAULT}/secret`,
+    relPath: "secret",
+    name: "secret",
+    depth: 0,
+    isDir: true,
+    isMd: false,
+    isSymlink: false,
+    expanded: false,
+    loading: false,
+    hasRenderedChildren: false,
+    childrenLoaded: false,
+    encryption: "locked",
+    ...overrides,
+  };
+}
+
+function makeProps(row: FlatRow) {
+  return {
+    row,
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onToggleExpand: vi.fn(),
+    onEnsureExpanded: vi.fn(),
+    onRefreshFolder: vi.fn(),
+    onPathChanged: vi.fn(),
+  };
+}
+
+describe("TreeRow locked-folder unlock flow (#354 follow-up)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    openUnlockModal.mockClear();
+  });
+
+  it("opens the unlock modal when a locked folder is clicked, not toggle", async () => {
+    const props = makeProps(lockedFolderRow());
+    const { container } = render(TreeRow, { props });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    row.click();
+    await tick();
+
+    expect(openUnlockModal).toHaveBeenCalledTimes(1);
+    expect(openUnlockModal.mock.calls[0][0]).toBe(`${VAULT}/secret`);
+    expect(props.onToggleExpand).not.toHaveBeenCalled();
+  });
+
+  it("calls onEnsureExpanded (not onToggleExpand) on successful unlock", async () => {
+    const props = makeProps(lockedFolderRow());
+    const { container } = render(TreeRow, { props });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    row.click();
+    await tick();
+
+    const unlockCallback = openUnlockModal.mock.calls[0][2];
+    expect(unlockCallback).toBeTypeOf("function");
+    await unlockCallback!();
+
+    expect(props.onEnsureExpanded).toHaveBeenCalledTimes(1);
+    expect(props.onEnsureExpanded.mock.calls[0][0]).toMatchObject({
+      path: `${VAULT}/secret`,
+      relPath: "secret",
+    });
+    // Toggle must not be used here — a toggle would *collapse* the folder
+    // if its relPath happened to be in `treeState.expanded` from before
+    // the lock, which is exactly the regression we're guarding against.
+    expect(props.onToggleExpand).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Sidebar/__tests__/TreeRowUnlockExpand.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRowUnlockExpand.test.ts
@@ -1,13 +1,15 @@
-// Regression: clicking a locked folder opens the password modal, and on
-// successful unlock the folder must open *immediately* — a second click
-// must not be required.
+// Regression for #355: clicking a locked folder opens the password
+// modal, and on successful unlock the folder must open *immediately* —
+// a second click must not be required.
 //
-// The bug: `handleClick` used to call `onToggleExpand(row)` from the unlock
-// callback. Because locking does not prune `treeState.expanded`, a folder
-// that was expanded before being locked stayed in the expanded set while
-// locked; toggling after unlock therefore *collapsed* the folder. The fix
-// routes the unlock-success path through `onEnsureExpanded`, an idempotent
-// guaranteed-expand that the Sidebar maps to `setExpanded(..., true)`.
+// Original bug: `handleClick` called `onToggleExpand(row)` from the
+// unlock callback. Locking does not prune `treeState.expanded`, so a
+// folder that was expanded before being locked still had its relPath
+// in the set while locked; toggling after unlock therefore *collapsed*
+// it. The fix routes through `onEnsureExpanded` (idempotent
+// guaranteed-expand) and refreshes the parent listing first so the
+// flat row's cached `encryption` flag is fresh before flattenTree
+// decides whether to descend.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
@@ -78,7 +80,7 @@ function makeProps(row: FlatRow) {
   };
 }
 
-describe("TreeRow locked-folder unlock flow (#354 follow-up)", () => {
+describe("TreeRow locked-folder unlock flow (#355)", () => {
   beforeEach(() => {
     vaultStore.reset();
     bookmarksStore.reset();
@@ -99,7 +101,7 @@ describe("TreeRow locked-folder unlock flow (#354 follow-up)", () => {
     expect(props.onToggleExpand).not.toHaveBeenCalled();
   });
 
-  it("calls onEnsureExpanded (not onToggleExpand) on successful unlock", async () => {
+  it("refreshes the parent, then ensures-expand, on successful unlock", async () => {
     const props = makeProps(lockedFolderRow());
     const { container } = render(TreeRow, { props });
     await tick();
@@ -107,10 +109,25 @@ describe("TreeRow locked-folder unlock flow (#354 follow-up)", () => {
     row.click();
     await tick();
 
+    // Track ordering: the parent refresh must complete before the
+    // ensure-expand fires, otherwise the flat row's cached
+    // `encryption: "locked"` flag is still in effect when flattenTree
+    // decides whether to descend into children, producing a brief
+    // "expanded but empty" flash.
+    const order: string[] = [];
+    props.onRefreshFolder.mockImplementation(async () => {
+      order.push("refresh");
+    });
+    props.onEnsureExpanded.mockImplementation(async () => {
+      order.push("ensure");
+    });
+
     const unlockCallback = openUnlockModal.mock.calls[0][2];
     expect(unlockCallback).toBeTypeOf("function");
     await unlockCallback!();
 
+    expect(order).toEqual(["refresh", "ensure"]);
+    expect(props.onRefreshFolder).toHaveBeenCalledWith(VAULT);
     expect(props.onEnsureExpanded).toHaveBeenCalledTimes(1);
     expect(props.onEnsureExpanded.mock.calls[0][0]).toMatchObject({
       path: `${VAULT}/secret`,
@@ -120,5 +137,24 @@ describe("TreeRow locked-folder unlock flow (#354 follow-up)", () => {
     // if its relPath happened to be in `treeState.expanded` from before
     // the lock, which is exactly the regression we're guarding against.
     expect(props.onToggleExpand).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the nested parent (not vault root) for a deeper locked folder", async () => {
+    const nested = lockedFolderRow({
+      path: `${VAULT}/outer/secret`,
+      relPath: "outer/secret",
+      depth: 1,
+    });
+    const props = makeProps(nested);
+    const { container } = render(TreeRow, { props });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    row.click();
+    await tick();
+
+    const unlockCallback = openUnlockModal.mock.calls[0][2];
+    await unlockCallback!();
+
+    expect(props.onRefreshFolder).toHaveBeenCalledWith(`${VAULT}/outer`);
   });
 });


### PR DESCRIPTION
## Summary

- Unlocking a folder that had been expanded before being locked no longer requires a second click — it opens immediately.
- Adds an idempotent `onEnsureExpanded` prop to `TreeRow`, wired to the Sidebar's existing `setExpanded(relPath, absPath, true)`.
- Unlock-success path now routes through ensure-expand instead of toggle.

Closes #355.

## Root cause

`TreeRow.handleClick`'s unlock-success callback called `onToggleExpand(row)`. `onToggleExpand` toggles based on `treeState.expanded.includes(row.relPath)`. Locking does **not** prune the expanded set, so a previously-expanded folder stayed in `treeState.expanded` while locked; toggling after unlock collapsed it instead of opening it.

## Test plan

- [x] `src/components/Sidebar/__tests__/TreeRowUnlockExpand.test.ts` — new regression: asserts click on locked folder opens unlock modal (not toggle), and that the success callback calls `onEnsureExpanded`, not `onToggleExpand`.
- [x] `npx vitest run src/components/Sidebar/` — 15 files, 31 tests green.
- [ ] Manual UAT: create folder, expand it, encrypt + lock, click → enter password → folder opens directly (no second click).
- [ ] Manual UAT: never-expanded locked folder — unlock opens it directly.
- [ ] Manual UAT: chevron toggle, context-menu "New file here", keyboard (Space/Enter) still behave as before.