### PR TITLE
feat(ascii): primitives + indexing/search-rebuild spinners (#358)

### DIFF
--- a/src/components/Progress/ProgressBar.svelte
+++ b/src/components/Progress/ProgressBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { progressStore } from "../../store/progressStore";
+  import AsciiProgressBar from "../ascii/AsciiProgressBar.svelte";
 
   // #357 \u2014 label is a prop so the vault-open flow can render
   // "Scanning and securing vault\u2026" while the indexer walk and the
@@ -30,13 +31,11 @@
            aria-valuemin="0"
            aria-valuemax={$progressStore.total}
            aria-valuenow={$progressStore.current}>
-        <div
-          class="vc-progress-fill"
-          data-testid="progress-fill"
-          style:width="{$progressStore.total > 0
-            ? ($progressStore.current / $progressStore.total) * 100
-            : 0}%"
-        ></div>
+        <AsciiProgressBar
+          value={$progressStore.current}
+          max={$progressStore.total}
+          testid="progress-fill"
+        />
       </div>
       <p class="vc-progress-file" data-testid="progress-file">
         {truncatePath($progressStore.currentFile)}
@@ -74,17 +73,12 @@
     color: var(--color-text-muted);
     text-align: right;
   }
+  /* The progressbar wrapper retains its semantic role + aria-valuemin/max/now;
+     the visual bar inside is now the AsciiProgressBar component. The old
+     coloured div + transition are intentionally gone \u2014 the ASCII pulse on
+     the filled run is the new motion language. */
   .vc-progress-track {
     width: 100%;
-    height: 8px;
-    background: var(--color-border);
-    border-radius: 4px;
-    overflow: hidden;
-  }
-  .vc-progress-fill {
-    height: 100%;
-    background: var(--color-accent);
-    transition: width 120ms linear;
   }
   .vc-progress-file {
     margin: 8px 0 0 0;

--- a/src/components/Progress/ProgressBar.svelte
+++ b/src/components/Progress/ProgressBar.svelte
@@ -27,7 +27,7 @@
       <p class="vc-progress-counter" data-testid="progress-counter">
         {formatCount($progressStore.current)} / {formatCount($progressStore.total)}
       </p>
-      <div class="vc-progress-track" role="progressbar"
+      <div role="progressbar"
            aria-valuemin="0"
            aria-valuemax={$progressStore.total}
            aria-valuenow={$progressStore.current}>
@@ -72,13 +72,6 @@
     font-size: 12px;
     color: var(--color-text-muted);
     text-align: right;
-  }
-  /* The progressbar wrapper retains its semantic role + aria-valuemin/max/now;
-     the visual bar inside is now the AsciiProgressBar component. The old
-     coloured div + transition are intentionally gone \u2014 the ASCII pulse on
-     the filled run is the new motion language. */
-  .vc-progress-track {
-    width: 100%;
   }
   .vc-progress-file {
     margin: 8px 0 0 0;

--- a/src/components/Progress/__tests__/ProgressBar.test.ts
+++ b/src/components/Progress/__tests__/ProgressBar.test.ts
@@ -1,0 +1,67 @@
+// Issue #358 PR A — ProgressBar refactor.
+// The bar-chart fill is replaced by an AsciiProgressBar. The wrapping
+// progressbar role + aria-valuemin/max/now must remain on a non-aria-hidden
+// element. The data-testid="progress-fill" stays in DOM so existing
+// integration assertions keep working.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+
+import ProgressBar from "../ProgressBar.svelte";
+import { progressStore } from "../../../store/progressStore";
+
+describe("ProgressBar ASCII refactor (#358)", () => {
+  beforeEach(() => {
+    progressStore.reset();
+  });
+
+  it("does not render when progressStore.active is false", () => {
+    const { container } = render(ProgressBar);
+    expect(container.querySelector('[data-testid="progress-overlay"]')).toBeNull();
+  });
+
+  it("renders the AsciiProgressBar when progressStore.active is true", () => {
+    progressStore.start(100);
+    progressStore.update(25, 100, "/notes/foo.md");
+    const { container } = render(ProgressBar);
+    expect(container.querySelector('[data-testid="progress-overlay"]')).toBeTruthy();
+    expect(container.querySelector(".vc-ascii-pb")).toBeTruthy();
+  });
+
+  it("preserves the data-testid=\"progress-fill\" hook on the ASCII bar root", () => {
+    progressStore.start(100);
+    progressStore.update(40, 100, "/notes/foo.md");
+    const { container } = render(ProgressBar);
+    const fill = container.querySelector('[data-testid="progress-fill"]');
+    expect(fill).toBeTruthy();
+    // The hook should live on the AsciiProgressBar host so old WDIO
+    // selectors keep resolving.
+    expect(fill!.classList.contains("vc-ascii-pb")).toBe(true);
+  });
+
+  it("keeps role=progressbar + aria-valuenow/min/max on a non-aria-hidden element", () => {
+    progressStore.start(100);
+    progressStore.update(40, 100, "/notes/foo.md");
+    const { container } = render(ProgressBar);
+    const pb = container.querySelector('[role="progressbar"]')!;
+    expect(pb).toBeTruthy();
+    // The progressbar element itself must not be hidden from AT.
+    expect(pb.getAttribute("aria-hidden")).not.toBe("true");
+    expect(pb.getAttribute("aria-valuemin")).toBe("0");
+    expect(pb.getAttribute("aria-valuemax")).toBe("100");
+    expect(pb.getAttribute("aria-valuenow")).toBe("40");
+  });
+
+  it("the filled cell count reflects the current/total ratio", () => {
+    progressStore.start(100);
+    progressStore.update(50, 100, "/notes/foo.md");
+    const { container } = render(ProgressBar);
+    const filled = container.querySelector(".vc-ascii-pb-filled")!.textContent ?? "";
+    const empty = container.querySelector(".vc-ascii-pb-empty")!.textContent ?? "";
+    // The total cell count should equal the filled+empty length and the
+    // filled count should be ~half (rounding tolerated).
+    const total = filled.length + empty.length;
+    expect(total).toBeGreaterThan(0);
+    expect(Math.abs(filled.length - total / 2)).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/components/Search/OmniSearch.svelte
+++ b/src/components/Search/OmniSearch.svelte
@@ -439,7 +439,13 @@
 
       {#if statusText}
         <p class="vc-omni-status" role="status" aria-live="polite">
-          <AsciiSpinner />
+          {#if !rebuildError}
+            <!-- Spinner only animates while a rebuild is actively in
+                 flight. In the error state the same <p> shows the
+                 failure copy + retry link, so spinning would imply
+                 progress where there is none. -->
+            <AsciiSpinner />
+          {/if}
           {statusText}
           {#if rebuildError}
             <!-- svelte-ignore a11y_invalid_attribute -->

--- a/src/components/Search/OmniSearch.svelte
+++ b/src/components/Search/OmniSearch.svelte
@@ -30,6 +30,11 @@
   import { extractSnippetMatch } from "../Editor/flashHighlight";
   import QuickSwitcherRow from "./QuickSwitcherRow.svelte";
   import SearchResultRow from "./SearchResultRow.svelte";
+  // #358 — ASCII spinner used inside the rebuild-status line. The German
+  // user-facing strings in this file ("Index wird neu aufgebaut…",
+  // "Keine Treffer", "Erneut versuchen", etc.) are intentionally left in
+  // place; translation is tracked outside #358.
+  import AsciiSpinner from "../ascii/AsciiSpinner.svelte";
   import {
     computeRecentFiles,
     recentsSignature,
@@ -434,6 +439,7 @@
 
       {#if statusText}
         <p class="vc-omni-status" role="status" aria-live="polite">
+          <AsciiSpinner />
           {statusText}
           {#if rebuildError}
             <!-- svelte-ignore a11y_invalid_attribute -->

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -166,6 +166,38 @@ describe("OmniSearch (#174)", () => {
     expect(container.querySelector(".vc-search-rebuild-btn")).toBeNull();
   });
 
+  // ── #358 — ASCII spinner inside the rebuild status line ────────────
+  // The spinner must live INSIDE the {#if statusText} block (Socrates v1
+  // s6). When neither rebuilding nor erroring, no status line and no
+  // spinner exist anywhere in the modal.
+
+  it("#358 renders an AsciiSpinner inside the rebuild status line while rebuilding", async () => {
+    (rebuildIndex as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {}),
+    );
+    searchStore.setIndexStale(true);
+    const { container } = mountOpen({ initialMode: "filename" });
+    await tick();
+    await Promise.resolve();
+
+    const status = container.querySelector(".vc-omni-status");
+    expect(status).toBeTruthy();
+    const spinnerInStatus = status!.querySelector(".vc-ascii-spinner");
+    expect(spinnerInStatus).toBeTruthy();
+  });
+
+  it("#358 does not render an AsciiSpinner when the index is fresh (no rebuild, no error)", async () => {
+    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    // indexStale starts false; rebuildError starts false.
+    const { container } = mountOpen({ initialMode: "filename" });
+    await tick();
+    await Promise.resolve();
+
+    expect(container.querySelector(".vc-omni-status")).toBeNull();
+    // And no stray spinner outside the conditional.
+    expect(container.querySelector(".vc-ascii-spinner")).toBeNull();
+  });
+
   it("clears the rebuild status line on success and flips indexStale off", async () => {
     (rebuildIndex as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -198,6 +198,30 @@ describe("OmniSearch (#174)", () => {
     expect(container.querySelector(".vc-ascii-spinner")).toBeNull();
   });
 
+  // Aristotle PR-A review — the spinner used to render unconditionally
+  // inside {#if statusText}, but statusText is non-empty in BOTH the
+  // rebuilding and the error states. Spinning while showing the
+  // failure message is wrong; the spinner must hide when rebuildError
+  // is true.
+  it("#358 does NOT render an AsciiSpinner inside the error status line (still shows error text)", async () => {
+    (rebuildIndex as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("boom"),
+    );
+    searchStore.setIndexStale(true);
+    const { container } = mountOpen({ initialMode: "filename" });
+    await tick();
+    await Promise.resolve();
+    await Promise.resolve();
+    await tick();
+
+    const status = container.querySelector(".vc-omni-status");
+    expect(status).toBeTruthy();
+    expect(status!.textContent).toMatch(/fehlgeschlagen/i);
+    // No spinner in the error state — only the rebuilding state should
+    // have one.
+    expect(status!.querySelector(".vc-ascii-spinner")).toBeNull();
+  });
+
   it("clears the rebuild status line on success and flips indexStale off", async () => {
     (rebuildIndex as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);

--- a/src/components/ascii/AsciiProgressBar.svelte
+++ b/src/components/ascii/AsciiProgressBar.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  // #358 — Decorative progress bar built from `█`/`░` glyphs. The host
+  // span is aria-hidden; the surrounding container in the caller owns
+  // role="progressbar" + aria-valuemin/max/now. The filled run pulses
+  // via CSS only; the empty run never animates.
+
+  interface Props {
+    value: number;
+    max: number;
+    width?: number;
+    /** Optional data-testid forwarded onto the host span so callers can
+        migrate existing test selectors without wrapping the component. */
+    testid?: string | undefined;
+  }
+
+  let { value, max, width = 24, testid = undefined }: Props = $props();
+
+  const ratio = $derived(max > 0 ? Math.min(1, Math.max(0, value / max)) : 0);
+  const filled = $derived(Math.round(ratio * width));
+  const empty = $derived(width - filled);
+  const filledStr = $derived("█".repeat(filled));
+  const emptyStr = $derived("░".repeat(empty));
+</script>
+
+<span class="vc-ascii-pb" aria-hidden="true" data-testid={testid}><!--
+  --><span class="vc-ascii-pb-filled">{filledStr}</span><!--
+  --><span class="vc-ascii-pb-empty">{emptyStr}</span><!--
+--></span>
+
+<style>
+  .vc-ascii-pb {
+    font-family: var(--vc-font-mono);
+    color: var(--color-text-muted);
+    letter-spacing: 0;
+    white-space: pre;
+  }
+  .vc-ascii-pb-filled {
+    animation: vc-ascii-pb-pulse 1400ms ease-in-out infinite;
+  }
+  /* Pulse is opacity-only on the filled run; ░ stays at full muted opacity. */
+  @keyframes vc-ascii-pb-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.55; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .vc-ascii-pb-filled { animation: none; opacity: 1; }
+  }
+</style>

--- a/src/components/ascii/AsciiSpinner.svelte
+++ b/src/components/ascii/AsciiSpinner.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  // #358 — Decorative single-glyph spinner. The art is aria-hidden; the
+  // surrounding container owns the meaningful aria-label / role. Frame
+  // rotation is driven entirely by CSS @keyframes on a ::before pseudo;
+  // there is no JS timer (no setInterval, setTimeout, or RAF tick).
+  // No props — every current call site uses the default. Re-introduce
+  // props only when a future caller justifies one.
+</script>
+
+<span class="vc-ascii-spinner" aria-hidden="true">─</span>
+
+<style>
+  /* The host span is invisible (visibility hidden) so only ::before
+     paints. width:1ch keeps the layout box stable across frames. */
+  .vc-ascii-spinner {
+    display: inline-block;
+    font-family: var(--vc-font-mono);
+    color: var(--color-text-muted);
+    line-height: 1;
+    width: 1ch;
+    text-align: center;
+    visibility: hidden;
+    position: relative;
+  }
+  .vc-ascii-spinner::before {
+    visibility: visible;
+    position: absolute;
+    inset: 0;
+    content: "─";
+    animation: vc-ascii-spin-frames 800ms steps(4, end) infinite;
+  }
+  /* Box-drawing diagonals only — never ASCII slashes. The U+2572 (╲)
+     and U+2571 (╱) glyphs are intentional; do not regress. */
+  @keyframes vc-ascii-spin-frames {
+    0%   { content: "─"; }
+    25%  { content: "╲"; }
+    50%  { content: "│"; }
+    75%  { content: "╱"; }
+    100% { content: "─"; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .vc-ascii-spinner::before {
+      animation: none;
+      content: "─";
+    }
+  }
+</style>

--- a/src/components/ascii/__tests__/AsciiProgressBar.test.ts
+++ b/src/components/ascii/__tests__/AsciiProgressBar.test.ts
@@ -1,0 +1,117 @@
+// Issue #358 PR A — primitives layer.
+// AsciiProgressBar renders `█`-filled cells over `░`-empty cells. Tests
+// codify §1.2 of the plan + Socrates v1 must-fixes/should-fixes:
+//   - exact filled/empty cell counts at boundary inputs
+//   - clamps negative/over-range values
+//   - max=0 does not divide by zero
+//   - aria-hidden on the host span
+//   - no JS timers
+//   - no text node injected between filled and empty spans (whitespace
+//     fragility under autoformatters)
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/svelte";
+
+import AsciiProgressBar from "../AsciiProgressBar.svelte";
+
+function filledOf(container: HTMLElement): string {
+  return container.querySelector(".vc-ascii-pb-filled")?.textContent ?? "";
+}
+function emptyOf(container: HTMLElement): string {
+  return container.querySelector(".vc-ascii-pb-empty")?.textContent ?? "";
+}
+
+describe("AsciiProgressBar (#358)", () => {
+  let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setIntervalSpy = vi.spyOn(window, "setInterval");
+  });
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+  });
+
+  it("value=0/max=100/width=10 renders all empty", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: 0, max: 100, width: 10 },
+    });
+    expect(filledOf(container)).toBe("");
+    expect(emptyOf(container)).toBe("░".repeat(10));
+  });
+
+  it("value=50/max=100/width=10 renders 5 filled + 5 empty", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: 50, max: 100, width: 10 },
+    });
+    expect(filledOf(container)).toBe("█".repeat(5));
+    expect(emptyOf(container)).toBe("░".repeat(5));
+  });
+
+  it("value=100/max=100/width=10 renders all filled", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: 100, max: 100, width: 10 },
+    });
+    expect(filledOf(container)).toBe("█".repeat(10));
+    expect(emptyOf(container)).toBe("");
+  });
+
+  it("clamps negative values to 0", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: -5, max: 100, width: 10 },
+    });
+    expect(filledOf(container)).toBe("");
+    expect(emptyOf(container)).toBe("░".repeat(10));
+  });
+
+  it("clamps over-range values to max", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: 200, max: 100, width: 10 },
+    });
+    expect(filledOf(container)).toBe("█".repeat(10));
+    expect(emptyOf(container)).toBe("");
+  });
+
+  it("max=0 renders all empty (no division-by-zero NaN)", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: 50, max: 0, width: 10 },
+    });
+    expect(filledOf(container)).toBe("");
+    expect(emptyOf(container)).toBe("░".repeat(10));
+  });
+
+  it("host carries aria-hidden=true", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: 25, max: 100, width: 10 },
+    });
+    const host = container.querySelector(".vc-ascii-pb")!;
+    expect(host.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not invoke setInterval on mount", () => {
+    render(AsciiProgressBar, { props: { value: 25, max: 100, width: 10 } });
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it("filled and empty spans are direct siblings with no intervening text node", () => {
+    const { container } = render(AsciiProgressBar, {
+      props: { value: 25, max: 100, width: 10 },
+    });
+    const host = container.querySelector(".vc-ascii-pb")!;
+    // Walk the children list — every node between the filled and empty
+    // <span>s must be a Comment, never a Text node. A Text node here
+    // would render as an extra glyph and break the bar.
+    const children = Array.from(host.childNodes);
+    const filledIdx = children.findIndex(
+      (n) => n.nodeType === 1 && (n as HTMLElement).classList.contains("vc-ascii-pb-filled"),
+    );
+    const emptyIdx = children.findIndex(
+      (n) => n.nodeType === 1 && (n as HTMLElement).classList.contains("vc-ascii-pb-empty"),
+    );
+    expect(filledIdx).toBeGreaterThanOrEqual(0);
+    expect(emptyIdx).toBeGreaterThan(filledIdx);
+    for (let i = filledIdx + 1; i < emptyIdx; i++) {
+      const between = children[i]!;
+      expect(between.nodeType).not.toBe(Node.TEXT_NODE);
+    }
+  });
+});

--- a/src/components/ascii/__tests__/AsciiSpinner.test.ts
+++ b/src/components/ascii/__tests__/AsciiSpinner.test.ts
@@ -56,19 +56,16 @@ describe("AsciiSpinner (#358)", () => {
     expect(src).toContain("╱");
   });
 
-  it("source does not use ASCII slashes (\\ U+005C, / U+002F) inside keyframe content", () => {
+  it("source uses no ASCII slashes (\\ U+005C, / U+002F) in any CSS `content:` declaration", () => {
     const src = readFileSync(SOURCE_PATH, "utf8");
-    // Extract the @keyframes block(s) and assert no ASCII slash content
-    // values appear there. ASCII `/` is allowed elsewhere (e.g. JSDoc,
-    // closing tags) but never as a spinner frame.
-    const keyframesMatch = src.match(/@keyframes[^{]+\{[\s\S]*?\n\s*\}/g);
-    expect(keyframesMatch).toBeTruthy();
-    for (const block of keyframesMatch!) {
-      // Look for `content: "..."` payloads inside the keyframes.
-      const contents = block.match(/content:\s*"([^"]*)"/g) ?? [];
-      for (const c of contents) {
-        expect(c).not.toMatch(/[\\/]/);
-      }
+    // Aristotle PR-A review — scan ALL `content:` declarations in the
+    // file (not just inside @keyframes), including the @media
+    // (prefers-reduced-motion) fallback. Any ASCII slash here would be
+    // a regression of the box-drawing-only palette constraint.
+    const declarations = src.match(/content:\s*"([^"]*)"/g) ?? [];
+    expect(declarations.length).toBeGreaterThan(0);
+    for (const decl of declarations) {
+      expect(decl).not.toMatch(/[\\/]/);
     }
   });
 

--- a/src/components/ascii/__tests__/AsciiSpinner.test.ts
+++ b/src/components/ascii/__tests__/AsciiSpinner.test.ts
@@ -1,0 +1,81 @@
+// Issue #358 PR A — primitives layer.
+// AsciiSpinner is a decorative single-glyph spinner. Tests codify the
+// constraints from the plan §0 hard constraints + Socrates v1 must-fixes:
+//   - aria-hidden on the visible art (parent owns the meaningful label)
+//   - frame set is box-drawing only (no ASCII slashes)
+//   - no JS timers (no setInterval / setTimeout)
+//   - no props (Socrates v1 nh-11 — `size` removed)
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import AsciiSpinner from "../AsciiSpinner.svelte";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SOURCE_PATH = resolve(HERE, "../AsciiSpinner.svelte");
+
+describe("AsciiSpinner (#358)", () => {
+  let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+  let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setIntervalSpy = vi.spyOn(window, "setInterval");
+    setTimeoutSpy = vi.spyOn(window, "setTimeout");
+  });
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("renders one <span> with class vc-ascii-spinner", () => {
+    const { container } = render(AsciiSpinner);
+    const span = container.querySelector("span.vc-ascii-spinner");
+    expect(span).toBeTruthy();
+    expect(span!.tagName).toBe("SPAN");
+  });
+
+  it("the rendered span carries aria-hidden=true", () => {
+    const { container } = render(AsciiSpinner);
+    const span = container.querySelector("span.vc-ascii-spinner")!;
+    expect(span.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not invoke any JS timer on mount", () => {
+    render(AsciiSpinner);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("source contains box-drawing diagonals U+2572 (╲) and U+2571 (╱)", () => {
+    const src = readFileSync(SOURCE_PATH, "utf8");
+    expect(src).toContain("╲");
+    expect(src).toContain("╱");
+  });
+
+  it("source does not use ASCII slashes (\\ U+005C, / U+002F) inside keyframe content", () => {
+    const src = readFileSync(SOURCE_PATH, "utf8");
+    // Extract the @keyframes block(s) and assert no ASCII slash content
+    // values appear there. ASCII `/` is allowed elsewhere (e.g. JSDoc,
+    // closing tags) but never as a spinner frame.
+    const keyframesMatch = src.match(/@keyframes[^{]+\{[\s\S]*?\n\s*\}/g);
+    expect(keyframesMatch).toBeTruthy();
+    for (const block of keyframesMatch!) {
+      // Look for `content: "..."` payloads inside the keyframes.
+      const contents = block.match(/content:\s*"([^"]*)"/g) ?? [];
+      for (const c of contents) {
+        expect(c).not.toMatch(/[\\/]/);
+      }
+    }
+  });
+
+  it("accepts no props (regression guard for the removed `size` prop)", () => {
+    // If AsciiSpinner takes any required props, render() with no props
+    // would throw or warn. Mounting clean is the contract.
+    const { container } = render(AsciiSpinner);
+    expect(container.querySelector("span.vc-ascii-spinner")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

PR A of 4 for issue #358 (ASCII-art aesthetic pass).

- Adds the ASCII primitives layer (`AsciiSpinner`, `AsciiProgressBar`) under `src/components/ascii/`. Both are theme-aware (`--vc-font-mono`, `--color-text-muted`), `aria-hidden`, and animation runs purely via CSS `@keyframes` (no JS timer).
- Wires `AsciiProgressBar` into the vault-indexing overlay (`src/components/Progress/ProgressBar.svelte`). The wrapping `[role=progressbar]` keeps `aria-valuemin/max/now`; the existing `data-testid="progress-fill"` migrates onto the ASCII bar host so existing assertions continue to resolve.
- Wires `AsciiSpinner` into the OmniSearch rebuild status line, inside the existing `{#if statusText}` block at `src/components/Search/OmniSearch.svelte:435`. No spinner renders when the index is fresh.

## Rationale

Issue #358 calls for a terminal-adjacent aesthetic that reads as "tool, not toy". This PR sets up the small, reusable primitives the rest of the cut depends on, and applies them to the two highest-visibility loading states (initial vault indexing, search rebuild). Subsequent PRs (B/C/D) layer the sidebar spinner, welcome wordmark, status-bar accent, editor empty-state, skeletons, and graph spinner on top.

Hard constraints from Plan v2 / Vitruvius / Socrates that this PR locks in:

- Glyph palette: box-drawing only (`─ │ ╲ ╱` for spinner, `█ ░` for bar). No ASCII slashes — diagonals are U+2572 / U+2571.
- Spinner animates `content` of a `::before` pseudo via `steps(4, end)` over 800 ms; reduced-motion locks to `─`.
- Progress bar pulse animates opacity on the filled run only; empty `░` cells never pulse.
- Existing ARIA on the progress overlay and the OmniSearch status `<p>` is preserved on the same DOM element it lived on; ASCII art carries `aria-hidden="true"`.
- German strings in `OmniSearch.svelte` are intentionally untouched (translation tracked outside #358).

## Test plan

- [x] `pnpm vitest run src/components/ascii src/components/Progress src/components/Search/__tests__/OmniSearch.test.ts` — 40 tests pass, including new regression guards for: no ASCII slashes in spinner keyframes, no JS timers, no text node between progress-bar filled/empty spans, spinner only renders inside the rebuild status line.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm vite build` — clean.
- [ ] Manual visual smoke (Tauri dev): open a vault to trigger indexing, confirm the ASCII bar pulses; trigger a search rebuild, confirm the spinner cycles through `─ ╲ │ ╱`. (Cannot run a desktop Tauri build from this agent shell — flagged for human UAT.)

Plan: `.plans/issue-358-plan.md`.

Closes part of #358.