### PR TITLE
fix(canvas): stack multi-block markdown in non-rectangular text nodes (#366)

### DIFF
--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -943,6 +943,7 @@
   .vc-canvas-node-text:not(.vc-shape-rectangle):not(.vc-shape-rounded-rectangle)
     > .vc-canvas-node-content {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
   }

--- a/src/components/Canvas/CanvasRenderer.svelte
+++ b/src/components/Canvas/CanvasRenderer.svelte
@@ -944,7 +944,6 @@
     > .vc-canvas-node-content {
     display: flex;
     flex-direction: column;
-    align-items: center;
     justify-content: center;
   }
 

--- a/src/components/Canvas/__tests__/CanvasRenderer.md.test.ts
+++ b/src/components/Canvas/__tests__/CanvasRenderer.md.test.ts
@@ -168,6 +168,12 @@ describe("CanvasRenderer markdown text nodes (#364)", () => {
     );
     expect(rule, "non-rectangular content flex rule must exist").toBeTruthy();
     expect(rule![0]).toMatch(/flex-direction:\s*column/);
+    // Coupled invariant: with flex-direction: column the cross axis is
+    // horizontal — `align-items: center` would shrink-wrap block children
+    // (<p>, <h1>) to max-content width and wrap them narrower than the
+    // shape's available area. Horizontal centering of the inline content
+    // is handled by `text-align: center` on the sibling rule above.
+    expect(rule![0]).not.toMatch(/align-items:\s*center/);
   });
 
   it("wiki-link clicks inside the textarea (during edit) do not trigger onOpenWikiTarget", async () => {

--- a/src/components/Canvas/__tests__/CanvasRenderer.md.test.ts
+++ b/src/components/Canvas/__tests__/CanvasRenderer.md.test.ts
@@ -148,6 +148,28 @@ describe("CanvasRenderer markdown text nodes (#364)", () => {
     expect(onCardKey).toHaveBeenCalledTimes(1);
   });
 
+  it("non-rectangular shapes stack multi-block markdown vertically (#366)", async () => {
+    // #362 added `display: flex` on non-rectangular content to center the
+    // single-line label inside ellipse / diamond / triangle silhouettes.
+    // #364 then started rendering Markdown HTML, which is multi-block —
+    // without `flex-direction: column` the default `row` direction laid
+    // <h1> + <p> next to each other. Vite-svelte does not inject scoped
+    // <style> into JSDOM, and JSDOM does not compute flex layout, so we
+    // assert against the source CSS directly: the only place the bug can
+    // be reintroduced is the rule itself.
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const source = await fs.readFile(
+      path.resolve(__dirname, "../CanvasRenderer.svelte"),
+      "utf8",
+    );
+    const rule = source.match(
+      /\.vc-canvas-node-text:not\(\.vc-shape-rectangle\):not\(\.vc-shape-rounded-rectangle\)\s*>\s*\.vc-canvas-node-content\s*\{[^}]*\}/,
+    );
+    expect(rule, "non-rectangular content flex rule must exist").toBeTruthy();
+    expect(rule![0]).toMatch(/flex-direction:\s*column/);
+  });
+
   it("wiki-link clicks inside the textarea (during edit) do not trigger onOpenWikiTarget", async () => {
     // While editing, only the textarea is rendered — there is no HTML link
     // to click. The display branch is fully replaced. This asserts the


### PR DESCRIPTION
## Summary
- Closes #366 — heading + paragraph rendered side-by-side instead of stacked in ellipse / diamond / triangle text nodes.
- Adds `flex-direction: column` to the non-rectangular content container in `CanvasRenderer.svelte`. The flex centering rule from #362 inherited the default `row` direction; with the multi-block Markdown HTML introduced in #364, that placed `<h1>` next to `<p>`.
- Vitest regression guard against the source CSS rule (Vite-svelte does not inject scoped `<style>` into JSDOM, and JSDOM does not lay out flex, so an asserted-rendering test is not feasible — the source-CSS check pins the exact regression vector).

## Test plan
- [x] `npx vitest run src/components/Canvas/__tests__/CanvasRenderer.md.test.ts` — 9/9 green, including the new `#366` case.
- [ ] Manual: ellipse / diamond / triangle text node with `# H` + Enter + `body` — heading on top, paragraph below, both centered.
- [ ] Manual: rectangle / rounded-rectangle text node unchanged.
- [ ] Manual: single-line text remains visually centered in non-rectangular shapes.