### PR TITLE
feat(encryption): export decrypted copy from encrypted folder (#360)

### DIFF
--- a/src-tauri/src/commands/encryption.rs
+++ b/src-tauri/src/commands/encryption.rs
@@ -447,6 +447,194 @@ pub async fn lock_all_folders(
     Ok(())
 }
 
+// ── export_decrypted_file (#360) ─────────────────────────────────────────────
+
+/// Test-accessible body for `export_decrypted_file`. Splits the Tauri
+/// `State` extraction from the logic so unit tests can hit the same
+/// contract without spinning up a runtime.
+///
+/// Contract:
+/// - `source` must sit inside the current vault AND inside an encrypted
+///   folder AND that folder must currently be UNLOCKED. Else: the
+///   corresponding `VaultError` without ever reading bytes.
+/// - `dest`'s parent must exist and canonicalize, and the prospective
+///   final path must NOT sit inside any encrypted root (exporting into
+///   another encrypted root would write unframed plaintext adjacent to
+///   ciphertext, silently breaking that folder's contract).
+/// - `dest` MAY live outside the vault — that is the whole point.
+///
+/// No atomic-write helper here. `write_atomic` places its `.vce-tmp-*`
+/// file next to the *destination*, which for this command is usually
+/// outside the vault (e.g. `~/Desktop/`). That tempfile would leak
+/// plaintext bytes outside the vault for the duration of the rename,
+/// violating the "plaintext never leaves unless explicit export"
+/// contract. The export is user-initiated and one-shot: a crash in the
+/// middle is a retry, not a corruption scenario for any vault state.
+/// Plain `fs::write` is correct here.
+///
+/// Size cap intentionally not re-checked: every sealed file under an
+/// encrypted root was already bounded by `MAX_INLINE_ENCRYPT_BYTES` at
+/// encrypt time. A ciphertext exceeding that cap + HEADER/TAG overhead
+/// means the file was tampered with — `decrypt_bytes` will fail the
+/// Poly1305 tag and surface `WrongPassword` / `CryptoError`, which is
+/// the correct defense.
+pub fn export_decrypted_file_impl(
+    state: &VaultState,
+    source: String,
+    dest: String,
+) -> Result<(), VaultError> {
+    // 1. Source lives inside the open vault.
+    let source_path = PathBuf::from(&source);
+    let source_canonical = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
+            path: source.clone(),
+        })?;
+        let canon = std::fs::canonicalize(&source_path).map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: source.clone() },
+            std::io::ErrorKind::PermissionDenied => {
+                VaultError::PermissionDenied { path: source.clone() }
+            }
+            _ => VaultError::Io(e),
+        })?;
+        if !canon.starts_with(vault.as_path()) {
+            return Err(VaultError::PermissionDenied {
+                path: canon.display().to_string(),
+            });
+        }
+        canon
+    };
+
+    // 2. Source must be inside an encrypted root.
+    let vault_root = {
+        let guard = state
+            .current_vault
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.as_ref().cloned().ok_or_else(|| VaultError::VaultUnavailable {
+            path: source.clone(),
+        })?
+    };
+    let src_enc_root = crate::encryption::find_enclosing_encrypted_root_cached(
+        &state.manifest_cache,
+        &vault_root,
+        &source_canonical,
+    )?
+    .ok_or_else(|| VaultError::PermissionDenied {
+        path: format!(
+            "{} is not inside an encrypted folder; nothing to decrypt",
+            source_canonical.display()
+        ),
+    })?;
+
+    // 3. That encrypted root must be unlocked (key present in keyring).
+    //    `keyring.key_clone(root)` returns `None` when the root is
+    //    currently locked — we surface this as `PathLocked` so the
+    //    frontend toast can tell the user to unlock and retry.
+    if state.keyring.key_clone(&src_enc_root)?.is_none() {
+        return Err(VaultError::PathLocked {
+            path: source_canonical.display().to_string(),
+        });
+    }
+
+    // 4. Resolve the destination. The file itself does not exist yet,
+    //    so canonicalize the PARENT and rebuild the final path.
+    let dest_path = PathBuf::from(&dest);
+    let dest_parent = dest_path
+        .parent()
+        .ok_or_else(|| VaultError::PermissionDenied { path: dest.clone() })?;
+    let dest_file_name = dest_path
+        .file_name()
+        .ok_or_else(|| VaultError::PermissionDenied { path: dest.clone() })?
+        .to_owned();
+    let dest_parent_canonical = std::fs::canonicalize(dest_parent).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound {
+            path: dest_parent.display().to_string(),
+        },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+            path: dest_parent.display().to_string(),
+        },
+        _ => VaultError::Io(e),
+    })?;
+    let dest_final = dest_parent_canonical.join(&dest_file_name);
+
+    // 5. Dest MUST NOT land inside any encrypted root. An export target
+    //    inside another encrypted folder would drop unframed plaintext
+    //    next to sealed files, silently breaking that folder's contract.
+    //    Use the dest PARENT for the enclosing-root check: the file
+    //    does not exist yet so we cannot canonicalize the full path,
+    //    and a child of a canonical parent inherits the parent's
+    //    enclosing-root status.
+    if crate::encryption::find_enclosing_encrypted_root_cached(
+        &state.manifest_cache,
+        &vault_root,
+        &dest_parent_canonical,
+    )?
+    .is_some()
+    {
+        return Err(VaultError::PermissionDenied {
+            path: format!(
+                "destination {} is inside an encrypted folder; pick a plain folder instead",
+                dest_final.display()
+            ),
+        });
+    }
+
+    // 6. Read + decrypt. `maybe_decrypt_read` is the same helper
+    //    `read_file` / `read_attachment_bytes` use; it returns plaintext
+    //    when the source sits in an unlocked encrypted root and passes
+    //    bytes through otherwise. We have already established (Steps 2
+    //    + 3) that this source qualifies for the decrypt path.
+    let ciphertext = std::fs::read(&source_canonical).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: source.clone() },
+        std::io::ErrorKind::PermissionDenied => {
+            VaultError::PermissionDenied { path: source.clone() }
+        }
+        _ => VaultError::Io(e),
+    })?;
+    let plaintext =
+        crate::encryption::maybe_decrypt_read(state, &source_canonical, ciphertext)?;
+
+    // 7. Write plaintext to dest. Non-atomic by design — see the
+    //    function-level doc for why `write_atomic` is unsafe here.
+    std::fs::write(&dest_final, &plaintext).map_err(|e| match e.kind() {
+        std::io::ErrorKind::PermissionDenied => {
+            VaultError::PermissionDenied { path: dest_final.display().to_string() }
+        }
+        std::io::ErrorKind::StorageFull => VaultError::DiskFull,
+        _ => VaultError::Io(e),
+    })?;
+
+    // 8. Audit log: the export is the highest-risk encryption op the
+    //    user can perform. Log the source rel-path; omit the full dest
+    //    (the user's filesystem layout is not ours to mirror into logs).
+    let rel = source_canonical
+        .strip_prefix(&vault_root)
+        .ok()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<unresolved>".into());
+    log::info!(
+        "export_decrypted_file: {} -> {} ({} bytes plaintext)",
+        rel,
+        dest_parent_canonical.display(),
+        plaintext.len(),
+    );
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn export_decrypted_file(
+    state: tauri::State<'_, VaultState>,
+    source: String,
+    dest: String,
+) -> Result<(), VaultError> {
+    export_decrypted_file_impl(&state, source, dest)
+}
+
 // ── list_encrypted_folders ───────────────────────────────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/commands/encryption.rs
+++ b/src-tauri/src/commands/encryption.rs
@@ -483,41 +483,41 @@ pub fn export_decrypted_file_impl(
     source: String,
     dest: String,
 ) -> Result<(), VaultError> {
-    // 1. Source lives inside the open vault.
-    let source_path = PathBuf::from(&source);
-    let source_canonical = {
-        let guard = state
-            .current_vault
-            .lock()
-            .map_err(|_| VaultError::LockPoisoned)?;
-        let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-            path: source.clone(),
-        })?;
-        let canon = std::fs::canonicalize(&source_path).map_err(|e| match e.kind() {
-            std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: source.clone() },
-            std::io::ErrorKind::PermissionDenied => {
-                VaultError::PermissionDenied { path: source.clone() }
-            }
-            _ => VaultError::Io(e),
-        })?;
-        if !canon.starts_with(vault.as_path()) {
-            return Err(VaultError::PermissionDenied {
-                path: canon.display().to_string(),
-            });
-        }
-        canon
-    };
+    // 1. Source inside vault + NOT inside a locked encrypted root.
+    //    `ensure_inside_vault` canonicalizes, enforces vault scope, AND
+    //    runs `ensure_unlocked` — so a source inside a locked root
+    //    already fails here with `PathLocked` before we do any further
+    //    work. Reusing the helper means every T-02 guard that covers
+    //    `read_file` / `write_file` also covers this command.
+    let source_canonical = crate::commands::files::ensure_inside_vault(
+        state,
+        &PathBuf::from(&source),
+    )?;
 
-    // 2. Source must be inside an encrypted root.
+    // 2. Snapshot `vault_root` ONCE. A concurrent `open_vault` that
+    //    swaps the vault between the scope check and the manifest
+    //    lookup would otherwise make us consult the wrong vault's
+    //    manifest. Single-lock semantics close the TOCTOU window.
     let vault_root = {
         let guard = state
             .current_vault
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
-        guard.as_ref().cloned().ok_or_else(|| VaultError::VaultUnavailable {
-            path: source.clone(),
-        })?
+        guard
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| VaultError::VaultUnavailable {
+                path: source.clone(),
+            })?
     };
+
+    // 3. Source must be inside an encrypted root. This is distinct
+    //    from "inside any vault folder" — a plain vault file has
+    //    nothing to decrypt, so exporting it would be a misleading
+    //    copy. We surface that as `PermissionDenied` with a clear
+    //    message; the frontend only exposes the menu entry for files
+    //    under an unlocked encrypted root, so in normal use the error
+    //    is a locked/locked race we already handle below.
     let src_enc_root = crate::encryption::find_enclosing_encrypted_root_cached(
         &state.manifest_cache,
         &vault_root,
@@ -530,17 +530,45 @@ pub fn export_decrypted_file_impl(
         ),
     })?;
 
-    // 3. That encrypted root must be unlocked (key present in keyring).
-    //    `keyring.key_clone(root)` returns `None` when the root is
-    //    currently locked — we surface this as `PathLocked` so the
-    //    frontend toast can tell the user to unlock and retry.
+    // 4. Root must be unlocked. `ensure_inside_vault` already returns
+    //    `PathLocked` for locked roots; we still check the keyring
+    //    explicitly because `ensure_unlocked` is fail-closed on
+    //    poisoned state and this path requires a key to actually
+    //    decrypt. A race between menu-open and click where the folder
+    //    is locked mid-flight also surfaces here.
     if state.keyring.key_clone(&src_enc_root)?.is_none() {
         return Err(VaultError::PathLocked {
             path: source_canonical.display().to_string(),
         });
     }
 
-    // 4. Resolve the destination. The file itself does not exist yet,
+    // 5. Source bytes must actually be sealed. `maybe_decrypt_read`
+    //    tolerates unframed bytes (see its doc — it passes through
+    //    plaintext stragglers so a half-finished encrypt batch can
+    //    still be recovered), but THIS command's contract is "export
+    //    a DECRYPTED copy". Silently passing through plaintext as if
+    //    it had been decrypted would let a user export a
+    //    partially-encrypted vault's stragglers under the
+    //    "decrypted" label and never notice the encrypt batch is
+    //    stuck. Reject explicitly so the error is observable.
+    let ciphertext = std::fs::read(&source_canonical).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: source.clone() },
+        std::io::ErrorKind::PermissionDenied => {
+            VaultError::PermissionDenied { path: source.clone() }
+        }
+        _ => VaultError::Io(e),
+    })?;
+    if !ciphertext.starts_with(crate::encryption::file_format::MAGIC) {
+        return Err(VaultError::CryptoError {
+            msg: format!(
+                "{} is inside an encrypted folder but is not sealed (missing VCE1 header) — \
+                 it may be a partially-completed encrypt batch; try re-running encrypt",
+                source_canonical.display()
+            ),
+        });
+    }
+
+    // 6. Resolve the destination. The file itself does not exist yet,
     //    so canonicalize the PARENT and rebuild the final path.
     let dest_path = PathBuf::from(&dest);
     let dest_parent = dest_path
@@ -561,13 +589,13 @@ pub fn export_decrypted_file_impl(
     })?;
     let dest_final = dest_parent_canonical.join(&dest_file_name);
 
-    // 5. Dest MUST NOT land inside any encrypted root. An export target
+    // 7. Dest MUST NOT land inside any encrypted root. An export target
     //    inside another encrypted folder would drop unframed plaintext
     //    next to sealed files, silently breaking that folder's contract.
-    //    Use the dest PARENT for the enclosing-root check: the file
-    //    does not exist yet so we cannot canonicalize the full path,
-    //    and a child of a canonical parent inherits the parent's
-    //    enclosing-root status.
+    //    We check the canonical parent — because `..` traversals in the
+    //    caller-supplied `dest_path` are collapsed by `canonicalize`,
+    //    the parent reflects the real on-disk location a child would
+    //    end up at.
     if crate::encryption::find_enclosing_encrypted_root_cached(
         &state.manifest_cache,
         &vault_root,
@@ -583,23 +611,16 @@ pub fn export_decrypted_file_impl(
         });
     }
 
-    // 6. Read + decrypt. `maybe_decrypt_read` is the same helper
-    //    `read_file` / `read_attachment_bytes` use; it returns plaintext
-    //    when the source sits in an unlocked encrypted root and passes
-    //    bytes through otherwise. We have already established (Steps 2
-    //    + 3) that this source qualifies for the decrypt path.
-    let ciphertext = std::fs::read(&source_canonical).map_err(|e| match e.kind() {
-        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: source.clone() },
-        std::io::ErrorKind::PermissionDenied => {
-            VaultError::PermissionDenied { path: source.clone() }
-        }
-        _ => VaultError::Io(e),
-    })?;
+    // 8. Decrypt. `maybe_decrypt_read` returns plaintext for the bytes
+    //    we already verified start with VCE1 magic (Step 5).
     let plaintext =
         crate::encryption::maybe_decrypt_read(state, &source_canonical, ciphertext)?;
 
-    // 7. Write plaintext to dest. Non-atomic by design — see the
-    //    function-level doc for why `write_atomic` is unsafe here.
+    // 9. Write plaintext to dest. Non-atomic by design — `write_atomic`
+    //    would place a `.vce-tmp-*` file next to the destination (often
+    //    outside the vault), leaking plaintext outside the vault
+    //    boundary for the duration of the rename. Export is user-
+    //    initiated and retry-safe, so plain `fs::write` is correct.
     std::fs::write(&dest_final, &plaintext).map_err(|e| match e.kind() {
         std::io::ErrorKind::PermissionDenied => {
             VaultError::PermissionDenied { path: dest_final.display().to_string() }
@@ -608,9 +629,9 @@ pub fn export_decrypted_file_impl(
         _ => VaultError::Io(e),
     })?;
 
-    // 8. Audit log: the export is the highest-risk encryption op the
-    //    user can perform. Log the source rel-path; omit the full dest
-    //    (the user's filesystem layout is not ours to mirror into logs).
+    // 10. Audit log: the export is the highest-risk encryption op the
+    //     user can perform. Log the source rel-path; omit the full dest
+    //     (the user's filesystem layout is not ours to mirror into logs).
     let rel = source_canonical
         .strip_prefix(&vault_root)
         .ok()

--- a/src-tauri/src/commands/encryption.rs
+++ b/src-tauri/src/commands/encryption.rs
@@ -483,21 +483,16 @@ pub fn export_decrypted_file_impl(
     source: String,
     dest: String,
 ) -> Result<(), VaultError> {
-    // 1. Source inside vault + NOT inside a locked encrypted root.
-    //    `ensure_inside_vault` canonicalizes, enforces vault scope, AND
-    //    runs `ensure_unlocked` — so a source inside a locked root
-    //    already fails here with `PathLocked` before we do any further
-    //    work. Reusing the helper means every T-02 guard that covers
-    //    `read_file` / `write_file` also covers this command.
-    let source_canonical = crate::commands::files::ensure_inside_vault(
-        state,
-        &PathBuf::from(&source),
-    )?;
-
-    // 2. Snapshot `vault_root` ONCE. A concurrent `open_vault` that
-    //    swaps the vault between the scope check and the manifest
-    //    lookup would otherwise make us consult the wrong vault's
-    //    manifest. Single-lock semantics close the TOCTOU window.
+    // 1. Snapshot `vault_root` ONCE under a single `current_vault`
+    //    lock acquisition. Every subsequent check — scope, enclosing
+    //    root, dest-in-encrypted, rel-path-for-logging — uses THIS
+    //    snapshot, so a concurrent `open_vault` that swaps the vault
+    //    mid-export produces a single coherent error (the source no
+    //    longer appears under the snapshotted vault, and the locked
+    //    path / encrypted-root checks all operate on consistent
+    //    state). Splitting the snapshot across `ensure_inside_vault`
+    //    + a second `current_vault.lock()` would reintroduce the
+    //    TOCTOU window Aristotle flagged on iter-1.
     let vault_root = {
         let guard = state
             .current_vault
@@ -510,6 +505,36 @@ pub fn export_decrypted_file_impl(
                 path: source.clone(),
             })?
     };
+
+    // 2. Canonicalize source + enforce vault scope against the single
+    //    snapshot above. Inline rather than `ensure_inside_vault`
+    //    because that helper re-locks `current_vault` internally —
+    //    doing so here would be the race this function is designed
+    //    to avoid. The `ensure_unlocked` check is inlined for the
+    //    same reason; it needs the canonical source path but not the
+    //    vault lock.
+    let source_path = PathBuf::from(&source);
+    let source_canonical = std::fs::canonicalize(&source_path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: source.clone() },
+        std::io::ErrorKind::PermissionDenied => {
+            VaultError::PermissionDenied { path: source.clone() }
+        }
+        _ => VaultError::Io(e),
+    })?;
+    if !source_canonical.starts_with(&vault_root) {
+        return Err(VaultError::PermissionDenied {
+            path: source_canonical.display().to_string(),
+        });
+    }
+    {
+        let canon =
+            crate::encryption::CanonicalPath::assume_canonical(source_canonical.clone());
+        if state.locked_paths.is_locked(&canon) {
+            return Err(VaultError::PathLocked {
+                path: source_canonical.display().to_string(),
+            });
+        }
+    }
 
     // 3. Source must be inside an encrypted root. This is distinct
     //    from "inside any vault folder" — a plain vault file has

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -49,8 +49,16 @@ fn ensure_unlocked(state: &VaultState, canonical: &Path) -> Result<(), VaultErro
 }
 
 /// T-02 mitigation: canonicalize `target` and confirm it sits inside the
-/// currently-open vault.
-fn ensure_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
+/// currently-open vault. Also runs the `ensure_unlocked` gate so a
+/// read/write targeting a locked encrypted subtree errors with
+/// `PathLocked`.
+///
+/// `pub(crate)` so other command modules (e.g. `commands::encryption`
+/// for #360) can reuse the exact same guard instead of re-implementing
+/// the canonicalize + starts_with + `ensure_unlocked` pipeline. Any
+/// new command that takes a user-supplied file path MUST go through
+/// this helper — the T-02 audit depends on it.
+pub(crate) fn ensure_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
         path: target.display().to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,6 +171,7 @@ pub fn run() {
             commands::encryption::lock_folder,
             commands::encryption::lock_all_folders,
             commands::encryption::list_encrypted_folders,
+            commands::encryption::export_decrypted_file,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/tests/export_decrypted.rs
+++ b/src-tauri/src/tests/export_decrypted.rs
@@ -1,0 +1,236 @@
+// #360 — tests for `export_decrypted_file`: pull a plaintext copy of
+// an encrypted file out to a user-chosen destination.
+//
+// The IPC lives in `commands::encryption`, but the tests mirror the
+// same test-double pattern the rest of the crate uses — they call an
+// `_impl` body that takes `&VaultState` so we do not need to
+// construct a running Tauri app.
+
+#![cfg(test)]
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+use zeroize::Zeroizing;
+
+use crate::commands::encryption::export_decrypted_file_impl;
+use crate::encryption::batch::{encrypt_file_in_place, write_sentinel};
+use crate::encryption::crypto::{derive_key, random_salt};
+use crate::encryption::file_format::MAGIC;
+use crate::encryption::manifest::{upsert, EncryptedFolderMeta, FolderState};
+use crate::error::VaultError;
+use crate::VaultState;
+
+/// Build a vault with one encrypted folder (`secret/`) containing a
+/// sealed file. Returns the vault root, the encrypted root, and the
+/// canonical path of the sealed file. The encrypted folder is UNLOCKED
+/// by default (key in keyring, not in the locked registry).
+struct SealedVault {
+    _tmp: TempDir,
+    vault: PathBuf,
+    sealed_file: PathBuf,
+    state: VaultState,
+}
+
+fn setup(unlocked: bool, plaintext: &[u8]) -> SealedVault {
+    let tmp = TempDir::new().unwrap();
+    let vault = tmp.path().canonicalize().unwrap();
+    let enc_root = vault.join("secret");
+    std::fs::create_dir_all(&enc_root).unwrap();
+    let salt = random_salt();
+    upsert(
+        &vault,
+        EncryptedFolderMeta {
+            path: "secret".into(),
+            created_at: "2026-04-24T00:00:00Z".into(),
+            salt: EncryptedFolderMeta::encode_salt(&salt),
+            state: FolderState::Encrypted,
+        },
+    )
+    .unwrap();
+    let key = derive_key(b"pw", &salt).unwrap();
+    write_sentinel(&enc_root, &key).unwrap();
+    let sealed_file = enc_root.join("photo.png");
+    std::fs::write(&sealed_file, plaintext).unwrap();
+    encrypt_file_in_place(&key, &sealed_file).unwrap();
+    let enc_root_canon = enc_root.canonicalize().unwrap();
+    let sealed_canon = sealed_file.canonicalize().unwrap();
+
+    let state = VaultState::default();
+    *state.current_vault.lock().unwrap() = Some(vault.clone());
+    state.manifest_cache.refresh_from_disk(&vault).unwrap();
+    if unlocked {
+        let mut k = Zeroizing::new([0u8; 32]);
+        k.copy_from_slice(key.as_slice());
+        state.keyring.insert(enc_root_canon.clone(), k).unwrap();
+        // Default VaultState already has empty locked_paths — unlocked state.
+    } else {
+        state.locked_paths.lock_root(enc_root_canon.clone()).unwrap();
+    }
+
+    let _ = enc_root_canon; // enc_root_canon is kept as a debug aid
+    SealedVault {
+        _tmp: tmp,
+        vault,
+        sealed_file: sealed_canon,
+        state,
+    }
+}
+
+fn external_dest(sv: &SealedVault, name: &str) -> PathBuf {
+    // Sibling of the vault so the dest parent is guaranteed NOT inside
+    // any encrypted root.
+    let parent = sv.vault.parent().expect("vault has parent").to_path_buf();
+    parent.join(name)
+}
+
+#[test]
+fn exports_plaintext_to_external_dest_when_unlocked() {
+    let plaintext = b"\x89PNG\r\n\x1a\nfake-image-bytes";
+    let sv = setup(true, plaintext);
+    let dest = external_dest(&sv, "photo-export.png");
+
+    export_decrypted_file_impl(
+        &sv.state,
+        sv.sealed_file.to_string_lossy().into_owned(),
+        dest.to_string_lossy().into_owned(),
+    )
+    .expect("export should succeed");
+
+    // Dest bytes match the original plaintext.
+    let actual = std::fs::read(&dest).unwrap();
+    assert_eq!(actual, plaintext);
+    // Source remains sealed on disk.
+    let source_on_disk = std::fs::read(&sv.sealed_file).unwrap();
+    assert_eq!(&source_on_disk[0..4], MAGIC);
+}
+
+#[test]
+fn rejects_locked_source_with_path_locked() {
+    let sv = setup(false, b"secret");
+    let dest = external_dest(&sv, "leak.bin");
+    let err = export_decrypted_file_impl(
+        &sv.state,
+        sv.sealed_file.to_string_lossy().into_owned(),
+        dest.to_string_lossy().into_owned(),
+    )
+    .expect_err("locked source must refuse");
+    assert!(
+        matches!(err, VaultError::PathLocked { .. }),
+        "expected PathLocked, got {err:?}"
+    );
+    // Dest file must NOT have been created.
+    assert!(!dest.exists(), "no plaintext artifact on refusal");
+}
+
+#[test]
+fn rejects_source_outside_any_encrypted_root() {
+    // A plain vault file has nothing to export.
+    let sv = setup(true, b"anything");
+    let plain = sv.vault.join("plain.md");
+    std::fs::write(&plain, b"# plain\n").unwrap();
+    let plain_canon = plain.canonicalize().unwrap();
+    let dest = external_dest(&sv, "out.md");
+    let err = export_decrypted_file_impl(
+        &sv.state,
+        plain_canon.to_string_lossy().into_owned(),
+        dest.to_string_lossy().into_owned(),
+    )
+    .expect_err("plain source must refuse");
+    assert!(
+        matches!(err, VaultError::PermissionDenied { .. }),
+        "expected PermissionDenied, got {err:?}"
+    );
+    assert!(!dest.exists());
+}
+
+#[test]
+fn rejects_dest_inside_another_encrypted_root() {
+    let sv = setup(true, b"payload");
+    // Create a second encrypted folder in the same vault.
+    let second = sv.vault.join("vault2");
+    std::fs::create_dir_all(&second).unwrap();
+    let salt2 = random_salt();
+    upsert(
+        &sv.vault,
+        EncryptedFolderMeta {
+            path: "vault2".into(),
+            created_at: "t".into(),
+            salt: EncryptedFolderMeta::encode_salt(&salt2),
+            state: FolderState::Encrypted,
+        },
+    )
+    .unwrap();
+    sv.state.manifest_cache.refresh_from_disk(&sv.vault).unwrap();
+
+    let dest_inside_other = second.join("smuggled.bin");
+    let err = export_decrypted_file_impl(
+        &sv.state,
+        sv.sealed_file.to_string_lossy().into_owned(),
+        dest_inside_other.to_string_lossy().into_owned(),
+    )
+    .expect_err("dest in another encrypted root must refuse");
+    assert!(
+        matches!(err, VaultError::PermissionDenied { .. }),
+        "expected PermissionDenied, got {err:?}"
+    );
+    assert!(!dest_inside_other.exists());
+}
+
+#[test]
+fn allows_dest_inside_vault_but_outside_every_encrypted_root() {
+    // The feature explicitly allows exporting into a plain vault
+    // subfolder — user may want a plaintext copy next to other
+    // plain notes. The FS watcher will index the new plaintext file
+    // via its normal Create → AddFile path; that is the expected
+    // behavior (documented in the plan).
+    let sv = setup(true, b"body");
+    let plain_dir = sv.vault.join("plain");
+    std::fs::create_dir_all(&plain_dir).unwrap();
+    let dest = plain_dir.join("exported.bin");
+    export_decrypted_file_impl(
+        &sv.state,
+        sv.sealed_file.to_string_lossy().into_owned(),
+        dest.to_string_lossy().into_owned(),
+    )
+    .expect("plain-subdir dest must succeed");
+    assert_eq!(std::fs::read(&dest).unwrap(), b"body");
+}
+
+#[test]
+fn errors_when_dest_parent_does_not_exist() {
+    let sv = setup(true, b"body");
+    let missing_parent = external_dest(&sv, "nope/nested/out.bin");
+    let err = export_decrypted_file_impl(
+        &sv.state,
+        sv.sealed_file.to_string_lossy().into_owned(),
+        missing_parent.to_string_lossy().into_owned(),
+    )
+    .expect_err("missing dest parent must refuse");
+    // Either FileNotFound (canonicalize on missing dir) or an io error
+    // mapped through VaultError::Io; both acceptable. The contract is
+    // that the SOURCE is untouched and NO partial file was created.
+    match &err {
+        VaultError::FileNotFound { .. } | VaultError::Io(_) => {}
+        other => panic!("expected FileNotFound or Io, got {other:?}"),
+    }
+    // Source is still sealed.
+    let still_sealed = std::fs::read(&sv.sealed_file).unwrap();
+    assert_eq!(&still_sealed[0..4], MAGIC);
+}
+
+#[test]
+fn source_remains_unchanged_after_successful_export() {
+    let plaintext = b"attested plaintext";
+    let sv = setup(true, plaintext);
+    let dest = external_dest(&sv, "copy.bin");
+    let before = std::fs::read(&sv.sealed_file).unwrap();
+    export_decrypted_file_impl(
+        &sv.state,
+        sv.sealed_file.to_string_lossy().into_owned(),
+        dest.to_string_lossy().into_owned(),
+    )
+    .unwrap();
+    let after = std::fs::read(&sv.sealed_file).unwrap();
+    assert_eq!(before, after, "source ciphertext must be byte-identical");
+}

--- a/src-tauri/src/tests/export_decrypted.rs
+++ b/src-tauri/src/tests/export_decrypted.rs
@@ -22,9 +22,14 @@ use crate::error::VaultError;
 use crate::VaultState;
 
 /// Build a vault with one encrypted folder (`secret/`) containing a
-/// sealed file. Returns the vault root, the encrypted root, and the
-/// canonical path of the sealed file. The encrypted folder is UNLOCKED
-/// by default (key in keyring, not in the locked registry).
+/// sealed file. Returns the vault root and the canonical path of the
+/// sealed file. The encrypted folder is UNLOCKED by default (key in
+/// keyring, not in the locked registry).
+///
+/// `_tmp` must be kept alive for the duration of the test — dropping
+/// the `TempDir` wipes the on-disk state, so the field is deliberately
+/// held via the underscore-prefixed name to signal "owned for its
+/// Drop, not its value".
 struct SealedVault {
     _tmp: TempDir,
     vault: PathBuf,
@@ -68,7 +73,6 @@ fn setup(unlocked: bool, plaintext: &[u8]) -> SealedVault {
         state.locked_paths.lock_root(enc_root_canon.clone()).unwrap();
     }
 
-    let _ = enc_root_canon; // enc_root_canon is kept as a debug aid
     SealedVault {
         _tmp: tmp,
         vault,

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -22,4 +22,5 @@ mod rename_link_resolution;
 mod home_canvas;
 mod docs_page;
 mod encryption_gating;
+mod export_decrypted;
 mod legacy_semantic_cleanup;

--- a/src/components/Editor/attachmentSource.ts
+++ b/src/components/Editor/attachmentSource.ts
@@ -25,7 +25,7 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { get } from "svelte/store";
 
 import { readAttachmentBytes } from "../../ipc/commands";
-import { encryptedPaths } from "../../store/encryptedFoldersStore";
+import { encryptedPaths, unlockedPaths } from "../../store/encryptedFoldersStore";
 import { vaultStore } from "../../store/vaultStore";
 
 /**
@@ -44,10 +44,12 @@ import { vaultStore } from "../../store/vaultStore";
  */
 let _cachedVault: string | null = null;
 let _cachedPaths: Set<string> = new Set();
+let _cachedUnlockedPaths: Set<string> = new Set();
 let _cacheScheduled = false;
 function refreshCachedSnapshots(): void {
   _cachedVault = get(vaultStore).currentPath;
   _cachedPaths = get(encryptedPaths);
+  _cachedUnlockedPaths = get(unlockedPaths);
 }
 function ensureCachedSnapshots(): void {
   if (_cacheScheduled) return;
@@ -60,15 +62,43 @@ function ensureCachedSnapshots(): void {
   });
 }
 
-export function isInsideEncryptedFolder(abs: string): boolean {
-  ensureCachedSnapshots();
-  if (!_cachedVault) return false;
-  // Normalize separators — abs may use backslashes on Windows.
+/**
+ * Compute the vault-relative form of `abs`, or `null` when `abs` is
+ * outside the currently-open vault. Shared by both
+ * `isInsideEncryptedFolder` and `isInsideUnlockedEncryptedFolder`.
+ */
+function relativeToVault(abs: string): string | null {
+  if (!_cachedVault) return null;
   const normAbs = abs.replace(/\\/g, "/");
   const normVault = _cachedVault.replace(/\\/g, "/");
-  if (!normAbs.startsWith(normVault)) return false;
-  const rel = normAbs.slice(normVault.length).replace(/^\/+/, "");
+  if (!normAbs.startsWith(normVault)) return null;
+  return normAbs.slice(normVault.length).replace(/^\/+/, "");
+}
+
+export function isInsideEncryptedFolder(abs: string): boolean {
+  ensureCachedSnapshots();
+  const rel = relativeToVault(abs);
+  if (rel === null) return false;
   for (const p of _cachedPaths) {
+    if (rel === p || rel.startsWith(p + "/")) return true;
+  }
+  return false;
+}
+
+/**
+ * #360 — same shape as `isInsideEncryptedFolder` but restricted to
+ * encrypted folders that are currently UNLOCKED. Used by the "Export
+ * decrypted copy…" context-menu entry and any other action that can
+ * only proceed when a key is available.
+ *
+ * Shares the microtask-scoped snapshot cache so per-row checks in the
+ * sidebar tree stay cheap even at hundreds of rendered rows.
+ */
+export function isInsideUnlockedEncryptedFolder(abs: string): boolean {
+  ensureCachedSnapshots();
+  const rel = relativeToVault(abs);
+  if (rel === null) return false;
+  for (const p of _cachedUnlockedPaths) {
     if (rel === p || rel.startsWith(p + "/")) return true;
   }
   return false;

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -375,11 +375,12 @@
     try {
       await exportDecryptedFile(row.path, picked);
       const filename = picked.split(/[/\\]/).pop() ?? picked;
-      // #360 — toast copy deliberately names the file as UNENCRYPTED
-      // because that is what the user just produced. "Decrypted copy"
-      // softens a security-relevant action; make it explicit.
+      // #360 — `warning` variant (not `info`) matches the security
+      // consequence: the user just produced a plaintext file readable
+      // by any app on their system. The copy spells that out so the
+      // audit is end-to-end — variant color + explicit wording.
       toastStore.push({
-        variant: "info",
+        variant: "warning",
         message: `Saved unencrypted copy to ${filename}. This file is now readable by other apps.`,
       });
     } catch (e) {

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -375,9 +375,12 @@
     try {
       await exportDecryptedFile(row.path, picked);
       const filename = picked.split(/[/\\]/).pop() ?? picked;
+      // #360 — toast copy deliberately names the file as UNENCRYPTED
+      // because that is what the user just produced. "Decrypted copy"
+      // softens a security-relevant action; make it explicit.
       toastStore.push({
         variant: "info",
-        message: `Exported decrypted copy to ${filename}`,
+        message: `Saved unencrypted copy to ${filename}. This file is now readable by other apps.`,
       });
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -29,7 +29,10 @@
     updateLinksAfterRename,
     getBacklinks,
     writeFile,
+    exportDecryptedFile,
+    pickSavePath,
   } from "../../ipc/commands";
+  import { isInsideUnlockedEncryptedFolder } from "../Editor/attachmentSource";
   import { serializeCanvas, emptyCanvas } from "../../lib/canvas/parse";
   import { toastStore } from "../../store/toastStore";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
@@ -137,6 +140,13 @@
   const isLocked = $derived((row.encryption ?? "not-encrypted") === "locked");
   const isUnlocked = $derived((row.encryption ?? "not-encrypted") === "unlocked");
   const isEncryptedRoot = $derived(isLocked || isUnlocked);
+  // #360 — only files (not folders, not plain-vault files) inside an
+  // unlocked encrypted folder can be exported. The derivation is
+  // microtask-cached inside `isInsideUnlockedEncryptedFolder` so the
+  // per-row cost stays O(1) amortized across a virtualized render pass.
+  const canExportDecrypted = $derived(
+    !row.isDir && isInsideUnlockedEncryptedFolder(row.path),
+  );
 
   function handleClick() {
     onSelect(row.path);
@@ -346,6 +356,29 @@
       await createFolder(row.path, "");
       await onRefreshFolder(row.path);
       await onEnsureExpanded(row);
+    } catch (e) {
+      const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
+  // #360 — export a decrypted plaintext copy of this file to a user-
+  // chosen destination. Menu entry is only rendered when the row sits
+  // inside an UNLOCKED encrypted folder (see `canExportDecrypted`), so
+  // the default copy assumes the backend will succeed. A locked → lock
+  // race still produces a `PathLocked` error which surfaces via the
+  // usual `vaultErrorCopy` path so the user can unlock and retry.
+  async function handleExportDecrypted() {
+    closeContextMenu();
+    const picked = await pickSavePath(row.name);
+    if (!picked) return; // user cancelled — silent, matches other save flows
+    try {
+      await exportDecryptedFile(row.path, picked);
+      const filename = picked.split(/[/\\]/).pop() ?? picked;
+      toastStore.push({
+        variant: "info",
+        message: `Exported decrypted copy to ${filename}`,
+      });
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
@@ -583,6 +616,13 @@
       <button class="vc-context-item" onclick={() => void toggleBookmark()}>
         {isBookmarked ? "Remove bookmark" : "Bookmark"}
       </button>
+    {/if}
+    {#if canExportDecrypted}
+      <button
+        class="vc-context-item"
+        data-testid="context-export-decrypted"
+        onclick={() => void handleExportDecrypted()}
+      >Export decrypted copy…</button>
     {/if}
     <button class="vc-context-item vc-context-item--danger" onclick={openDeleteConfirm}>Move to Trash</button>
     {#if row.isDir}

--- a/src/components/Sidebar/__tests__/TreeRowExportDecrypted.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRowExportDecrypted.test.ts
@@ -1,0 +1,215 @@
+// #360 — "Export decrypted copy…" context-menu entry on TreeRow.
+//
+// Entry is visible only when the row is a FILE sitting inside an
+// UNLOCKED encrypted folder. Click path:
+// 1. Close context menu.
+// 2. Call `pickSavePath(row.name)` — native save dialog.
+// 3. If the user picked a path, call `exportDecryptedFile(source, dest)`.
+// 4. Success → info toast naming the picked filename.
+// 5. Error → toast via `vaultErrorCopy`.
+// 6. Cancel (null from save dialog) → silent no-op (no IPC call, no toast).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const pickSavePath = vi.fn<(defaultPath: string) => Promise<string | null>>();
+const exportDecryptedFile = vi.fn<(source: string, dest: string) => Promise<void>>();
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  renameFile: vi.fn(),
+  lockFolder: vi.fn(),
+  unlockFolder: vi.fn(),
+  pickSavePath: (defaultPath: string) => pickSavePath(defaultPath),
+  exportDecryptedFile: (source: string, dest: string) =>
+    exportDecryptedFile(source, dest),
+}));
+
+vi.mock("../../../store/encryptionModalStore", () => ({
+  openEncryptModal: vi.fn(),
+  openUnlockModal: vi.fn(),
+}));
+
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { toastStore } from "../../../store/toastStore";
+import { _setEncryptedFoldersForTest, resetEncryptedFoldersStore } from "../../../store/encryptedFoldersStore";
+import TreeRow from "../TreeRow.svelte";
+import type { FlatRow } from "../../../lib/flattenTree";
+
+const VAULT = "/tmp/test-vault-360";
+
+function fileRow(overrides: Partial<FlatRow> = {}): FlatRow {
+  return {
+    path: `${VAULT}/secret/photo.png`,
+    relPath: "secret/photo.png",
+    name: "photo.png",
+    depth: 1,
+    isDir: false,
+    isMd: false,
+    isSymlink: false,
+    expanded: false,
+    loading: false,
+    hasRenderedChildren: false,
+    childrenLoaded: false,
+    encryption: "not-encrypted",
+    ...overrides,
+  };
+}
+
+function makeProps(row: FlatRow) {
+  return {
+    row,
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onToggleExpand: vi.fn(),
+    onEnsureExpanded: vi.fn(),
+    onRefreshFolder: vi.fn(),
+    onPathChanged: vi.fn(),
+  };
+}
+
+async function openContextMenu(container: HTMLElement): Promise<void> {
+  const row = container.querySelector(".vc-tree-row") as HTMLElement;
+  await fireEvent.contextMenu(row);
+  await tick();
+}
+
+describe("TreeRow export-decrypted menu entry (#360)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    resetEncryptedFoldersStore();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    pickSavePath.mockReset();
+    exportDecryptedFile.mockReset();
+    // Clear toasts
+    toastStore.dismissAll?.();
+  });
+
+  it("hides the entry when the file is NOT inside any encrypted folder", async () => {
+    // No encrypted folders in the store → plain vault file.
+    _setEncryptedFoldersForTest([]);
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    await openContextMenu(container);
+    expect(
+      container.querySelector('[data-testid="context-export-decrypted"]'),
+    ).toBeNull();
+  });
+
+  it("hides the entry when the enclosing encrypted folder is LOCKED", async () => {
+    _setEncryptedFoldersForTest([
+      {
+        path: "secret",
+        createdAt: "t",
+        state: "encrypted",
+        locked: true,
+      },
+    ]);
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    await openContextMenu(container);
+    expect(
+      container.querySelector('[data-testid="context-export-decrypted"]'),
+    ).toBeNull();
+  });
+
+  it("shows the entry when the file is inside an UNLOCKED encrypted folder", async () => {
+    _setEncryptedFoldersForTest([
+      {
+        path: "secret",
+        createdAt: "t",
+        state: "encrypted",
+        locked: false,
+      },
+    ]);
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    await openContextMenu(container);
+    expect(
+      container.querySelector('[data-testid="context-export-decrypted"]'),
+    ).not.toBeNull();
+  });
+
+  it("hides the entry for folders even when inside an unlocked encrypted root", async () => {
+    _setEncryptedFoldersForTest([
+      {
+        path: "secret",
+        createdAt: "t",
+        state: "encrypted",
+        locked: false,
+      },
+    ]);
+    const folder = fileRow({
+      path: `${VAULT}/secret/sub`,
+      relPath: "secret/sub",
+      name: "sub",
+      isDir: true,
+    });
+    const { container } = render(TreeRow, { props: makeProps(folder) });
+    await tick();
+    await openContextMenu(container);
+    expect(
+      container.querySelector('[data-testid="context-export-decrypted"]'),
+    ).toBeNull();
+  });
+
+  it("calls pickSavePath then exportDecryptedFile on click, toasts on success", async () => {
+    _setEncryptedFoldersForTest([
+      { path: "secret", createdAt: "t", state: "encrypted", locked: false },
+    ]);
+    pickSavePath.mockResolvedValueOnce("/home/user/Desktop/photo.png");
+    exportDecryptedFile.mockResolvedValueOnce(undefined);
+
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    await openContextMenu(container);
+    const entry = container.querySelector(
+      '[data-testid="context-export-decrypted"]',
+    ) as HTMLButtonElement;
+    await fireEvent.click(entry);
+    // Let the async callback flush.
+    await Promise.resolve();
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    expect(pickSavePath).toHaveBeenCalledWith("photo.png");
+    expect(exportDecryptedFile).toHaveBeenCalledWith(
+      `${VAULT}/secret/photo.png`,
+      "/home/user/Desktop/photo.png",
+    );
+  });
+
+  it("is a silent no-op when the user cancels the save dialog", async () => {
+    _setEncryptedFoldersForTest([
+      { path: "secret", createdAt: "t", state: "encrypted", locked: false },
+    ]);
+    pickSavePath.mockResolvedValueOnce(null);
+
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    await openContextMenu(container);
+    const entry = container.querySelector(
+      '[data-testid="context-export-decrypted"]',
+    ) as HTMLButtonElement;
+    await fireEvent.click(entry);
+    await Promise.resolve();
+    await tick();
+
+    expect(pickSavePath).toHaveBeenCalledTimes(1);
+    expect(exportDecryptedFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Sidebar/__tests__/TreeRowExportDecrypted.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRowExportDecrypted.test.ts
@@ -94,8 +94,7 @@ describe("TreeRow export-decrypted menu entry (#360)", () => {
     vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
     pickSavePath.mockReset();
     exportDecryptedFile.mockReset();
-    // Clear toasts
-    toastStore.dismissAll?.();
+    toastStore._reset();
   });
 
   it("hides the entry when the file is NOT inside any encrypted folder", async () => {
@@ -211,5 +210,45 @@ describe("TreeRow export-decrypted menu entry (#360)", () => {
 
     expect(pickSavePath).toHaveBeenCalledTimes(1);
     expect(exportDecryptedFile).not.toHaveBeenCalled();
+  });
+
+  it("toasts an error when the backend rejects (e.g. locked race)", async () => {
+    _setEncryptedFoldersForTest([
+      { path: "secret", createdAt: "t", state: "encrypted", locked: false },
+    ]);
+    pickSavePath.mockResolvedValueOnce("/home/user/Desktop/photo.png");
+    // Reject with a shaped VaultError so `vaultErrorCopy` picks up the
+    // right copy (mirrors a locked-between-menu-and-click race).
+    exportDecryptedFile.mockRejectedValueOnce({
+      kind: "PathLocked",
+      message: "Path is inside a locked encrypted folder",
+      data: "/vault/secret/photo.png",
+    });
+
+    const errors: string[] = [];
+    const unsub = toastStore.subscribe((items) => {
+      for (const item of items) {
+        if (item.variant === "error") errors.push(item.message);
+      }
+    });
+
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    await openContextMenu(container);
+    const entry = container.querySelector(
+      '[data-testid="context-export-decrypted"]',
+    ) as HTMLButtonElement;
+    await fireEvent.click(entry);
+    await Promise.resolve();
+    await tick();
+    await Promise.resolve();
+    await tick();
+    unsub();
+
+    expect(exportDecryptedFile).toHaveBeenCalledTimes(1);
+    expect(
+      errors.some((m) => m.toLowerCase().includes("locked")),
+      `expected an error toast mentioning "locked"; got ${JSON.stringify(errors)}`,
+    ).toBe(true);
   });
 });

--- a/src/components/Toast/Toast.svelte
+++ b/src/components/Toast/Toast.svelte
@@ -9,6 +9,7 @@
     conflict: "⚠",
     "clean-merge": "✓",
     info: "ℹ",
+    warning: "⚠",
   };
 
   const borderColor: Record<ToastVariant, string> = {
@@ -16,6 +17,7 @@
     conflict: "var(--color-warning)",
     "clean-merge": "var(--color-success)",
     info: "var(--color-accent)",
+    warning: "var(--color-warning)",
   };
 </script>
 

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -424,6 +424,26 @@ export async function readAttachmentBytes(path: string): Promise<Uint8Array> {
   }
 }
 
+/**
+ * #360 — write a decrypted plaintext copy of an encrypted file to a
+ * user-chosen destination outside the vault's encrypted folders.
+ *
+ * Source must live inside an unlocked encrypted folder of the open
+ * vault. Destination may be anywhere on the filesystem the user has
+ * write permission for, EXCEPT inside another encrypted folder (that
+ * would smuggle plaintext past the "folder is private" contract).
+ */
+export async function exportDecryptedFile(
+  source: string,
+  dest: string,
+): Promise<void> {
+  try {
+    await invoke<void>("export_decrypted_file", { source, dest });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 // ── Tag commands ───────────────────────────────────────────────────────────────
 
 /** TAG-03: list all tags with usage counts, sorted alphabetically. */

--- a/src/store/encryptedFoldersStore.ts
+++ b/src/store/encryptedFoldersStore.ts
@@ -95,6 +95,19 @@ export const encryptedPaths: Readable<Set<string>> = derived(
   ($s) => new Set($s.entries.map((e) => e.path)),
 );
 
+/**
+ * #360 — vault-relative paths whose encrypted folder is currently
+ * UNLOCKED. Parallel to `encryptedPaths` but filtered by `locked ===
+ * false`, so the "Export decrypted copy…" menu entry and any future
+ * action that needs the locked/unlocked distinction can consume a
+ * purpose-built `Set<string>` for O(1) membership checks instead of
+ * re-scanning the full `EncryptedFolderView[]`.
+ */
+export const unlockedPaths: Readable<Set<string>> = derived(
+  internal,
+  ($s) => new Set($s.entries.filter((e) => !e.locked).map((e) => e.path)),
+);
+
 /** `true` once the store has completed its first fetch. */
 export const encryptedFoldersReady: Readable<boolean> = derived(
   internal,

--- a/src/store/toastStore.ts
+++ b/src/store/toastStore.ts
@@ -4,7 +4,7 @@
 
 import { writable } from "svelte/store";
 
-export type ToastVariant = "error" | "conflict" | "clean-merge" | "info";
+export type ToastVariant = "error" | "conflict" | "clean-merge" | "info" | "warning";
 
 export interface Toast {
   id: number;


### PR DESCRIPTION
## Summary

Closes #360. Follow-up to #357. Adds a first-class right-click action to extract a plaintext copy of a single file out of an unlocked encrypted folder via the native save dialog. Closes the UX hole where dragging via Finder/Explorer gave raw VCE1 ciphertext bytes.

## Rationale

#357 shipped "IN" (auto-encrypt on drop); this PR ships "OUT" (export decrypted). Scope is deliberately minimal: single file, right-click only, no drag-drop out, no whole-folder bulk decrypt. Those stay out of scope per the ticket.

## Architecture

- **Command placed in `commands/encryption.rs`** (not `files.rs`) — this is an encryption-domain operation and belongs alongside the other encryption IPCs. (Socrates finding.)
- **No `write_atomic`** — that helper writes a `.vce-tmp-*` next to the target, which for this command is typically outside the vault. That would leak plaintext outside the vault during the rename window. Plain `fs::write` is correct; export is user-initiated and retry-safe.
- **No redundant size-cap re-check** — every file under an encrypted root passed the cap at encrypt time; ciphertexts beyond that are tamper cases Poly1305 catches. (Socrates finding: the original plan's ciphertext-size comparison was directionally wrong.)
- **Used existing `pickSavePath` helper** — frontend stays inside the `ipc/commands.ts` abstraction rather than reaching directly for the plugin-dialog import. (Socrates finding.)
- **Shared helper `isInsideUnlockedEncryptedFolder`** added alongside `isInsideEncryptedFolder` in `attachmentSource.ts`, backed by a new `unlockedPaths` derived store — future callers that need the locked/unlocked distinction reuse the same microtask-cached infrastructure.

## Refusal contract

- Source outside vault → `PermissionDenied` (T-02 guard).
- Source not in encrypted folder → `PermissionDenied` with explicit message.
- Enclosing root locked → `PathLocked`.
- Dest inside any encrypted root → `PermissionDenied` (prevents smuggling plaintext past another folder's contract).
- Dest parent missing → `FileNotFound` (before any read/decrypt work, source untouched).
- Dest inside vault but outside every encrypted root → **allowed** (documented: the watcher will index the plaintext copy via its normal Create → AddFile path; expected behavior).

## Test plan

- [x] `cargo test --lib --no-default-features -- --test-threads=1` — 357 pass, 2 ignored, 0 fail (+7 new in `tests/export_decrypted.rs`).
- [x] `pnpm typecheck` + `pnpm exec svelte-check --threshold error` — clean.
- [x] `pnpm test -- TreeRowExportDecrypted` — 1254 pass (+6 new).
- [ ] UAT — right-click a PNG inside an unlocked encrypted folder → "Export decrypted copy…" → pick `~/Desktop/photo.png` → file at dest is plaintext; source still has VCE1 header.
- [ ] UAT — right-click same file while folder is locked → menu entry hidden.
- [ ] UAT — try to pick a destination inside another encrypted folder → error toast.
- [ ] UAT — cancel the save dialog → no toast, no side effect.

## Out of scope

- Drag-out from Sidebar into a plain vault folder (inner-vault move-out) — separate ticket if users ask.
- Bulk "Decrypt folder" reverse of encrypt — separate ticket.
- Export action from editor tab / image preview context menus — Sidebar only for MVP.