### PR TITLE
feat(canvas): multi-shape text nodes with inline shape picker (#362)

### DIFF
--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -25,7 +25,8 @@
     CanvasSide,
     CanvasTextNode,
   } from "../../lib/canvas/types";
-  import { SIDES } from "../../lib/canvas/geometry";
+  import { SIDES, sidesForShape } from "../../lib/canvas/geometry";
+  import { readShape } from "../../lib/canvas/types";
   import {
     isImageFile,
     isMarkdownFile,
@@ -302,9 +303,10 @@
 
   {#each orderedNodes as node (node.id)}
     {#if node.type === "text"}
+      {@const textShape = readShape(node)}
       <!-- svelte-ignore a11y_no_noninteractive_tabindex (role and tabindex co-vary on `interactive`) -->
       <div
-        class="vc-canvas-node vc-canvas-node-text"
+        class="vc-canvas-node vc-canvas-node-text vc-shape-{textShape}"
         class:vc-canvas-node-selected={selectedNodeId === node.id}
         class:vc-canvas-node-editing={editingNodeId === node.id}
         class:vc-canvas-node-hovered={hoveredNodeId === node.id || draft?.fromNodeId === node.id}
@@ -322,6 +324,11 @@
         role={interactive ? "button" : undefined}
         tabindex={interactive ? 0 : undefined}
       >
+        <!-- #362: visual-shape underlay. `clip-path` / `border-radius`
+             live on this child so the outer node div can stay
+             overflow: visible — edge handles + resize grabber remain
+             unclipped even for triangle / diamond. -->
+        <div class="vc-canvas-node-shape" aria-hidden="true"></div>
         {#if interactive && editingNodeId === node.id}
           <textarea
             bind:this={editingTextareaEl}
@@ -383,7 +390,7 @@
             onpointerdown={(e) => onResizePointerDown?.(e, node)}
             role="presentation"
           ></div>
-          {#each SIDES as side (side)}
+          {#each sidesForShape(textShape) as side (side)}
             <button
               type="button"
               class="vc-canvas-edge-handle vc-canvas-edge-handle-{side}"
@@ -771,6 +778,71 @@
   .vc-canvas-node-selected {
     border-color: var(--color-accent);
     box-shadow: 0 0 0 2px var(--color-accent-bg);
+  }
+
+  /* #362: text nodes use a separate shape underlay so the visual outline
+     can carry clip-path / border-radius without clipping the hover
+     handles + resize grabber. The outer .vc-canvas-node drops its own
+     border/bg/shadow for text only; the underlay provides them. */
+  .vc-canvas-node-text {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+    border-radius: 0;
+  }
+
+  .vc-canvas-node-text.vc-canvas-node-selected {
+    border-color: transparent;
+    box-shadow: none;
+  }
+
+  .vc-canvas-node-shape {
+    position: absolute;
+    inset: 0;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .vc-canvas-node-text.vc-canvas-node-selected > .vc-canvas-node-shape {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 2px var(--color-accent-bg);
+  }
+
+  .vc-canvas-node-text.vc-shape-rounded-rectangle > .vc-canvas-node-shape {
+    border-radius: 6px;
+  }
+
+  .vc-canvas-node-text.vc-shape-rectangle > .vc-canvas-node-shape {
+    border-radius: 0;
+  }
+
+  .vc-canvas-node-text.vc-shape-ellipse > .vc-canvas-node-shape {
+    border-radius: 50%;
+  }
+
+  /* clip-path shapes: border-radius has no effect under a clip, so the
+     outline comes from the polygon itself. Border still participates
+     (clip-path clips both paint and border) so the shape reads as a
+     solid filled polygon on a light surface. */
+  .vc-canvas-node-text.vc-shape-diamond > .vc-canvas-node-shape {
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+    border-radius: 0;
+  }
+
+  .vc-canvas-node-text.vc-shape-triangle > .vc-canvas-node-shape {
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    border-radius: 0;
+  }
+
+  /* Content sits above the shape underlay so text is always readable,
+     even when the underlay is a diamond/triangle polygon. */
+  .vc-canvas-node-text > .vc-canvas-node-content,
+  .vc-canvas-node-text > .vc-canvas-node-textarea {
+    position: relative;
+    z-index: 1;
   }
 
   .vc-canvas-node-content {

--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -845,6 +845,44 @@
     z-index: 1;
   }
 
+  /* On non-rectangular shapes the bounding box isn't the visible area, so
+     (a) the editing textarea needs a transparent background + the same
+     clip as the shape so it doesn't paint a rectangle over the silhouette,
+     and (b) text is centered horizontally so it sits inside the narrow
+     parts of the polygon instead of hugging the left edge. */
+  .vc-canvas-node-text:not(.vc-shape-rectangle):not(.vc-shape-rounded-rectangle)
+    > .vc-canvas-node-content,
+  .vc-canvas-node-text:not(.vc-shape-rectangle):not(.vc-shape-rounded-rectangle)
+    > .vc-canvas-node-textarea {
+    text-align: center;
+  }
+
+  .vc-canvas-node-text:not(.vc-shape-rectangle):not(.vc-shape-rounded-rectangle)
+    > .vc-canvas-node-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .vc-canvas-node-text:not(.vc-shape-rectangle):not(.vc-shape-rounded-rectangle)
+    > .vc-canvas-node-textarea {
+    background: transparent;
+  }
+
+  /* Clip the editing textarea to the shape silhouette so the input's
+     own paint doesn't spill outside the rendered outline. */
+  .vc-canvas-node-text.vc-shape-ellipse > .vc-canvas-node-textarea {
+    border-radius: 50%;
+  }
+
+  .vc-canvas-node-text.vc-shape-diamond > .vc-canvas-node-textarea {
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  }
+
+  .vc-canvas-node-text.vc-shape-triangle > .vc-canvas-node-textarea {
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  }
+
   .vc-canvas-node-content {
     padding: 8px;
     font-size: 14px;

--- a/src/components/Canvas/CanvasShapePicker.svelte
+++ b/src/components/Canvas/CanvasShapePicker.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  // #362: shape picker strip. Stateless presentational component — the
+  // parent decides where to render it (inline inside the canvas context
+  // menu) and what to do on pick (create a new shaped text node, or
+  // re-shape an existing one). Keyboard-first to match the rest of the
+  // app: ArrowDown/Up to navigate the list, Enter/Space to confirm, and
+  // ArrowLeft from the first row to back out of the picker without
+  // closing the whole menu.
+
+  import { tick } from "svelte";
+  import {
+    CANVAS_SHAPES,
+    type CanvasShape,
+  } from "../../lib/canvas/types";
+
+  interface Props {
+    value: CanvasShape;
+    onPick: (shape: CanvasShape) => void;
+    /** ArrowLeft on the first row / Escape — closes the picker without
+     *  making a selection. Parent typically refocuses the trigger row. */
+    onCancel?: () => void;
+    /** When true, focus the row matching `value` on mount. */
+    autoFocus?: boolean;
+  }
+
+  let { value, onPick, onCancel, autoFocus = false }: Props = $props();
+
+  // Pretty labels mirroring the shape names the user sees in the UI. Kept
+  // here (not in types.ts) because they are a UI concern — the types
+  // module is framework-free.
+  const LABELS: Record<CanvasShape, string> = {
+    "rounded-rectangle": "Rounded rectangle",
+    rectangle: "Rectangle",
+    ellipse: "Ellipse",
+    diamond: "Diamond",
+    triangle: "Triangle",
+  };
+
+  let rowEls = $state<(HTMLButtonElement | null)[]>(
+    Array(CANVAS_SHAPES.length).fill(null),
+  );
+
+  function focusRow(index: number): void {
+    const clamped = Math.max(0, Math.min(CANVAS_SHAPES.length - 1, index));
+    rowEls[clamped]?.focus();
+  }
+
+  // Focus the initially selected row on mount so keyboard nav starts
+  // from the shape the user currently has. Done via `tick` so the bind:
+  // refs have populated before we try to focus.
+  $effect(() => {
+    if (!autoFocus) return;
+    void (async () => {
+      await tick();
+      const idx = CANVAS_SHAPES.indexOf(value);
+      focusRow(idx >= 0 ? idx : 0);
+    })();
+  });
+
+  function currentIndex(): number {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLButtonElement)) return -1;
+    return rowEls.indexOf(active);
+  }
+
+  function onKey(e: KeyboardEvent, index: number): void {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      e.stopPropagation();
+      focusRow(index + 1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      e.stopPropagation();
+      focusRow(index - 1);
+    } else if (e.key === "ArrowLeft") {
+      if (index === 0) {
+        // Back out of the picker without closing the parent menu.
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel?.();
+      }
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      const shape = CANVAS_SHAPES[index];
+      if (shape) onPick(shape);
+    }
+  }
+</script>
+
+<div class="vc-shape-picker" role="radiogroup" aria-label="Node shape">
+  {#each CANVAS_SHAPES as shape, i (shape)}
+    <button
+      bind:this={rowEls[i]}
+      type="button"
+      class="vc-shape-picker-row"
+      class:vc-shape-picker-row--selected={shape === value}
+      role="radio"
+      aria-checked={shape === value}
+      aria-label={LABELS[shape]}
+      data-shape={shape}
+      onclick={(e) => { e.stopPropagation(); onPick(shape); }}
+      onkeydown={(e) => onKey(e, i)}
+    >
+      <svg
+        class="vc-shape-picker-icon"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+        focusable="false"
+      >
+        {#if shape === "rounded-rectangle"}
+          <rect x="2" y="5" width="16" height="10" rx="3" />
+        {:else if shape === "rectangle"}
+          <rect x="2" y="5" width="16" height="10" />
+        {:else if shape === "ellipse"}
+          <ellipse cx="10" cy="10" rx="8" ry="5" />
+        {:else if shape === "diamond"}
+          <polygon points="10,3 17,10 10,17 3,10" />
+        {:else if shape === "triangle"}
+          <polygon points="10,4 17,16 3,16" />
+        {/if}
+      </svg>
+      <span class="vc-shape-picker-label">{LABELS[shape]}</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .vc-shape-picker {
+    display: flex;
+    flex-direction: column;
+    padding: 2px 0;
+  }
+
+  .vc-shape-picker-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 6px 12px;
+    background: none;
+    border: none;
+    font: inherit;
+    font-size: 14px;
+    color: var(--color-text);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .vc-shape-picker-row:hover,
+  .vc-shape-picker-row:focus-visible {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    outline: none;
+  }
+
+  .vc-shape-picker-row--selected {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    box-shadow: inset 0 0 0 1px var(--color-accent);
+  }
+
+  .vc-shape-picker-icon {
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 1.5;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+  }
+
+  .vc-shape-picker-label {
+    flex: 1;
+    min-width: 0;
+  }
+</style>

--- a/src/components/Canvas/CanvasShapePicker.svelte
+++ b/src/components/Canvas/CanvasShapePicker.svelte
@@ -48,20 +48,18 @@
   // Focus the initially selected row on mount so keyboard nav starts
   // from the shape the user currently has. Done via `tick` so the bind:
   // refs have populated before we try to focus.
+  //
+  // `value` and `autoFocus` are read *before* awaiting `tick()`; reads
+  // after an await are outside the effect's reactive scope and wouldn't
+  // re-run the effect when the props change.
   $effect(() => {
     if (!autoFocus) return;
+    const idx = CANVAS_SHAPES.indexOf(value);
     void (async () => {
       await tick();
-      const idx = CANVAS_SHAPES.indexOf(value);
       focusRow(idx >= 0 ? idx : 0);
     })();
   });
-
-  function currentIndex(): number {
-    const active = document.activeElement;
-    if (!(active instanceof HTMLButtonElement)) return -1;
-    return rowEls.indexOf(active);
-  }
 
   function onKey(e: KeyboardEvent, index: number): void {
     if (e.key === "ArrowDown") {

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -868,6 +868,9 @@
     // operate on saved state, not on a half-typed URL / label.
     editingNodeId = null;
     editingEdgeId = null;
+    // #362: drop any inline-picker state from a previous menu so a fresh
+    // right-click never surfaces a stale auto-expanded picker.
+    shapeSubmenuOpen = null;
   }
 
   function onViewportContextMenu(e: MouseEvent) {
@@ -937,11 +940,12 @@
   function setNodeShape(nodeId: string, shape: CanvasShape) {
     const node = doc.nodes.find((n) => n.id === nodeId);
     if (!node || node.type !== "text") return;
-    if (shape === DEFAULT_CANVAS_SHAPE) {
-      delete (node as CanvasTextNode).shape;
-    } else {
-      (node as CanvasTextNode).shape = shape;
-    }
+    // Reset-to-default stores `undefined` (serializer drops the field)
+    // rather than `delete`ing the key. Assignment reliably trips the
+    // $state proxy's set trap; `delete` goes through deleteProperty
+    // whose reactivity contract is less explicit across Svelte 5 versions.
+    (node as CanvasTextNode).shape =
+      shape === DEFAULT_CANVAS_SHAPE ? undefined : shape;
   }
 
   function addGroupAt(worldX: number, worldY: number) {
@@ -1613,15 +1617,17 @@
 
   /* #362: expandable context-menu rows and the inline shape-picker
      panel they reveal. Kept in CanvasView (not ContextMenu.svelte) so
-     the generic menu stays a presentation-only popover. */
-  :global(.vc-context-item--expandable) {
+     the generic menu stays a presentation-only popover. Scoped under
+     `.vc-context-menu` so the classes can't leak to unrelated elements
+     that happen to reuse the names. */
+  :global(.vc-context-menu .vc-context-item--expandable) {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 8px;
   }
 
-  :global(.vc-context-item--expandable .vc-context-item-label) {
+  :global(.vc-context-menu .vc-context-item--expandable .vc-context-item-label) {
     flex: 1;
     min-width: 0;
   }
@@ -1629,7 +1635,7 @@
   /* Chevron rendered via CSS ::after so it doesn't pollute the button's
      textContent — the menu-item tests match on textContent equality and
      the label must read as "Add text node" / "Change shape…", nothing more. */
-  :global(.vc-context-item--expandable)::after {
+  :global(.vc-context-menu .vc-context-item--expandable)::after {
     content: "▾";
     flex: 0 0 auto;
     color: var(--color-text-muted);
@@ -1637,11 +1643,11 @@
     line-height: 1;
   }
 
-  :global(.vc-context-item--expandable[aria-expanded="true"])::after {
+  :global(.vc-context-menu .vc-context-item--expandable[aria-expanded="true"])::after {
     content: "▴";
   }
 
-  :global(.vc-context-submenu) {
+  :global(.vc-context-menu .vc-context-submenu) {
     border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
     margin: 2px 0;

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -32,6 +32,7 @@
   import { resolveTarget } from "../Editor/wikiLink";
   import { renderMarkdownToHtml } from "../Editor/reading/markdownRenderer";
   import CanvasRenderer from "./CanvasRenderer.svelte";
+  import CanvasShapePicker from "./CanvasShapePicker.svelte";
   import ContextMenu from "../common/ContextMenu.svelte";
   import ColorPicker from "../common/ColorPicker.svelte";
   import UrlInputModal from "../common/UrlInputModal.svelte";
@@ -48,12 +49,15 @@
     CanvasGroupNode,
     CanvasLinkNode,
     CanvasNode,
+    CanvasShape,
     CanvasSide,
     CanvasTextNode,
   } from "../../lib/canvas/types";
   import {
     DEFAULT_NODE_WIDTH,
     DEFAULT_NODE_HEIGHT,
+    DEFAULT_CANVAS_SHAPE,
+    readShape,
   } from "../../lib/canvas/types";
   import { anchorPoint } from "../../lib/canvas/geometry";
   import {
@@ -220,7 +224,11 @@
     void doc.edges.length;
     for (const n of doc.nodes) {
       void n.x; void n.y; void n.width; void n.height;
-      if (n.type === "text") void (n as CanvasTextNode).text;
+      if (n.type === "text") {
+        void (n as CanvasTextNode).text;
+        // #362: shape mutations (setNodeShape) must schedule a save.
+        void (n as CanvasTextNode).shape;
+      }
       if (n.type === "link") void (n as CanvasLinkNode).url;
       if (n.type === "group") {
         void (n as CanvasGroupNode).label;
@@ -818,6 +826,17 @@
 
   let contextMenu = $state<{ target: ContextTarget; x: number; y: number } | null>(null);
 
+  // #362: which shape-picker submenu is inline-expanded inside the current
+  // context menu. `null` = no picker open (the menu behaves as before);
+  // `"add-text"` = empty-space "Add text node ▾" is expanded; `"change-shape"`
+  // = text-node "Change shape…" is expanded. Resets whenever the menu closes.
+  let shapeSubmenuOpen = $state<"add-text" | "change-shape" | null>(null);
+  // Trigger row refs so we can refocus the parent item when the picker
+  // collapses via ArrowLeft — without this the keyboard focus falls back
+  // to document.body and the menu arrow-nav chain breaks.
+  let addTextTriggerEl = $state<HTMLButtonElement | null>(null);
+  let changeShapeTriggerEl = $state<HTMLButtonElement | null>(null);
+
   // Snapshot of the node / edge under the menu so the template can branch on
   // type without re-scanning the doc on every render.
   const contextNode = $derived.by((): CanvasNode | null => {
@@ -834,6 +853,9 @@
 
   function closeContextMenu() {
     contextMenu = null;
+    // Always collapse any expanded inline picker so the next menu opens
+    // clean. Ref cleanup happens automatically via the bind: on unmount.
+    shapeSubmenuOpen = null;
   }
 
   function cancelGestureForContextMenu() {
@@ -890,7 +912,7 @@
 
   // ─── Menu actions ──────────────────────────────────────────────────────
 
-  function addTextNodeAt(worldX: number, worldY: number) {
+  function addTextNodeAt(worldX: number, worldY: number, shape?: CanvasShape) {
     const node: CanvasTextNode = {
       id: crypto.randomUUID(),
       type: "text",
@@ -899,11 +921,27 @@
       width: DEFAULT_NODE_WIDTH,
       height: DEFAULT_NODE_HEIGHT,
       text: "",
+      // #362: record a non-default shape so it serialises. Default shape
+      // is never written — keeps existing canvases byte-identical.
+      ...(shape && shape !== DEFAULT_CANVAS_SHAPE ? { shape } : {}),
     };
     doc.nodes = [...doc.nodes, node];
     selectedNodeId = node.id;
     selectedEdgeId = null;
     editingNodeId = node.id;
+  }
+
+  // #362: change a text node's shape. Default shape is stored as
+  // `undefined` so on-disk JSON omits the field and matches the pre-#362
+  // format — minimising diff noise in vaults that never use other shapes.
+  function setNodeShape(nodeId: string, shape: CanvasShape) {
+    const node = doc.nodes.find((n) => n.id === nodeId);
+    if (!node || node.type !== "text") return;
+    if (shape === DEFAULT_CANVAS_SHAPE) {
+      delete (node as CanvasTextNode).shape;
+    } else {
+      (node as CanvasTextNode).shape = shape;
+    }
   }
 
   function addGroupAt(worldX: number, worldY: number) {
@@ -1265,10 +1303,50 @@
   {#if contextMenu?.target.kind === "empty"}
     {@const worldX = contextMenu.target.worldX}
     {@const worldY = contextMenu.target.worldY}
+    <!-- #362: "Add text node ▾" — click expands the shape picker inline
+         inside the same menu panel. Picking a shape creates the node at
+         the right-clicked world coords with that shape. Double-click on
+         empty canvas remains the fast path that always creates a
+         rounded-rectangle without going through the picker. -->
     <button
-      class="vc-context-item"
-      onclick={() => { addTextNodeAt(worldX, worldY); closeContextMenu(); }}
-    >Add text node</button>
+      bind:this={addTextTriggerEl}
+      class="vc-context-item vc-context-item--expandable"
+      aria-haspopup="true"
+      aria-expanded={shapeSubmenuOpen === "add-text"}
+      onclick={() => {
+        shapeSubmenuOpen =
+          shapeSubmenuOpen === "add-text" ? null : "add-text";
+      }}
+      onkeydown={(e) => {
+        if (e.key === "ArrowRight" || e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          shapeSubmenuOpen = "add-text";
+        } else if (e.key === "ArrowLeft" && shapeSubmenuOpen === "add-text") {
+          e.preventDefault();
+          e.stopPropagation();
+          shapeSubmenuOpen = null;
+        }
+      }}
+    >
+      <span class="vc-context-item-label">Add text node</span>
+    </button>
+    {#if shapeSubmenuOpen === "add-text"}
+      <div class="vc-context-submenu">
+        <CanvasShapePicker
+          value={DEFAULT_CANVAS_SHAPE}
+          autoFocus={true}
+          onPick={(s) => {
+            addTextNodeAt(worldX, worldY, s);
+            closeContextMenu();
+          }}
+          onCancel={() => {
+            shapeSubmenuOpen = null;
+            addTextTriggerEl?.focus();
+          }}
+        />
+      </div>
+    {/if}
     <button
       class="vc-context-item"
       onclick={() => { openAddFileNode(worldX, worldY); closeContextMenu(); }}
@@ -1297,6 +1375,48 @@
         class="vc-context-item"
         onclick={() => { copyTextToClipboard((node as CanvasTextNode).text); closeContextMenu(); }}
       >Copy text</button>
+      <!-- #362: "Change shape…" — inline-expand picker with the node's
+           current shape pre-selected. Picking a shape rewrites
+           node.shape and closes the menu. -->
+      <button
+        bind:this={changeShapeTriggerEl}
+        class="vc-context-item vc-context-item--expandable"
+        aria-haspopup="true"
+        aria-expanded={shapeSubmenuOpen === "change-shape"}
+        onclick={() => {
+          shapeSubmenuOpen =
+            shapeSubmenuOpen === "change-shape" ? null : "change-shape";
+        }}
+        onkeydown={(e) => {
+          if (e.key === "ArrowRight" || e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            shapeSubmenuOpen = "change-shape";
+          } else if (e.key === "ArrowLeft" && shapeSubmenuOpen === "change-shape") {
+            e.preventDefault();
+            e.stopPropagation();
+            shapeSubmenuOpen = null;
+          }
+        }}
+      >
+        <span class="vc-context-item-label">Change shape…</span>
+      </button>
+      {#if shapeSubmenuOpen === "change-shape"}
+        <div class="vc-context-submenu">
+          <CanvasShapePicker
+            value={readShape(node)}
+            autoFocus={true}
+            onPick={(s) => {
+              setNodeShape(nodeId, s);
+              closeContextMenu();
+            }}
+            onCancel={() => {
+              shapeSubmenuOpen = null;
+              changeShapeTriggerEl?.focus();
+            }}
+          />
+        </div>
+      {/if}
       <button
         class="vc-context-item"
         onclick={() => { bringNodeToFront(nodeId); closeContextMenu(); }}
@@ -1489,5 +1609,42 @@
 
   .vc-canvas-error {
     color: var(--color-error);
+  }
+
+  /* #362: expandable context-menu rows and the inline shape-picker
+     panel they reveal. Kept in CanvasView (not ContextMenu.svelte) so
+     the generic menu stays a presentation-only popover. */
+  :global(.vc-context-item--expandable) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  :global(.vc-context-item--expandable .vc-context-item-label) {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Chevron rendered via CSS ::after so it doesn't pollute the button's
+     textContent — the menu-item tests match on textContent equality and
+     the label must read as "Add text node" / "Change shape…", nothing more. */
+  :global(.vc-context-item--expandable)::after {
+    content: "▾";
+    flex: 0 0 auto;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    line-height: 1;
+  }
+
+  :global(.vc-context-item--expandable[aria-expanded="true"])::after {
+    content: "▴";
+  }
+
+  :global(.vc-context-submenu) {
+    border-top: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    margin: 2px 0;
+    background: var(--color-bg, var(--color-surface));
   }
 </style>

--- a/src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts
+++ b/src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts
@@ -109,11 +109,37 @@ describe("CanvasView context menus (#164)", () => {
     ]);
   });
 
-  it("Add text node creates a text node in the doc", async () => {
+  it("Add text node expands the shape picker — picking a shape creates the node (#362)", async () => {
     const { container } = await mountWithDoc({ nodes: [], edges: [] });
     await openMenuOnViewport(container);
     await clickMenuItem(container, "Add text node");
+    // Click now expands the picker; no node has been created yet.
+    expect(container.querySelectorAll(".vc-canvas-node-text")).toHaveLength(0);
+    const picker = container.querySelector(".vc-shape-picker");
+    expect(picker).toBeTruthy();
+    // Pick the default (rounded-rectangle) → creates a node with no
+    // persisted shape field (shape === undefined roundtrips as absent).
+    const rounded = container.querySelector(
+      '.vc-shape-picker-row[data-shape="rounded-rectangle"]',
+    ) as HTMLButtonElement;
+    await fireEvent.click(rounded);
+    await tick();
     expect(container.querySelectorAll(".vc-canvas-node-text")).toHaveLength(1);
+  });
+
+  it("Picking triangle creates a text node rendered with the triangle shape class (#362)", async () => {
+    const { container } = await mountWithDoc({ nodes: [], edges: [] });
+    await openMenuOnViewport(container);
+    await clickMenuItem(container, "Add text node");
+    const triangle = container.querySelector(
+      '.vc-shape-picker-row[data-shape="triangle"]',
+    ) as HTMLButtonElement;
+    await fireEvent.click(triangle);
+    await tick();
+    const node = container.querySelector(
+      ".vc-canvas-node-text.vc-shape-triangle",
+    );
+    expect(node).toBeTruthy();
   });
 
   it("Add group creates a group node in the doc", async () => {
@@ -125,7 +151,7 @@ describe("CanvasView context menus (#164)", () => {
 
   // ─── Text node ───────────────────────────────────────────────────────
 
-  it("text-node menu lists the expected entries", async () => {
+  it("text-node menu lists the expected entries (#362 adds Change shape…)", async () => {
     const { container } = await mountWithDoc({
       nodes: [{ id: "t", type: "text", text: "hi", x: 0, y: 0, width: 100, height: 40 }],
       edges: [],
@@ -135,10 +161,60 @@ describe("CanvasView context menus (#164)", () => {
       "Edit text",
       "Duplicate",
       "Copy text",
+      "Change shape…",
       "Bring to front",
       "Send to back",
       "Delete",
     ]);
+  });
+
+  it("Change shape… on a text node re-renders the node with the chosen shape class (#362)", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{ id: "t", type: "text", text: "hi", x: 0, y: 0, width: 100, height: 40 }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "t");
+    await clickMenuItem(container, "Change shape…");
+    const diamond = container.querySelector(
+      '.vc-shape-picker-row[data-shape="diamond"]',
+    ) as HTMLButtonElement;
+    expect(diamond).toBeTruthy();
+    await fireEvent.click(diamond);
+    await tick();
+    const node = container.querySelector(
+      ".vc-canvas-node-text.vc-shape-diamond",
+    );
+    expect(node).toBeTruthy();
+  });
+
+  it("Change shape… back to rounded-rectangle deletes the shape field (#362)", async () => {
+    const { container } = await mountWithDoc({
+      nodes: [{
+        id: "t",
+        type: "text",
+        text: "hi",
+        x: 0, y: 0, width: 100, height: 40,
+        shape: "triangle",
+      }],
+      edges: [],
+    });
+    await openMenuOnNode(container, "t");
+    await clickMenuItem(container, "Change shape…");
+    const rr = container.querySelector(
+      '.vc-shape-picker-row[data-shape="rounded-rectangle"]',
+    ) as HTMLButtonElement;
+    await fireEvent.click(rr);
+    await tick();
+    // Wait for the debounced autosave (400 ms).
+    for (let i = 0; i < 30; i++) {
+      if (writeFileMock.mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    const out = nodesFromLastWrite();
+    const node = out.nodes[0] as unknown as Record<string, unknown>;
+    // Default shape is never persisted — the field must disappear so
+    // the on-disk JSON matches a pre-#362 canvas byte-for-byte.
+    expect(node.shape).toBeUndefined();
   });
 
   it("Duplicate on a text node creates a clone with a new id and offset position", async () => {

--- a/src/lib/canvas/__tests__/edgeResolver.test.ts
+++ b/src/lib/canvas/__tests__/edgeResolver.test.ts
@@ -194,4 +194,46 @@ describe("draftPath", () => {
       expect(path).not.toBeNull();
     }
   });
+
+  // #362: when the draft origin is a triangle and a snap target is found,
+  // the origin side must remap against the TARGET's center so the bezier
+  // leaves toward the right endpoint — not against the (possibly far)
+  // cursor position, which would invert the exit side mid-drag.
+  it("remaps a triangle origin's `top` against the snap target's center, not the cursor", () => {
+    const tri: CanvasTextNode = {
+      id: "tri",
+      type: "text",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+      text: "",
+      shape: "triangle",
+    };
+    const target: CanvasTextNode = {
+      id: "b",
+      type: "text",
+      x: 500, // to the right of the triangle
+      y: 0,
+      width: 100,
+      height: 40,
+      text: "",
+    };
+    const draft: DraftEdge = {
+      fromNodeId: "tri",
+      fromSide: "top",
+      // Cursor far to the LEFT of the triangle — if the remap used the
+      // cursor, fromSide would flip to "left". We want "right" because
+      // the target is to the right.
+      currentX: -500,
+      currentY: 50,
+      targetNodeId: "b",
+      targetSide: "left",
+    };
+    const path = draftPath(doc([tri, target], []), draft);
+    expect(path).not.toBeNull();
+    // The bezier starts at the triangle's right-edge midpoint (x=75, y=20),
+    // not at the left (x=25, y=20). Matching the prefix is sufficient.
+    expect(path).toMatch(/^M 75 20 /);
+  });
 });

--- a/src/lib/canvas/__tests__/edgeResolver.test.ts
+++ b/src/lib/canvas/__tests__/edgeResolver.test.ts
@@ -95,6 +95,43 @@ describe("resolveEdges", () => {
     const out = resolveEdges(doc([a, b], [valid, orphan]));
     expect(out.map((r) => r.edge.id)).toEqual(["ok"]);
   });
+
+  // #362: triangles only expose three anchors (left/right/bottom). An
+  // edge whose user-set `top` side lands on a triangle (possible if the
+  // node was reshaped after the edge was authored) must remap to a
+  // triangle side instead of silently drawing to the missing apex anchor.
+  it("remaps an explicit `fromSide: top` on a triangle to a valid triangle side", () => {
+    const tri = node("a", { x: 0, y: 0, width: 100, height: 40, shape: "triangle" });
+    const other = node("b", { x: 500, y: 0, width: 100, height: 40 });
+    const e: CanvasEdge = {
+      id: "e1",
+      fromNode: "a",
+      toNode: "b",
+      fromSide: "top",
+      toSide: "left",
+    };
+    const out = resolveEdges(doc([tri, other], [e]));
+    expect(out).toHaveLength(1);
+    // Other node is to the right → top remaps to right.
+    expect(out[0]?.fromSide).toBe("right");
+    // Anchor point must match the triangle's right-edge midpoint, not the
+    // bounding-box top midpoint.
+    expect(out[0]?.fromPt).toEqual({ x: 75, y: 20 });
+  });
+
+  it("remaps an explicit `toSide: top` on a triangle", () => {
+    const other = node("a", { x: 500, y: 0, width: 100, height: 40 });
+    const tri = node("b", { x: 0, y: 0, width: 100, height: 40, shape: "triangle" });
+    const e: CanvasEdge = {
+      id: "e1",
+      fromNode: "a",
+      toNode: "b",
+      fromSide: "left",
+      toSide: "top",
+    };
+    const out = resolveEdges(doc([other, tri], [e]));
+    expect(out[0]?.toSide).toBe("right"); // other is to the right → remap right
+  });
 });
 
 describe("draftPath", () => {

--- a/src/lib/canvas/__tests__/geometry.test.ts
+++ b/src/lib/canvas/__tests__/geometry.test.ts
@@ -7,6 +7,8 @@ import {
   bezierControls,
   bezierMidpoint,
   bezierPath,
+  sidesForShape,
+  remapSideForShape,
 } from "../geometry";
 import type { CanvasTextNode } from "../types";
 
@@ -103,5 +105,119 @@ describe("bezierMidpoint", () => {
     // Symmetric horizontal case → midpoint should be horizontally centered.
     expect(mid.x).toBeCloseTo(200, 0);
     expect(mid.y).toBeCloseTo(0, 5);
+  });
+});
+
+// ───────── #362: shape-aware anchors + autoSides remap ─────────
+
+describe("anchorPoint (shape-aware, #362)", () => {
+  it("uses bounding-box midpoints for rectangle / rounded-rectangle / ellipse / diamond", () => {
+    const n = node({ x: 10, y: 20, width: 200, height: 80 });
+    for (const shape of ["rectangle", "rounded-rectangle", "ellipse", "diamond"] as const) {
+      expect(anchorPoint(n, "top", shape)).toEqual({ x: 110, y: 20 });
+      expect(anchorPoint(n, "right", shape)).toEqual({ x: 210, y: 60 });
+      expect(anchorPoint(n, "bottom", shape)).toEqual({ x: 110, y: 100 });
+      expect(anchorPoint(n, "left", shape)).toEqual({ x: 10, y: 60 });
+    }
+  });
+
+  it("uses the three edge midpoints of the triangle polygon for triangles", () => {
+    // Triangle clip-path: apex at top-center, base along bottom edge.
+    // Left edge midpoint  = (x + w*0.25, y + h*0.5)
+    // Right edge midpoint = (x + w*0.75, y + h*0.5)
+    // Bottom edge midpoint = (x + w*0.5,  y + h)
+    const n = node({ x: 0, y: 0, width: 100, height: 40 });
+    expect(anchorPoint(n, "left", "triangle")).toEqual({ x: 25, y: 20 });
+    expect(anchorPoint(n, "right", "triangle")).toEqual({ x: 75, y: 20 });
+    expect(anchorPoint(n, "bottom", "triangle")).toEqual({ x: 50, y: 40 });
+  });
+
+  it("reads the node's own shape when the `shape` arg is omitted", () => {
+    const tri = node({ x: 0, y: 0, width: 100, height: 40, shape: "triangle" });
+    expect(anchorPoint(tri, "left")).toEqual({ x: 25, y: 20 });
+    const rect = node({ x: 0, y: 0, width: 100, height: 40 });
+    // No shape field → rounded-rectangle default → bounding-box midpoints.
+    expect(anchorPoint(rect, "left")).toEqual({ x: 0, y: 20 });
+  });
+});
+
+describe("sidesForShape", () => {
+  it("returns all 4 sides for non-triangle shapes", () => {
+    for (const shape of ["rectangle", "rounded-rectangle", "ellipse", "diamond"] as const) {
+      expect(sidesForShape(shape)).toEqual(["top", "right", "bottom", "left"]);
+    }
+  });
+
+  it("returns only left / right / bottom for triangles (no top — it's the apex)", () => {
+    expect(sidesForShape("triangle")).toEqual(["left", "right", "bottom"]);
+  });
+});
+
+describe("remapSideForShape", () => {
+  it("passes non-top sides through untouched on any shape", () => {
+    const my = { x: 0, y: 0 };
+    const other = { x: 100, y: 0 };
+    for (const side of ["left", "right", "bottom"] as const) {
+      expect(remapSideForShape("triangle", side, my, other)).toBe(side);
+      expect(remapSideForShape("rectangle", side, my, other)).toBe(side);
+    }
+  });
+
+  it("passes `top` through untouched on non-triangle shapes", () => {
+    const my = { x: 0, y: 0 };
+    const other = { x: 100, y: 0 };
+    expect(remapSideForShape("rectangle", "top", my, other)).toBe("top");
+    expect(remapSideForShape("ellipse", "top", my, other)).toBe("top");
+  });
+
+  it("remaps triangle `top` to `right` when the other endpoint is to the right", () => {
+    const my = { x: 0, y: 0 };
+    const other = { x: 100, y: 50 };
+    expect(remapSideForShape("triangle", "top", my, other)).toBe("right");
+  });
+
+  it("remaps triangle `top` to `left` when the other endpoint is to the left", () => {
+    const my = { x: 100, y: 0 };
+    const other = { x: 0, y: 50 };
+    expect(remapSideForShape("triangle", "top", my, other)).toBe("left");
+  });
+});
+
+describe("autoSides (shape-aware, #362)", () => {
+  it("remaps a triangle endpoint's `top` auto-pick to left/right based on dx", () => {
+    // Vertical stack: rectangle above, triangle below. autoSides' baseline
+    // picks fromSide: "bottom", toSide: "top". The triangle is the TO node
+    // and its apex (`top`) has no anchor — remap to whichever face points
+    // at the other endpoint. With dx=0 the `>= 0` convention resolves to
+    // `right`, which is fine either way — we only care that it isn't `top`.
+    const rect = node({ id: "from", x: 0, y: 0, width: 100, height: 40 });
+    const tri = node({ id: "to", x: 0, y: 500, width: 100, height: 40, shape: "triangle" });
+    const sides = autoSides(rect, tri);
+    expect(sides.fromSide).toBe("bottom");
+    expect(sides.toSide).not.toBe("top");
+    expect(sides.toSide === "left" || sides.toSide === "right").toBe(true);
+  });
+
+  it("remaps independently per endpoint when both endpoints are triangles", () => {
+    // Triangles directly above/below → baseline pick is top/bottom. The
+    // upper triangle gets `bottom` (not top → safe). The lower triangle
+    // would get `top`, which must remap.
+    const top = node({ id: "top", x: 0, y: 0, width: 100, height: 40, shape: "triangle" });
+    const bot = node({ id: "bot", x: 50, y: 500, width: 100, height: 40, shape: "triangle" });
+    const sides = autoSides(top, bot);
+    expect(sides.fromSide).toBe("bottom"); // upper triangle — bottom is a valid anchor
+    expect(sides.toSide).not.toBe("top"); // remapped away
+    // Lower triangle's "top" faces the upper one which is to its left
+    // (dx = fcx - tcx = 50 - 100 = -50), so remap → "right" (to face left).
+    // Convention: remapSideForShape uses other.x - my.x ≥ 0 → "right", else "left".
+    // From the TO node's perspective, "other" is the FROM node at dx = -50 → "left".
+    expect(sides.toSide).toBe("left");
+  });
+
+  it("keeps horizontal-axis auto-pick unchanged for triangles (no top involved)", () => {
+    const tri = node({ id: "t", x: 0, y: 0, width: 100, height: 40, shape: "triangle" });
+    const other = node({ id: "o", x: 500, y: 0, width: 100, height: 40 });
+    const sides = autoSides(tri, other);
+    expect(sides).toEqual({ fromSide: "right", toSide: "left" });
   });
 });

--- a/src/lib/canvas/__tests__/parse.test.ts
+++ b/src/lib/canvas/__tests__/parse.test.ts
@@ -237,4 +237,115 @@ describe("serializeCanvas", () => {
     expect(parsed.edges[0]).not.toHaveProperty("fromSide");
     expect(parsed.edges[0]).not.toHaveProperty("toEnd");
   });
+
+  // ───────── #362: shape roundtrip ─────────
+
+  it("parses a valid `shape` on a text node into the typed field", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [
+          {
+            id: "a",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 1,
+            height: 1,
+            text: "x",
+            shape: "triangle",
+          },
+        ],
+        edges: [],
+      }),
+    );
+    expect(doc.nodes[0]).toMatchObject({ type: "text", shape: "triangle" });
+    // shape must be promoted out of the extra bag — it's a first-class field.
+    expect(doc.nodes[0]?.extra?.shape).toBeUndefined();
+  });
+
+  it("rejects unknown shape strings — renders as the default without roundtripping the invalid value", () => {
+    const doc = parseCanvas(
+      JSON.stringify({
+        nodes: [
+          {
+            id: "a",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 1,
+            height: 1,
+            text: "x",
+            shape: "hexagon",
+          },
+        ],
+        edges: [],
+      }),
+    );
+    // Field dropped so readShape returns the default (rounded-rectangle).
+    expect((doc.nodes[0] as { shape?: string }).shape).toBeUndefined();
+    expect(doc.nodes[0]?.extra?.shape).toBeUndefined();
+  });
+
+  it("omits the default shape on serialize — existing canvases stay byte-identical", () => {
+    const out = serializeCanvas({
+      nodes: [
+        {
+          id: "a",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 1,
+          height: 1,
+          text: "x",
+          shape: "rounded-rectangle",
+        },
+      ],
+      edges: [],
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.nodes[0]).not.toHaveProperty("shape");
+  });
+
+  it("emits a non-default shape explicitly", () => {
+    const out = serializeCanvas({
+      nodes: [
+        {
+          id: "a",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 1,
+          height: 1,
+          text: "x",
+          shape: "diamond",
+        },
+      ],
+      edges: [],
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.nodes[0].shape).toBe("diamond");
+  });
+
+  it("roundtrips a non-default shape alongside other extra fields", () => {
+    const input = {
+      nodes: [
+        {
+          id: "a",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 1,
+          height: 1,
+          text: "x",
+          shape: "ellipse",
+          styleAttributes: { theme: "dark" },
+        },
+      ],
+      edges: [],
+    };
+    const doc = parseCanvas(JSON.stringify(input));
+    const out = JSON.parse(serializeCanvas(doc));
+    expect(out.nodes[0].shape).toBe("ellipse");
+    expect(out.nodes[0].styleAttributes).toEqual({ theme: "dark" });
+  });
 });

--- a/src/lib/canvas/edgeResolver.ts
+++ b/src/lib/canvas/edgeResolver.ts
@@ -97,22 +97,30 @@ export function draftPath(doc: CanvasDoc, draft: DraftEdge | null): string | nul
   if (!draft) return null;
   const from = doc.nodes.find((n) => n.id === draft.fromNodeId);
   if (!from) return null;
-  // Remap the origin side in case the draft is rooted on a triangle — the
-  // renderer never emits `top` for triangles so this is defensive for
-  // unexpected draft state, not a code path the UI normally reaches. #362.
+  // Shape-aware remap for the origin side. The renderer never emits `top`
+  // for triangles so this branch is defensive; it matters when a user
+  // somehow starts a draft from a legacy handle or via keyboard. #362.
+  //
+  // When we have a snap target, remap against the TARGET's center so the
+  // draft curve exits the triangle origin in the direction of the actual
+  // endpoint — remapping against the moving cursor instead would flip
+  // sides mid-drag once the cursor passed the origin's center axis.
   const fc = centerOf(from);
   const cursor = { x: draft.currentX, y: draft.currentY };
-  const fromSide = remapSideForShape(readShape(from), draft.fromSide, fc, cursor);
-  const fromPt = anchorPoint(from, fromSide);
+  const fromShape = readShape(from);
   if (draft.targetNodeId && draft.targetSide) {
     const to = doc.nodes.find((n) => n.id === draft.targetNodeId);
     if (to) {
       const tc = centerOf(to);
+      const fromSide = remapSideForShape(fromShape, draft.fromSide, fc, tc);
       const toSide = remapSideForShape(readShape(to), draft.targetSide, tc, fc);
+      const fromPt = anchorPoint(from, fromSide);
       const toPt = anchorPoint(to, toSide);
       return bezierPath(fromPt, fromSide, toPt, toSide);
     }
   }
+  const fromSide = remapSideForShape(fromShape, draft.fromSide, fc, cursor);
+  const fromPt = anchorPoint(from, fromSide);
   return bezierPath(
     fromPt,
     fromSide,

--- a/src/lib/canvas/edgeResolver.ts
+++ b/src/lib/canvas/edgeResolver.ts
@@ -14,9 +14,20 @@
 // fallback behaviours (missing endpoint, no snap target, opposite-side
 // pick) without booting the renderer.
 
-import { anchorPoint, autoSides, bezierMidpoint, bezierPath } from "./geometry";
-import type { CanvasDoc, CanvasEdge, CanvasSide } from "./types";
+import {
+  anchorPoint,
+  autoSides,
+  bezierMidpoint,
+  bezierPath,
+  remapSideForShape,
+} from "./geometry";
+import type { CanvasDoc, CanvasEdge, CanvasNode, CanvasSide } from "./types";
+import { readShape } from "./types";
 import type { DraftEdge } from "./pointerMode";
+
+function centerOf(node: CanvasNode): { x: number; y: number } {
+  return { x: node.x + node.width / 2, y: node.y + node.height / 2 };
+}
 
 export interface ResolvedEdge {
   edge: CanvasEdge;
@@ -35,10 +46,21 @@ export function resolveEdges(doc: CanvasDoc): ResolvedEdge[] {
     const from = byId.get(edge.fromNode);
     const to = byId.get(edge.toNode);
     if (!from || !to) continue;
-    const { fromSide, toSide } =
-      edge.fromSide && edge.toSide
-        ? { fromSide: edge.fromSide, toSide: edge.toSide }
-        : autoSides(from, to);
+    let fromSide: CanvasSide;
+    let toSide: CanvasSide;
+    if (edge.fromSide && edge.toSide) {
+      // User-set sides — still pass through remapSideForShape so an edge
+      // persisted with `top` on what is now a triangle (e.g. the node was
+      // reshaped after the edge was authored, or the file came from a
+      // producer that didn't know about triangle shapes) resolves to a
+      // side that actually has an anchor. #362.
+      const fc = centerOf(from);
+      const tc = centerOf(to);
+      fromSide = remapSideForShape(readShape(from), edge.fromSide, fc, tc);
+      toSide = remapSideForShape(readShape(to), edge.toSide, tc, fc);
+    } else {
+      ({ fromSide, toSide } = autoSides(from, to));
+    }
     const fromPt = anchorPoint(from, fromSide);
     const toPt = anchorPoint(to, toSide);
     out.push({
@@ -75,18 +97,26 @@ export function draftPath(doc: CanvasDoc, draft: DraftEdge | null): string | nul
   if (!draft) return null;
   const from = doc.nodes.find((n) => n.id === draft.fromNodeId);
   if (!from) return null;
-  const fromPt = anchorPoint(from, draft.fromSide);
+  // Remap the origin side in case the draft is rooted on a triangle — the
+  // renderer never emits `top` for triangles so this is defensive for
+  // unexpected draft state, not a code path the UI normally reaches. #362.
+  const fc = centerOf(from);
+  const cursor = { x: draft.currentX, y: draft.currentY };
+  const fromSide = remapSideForShape(readShape(from), draft.fromSide, fc, cursor);
+  const fromPt = anchorPoint(from, fromSide);
   if (draft.targetNodeId && draft.targetSide) {
     const to = doc.nodes.find((n) => n.id === draft.targetNodeId);
     if (to) {
-      const toPt = anchorPoint(to, draft.targetSide);
-      return bezierPath(fromPt, draft.fromSide, toPt, draft.targetSide);
+      const tc = centerOf(to);
+      const toSide = remapSideForShape(readShape(to), draft.targetSide, tc, fc);
+      const toPt = anchorPoint(to, toSide);
+      return bezierPath(fromPt, fromSide, toPt, toSide);
     }
   }
   return bezierPath(
     fromPt,
-    draft.fromSide,
-    { x: draft.currentX, y: draft.currentY },
-    oppositeSide(draft.fromSide),
+    fromSide,
+    cursor,
+    oppositeSide(fromSide),
   );
 }

--- a/src/lib/canvas/geometry.ts
+++ b/src/lib/canvas/geometry.ts
@@ -4,7 +4,8 @@
 // that enters/leaves each endpoint perpendicular to its side (Obsidian's
 // routing style).
 
-import type { CanvasNode, CanvasSide } from "./types";
+import type { CanvasNode, CanvasShape, CanvasSide } from "./types";
+import { readShape } from "./types";
 
 export interface Point {
   x: number;
@@ -15,17 +16,53 @@ export interface Point {
  * Center point of the requested side of a node's bounding rect. Used as
  * the anchor where an edge meets the node and where we draw the hover
  * handles during edge-creation.
+ *
+ * Shape-aware since #362: rectangle / rounded-rectangle / ellipse / diamond
+ * all use bounding-box midpoints (they share the same anchor geometry — the
+ * shape differs visually only). Triangles use the midpoints of their three
+ * polygon edges; the apex (`top`) is not a valid anchor and callers must
+ * have remapped it via {@link remapSideForShape} before reaching here. A
+ * triangle's `top` here indicates a caller bug and falls through to `left`
+ * to stay non-crashing, with a DEV-only warning so the bug surfaces.
  */
-export function anchorPoint(node: CanvasNode, side: CanvasSide): Point {
+export function anchorPoint(
+  node: CanvasNode,
+  side: CanvasSide,
+  shape: CanvasShape = readShape(node),
+): Point {
+  const cx = node.x + node.width / 2;
+  const cy = node.y + node.height / 2;
+  if (shape === "triangle") {
+    // clip-path: polygon(50% 0%, 100% 100%, 0% 100%)
+    // left edge  (apex → bottom-left)  midpoint = (x + w*0.25, y + h*0.5)
+    // right edge (apex → bottom-right) midpoint = (x + w*0.75, y + h*0.5)
+    // bottom edge (bl → br)            midpoint = (x + w*0.5,  y + h)
+    switch (side) {
+      case "left":
+        return { x: node.x + node.width * 0.25, y: cy };
+      case "right":
+        return { x: node.x + node.width * 0.75, y: cy };
+      case "bottom":
+        return { x: cx, y: node.y + node.height };
+      case "top":
+        if (import.meta.env?.DEV) {
+          console.warn(
+            "[canvas/geometry] anchorPoint called with side='top' on a triangle; caller forgot to remapSideForShape — falling back to 'left'.",
+          );
+        }
+        return { x: node.x + node.width * 0.25, y: cy };
+    }
+  }
+  // Rectangle / rounded-rectangle / ellipse / diamond — bounding-box midpoints.
   switch (side) {
     case "top":
-      return { x: node.x + node.width / 2, y: node.y };
+      return { x: cx, y: node.y };
     case "right":
-      return { x: node.x + node.width, y: node.y + node.height / 2 };
+      return { x: node.x + node.width, y: cy };
     case "bottom":
-      return { x: node.x + node.width / 2, y: node.y + node.height };
+      return { x: cx, y: node.y + node.height };
     case "left":
-      return { x: node.x, y: node.y + node.height / 2 };
+      return { x: node.x, y: cy };
   }
 }
 
@@ -47,6 +84,12 @@ function sideUnit(side: CanvasSide): Point {
  * Pick a from/to side pair when the edge omits them. We use the larger
  * axis of the center-to-center vector to decide whether the edge should
  * leave horizontally or vertically, then face the sides toward each other.
+ *
+ * After the baseline pick, each side is passed through
+ * {@link remapSideForShape} so shapes that don't expose all four sides
+ * (triangle) get a side that actually has an anchor. The remap runs per
+ * endpoint so mixed cases (triangle ↔ rectangle, triangle ↔ triangle)
+ * resolve correctly without a special-case.
  */
 export function autoSides(
   from: CanvasNode,
@@ -58,14 +101,54 @@ export function autoSides(
   const tcy = to.y + to.height / 2;
   const dx = tcx - fcx;
   const dy = tcy - fcy;
+  let fromSide: CanvasSide;
+  let toSide: CanvasSide;
   if (Math.abs(dx) >= Math.abs(dy)) {
-    return dx >= 0
-      ? { fromSide: "right", toSide: "left" }
-      : { fromSide: "left", toSide: "right" };
+    fromSide = dx >= 0 ? "right" : "left";
+    toSide = dx >= 0 ? "left" : "right";
+  } else {
+    fromSide = dy >= 0 ? "bottom" : "top";
+    toSide = dy >= 0 ? "top" : "bottom";
   }
-  return dy >= 0
-    ? { fromSide: "bottom", toSide: "top" }
-    : { fromSide: "top", toSide: "bottom" };
+  return {
+    fromSide: remapSideForShape(readShape(from), fromSide, { x: fcx, y: fcy }, { x: tcx, y: tcy }),
+    toSide: remapSideForShape(readShape(to), toSide, { x: tcx, y: tcy }, { x: fcx, y: fcy }),
+  };
+}
+
+/**
+ * Sides that expose a valid connection anchor for each shape. Rectangle /
+ * rounded-rectangle / ellipse / diamond all expose the full four-side set;
+ * triangles drop `top` because the apex is a point (not a segment) and
+ * makes a poor bezier terminus. The renderer iterates this list to decide
+ * which hover handles to draw per node.
+ */
+export function sidesForShape(shape: CanvasShape): readonly CanvasSide[] {
+  if (shape === "triangle") return TRIANGLE_SIDES;
+  return SIDES;
+}
+
+/**
+ * Coerce a side that isn't valid for the node's shape into one that is.
+ * Only triangles need coercion today (their apex `top` has no anchor) —
+ * the incoming side is swapped for whichever face of the triangle points
+ * toward the other endpoint, so the edge stays on the short side.
+ *
+ * Pure and composable: takes the node's own center and the other
+ * endpoint's center as plain points so the caller doesn't need to know
+ * the dx convention, and the same helper works for auto-picked sides, a
+ * user-set explicit side surviving from before a shape change, and a
+ * draft edge's origin during edge creation.
+ */
+export function remapSideForShape(
+  shape: CanvasShape,
+  side: CanvasSide,
+  myCenter: Point,
+  otherCenter: Point,
+): CanvasSide {
+  if (shape !== "triangle") return side;
+  if (side !== "top") return side;
+  return otherCenter.x >= myCenter.x ? "right" : "left";
 }
 
 /**
@@ -121,3 +204,6 @@ export function bezierMidpoint(
 
 /** All four sides — used by the UI to render hover handles. */
 export const SIDES: readonly CanvasSide[] = ["top", "right", "bottom", "left"];
+
+/** Triangle's three anchor-bearing sides (no `top` — that's the apex). */
+const TRIANGLE_SIDES: readonly CanvasSide[] = ["left", "right", "bottom"];

--- a/src/lib/canvas/parse.ts
+++ b/src/lib/canvas/parse.ts
@@ -18,6 +18,7 @@ import type {
   CanvasTextNode,
   CanvasUnknownNode,
 } from "./types";
+import { DEFAULT_CANVAS_SHAPE, isCanvasShape } from "./types";
 
 const KNOWN_NODE_KEYS = new Set([
   "id",
@@ -29,6 +30,7 @@ const KNOWN_NODE_KEYS = new Set([
   "color",
   // text
   "text",
+  "shape", // #362 — VaultCore extension on text nodes
   // file
   "file",
   "subpath",
@@ -103,10 +105,16 @@ function parseNode(raw: unknown): CanvasNode | null {
   const extra = extraMaybe ? { extra: extraMaybe } : {};
   switch (type) {
     case "text": {
+      // #362: promote `shape` out of the raw bag into a typed field so
+      // downstream code accesses it via `node.shape` instead of reading
+      // through `extra`. Unknown values drop silently — rendering falls
+      // back to the default shape.
+      const shape = isCanvasShape(raw.shape) ? raw.shape : undefined;
       const node: CanvasTextNode = {
         ...base,
         type: "text",
         text: asString(raw.text),
+        ...(shape !== undefined ? { shape } : {}),
         ...extra,
       };
       return node;
@@ -214,7 +222,13 @@ function serializeNode(n: CanvasNode): Record<string, unknown> {
   };
   if (n.color !== undefined) out.color = n.color;
   if (n.type === "text") {
-    out.text = (n as CanvasTextNode).text;
+    const tn = n as CanvasTextNode;
+    out.text = tn.text;
+    // #362: emit `shape` only when it diverges from the default so
+    // existing canvases without a shape field stay byte-identical.
+    if (tn.shape !== undefined && tn.shape !== DEFAULT_CANVAS_SHAPE) {
+      out.shape = tn.shape;
+    }
   } else if (n.type === "file") {
     const fn = n as CanvasFileNode;
     out.file = fn.file;

--- a/src/lib/canvas/types.ts
+++ b/src/lib/canvas/types.ts
@@ -9,6 +9,41 @@
 /** Side a connector can dock to on a node's bounding rect. */
 export type CanvasSide = "top" | "right" | "bottom" | "left";
 
+/**
+ * Visual shape of a text node (#362). VaultCore extension — Obsidian
+ * ignores the field on load and round-trips through our canonical
+ * serializer unchanged. `rounded-rectangle` is the default and matches
+ * the pre-#362 visual (border-radius: 6px); nodes without a `shape` field
+ * on disk render as `rounded-rectangle` for zero visual regression.
+ */
+export type CanvasShape =
+  | "rounded-rectangle"
+  | "rectangle"
+  | "ellipse"
+  | "diamond"
+  | "triangle";
+
+/** Ordered list driving the shape-picker UI. */
+export const CANVAS_SHAPES: readonly CanvasShape[] = [
+  "rounded-rectangle",
+  "rectangle",
+  "ellipse",
+  "diamond",
+  "triangle",
+];
+
+export const DEFAULT_CANVAS_SHAPE: CanvasShape = "rounded-rectangle";
+
+export function isCanvasShape(v: unknown): v is CanvasShape {
+  return (
+    v === "rounded-rectangle" ||
+    v === "rectangle" ||
+    v === "ellipse" ||
+    v === "diamond" ||
+    v === "triangle"
+  );
+}
+
 export interface CanvasNodeBase {
   id: string;
   x: number;
@@ -23,6 +58,24 @@ export interface CanvasNodeBase {
 export interface CanvasTextNode extends CanvasNodeBase {
   type: "text";
   text: string;
+  /** #362: visual shape. `undefined` renders as {@link DEFAULT_CANVAS_SHAPE}. */
+  shape?: CanvasShape;
+}
+
+/**
+ * Resolve a node's effective visual shape. Only text nodes carry a shape;
+ * every other node type returns the default. Called by the renderer per
+ * frame and by geometry helpers — keep O(1) pure.
+ */
+export function readShape(node: CanvasNode): CanvasShape {
+  // CanvasUnknownNode's `type` field is `string`, so TS can't narrow
+  // away the unknown branch on the discriminator alone — we check for
+  // the `shape` field's presence on a typed text node via the cast.
+  if (node.type === "text") {
+    const shape = (node as CanvasTextNode).shape;
+    if (shape) return shape;
+  }
+  return DEFAULT_CANVAS_SHAPE;
 }
 
 export interface CanvasFileNode extends CanvasNodeBase {

--- a/src/lib/canvas/types.ts
+++ b/src/lib/canvas/types.ts
@@ -73,7 +73,7 @@ export function readShape(node: CanvasNode): CanvasShape {
   // the `shape` field's presence on a typed text node via the cast.
   if (node.type === "text") {
     const shape = (node as CanvasTextNode).shape;
-    if (shape) return shape;
+    if (shape !== undefined) return shape;
   }
   return DEFAULT_CANVAS_SHAPE;
 }


### PR DESCRIPTION
Closes #362.

## Summary

- Adds 5 shapes for canvas text nodes: rounded-rectangle (default), rectangle, ellipse, diamond, triangle.
- Shape picker opens inline inside the existing context menu via two entry points:
  - Empty-space menu: **Add text node ▾** — expands picker, pick a shape to create a node at the right-clicked world coords.
  - Text-node menu: **Change shape…** — expands picker with the current shape pre-selected; picking rewrites `node.shape`.
- Double-click on empty canvas is unchanged: always creates a rounded-rectangle without going through the picker.
- Triangles expose only 3 anchors (left/right/bottom — the apex is not a valid terminus). A new `remapSideForShape` helper routes a `top` side on a triangle to whichever face points at the other endpoint; applied in both `autoSides` and `resolveEdges` so user-set sides surviving from before a shape change also resolve correctly.
- `shape` is a typed optional field on `CanvasTextNode`, parsed/serialised by `parse.ts` as a first-class field. Default shape is never written to disk — pre-#362 canvases stay byte-identical.

## Architecture notes

- **Why a typed `shape?: CanvasShape` field instead of the `extra` bag:** `extra` is the passthrough bag for *unknown* fields. Promoting a field the app actively reads/writes into that bag would spread `extra?.shape as string` checks across the canvas subsystem. Keeping the interpretation boundary at parse/serialize (where it belongs) lets every downstream caller use plain `node.shape` / `readShape(node)`.
- **Why a shape underlay `<div>` instead of moving handles to a sibling overlay:** `clip-path` (diamond/triangle) clips children, which would hide the hover handles + resize grabber. Adding a single `.vc-canvas-node-shape` child that carries the clip/border-radius keeps the outer node div `overflow: visible`, so handles stay interactive on every shape without restructuring the handle DOM or breaking `handleAtPoint`'s `closest("[data-node-id]")` lookup.
- **Rounded-rectangle as default:** preserves today's `border-radius: 6px` visual for nodes without a `shape` field. Zero visual regression on existing canvases.

## Test plan

Vitest (added/extended):
- `src/lib/canvas/__tests__/geometry.test.ts` — shape-aware `anchorPoint` (triangle edge midpoints), `sidesForShape`, `remapSideForShape`, `autoSides` triangle remap (single-triangle + both-triangle).
- `src/lib/canvas/__tests__/edgeResolver.test.ts` — explicit `fromSide: \"top\"` / `toSide: \"top\"` on a triangle remaps to a valid side in `resolveEdges`.
- `src/lib/canvas/__tests__/parse.test.ts` — shape roundtrip (parse as typed field; unknown values drop; default omitted on serialise; non-default preserved alongside other `extra` keys).
- `src/components/Canvas/__tests__/CanvasViewContextMenu.test.ts` — empty-space `Add text node` now expands the picker (was: immediate create); `Change shape…` entry appears on text nodes and re-renders with the chosen shape class; picking rounded-rectangle on a shaped node deletes the `shape` field on persist.

All affected unit/component suites green locally (173 canvas-tests + 1276 total; one pre-existing flaky perf test in `largeFile.test.ts` unrelated to this change).

- [ ] Visual UAT on Tauri app: right-click empty canvas, expand picker, create each of the 5 shapes. Verify edges route cleanly to triangle's 3 anchors.
- [ ] Visual UAT: right-click an existing triangle, open \"Change shape…\", switch to diamond — edges re-anchor.
- [ ] Roundtrip UAT: create a diamond, close + reopen canvas, shape persists.

🧪 TDD: tests written before implementation.