### PR TITLE
feat(ascii): sidebar loading spinner + boy-scout comment fix (#358)

### DIFF
--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -211,10 +211,10 @@
     const willExpand = !treeState.expanded.includes(row.relPath);
     if (willExpand) {
       // Optimistically expand the folder — the vault-tree status spinner
-      // above (around line 727) covers the loading indicator while
-      // listDirectory resolves. Persist only once listDirectory resolves —
-      // matches #336 B3 so a failure doesn't stick in `expanded` across
-      // sessions.
+      // (the {#if loading} block above the tree container) covers the
+      // loading indicator while listDirectory resolves. Persist only
+      // once listDirectory resolves — matches #336 B3 so a failure
+      // doesn't stick in `expanded` across sessions.
       const expanded = new Set(treeState.expanded);
       expanded.add(row.relPath);
       treeState = { ...treeState, expanded: Array.from(expanded) };
@@ -719,6 +719,19 @@
 
   <BookmarksPanel />
 
+  <!-- #358 — the loading placeholder is a SIBLING of the tree container,
+       never a child. role="status" inside role="tree" is invalid ARIA
+       (live region won't fire and the tree role is malformed). -->
+  {#if loading}
+    <p
+      class="vc-sidebar-status"
+      role="status"
+      aria-label="Loading vault tree"
+    >
+      <AsciiSpinner /> Loading
+    </p>
+  {/if}
+
   <!-- Tree area (virtualized) -->
   <div
     class="vc-sidebar-tree"
@@ -728,13 +741,9 @@
     onscroll={onScroll}
   >
     {#if loading}
-      <p
-        class="vc-sidebar-status"
-        role="status"
-        aria-label="Loading vault tree"
-      >
-        <AsciiSpinner /> Loading
-      </p>
+      <!-- Loader rendered above; this branch is intentionally empty so
+           the rest of the if/else chain (loadError, empty, populated)
+           keeps its mutual exclusivity. -->
     {:else if loadError}
       <p class="vc-sidebar-status vc-sidebar-status--error">{loadError}</p>
     {:else if flatRows.length === 0}

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -35,6 +35,7 @@
   import { Hash } from "lucide-svelte";
   import TreeRow from "./TreeRow.svelte";
   import ProgressBar from "../Progress/ProgressBar.svelte";
+  import AsciiSpinner from "../ascii/AsciiSpinner.svelte";
   import TagsPanel from "../Tags/TagsPanel.svelte";
   import BookmarksPanel from "../Bookmarks/BookmarksPanel.svelte";
   import { bookmarksStore } from "../../store/bookmarksStore";
@@ -209,9 +210,11 @@
     if (!row.isDir) return;
     const willExpand = !treeState.expanded.includes(row.relPath);
     if (willExpand) {
-      // Optimistically show the folder as expanded (with spinner) while the
-      // load is in flight. Persist only once listDirectory resolves — matches
-      // #336 B3 so a failure doesn't stick in `expanded` across sessions.
+      // Optimistically expand the folder — the vault-tree status spinner
+      // above (around line 727) covers the loading indicator while
+      // listDirectory resolves. Persist only once listDirectory resolves —
+      // matches #336 B3 so a failure doesn't stick in `expanded` across
+      // sessions.
       const expanded = new Set(treeState.expanded);
       expanded.add(row.relPath);
       treeState = { ...treeState, expanded: Array.from(expanded) };
@@ -725,7 +728,13 @@
     onscroll={onScroll}
   >
     {#if loading}
-      <p class="vc-sidebar-status">Loading...</p>
+      <p
+        class="vc-sidebar-status"
+        role="status"
+        aria-label="Loading vault tree"
+      >
+        <AsciiSpinner /> Loading
+      </p>
     {:else if loadError}
       <p class="vc-sidebar-status vc-sidebar-status--error">{loadError}</p>
     {:else if flatRows.length === 0}

--- a/src/components/Sidebar/__tests__/sidebarLoading.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarLoading.test.ts
@@ -1,0 +1,99 @@
+// Issue #358 PR B — sidebar loading state.
+// While the vault tree is loading, the placeholder row must show an
+// AsciiSpinner alongside the literal text "Loading", and the container
+// must surface role="status" + aria-label="Loading vault tree" so screen
+// readers announce it.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import Sidebar from "../Sidebar.svelte";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+const VAULT = "/tmp/sidebar-loading-vault";
+
+describe("Sidebar loading state (#358)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vi.clearAllMocks();
+  });
+
+  it("shows an AsciiSpinner + 'Loading' text while listDirectory is in flight", async () => {
+    // listDirectory never resolves — keeps the loading flag on.
+    (listDirectory as any).mockImplementation(() => new Promise(() => {}));
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    const status = container.querySelector(".vc-sidebar-status");
+    expect(status).toBeTruthy();
+    expect(status!.querySelector(".vc-ascii-spinner")).toBeTruthy();
+    expect(status!.textContent).toMatch(/Loading/);
+  });
+
+  it("surfaces role=status + aria-label on the loading container for screen readers", async () => {
+    (listDirectory as any).mockImplementation(() => new Promise(() => {}));
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    const status = container.querySelector(".vc-sidebar-status");
+    expect(status).toBeTruthy();
+    expect(status!.getAttribute("role")).toBe("status");
+    expect(status!.getAttribute("aria-label")).toBe("Loading vault tree");
+  });
+});

--- a/src/components/Sidebar/__tests__/sidebarLoading.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarLoading.test.ts
@@ -96,4 +96,48 @@ describe("Sidebar loading state (#358)", () => {
     expect(status!.getAttribute("role")).toBe("status");
     expect(status!.getAttribute("aria-label")).toBe("Loading vault tree");
   });
+
+  // Aristotle PR-B review — `role="status"` nested inside `role="tree"`
+  // is invalid WAI-ARIA: the live region won't fire AND the tree is
+  // malformed. The loading placeholder must be a sibling of the tree
+  // container, not a child.
+  it("the loading placeholder is OUTSIDE the role=tree container", async () => {
+    (listDirectory as any).mockImplementation(() => new Promise(() => {}));
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    const tree = container.querySelector('[role="tree"]');
+    const status = container.querySelector('[role="status"]');
+    expect(tree).toBeTruthy();
+    expect(status).toBeTruthy();
+    // The status block must not be a descendant of the tree container.
+    expect(tree!.contains(status)).toBe(false);
+  });
+
+  // Regression: the loading-flag must clear once listDirectory resolves
+  // even when the vault is empty. Previously the loading <p> would stay
+  // mounted indefinitely (loading-flag leak called out by Socrates).
+  it("loader unmounts and the empty-vault message renders once listDirectory resolves with []", async () => {
+    (listDirectory as any).mockResolvedValue([]);
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+
+    const { container } = render(Sidebar, { props: makeProps() });
+
+    // Drain the IPC promise + the post-resolve effect chain.
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+      await tick();
+    }
+
+    // The loading status must be gone.
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    // And the empty-vault copy must be visible.
+    const empty = container.querySelector(".vc-sidebar-status");
+    expect(empty).toBeTruthy();
+    expect(empty!.textContent).toMatch(/No files in vault/);
+  });
 });


### PR DESCRIPTION
Re-open of #369 after auto-closure when the stacked base branch was deleted on PR A merge.

## Summary
- Sidebar loading state replaced with `<AsciiSpinner />` + `Loading` label inside a `role="status"` paragraph that sits as a sibling above the `role="tree"` container (Aristotle round-1: nesting status inside tree was invalid WAI-ARIA).
- Boy Scout: rewrote the misleading "Optimistically show the folder as expanded (with spinner)" comment in `onToggleExpand` (Plan v2 task).

## Test plan
- [x] \`pnpm vitest run src/components/Sidebar/__tests__/sidebarLoading.test.ts\` — 4/4
- [x] \`pnpm vitest run src/components/Sidebar\` — 44/44 (no regressions)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vite build\` clean
- [ ] Tauri visual smoke (UAT — confirmed by user on integration branch)

Both Aristotle review rounds approved this branch (rounds 1 and 2). Replaces the closed #369.