### PR TITLE
feat(ascii): welcome wordmark + statusbar accent + editor empty-state (#358)

### DIFF
--- a/e2e/specs/ascii-aesthetic.spec.ts
+++ b/e2e/specs/ascii-aesthetic.spec.ts
@@ -51,14 +51,22 @@ describe("ASCII aesthetic smoke (#358)", () => {
 
     // The encryption pill may not exist if no encrypted folder is in
     // the vault — only run the geometry check when both elements are
-    // displayed.
-    const pill = await browser.$(".vc-encryption-statusbar");
+    // displayed. Class is `.vc-encrypt-bar` (the
+    // EncryptionStatusbar.svelte source); a previous selector
+    // `.vc-encryption-statusbar` silently skipped the assertion.
+    const pill = await browser.$(".vc-encrypt-bar");
     if (await pill.isExisting()) {
       const pillBox = await pill.getLocation();
       const pillSize = await pill.getSize();
+      // Both elements must have non-zero height so the geometry check
+      // is meaningful — a 0×0 element trivially "doesn't overlap".
+      expect(accentSize.height).toBeGreaterThan(0);
+      expect(pillSize.height).toBeGreaterThan(0);
       const accentBottom = accentBox.y + accentSize.height;
-      const pillTop = pillBox.y;
-      expect(accentBottom <= pillTop || pillBox.y + pillSize.height <= accentBox.y).toBe(true);
+      const pillBottom = pillBox.y + pillSize.height;
+      // No vertical overlap: either accent ends above pill, or pill
+      // ends above accent.
+      expect(accentBottom <= pillBox.y || pillBottom <= accentBox.y).toBe(true);
     }
   });
 

--- a/e2e/specs/ascii-aesthetic.spec.ts
+++ b/e2e/specs/ascii-aesthetic.spec.ts
@@ -51,9 +51,7 @@ describe("ASCII aesthetic smoke (#358)", () => {
 
     // The encryption pill may not exist if no encrypted folder is in
     // the vault — only run the geometry check when both elements are
-    // displayed. Class is `.vc-encrypt-bar` (the
-    // EncryptionStatusbar.svelte source); a previous selector
-    // `.vc-encryption-statusbar` silently skipped the assertion.
+    // displayed.
     const pill = await browser.$(".vc-encrypt-bar");
     if (await pill.isExisting()) {
       const pillBox = await pill.getLocation();

--- a/e2e/specs/ascii-aesthetic.spec.ts
+++ b/e2e/specs/ascii-aesthetic.spec.ts
@@ -1,0 +1,73 @@
+// Issue #358 — ASCII aesthetic smoke. Three assertions, no spinner
+// timing checks (Vitest covers correctness; WDIO covers cross-platform
+// rendering smoke).
+//
+// 1. Welcome screen shows the ASCII wordmark <pre>.
+// 2. With a loaded vault, the permanent statusbar accent is mounted and
+//    its bounding box does not overlap the encryption pill.
+// 3. With an empty editor pane, the ASCII vault-door <pre> is visible.
+
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+
+describe("ASCII aesthetic smoke (#358)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  it("welcome screen renders the ASCII wordmark", async () => {
+    // Drop back to the welcome screen.
+    await browser.execute(() => {
+      void window.__e2e__!.closeVault();
+    });
+
+    const screen = await browser.$('[data-testid="welcome-screen"]');
+    await screen.waitForDisplayed({ timeout: 3000 });
+
+    const wordmark = await browser.$("pre.vc-welcome-wordmark");
+    await wordmark.waitForDisplayed({ timeout: 2000 });
+    const text = await wordmark.getText();
+    expect(text).toContain("V A U L T C O R E");
+
+    // Re-open the vault for downstream assertions.
+    await openVaultInApp(vault.path);
+  });
+
+  it("statusbar accent is mounted and does not overlap the encryption pill", async () => {
+    const sidebar = await browser.$('[data-testid="sidebar"]');
+    await sidebar.waitForDisplayed({ timeout: 5000 });
+
+    const accent = await browser.$(".vc-statusbar-accent");
+    await accent.waitForExist({ timeout: 2000 });
+    const accentBox = await accent.getLocation();
+    const accentSize = await accent.getSize();
+
+    // The encryption pill may not exist if no encrypted folder is in
+    // the vault — only run the geometry check when both elements are
+    // displayed.
+    const pill = await browser.$(".vc-encryption-statusbar");
+    if (await pill.isExisting()) {
+      const pillBox = await pill.getLocation();
+      const pillSize = await pill.getSize();
+      const accentBottom = accentBox.y + accentSize.height;
+      const pillTop = pillBox.y;
+      expect(accentBottom <= pillTop || pillBox.y + pillSize.height <= accentBox.y).toBe(true);
+    }
+  });
+
+  it("editor empty state renders the ASCII vault door", async () => {
+    // No tabs open in a fresh vault → empty state shows.
+    const door = await browser.$("pre.vc-editor-empty-door");
+    await door.waitForDisplayed({ timeout: 3000 });
+    const text = await door.getText();
+    expect(text).toContain("┌");
+    expect(text).toContain("└");
+  });
+});

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -40,6 +40,12 @@
   import { decideExternalModifyAction, sha256Hex } from "./externalChangeHandler";
   import { listenFileChange, listenVaultStatus, type FileChangePayload } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
+  import { formatShortcut } from "../../lib/shortcuts";
+
+  // #358 — open-file shortcut for the empty-state legend. The Quick
+  // Switcher (defaultCommands.ts) is bound to meta+O; formatShortcut
+  // resolves to "⌘+O" on macOS and "Ctrl+O" elsewhere.
+  const emptyOpenShortcut = formatShortcut({ meta: true, key: "O" });
 
   let {
     paneId,
@@ -923,8 +929,17 @@
   <div class="vc-editor-content" class:has-graph-bg={showGraphBg}>
     {#if paneTabs.length === 0}
       <div class="vc-editor-empty">
-        <p class="vc-editor-empty-heading">No file open</p>
-        <p class="vc-editor-empty-body">Select a file from the sidebar to get started.</p>
+        <h2 class="vc-sr-only">No file open — press {emptyOpenShortcut} to open a file</h2>
+        <pre class="vc-editor-empty-door" aria-hidden="true">{`┌────────────┐
+│  ┌──────┐  │
+│  │  ░░  │  │
+│  │  ░░  │  │
+│  │  ▒▒  │  │
+│  └──────┘  │
+└────────────┘`}</pre>
+        <pre class="vc-editor-empty-legend">{`[ ] = open file   {${emptyOpenShortcut}}
+ ░  = locked
+ ▒  = sealed`}</pre>
       </div>
     {/if}
     <!-- #87: ambient local-graph background behind the editor in edit mode -->
@@ -1066,17 +1081,28 @@
     pointer-events: none;
   }
 
-  .vc-editor-empty-heading {
+  /* #358 — empty-state ASCII vault door (decorative, aria-hidden) plus
+     the symbol-key legend (meaningful). Both share --vc-font-mono;
+     the door uses --color-text-muted, the legend uses --color-text so
+     the keybind reads first against the door's softer outline. */
+  .vc-editor-empty-door {
     margin: 0;
+    padding: 0;
+    font-family: var(--vc-font-mono);
     font-size: 14px;
-    font-weight: 700;
+    line-height: 1.2;
+    color: var(--color-text-muted);
+    white-space: pre;
   }
 
-  .vc-editor-empty-body {
+  .vc-editor-empty-legend {
     margin: 0;
-    font-size: 14px;
-    text-align: center;
-    max-width: 280px;
+    padding: 0;
+    font-family: var(--vc-font-mono);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-text);
+    white-space: pre;
   }
 
   .vc-editor-readonly-overlay {

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -42,9 +42,11 @@
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import { formatShortcut } from "../../lib/shortcuts";
 
-  // #358 — open-file shortcut for the empty-state legend. The Quick
-  // Switcher (defaultCommands.ts) is bound to meta+O; formatShortcut
-  // resolves to "⌘+O" on macOS and "Ctrl+O" elsewhere.
+  // #358 — open-file shortcut for the empty-state legend.
+  // formatShortcut resolves to "⌘+O" on macOS and "Ctrl+O" elsewhere.
+  // The bound key in defaultCommands.ts is lowercase "o"; formatShortcut
+  // uppercases the displayed glyph, so passing "O" here matches the
+  // displayed label and is what the helper expects.
   const emptyOpenShortcut = formatShortcut({ meta: true, key: "O" });
 
   let {

--- a/src/components/Editor/__tests__/editorEmpty.test.ts
+++ b/src/components/Editor/__tests__/editorEmpty.test.ts
@@ -1,0 +1,112 @@
+// Issue #358 PR C — editor empty state replaces the prose copy with an
+// ASCII vault-door diagram (decorative, aria-hidden) plus a symbol-key
+// legend (meaningful, NOT aria-hidden) and a visually-hidden <h2>
+// summary so screen readers continue to announce "No file open" with
+// the platform-aware open-file shortcut.
+//
+// Heavy IPC and graph deps are mocked so EditorPane mounts cleanly in
+// jsdom — only the empty-state branch is exercised.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile: vi.fn().mockResolvedValue(""),
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  createFile: vi.fn().mockResolvedValue(""),
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+// Sidestep the sigma / WebGL import tree for the graph view.
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  // @ts-ignore
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+vi.mock("../../Graph/graphRender", () => ({
+  mountGraph: vi.fn(),
+  updateGraph: vi.fn(),
+  destroyGraph: vi.fn(),
+  DEFAULT_FORCE_SETTINGS: {},
+}));
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import EditorPane from "../EditorPane.svelte";
+
+describe("EditorPane empty state — ASCII vault door + legend (#358)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({ currentPath: "/vault", fileList: [], fileCount: 0 });
+  });
+
+  it("renders the vault-door <pre> with aria-hidden=true", async () => {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const door = container.querySelector("pre.vc-editor-empty-door");
+    expect(door).toBeTruthy();
+    expect(door!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("renders a legend block that is NOT aria-hidden (it's meaningful)", async () => {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const legend = container.querySelector(".vc-editor-empty-legend");
+    expect(legend).toBeTruthy();
+    expect(legend!.getAttribute("aria-hidden")).not.toBe("true");
+    const text = legend!.textContent ?? "";
+    expect(text).toContain("[ ]");
+    expect(text).toContain("░");
+    expect(text).toContain("▒");
+  });
+
+  it("renders a visually-hidden <h2> summary mentioning 'No file open'", async () => {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const h2 = container.querySelector("h2.vc-sr-only");
+    expect(h2).toBeTruthy();
+    expect(h2!.textContent).toMatch(/No file open/i);
+  });
+
+  it("does not render the legacy 'Select a file from the sidebar to get started.' copy", async () => {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const text = container.textContent ?? "";
+    expect(text).not.toMatch(/Select a file from the sidebar to get started/);
+  });
+
+  it("the legend mentions the open-file shortcut (⌘ on macOS or Ctrl elsewhere)", async () => {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    const legend = container.querySelector(".vc-editor-empty-legend")!;
+    const text = legend.textContent ?? "";
+    expect(text).toMatch(/[⌘]|Ctrl/);
+    expect(text).toMatch(/O/);
+  });
+});

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -947,6 +947,15 @@
   />
 {/if}
 
+<!-- #358 — permanent ASCII status-bar accent. Lives at the absolute end
+     of the layout (after the modal {#if} blocks) so it is always
+     mounted, never inside a conditional. Decorative; pointer-events:none
+     so it never steals clicks from the editor or the encryption pill. -->
+<footer class="vc-statusbar-accent" aria-hidden="true">
+  <span class="vc-statusbar-rule">┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄</span>
+  <span class="vc-statusbar-badge">[VaultCore]</span>
+</footer>
+
 <style>
   .vc-vault-layout {
     display: grid;
@@ -956,11 +965,45 @@
       1fr
       auto
       var(--right-sidebar-width, 0px);
-    height: 100vh;
+    /* #358 — leave 18 px clear at the bottom for the permanent
+       statusbar-accent footer so the last editor line never sits under
+       it. The footer's `position: fixed; bottom: 0; height: 18px` is
+       the source of truth; if you change the height, change this too. */
+    height: calc(100vh - 18px);
     background: var(--color-bg);
     overflow: hidden;
     transition: grid-template-columns 200ms ease;
   }
+
+  /* #358 — htop-style decorative accent. Permanent chrome, never
+     conditional. z-index 10 sits below the encryption pill (z-index 40)
+     so the live-status pill floats visually above the static accent;
+     well below modals (100) and toasts. */
+  .vc-statusbar-accent {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 8px;
+    font-family: var(--vc-font-mono);
+    font-size: 11px;
+    color: var(--color-text-muted);
+    pointer-events: none;
+    z-index: 10;
+    user-select: none;
+    background: var(--color-bg);
+  }
+  .vc-statusbar-rule {
+    flex: 1 1 auto;
+    overflow: hidden;
+    white-space: nowrap;
+    letter-spacing: 0;
+  }
+  .vc-statusbar-badge { flex: 0 0 auto; padding-left: 8px; }
 
   .vc-vault-layout--dragging {
     cursor: col-resize;

--- a/src/components/Welcome/WelcomeScreen.svelte
+++ b/src/components/Welcome/WelcomeScreen.svelte
@@ -15,7 +15,10 @@
 
 <main class="vc-welcome" data-testid="welcome-screen">
   <div class="vc-welcome-card">
-    <h1 class="vc-welcome-heading">VaultCore</h1>
+    <h1 class="vc-sr-only">VaultCore</h1>
+    <pre class="vc-welcome-wordmark" aria-hidden="true">{`┌──────────────────────────────────────────────────┐
+│  V A U L T C O R E                               │
+└──────────────────────────────────────────────────┘`}</pre>
     <p class="vc-welcome-tagline">A faster Markdown workspace for large vaults.</p>
 
     <button
@@ -65,12 +68,20 @@
     border-radius: 8px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   }
-  .vc-welcome-heading {
-    margin: 0 0 8px 0;
-    font-size: 20px;
-    font-weight: 700;
+  /* #358 — ASCII wordmark replaces the visible <h1>. The h1 itself is
+     kept in the DOM via .vc-sr-only so screen readers still announce
+     "VaultCore". Font is sized down to 12 px so the 52-col art fits
+     inside the 480 px card with its 32 px horizontal padding (Plan §9
+     risk 3 mitigation: ~7.2 px/glyph × 52 ≈ 374 px). */
+  .vc-welcome-wordmark {
+    margin: 0 0 16px 0;
+    padding: 0;
+    font-family: var(--vc-font-mono);
+    font-size: 12px;
     line-height: 1.2;
-    color: var(--color-text);
+    color: var(--color-text-muted);
+    white-space: pre;
+    overflow: hidden;
   }
   .vc-welcome-tagline {
     margin: 0 0 32px 0;

--- a/src/components/Welcome/WelcomeScreen.svelte
+++ b/src/components/Welcome/WelcomeScreen.svelte
@@ -81,7 +81,10 @@
     line-height: 1.2;
     color: var(--color-text-muted);
     white-space: pre;
-    overflow: hidden;
+    /* Reveal — not silently clip — any overflow if the user's mono
+       fallback renders wider than JetBrains Mono. `overflow-x: auto`
+       surfaces the visual regression instead of swallowing it. */
+    overflow-x: auto;
   }
   .vc-welcome-tagline {
     margin: 0 0 32px 0;

--- a/src/components/Welcome/__tests__/WelcomeScreen.test.ts
+++ b/src/components/Welcome/__tests__/WelcomeScreen.test.ts
@@ -1,0 +1,55 @@
+// Issue #358 PR C — welcome wordmark.
+// Replaces the visible <h1>VaultCore</h1> with a visually-hidden h1 (so
+// SR users still hear the heading) plus an aria-hidden ASCII wordmark
+// in a <pre>. The existing tagline below stays as the visible body
+// copy. The wordmark is exactly 3 lines (top edge + spaced-letters row
+// + bottom edge); the in-box tagline is intentionally dropped.
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+
+import WelcomeScreen from "../WelcomeScreen.svelte";
+
+function makeProps() {
+  return {
+    recent: [],
+    onOpenVault: () => {},
+    onPickVault: () => {},
+  };
+}
+
+describe("WelcomeScreen ASCII wordmark (#358)", () => {
+  it("keeps an h1 with text 'VaultCore' in the DOM (SR-accessible)", () => {
+    const { container } = render(WelcomeScreen, makeProps());
+    const h1 = container.querySelector("h1");
+    expect(h1).toBeTruthy();
+    expect(h1!.textContent?.trim()).toBe("VaultCore");
+  });
+
+  it("renders the ASCII wordmark in a <pre class=vc-welcome-wordmark> with aria-hidden", () => {
+    const { container } = render(WelcomeScreen, makeProps());
+    const pre = container.querySelector("pre.vc-welcome-wordmark");
+    expect(pre).toBeTruthy();
+    expect(pre!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("the wordmark contains the spaced-letter sequence V A U L T C O R E", () => {
+    const { container } = render(WelcomeScreen, makeProps());
+    const text = container.querySelector("pre.vc-welcome-wordmark")!.textContent ?? "";
+    expect(text).toContain("V A U L T C O R E");
+  });
+
+  it("the wordmark is exactly 3 lines (top edge, wordmark row, bottom edge)", () => {
+    const { container } = render(WelcomeScreen, makeProps());
+    const text = container.querySelector("pre.vc-welcome-wordmark")!.textContent ?? "";
+    const lines = text.split("\n");
+    expect(lines).toHaveLength(3);
+    // The first and last lines are box-drawing edges; assert they
+    // include the corner glyphs so a future regression that swaps
+    // them for a different shape fails fast.
+    expect(lines[0]).toContain("┌");
+    expect(lines[0]).toContain("┐");
+    expect(lines[2]).toContain("└");
+    expect(lines[2]).toContain("┘");
+  });
+});

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -122,6 +122,21 @@ html, body, #app {
   }
 }
 
+/* #358 — visually-hidden helper for screen-reader-only headings/text.
+   Used where the visible chrome is decorative ASCII (e.g. the welcome
+   wordmark) and the meaningful label still needs to reach AT. */
+.vc-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Phase 3 — Sidebar tabs */
 .vc-sidebar-tabs {
   display: flex;

--- a/tests/asciiAestheticSelectors.test.ts
+++ b/tests/asciiAestheticSelectors.test.ts
@@ -1,0 +1,61 @@
+// Issue #358 PR C — guard against silent class-rename drift between the
+// WDIO ASCII-aesthetic smoke spec and the components it queries.
+//
+// Aristotle PR-C round 1 caught a real bug: the spec used
+// `.vc-encryption-statusbar` (which doesn't exist) so the encryption-pill
+// geometry assertion silently never ran. This test reads the spec + the
+// referenced source files and asserts the selectors map onto class names
+// that actually exist. A future rename in either direction will fail
+// fast at unit-test time instead of months later in WDIO.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..");
+const SPEC = readFileSync(
+  resolve(REPO_ROOT, "e2e/specs/ascii-aesthetic.spec.ts"),
+  "utf8",
+);
+const ENCRYPTION_STATUSBAR = readFileSync(
+  resolve(REPO_ROOT, "src/components/Statusbar/EncryptionStatusbar.svelte"),
+  "utf8",
+);
+const WELCOME_SCREEN = readFileSync(
+  resolve(REPO_ROOT, "src/components/Welcome/WelcomeScreen.svelte"),
+  "utf8",
+);
+const VAULT_LAYOUT = readFileSync(
+  resolve(REPO_ROOT, "src/components/Layout/VaultLayout.svelte"),
+  "utf8",
+);
+const EDITOR_PANE = readFileSync(
+  resolve(REPO_ROOT, "src/components/Editor/EditorPane.svelte"),
+  "utf8",
+);
+
+describe("ASCII aesthetic WDIO spec selectors (#358)", () => {
+  it("the encryption-pill selector matches the actual class in EncryptionStatusbar.svelte", () => {
+    // The spec references the pill so the geometry no-overlap check
+    // can run when an encrypted folder exists.
+    expect(SPEC).toContain(".vc-encrypt-bar");
+    expect(SPEC).not.toContain(".vc-encryption-statusbar");
+    // And the class itself is declared in the source file.
+    expect(ENCRYPTION_STATUSBAR).toMatch(/class="vc-encrypt-bar"/);
+  });
+
+  it("the wordmark selector matches WelcomeScreen.svelte", () => {
+    expect(SPEC).toContain("pre.vc-welcome-wordmark");
+    expect(WELCOME_SCREEN).toMatch(/class="vc-welcome-wordmark"/);
+  });
+
+  it("the statusbar accent selector matches VaultLayout.svelte", () => {
+    expect(SPEC).toContain(".vc-statusbar-accent");
+    expect(VAULT_LAYOUT).toMatch(/class="vc-statusbar-accent"/);
+  });
+
+  it("the editor empty-state door selector matches EditorPane.svelte", () => {
+    expect(SPEC).toContain("pre.vc-editor-empty-door");
+    expect(EDITOR_PANE).toMatch(/class="vc-editor-empty-door"/);
+  });
+});


### PR DESCRIPTION
## Summary

PR C of 4 for issue #358 (ASCII-art aesthetic pass). No dependency on PRs A/B — this is a brand/chrome PR.

- **Welcome wordmark**: replaces `<h1 class="vc-welcome-heading">VaultCore</h1>` with a visually-hidden `<h1 class="vc-sr-only">VaultCore</h1>` plus an `aria-hidden` `<pre class="vc-welcome-wordmark">` containing the 3-line spaced-letter wordmark `V A U L T C O R E` inside a box-drawing frame. The existing `.vc-welcome-tagline` `<p>` below stays as the only tagline.
- **Status-bar accent**: new permanent `<footer class="vc-statusbar-accent">` mounted at the absolute end of `VaultLayout.svelte` (after the final `{/if}` at line 948 — outside any modal conditional). Renders a dashed `┄` rule across the bottom plus a `[VaultCore]` badge. `position: fixed; bottom: 0; height: 18px; pointer-events: none; z-index: 10`.
- **Layout clearance**: `.vc-vault-layout` height changes from `100vh` to `calc(100vh - 18px)` so the editor never sits under the new permanent footer.
- **Editor empty state**: replaces the `No file open` heading + body prose with an `aria-hidden` ASCII vault-door `<pre>` and a meaningful symbol-key legend (`[ ] = open file   {⌘+O}`, ` ░  = locked`, ` ▒  = sealed`). The shortcut glyph is platform-aware via `formatShortcut({ meta: true, key: "O" })` from `src/lib/shortcuts.ts` — `⌘+O` on macOS, `Ctrl+O` elsewhere. A visually-hidden `<h2 class="vc-sr-only">No file open — press {shortcut} to open a file</h2>` preserves the SR-meaningful summary.
- **New utility**: `.vc-sr-only` added to `src/styles/tailwind.css` (standard visually-hidden technique).
- **WDIO smoke**: new `e2e/specs/ascii-aesthetic.spec.ts` with 3 assertions — wordmark visible on welcome, statusbar accent mounted without overlapping the encryption pill, vault-door visible on empty editor pane.

## Rationale

Plan v2 §4 (welcome wordmark), §5 (statusbar accent), §6 PR-C (editor empty state). All three locked decisions from the user (2026-04-29) are honored:

- Wordmark in-box tagline dropped — box contains only the spaced wordmark; the existing sans-serif `<p class="vc-welcome-tagline">` is the single tagline source.
- Statusbar accent uses `┄` (dashed) glyph, not solid `─`.
- Editor empty-state legend is the symbol key, not the legacy "Select a file…" prose.

Hard constraints upheld:

- Box-drawing only (`┌ ┐ └ ┘ │ ┄ █ ▓ ▒ ░`). No braille, no bespoke gradients, no ANSI color.
- All ASCII art carries `aria-hidden="true"`. The legend is intentionally NOT aria-hidden — its keybind hint is meaningful info.
- Statusbar footer z-index 10: intentionally below the encryption pill at z-index 40 so the live-status pill floats visually above the static accent (Plan §5 + Socrates v1 nh-14 stacking note).
- `.vc-vault-layout` height adjusts to leave 18 px clear so the editor never clips behind the permanent footer (Socrates v1 should-fix #7, promoted from "if observed" to required).

## Test plan

- [x] `pnpm vitest run src/components/Welcome src/components/Editor/__tests__/editorEmpty.test.ts` — 9 new tests pass (wordmark structure, h1-still-present-for-SR, vault-door aria-hidden, legend not-aria-hidden, sr-only h2, legacy prose absent, platform-aware shortcut).
- [x] `pnpm vitest run tests/WelcomeScreen.test.ts` — 6 existing tests still pass; the heading-by-name lookup `getByRole('heading', { name: 'VaultCore' })` matches the visually-hidden `<h1>`.
- [x] `pnpm vitest run tests/VaultLayout.noThrowawaySubs.test.ts` — passes; layout-level subscription tests not regressed.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm vite build` — clean.
- [ ] `pnpm wdio run wdio.conf.ts --spec e2e/specs/ascii-aesthetic.spec.ts` — added but not executed in this agent shell (requires a built Tauri binary). Flagged for human run as the cross-platform smoke check.
- [ ] Manual visual smoke (Tauri dev): confirm wordmark renders inside the 480 px welcome card without horizontal scroll, the dashed footer reads softly, the editor empty-state door + legend stack center-aligned. Same shell limitation — flagged for UAT.

Plan: `.plans/issue-358-plan.md`.

Closes part of #358.