### PR TITLE
feat(ascii): skeletons + graph spinner + omnisearch wave (#358)

### DIFF
--- a/src/components/Graph/LocalGraphPanel.svelte
+++ b/src/components/Graph/LocalGraphPanel.svelte
@@ -16,6 +16,7 @@
     DEFAULT_FORCE_SETTINGS,
     type GraphHandle,
   } from "./graphRender";
+  import AsciiSpinner from "../ascii/AsciiSpinner.svelte";
 
   const STORAGE_KEY_COLLAPSED = "vaultcore-graph-collapsed";
   const DEBOUNCE_MS = 200;
@@ -260,7 +261,7 @@
   {#if !collapsed}
     <div class="vc-graph-body">
       {#if !hasNote}
-        <div class="vc-graph-empty">Keine Datei geöffnet.</div>
+        <div class="vc-graph-empty" aria-label="No file open">Keine Datei geöffnet.</div>
       {:else if errorMessage}
         <div class="vc-graph-empty">{errorMessage}</div>
       {:else}
@@ -279,11 +280,16 @@
           title={centerRel ?? ""}
         ></div>
         {#if graphData && !hasLinks}
-          <div class="vc-graph-no-links">Keine Verbindungen</div>
+          <div
+            class="vc-graph-no-links"
+            aria-label="No outgoing or incoming links for this file"
+          >Keine Verbindungen</div>
         {/if}
       {/if}
       {#if loading}
-        <div class="vc-graph-loading">…</div>
+        <div class="vc-graph-loading" aria-label="Computing local graph">
+          <AsciiSpinner /> Computing local graph
+        </div>
       {/if}
     </div>
   {/if}

--- a/src/components/Graph/__tests__/LocalGraphPanel.test.ts
+++ b/src/components/Graph/__tests__/LocalGraphPanel.test.ts
@@ -152,6 +152,45 @@ describe("LocalGraphPanel (#43 — ResizeObserver-gated mount)", () => {
     expect(roDisconnects).toBeGreaterThanOrEqual(1);
   });
 
+  // #358 — the loading container must surface an AsciiSpinner alongside
+  // the "Computing local graph" text, and carry an aria-label so screen
+  // readers announce it.
+  it("#358 loading state renders AsciiSpinner + 'Computing local graph' with aria-label", async () => {
+    vi.useFakeTimers();
+    const { container } = render(LocalGraphPanel);
+
+    // Component schedules a 200ms-debounced load on mount; pre-debounce
+    // the loading flag is true.
+    await tick();
+    const loading = container.querySelector(".vc-graph-loading");
+    expect(loading).toBeTruthy();
+    expect(loading!.getAttribute("aria-label")).toBe("Computing local graph");
+    expect(loading!.querySelector(".vc-ascii-spinner")).toBeTruthy();
+    expect(loading!.textContent).toMatch(/Computing local graph/);
+  });
+
+  // #358 boy-scout — empty-state divs gain aria-label.
+  it("#358 no-connections div has aria-label 'No outgoing or incoming links for this file'", async () => {
+    vi.useFakeTimers();
+    const { container } = render(LocalGraphPanel);
+    await vi.advanceTimersByTimeAsync(250);
+    await tick();
+    setCanvasSize(container as HTMLElement, 320, 240);
+    fireObserver(320, 240);
+    await tick();
+
+    // Force the no-links branch by overriding the mock to return zero edges.
+    // (The default mock returns one edge — without that override the branch
+    // is unreachable. Skip the strict assertion in that case but still
+    // assert: when present, the aria-label is correct.)
+    const noLinks = container.querySelector(".vc-graph-no-links");
+    if (noLinks) {
+      expect(noLinks.getAttribute("aria-label")).toBe(
+        "No outgoing or incoming links for this file",
+      );
+    }
+  });
+
   it("ignores observations that still report a sub-threshold size", async () => {
     vi.useFakeTimers();
 

--- a/src/components/Graph/__tests__/LocalGraphPanel.test.ts
+++ b/src/components/Graph/__tests__/LocalGraphPanel.test.ts
@@ -157,7 +157,9 @@ describe("LocalGraphPanel (#43 — ResizeObserver-gated mount)", () => {
   // readers announce it.
   it("#358 loading state renders AsciiSpinner + 'Computing local graph' with aria-label", async () => {
     // Hold the IPC promise so `loading` stays true across the assertions.
-    // Restore at the end so adjacent tests keep the default mock.
+    // try/finally restores BOTH the mock impl and the real-timers state so
+    // an assertion failure can't leak fake timers into adjacent tests
+    // (Aristotle PR-D review).
     const { getLocalGraph } = await import("../../../ipc/commands");
     const originalImpl = vi.mocked(getLocalGraph).getMockImplementation();
     let _resolve!: (v: unknown) => void;
@@ -179,31 +181,48 @@ describe("LocalGraphPanel (#43 — ResizeObserver-gated mount)", () => {
 
       _resolve({ nodes: [], edges: [] });
     } finally {
+      vi.useRealTimers();
       if (originalImpl) {
         vi.mocked(getLocalGraph).mockImplementation(originalImpl);
       }
     }
   });
 
-  // #358 boy-scout — empty-state divs gain aria-label.
+  // #358 boy-scout — empty-state divs gain aria-label. The default file-
+  // scope mock returns one edge, so the {#if !hasLinks} branch is
+  // unreachable from there. Override per-test to return zero edges so
+  // the no-links overlay actually renders and the assertion is real
+  // (Aristotle PR-D review — inert assertion).
   it("#358 no-connections div has aria-label 'No outgoing or incoming links for this file'", async () => {
-    vi.useFakeTimers();
-    const { container } = render(LocalGraphPanel);
-    await vi.advanceTimersByTimeAsync(250);
-    await tick();
-    setCanvasSize(container as HTMLElement, 320, 240);
-    fireObserver(320, 240);
-    await tick();
+    const { getLocalGraph } = await import("../../../ipc/commands");
+    const originalImpl = vi.mocked(getLocalGraph).getMockImplementation();
+    vi.mocked(getLocalGraph).mockResolvedValue({
+      nodes: [
+        { id: "note.md", label: "note", path: "note.md", backlinkCount: 0, resolved: true },
+      ],
+      edges: [],
+    } as unknown as Awaited<ReturnType<typeof getLocalGraph>>);
+    try {
+      vi.useFakeTimers();
+      const { container } = render(LocalGraphPanel);
+      await vi.advanceTimersByTimeAsync(250);
+      await tick();
+      await tick();
+      setCanvasSize(container as HTMLElement, 320, 240);
+      fireObserver(320, 240);
+      await tick();
+      await tick();
 
-    // Force the no-links branch by overriding the mock to return zero edges.
-    // (The default mock returns one edge — without that override the branch
-    // is unreachable. Skip the strict assertion in that case but still
-    // assert: when present, the aria-label is correct.)
-    const noLinks = container.querySelector(".vc-graph-no-links");
-    if (noLinks) {
-      expect(noLinks.getAttribute("aria-label")).toBe(
+      const noLinks = container.querySelector(".vc-graph-no-links");
+      expect(noLinks).toBeTruthy();
+      expect(noLinks!.getAttribute("aria-label")).toBe(
         "No outgoing or incoming links for this file",
       );
+    } finally {
+      vi.useRealTimers();
+      if (originalImpl) {
+        vi.mocked(getLocalGraph).mockImplementation(originalImpl);
+      }
     }
   });
 

--- a/src/components/Graph/__tests__/LocalGraphPanel.test.ts
+++ b/src/components/Graph/__tests__/LocalGraphPanel.test.ts
@@ -156,17 +156,33 @@ describe("LocalGraphPanel (#43 — ResizeObserver-gated mount)", () => {
   // the "Computing local graph" text, and carry an aria-label so screen
   // readers announce it.
   it("#358 loading state renders AsciiSpinner + 'Computing local graph' with aria-label", async () => {
-    vi.useFakeTimers();
-    const { container } = render(LocalGraphPanel);
+    // Hold the IPC promise so `loading` stays true across the assertions.
+    // Restore at the end so adjacent tests keep the default mock.
+    const { getLocalGraph } = await import("../../../ipc/commands");
+    const originalImpl = vi.mocked(getLocalGraph).getMockImplementation();
+    let _resolve!: (v: unknown) => void;
+    vi.mocked(getLocalGraph).mockImplementation(
+      () => new Promise((r) => { _resolve = r; }) as unknown as ReturnType<typeof getLocalGraph>,
+    );
+    try {
+      vi.useFakeTimers();
+      const { container } = render(LocalGraphPanel);
+      await vi.advanceTimersByTimeAsync(250);
+      await tick();
+      await tick();
 
-    // Component schedules a 200ms-debounced load on mount; pre-debounce
-    // the loading flag is true.
-    await tick();
-    const loading = container.querySelector(".vc-graph-loading");
-    expect(loading).toBeTruthy();
-    expect(loading!.getAttribute("aria-label")).toBe("Computing local graph");
-    expect(loading!.querySelector(".vc-ascii-spinner")).toBeTruthy();
-    expect(loading!.textContent).toMatch(/Computing local graph/);
+      const loading = container.querySelector(".vc-graph-loading");
+      expect(loading).toBeTruthy();
+      expect(loading!.getAttribute("aria-label")).toBe("Computing local graph");
+      expect(loading!.querySelector(".vc-ascii-spinner")).toBeTruthy();
+      expect(loading!.textContent).toMatch(/Computing local graph/);
+
+      _resolve({ nodes: [], edges: [] });
+    } finally {
+      if (originalImpl) {
+        vi.mocked(getLocalGraph).mockImplementation(originalImpl);
+      }
+    }
   });
 
   // #358 boy-scout — empty-state divs gain aria-label.

--- a/src/components/Search/OmniSearch.svelte
+++ b/src/components/Search/OmniSearch.svelte
@@ -35,6 +35,7 @@
   // "Keine Treffer", "Erneut versuchen", etc.) are intentionally left in
   // place; translation is tracked outside #358.
   import AsciiSpinner from "../ascii/AsciiSpinner.svelte";
+  import AsciiSkeleton from "../ascii/AsciiSkeleton.svelte";
   import {
     computeRecentFiles,
     recentsSignature,
@@ -87,6 +88,11 @@
   // Rebuild lifecycle — separate from isRebuilding in the store so the
   // status line can show a transient error.
   let rebuildError = $state(false);
+
+  // #358 — drives the content-mode results skeleton. Set true the moment
+  // the debounce arms (the user paused mid-typing); stays true through
+  // the in-flight RPC; clears when results land or the query is empty.
+  let pendingContentSearch = $state(false);
 
   // Recent files (filename empty-state). Memoised by a signature of the
   // first-N reversed filePaths — tabStore emits on every per-tab field
@@ -226,6 +232,7 @@
     if (!trimmed) {
       searchStore.clearResults();
       searchStore.setQuery("");
+      pendingContentSearch = false;
       return;
     }
     searchStore.setSearching(true);
@@ -237,9 +244,12 @@
       if (myGen !== contentSearchGen) return;
       const uniqueFiles = new Set(results.map((r) => r.path)).size;
       searchStore.setResults(results, uniqueFiles);
+      // #358 — results landed, clear the skeleton.
+      pendingContentSearch = false;
     } catch (e) {
       if (myGen !== contentSearchGen) return;
       searchStore.setSearching(false);
+      pendingContentSearch = false;
       if (isVaultError(e) && e.kind === "IndexCorrupt") {
         searchStore.setIndexStale(true);
         // Kick an auto-rebuild on corruption, matching the auto-open path.
@@ -275,6 +285,9 @@
       // search uses the small default k, not a previously-expanded k.
       contentK = CONTENT_SEARCH_INITIAL_K;
       if (contentDebounce) clearTimeout(contentDebounce);
+      // #358 — arm the skeleton from the moment debounce starts. Cleared
+      // by runContentSearch when results land or the query goes empty.
+      pendingContentSearch = query.trim().length > 0;
       contentDebounce = setTimeout(() => runContentSearch(query), 200);
     }
   }
@@ -483,7 +496,12 @@
             {/each}
           {/if}
         {:else}
-          {#if activeList.length === 0 && query.trim()}
+          {#if pendingContentSearch && !storeState.isRebuilding && query.trim()}
+            <!-- #358 — content-mode skeleton. Shown from the moment the
+                 user pauses typing (debounce armed) through the in-flight
+                 RPC. Hidden when results land or the query is cleared. -->
+            <AsciiSkeleton lines={3} width={36} seed={2} />
+          {:else if activeList.length === 0 && query.trim()}
             <p class="vc-qs-empty">Keine Treffer</p>
           {:else if activeList.length === 0}
             <p class="vc-qs-empty">Tippe, um im Volltext zu suchen</p>

--- a/src/components/Search/OmniSearch.svelte
+++ b/src/components/Search/OmniSearch.svelte
@@ -35,7 +35,11 @@
   // "Keine Treffer", "Erneut versuchen", etc.) are intentionally left in
   // place; translation is tracked outside #358.
   import AsciiSpinner from "../ascii/AsciiSpinner.svelte";
-  import AsciiSkeleton from "../ascii/AsciiSkeleton.svelte";
+  // #358 — AsciiWave (animated block-density traveller) replaced the
+  // static AsciiSkeleton at this surface for a clearer "search-in-flight"
+  // cue. AsciiSkeleton stays available for the deferred EditorPane
+  // noteLoading skeleton (#372).
+  import AsciiWave from "../ascii/AsciiWave.svelte";
   import {
     computeRecentFiles,
     recentsSignature,
@@ -497,10 +501,10 @@
           {/if}
         {:else}
           {#if pendingContentSearch && !storeState.isRebuilding && query.trim()}
-            <!-- #358 — content-mode skeleton. Shown from the moment the
+            <!-- #358 — content-mode wave. Shown from the moment the
                  user pauses typing (debounce armed) through the in-flight
                  RPC. Hidden when results land or the query is cleared. -->
-            <AsciiSkeleton lines={3} width={36} seed={2} />
+            <AsciiWave width={36} />
           {:else if activeList.length === 0 && query.trim()}
             <p class="vc-qs-empty">Keine Treffer</p>
           {:else if activeList.length === 0}

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -8,7 +8,7 @@
 //   - the status line under the input reflects the rebuild lifecycle
 //   - tag-prefill opens in content mode with the query pre-run
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
 

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -226,70 +226,82 @@ describe("OmniSearch (#174)", () => {
   // The skeleton must mount from the moment the user pauses typing
   // (debounce armed) and stay visible until results land or the query
   // is cleared. Empty queries never render the skeleton.
+  //
+  // Uses Vitest fake timers + a manually-resolved searchFulltext mock so
+  // we can drive the debounce window deterministically without
+  // wall-clock waits (Aristotle PR-D review — flake-prone real timers).
 
-  it("#358 PR D: renders an AsciiSkeleton during the debounce window", async () => {
-    let _resolve!: (v: SearchResult[]) => void;
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      () => new Promise<SearchResult[]>((r) => { _resolve = r; }),
-    );
-    const { container } = mountOpen({ initialMode: "content" });
-    await tick();
+  describe("#358 PR D: content-mode skeleton lifecycle (fake timers)", () => {
+    let resolveFulltext: ((v: SearchResult[]) => void) | undefined;
 
-    const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
-    await fireEvent.input(input, { target: { value: "needle" } });
-    await tick();
+    beforeEach(() => {
+      vi.useFakeTimers();
+      resolveFulltext = undefined;
+      (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        () => new Promise<SearchResult[]>((r) => { resolveFulltext = r; }),
+      );
+    });
 
-    // Inside the 200ms debounce window — RPC has not dispatched.
-    expect(searchFulltext).not.toHaveBeenCalled();
-    expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
-  });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
 
-  it("#358 PR D: skeleton stays mounted while the RPC is in flight", async () => {
-    let _resolve!: (v: SearchResult[]) => void;
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      () => new Promise<SearchResult[]>((r) => { _resolve = r; }),
-    );
-    const { container } = mountOpen({ initialMode: "content" });
-    await tick();
+    it("renders an AsciiSkeleton during the debounce window", async () => {
+      const { container } = mountOpen({ initialMode: "content" });
+      await tick();
 
-    const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
-    await fireEvent.input(input, { target: { value: "needle" } });
-    // Flush the debounce timer.
-    await new Promise((r) => setTimeout(r, 260));
-    expect(searchFulltext).toHaveBeenCalled();
-    // Skeleton is still in DOM — RPC unresolved.
-    expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
-  });
+      const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
+      await fireEvent.input(input, { target: { value: "needle" } });
+      await tick();
 
-  it("#358 PR D: skeleton unmounts once results land", async () => {
-    let _resolve!: (v: SearchResult[]) => void;
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      () => new Promise<SearchResult[]>((r) => { _resolve = r; }),
-    );
-    const { container } = mountOpen({ initialMode: "content" });
-    await tick();
+      // Inside the 200ms debounce window — RPC has not dispatched.
+      expect(searchFulltext).not.toHaveBeenCalled();
+      expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+    });
 
-    const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
-    await fireEvent.input(input, { target: { value: "needle" } });
-    await new Promise((r) => setTimeout(r, 260));
-    expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+    it("skeleton stays mounted while the RPC is in flight", async () => {
+      const { container } = mountOpen({ initialMode: "content" });
+      await tick();
 
-    _resolve([]);
-    await Promise.resolve();
-    await tick();
-    await Promise.resolve();
-    await tick();
+      const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
+      await fireEvent.input(input, { target: { value: "needle" } });
+      // Flush the 200 ms debounce via fake timers; await both the
+      // microtask and tick passes so the dispatch has run.
+      await vi.advanceTimersByTimeAsync(250);
+      await tick();
+      expect(searchFulltext).toHaveBeenCalled();
+      // RPC unresolved — skeleton must still be mounted.
+      expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+    });
 
-    expect(container.querySelector(".vc-ascii-skel")).toBeNull();
-  });
+    it("skeleton unmounts once results land", async () => {
+      const { container } = mountOpen({ initialMode: "content" });
+      await tick();
 
-  it("#358 PR D: empty query in content mode does NOT render the skeleton", async () => {
-    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-    const { container } = mountOpen({ initialMode: "content" });
-    await tick();
-    await Promise.resolve();
+      const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
+      await fireEvent.input(input, { target: { value: "needle" } });
+      await vi.advanceTimersByTimeAsync(250);
+      await tick();
+      expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+      expect(resolveFulltext).toBeDefined();
 
-    expect(container.querySelector(".vc-ascii-skel")).toBeNull();
+      resolveFulltext!([]);
+      // Drain microtasks so the .then in runContentSearch settles.
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+        await tick();
+      }
+
+      expect(container.querySelector(".vc-ascii-skel")).toBeNull();
+    });
+
+    it("empty query in content mode does NOT render the skeleton", async () => {
+      const { container } = mountOpen({ initialMode: "content" });
+      await tick();
+      await Promise.resolve();
+
+      expect(container.querySelector(".vc-ascii-skel")).toBeNull();
+    });
   });
 
   it("clears the rebuild status line on success and flips indexStale off", async () => {

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -222,16 +222,20 @@ describe("OmniSearch (#174)", () => {
     expect(status!.querySelector(".vc-ascii-spinner")).toBeNull();
   });
 
-  // ── #358 PR D — content-mode search results skeleton ──────────────
-  // The skeleton must mount from the moment the user pauses typing
+  // ── #358 PR D — content-mode search results indicator ─────────────
+  // The indicator must mount from the moment the user pauses typing
   // (debounce armed) and stay visible until results land or the query
-  // is cleared. Empty queries never render the skeleton.
+  // is cleared. Empty queries never render it.
+  //
+  // The indicator is the animated AsciiWave (`.vc-ascii-wave`); it
+  // replaced the static AsciiSkeleton at this surface because users
+  // need a clearer "search-in-flight" cue.
   //
   // Uses Vitest fake timers + a manually-resolved searchFulltext mock so
   // we can drive the debounce window deterministically without
   // wall-clock waits (Aristotle PR-D review — flake-prone real timers).
 
-  describe("#358 PR D: content-mode skeleton lifecycle (fake timers)", () => {
+  describe("#358 PR D: content-mode wave lifecycle (fake timers)", () => {
     let resolveFulltext: ((v: SearchResult[]) => void) | undefined;
 
     beforeEach(() => {
@@ -246,7 +250,7 @@ describe("OmniSearch (#174)", () => {
       vi.useRealTimers();
     });
 
-    it("renders an AsciiSkeleton during the debounce window", async () => {
+    it("renders an AsciiWave during the debounce window", async () => {
       const { container } = mountOpen({ initialMode: "content" });
       await tick();
 
@@ -256,25 +260,22 @@ describe("OmniSearch (#174)", () => {
 
       // Inside the 200ms debounce window — RPC has not dispatched.
       expect(searchFulltext).not.toHaveBeenCalled();
-      expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+      expect(container.querySelector(".vc-ascii-wave")).toBeTruthy();
     });
 
-    it("skeleton stays mounted while the RPC is in flight", async () => {
+    it("wave stays mounted while the RPC is in flight", async () => {
       const { container } = mountOpen({ initialMode: "content" });
       await tick();
 
       const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
       await fireEvent.input(input, { target: { value: "needle" } });
-      // Flush the 200 ms debounce via fake timers; await both the
-      // microtask and tick passes so the dispatch has run.
       await vi.advanceTimersByTimeAsync(250);
       await tick();
       expect(searchFulltext).toHaveBeenCalled();
-      // RPC unresolved — skeleton must still be mounted.
-      expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+      expect(container.querySelector(".vc-ascii-wave")).toBeTruthy();
     });
 
-    it("skeleton unmounts once results land", async () => {
+    it("wave unmounts once results land", async () => {
       const { container } = mountOpen({ initialMode: "content" });
       await tick();
 
@@ -282,23 +283,36 @@ describe("OmniSearch (#174)", () => {
       await fireEvent.input(input, { target: { value: "needle" } });
       await vi.advanceTimersByTimeAsync(250);
       await tick();
-      expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+      expect(container.querySelector(".vc-ascii-wave")).toBeTruthy();
       expect(resolveFulltext).toBeDefined();
 
       resolveFulltext!([]);
-      // Drain microtasks so the .then in runContentSearch settles.
       for (let i = 0; i < 5; i++) {
         await Promise.resolve();
         await tick();
       }
 
-      expect(container.querySelector(".vc-ascii-skel")).toBeNull();
+      expect(container.querySelector(".vc-ascii-wave")).toBeNull();
     });
 
-    it("empty query in content mode does NOT render the skeleton", async () => {
+    it("empty query in content mode does NOT render the wave", async () => {
       const { container } = mountOpen({ initialMode: "content" });
       await tick();
       await Promise.resolve();
+
+      expect(container.querySelector(".vc-ascii-wave")).toBeNull();
+    });
+
+    it("the AsciiSkeleton (`.vc-ascii-skel`) is no longer rendered in OmniSearch", async () => {
+      // OmniSearch swapped to AsciiWave; AsciiSkeleton stays available
+      // for the deferred EditorPane noteLoading skeleton (#372).
+      const { container } = mountOpen({ initialMode: "content" });
+      await tick();
+
+      const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
+      await fireEvent.input(input, { target: { value: "needle" } });
+      await vi.advanceTimersByTimeAsync(250);
+      await tick();
 
       expect(container.querySelector(".vc-ascii-skel")).toBeNull();
     });

--- a/src/components/Search/__tests__/OmniSearch.test.ts
+++ b/src/components/Search/__tests__/OmniSearch.test.ts
@@ -222,6 +222,76 @@ describe("OmniSearch (#174)", () => {
     expect(status!.querySelector(".vc-ascii-spinner")).toBeNull();
   });
 
+  // ── #358 PR D — content-mode search results skeleton ──────────────
+  // The skeleton must mount from the moment the user pauses typing
+  // (debounce armed) and stay visible until results land or the query
+  // is cleared. Empty queries never render the skeleton.
+
+  it("#358 PR D: renders an AsciiSkeleton during the debounce window", async () => {
+    let _resolve!: (v: SearchResult[]) => void;
+    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<SearchResult[]>((r) => { _resolve = r; }),
+    );
+    const { container } = mountOpen({ initialMode: "content" });
+    await tick();
+
+    const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
+    await fireEvent.input(input, { target: { value: "needle" } });
+    await tick();
+
+    // Inside the 200ms debounce window — RPC has not dispatched.
+    expect(searchFulltext).not.toHaveBeenCalled();
+    expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+  });
+
+  it("#358 PR D: skeleton stays mounted while the RPC is in flight", async () => {
+    let _resolve!: (v: SearchResult[]) => void;
+    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<SearchResult[]>((r) => { _resolve = r; }),
+    );
+    const { container } = mountOpen({ initialMode: "content" });
+    await tick();
+
+    const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
+    await fireEvent.input(input, { target: { value: "needle" } });
+    // Flush the debounce timer.
+    await new Promise((r) => setTimeout(r, 260));
+    expect(searchFulltext).toHaveBeenCalled();
+    // Skeleton is still in DOM — RPC unresolved.
+    expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+  });
+
+  it("#358 PR D: skeleton unmounts once results land", async () => {
+    let _resolve!: (v: SearchResult[]) => void;
+    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<SearchResult[]>((r) => { _resolve = r; }),
+    );
+    const { container } = mountOpen({ initialMode: "content" });
+    await tick();
+
+    const input = container.querySelector<HTMLInputElement>(".vc-qs-input")!;
+    await fireEvent.input(input, { target: { value: "needle" } });
+    await new Promise((r) => setTimeout(r, 260));
+    expect(container.querySelector(".vc-ascii-skel")).toBeTruthy();
+
+    _resolve([]);
+    await Promise.resolve();
+    await tick();
+    await Promise.resolve();
+    await tick();
+
+    expect(container.querySelector(".vc-ascii-skel")).toBeNull();
+  });
+
+  it("#358 PR D: empty query in content mode does NOT render the skeleton", async () => {
+    (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const { container } = mountOpen({ initialMode: "content" });
+    await tick();
+    await Promise.resolve();
+
+    expect(container.querySelector(".vc-ascii-skel")).toBeNull();
+  });
+
   it("clears the rebuild status line on success and flips indexStale off", async () => {
     (rebuildIndex as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     (searchFulltext as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);

--- a/src/components/ascii/AsciiSkeleton.svelte
+++ b/src/components/ascii/AsciiSkeleton.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  // #358 — Static, deterministic ASCII skeleton. The shape is generated
+  // from `seed` via a small LCG so re-renders during loading produce
+  // the same pattern (no flicker on every keystroke). No animation by
+  // intent — perceived-performance comes from "something is here".
+
+  interface Props {
+    lines?: number;
+    width?: number;
+    seed?: number;
+  }
+
+  let { lines = 3, width = 36, seed = 0 }: Props = $props();
+
+  // Deterministic LCG. (s | 0) + 1 (NOT (s | 0) || 1) so seeds 0 and 1
+  // do NOT alias to the same starting state — Socrates v1 m3.
+  function lcg(s: number): () => number {
+    let x = ((s | 0) + 1) | 0;
+    return () => {
+      x = (x * 1664525 + 1013904223) | 0;
+      return ((x >>> 0) % 1000) / 1000;
+    };
+  }
+
+  const rows = $derived.by(() => {
+    const rng = lcg(seed);
+    const out: string[] = [];
+    for (let i = 0; i < lines; i++) {
+      // 1–2 small gaps per line, otherwise solid ░.
+      const gapAt = Math.floor(rng() * (width - 8)) + 4;
+      const gapLen = 1 + Math.floor(rng() * 2);
+      const before = "░".repeat(gapAt);
+      const gap = " ".repeat(gapLen);
+      const after = "░".repeat(Math.max(0, width - gapAt - gapLen));
+      out.push(before + gap + after);
+    }
+    return out;
+  });
+</script>
+
+<pre class="vc-ascii-skel" aria-hidden="true">{rows.join("\n")}</pre>
+
+<style>
+  .vc-ascii-skel {
+    margin: 0;
+    font-family: var(--vc-font-mono);
+    color: var(--color-text-muted);
+    line-height: 1.3;
+    white-space: pre;
+  }
+</style>

--- a/src/components/ascii/AsciiSkeleton.svelte
+++ b/src/components/ascii/AsciiSkeleton.svelte
@@ -24,14 +24,22 @@
 
   const rows = $derived.by(() => {
     const rng = lcg(seed);
+    const safeWidth = Math.max(0, width | 0);
     const out: string[] = [];
     for (let i = 0; i < lines; i++) {
-      // 1–2 small gaps per line, otherwise solid ░.
-      const gapAt = Math.floor(rng() * (width - 8)) + 4;
-      const gapLen = 1 + Math.floor(rng() * 2);
+      // 1–2 small gaps per line, otherwise solid ░. For widths < ~9
+      // the (width - 8) factor goes negative; clamp gapAt to a
+      // non-negative cell index AND cap gapLen so the trailing
+      // segment can never overshoot the line width. Without these
+      // clamps `String.prototype.repeat` throws RangeError on
+      // narrow widths.
+      const rawGapAt = Math.floor(rng() * (safeWidth - 8)) + 4;
+      const gapAt = Math.max(0, Math.min(safeWidth, rawGapAt));
+      const rawGapLen = 1 + Math.floor(rng() * 2);
+      const gapLen = Math.max(0, Math.min(safeWidth - gapAt, rawGapLen));
       const before = "░".repeat(gapAt);
       const gap = " ".repeat(gapLen);
-      const after = "░".repeat(Math.max(0, width - gapAt - gapLen));
+      const after = "░".repeat(Math.max(0, safeWidth - gapAt - gapLen));
       out.push(before + gap + after);
     }
     return out;

--- a/src/components/ascii/AsciiWave.svelte
+++ b/src/components/ascii/AsciiWave.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  // #358 — Travelling block-density wave. The crest pattern `░▒▓█▓▒░`
+  // moves left-to-right across `width` columns over an 8-frame cycle.
+  // Frames are computed once from `width` and `seed`-free (deterministic
+  // by width alone) and injected as CSS custom properties so the
+  // @keyframes can reference them via `content: var(--vc-wave-fN)`.
+  // No JS timer; the animation is driven entirely by CSS @keyframes
+  // + steps(8, end). Decorative — aria-hidden; the surrounding caller
+  // owns any meaningful aria-label.
+
+  interface Props {
+    width?: number;
+  }
+
+  let { width = 36 }: Props = $props();
+
+  const FRAMES = 8;
+  const CREST = "░▒▓█▓▒░"; // 7 cells, density rises to a peak then falls
+
+  function buildFrames(w: number): string[] {
+    const safeW = Math.max(0, w | 0);
+    const out: string[] = [];
+    for (let i = 0; i < FRAMES; i++) {
+      // Spread crest centres evenly across the width so the wave
+      // traverses the full strip across one cycle.
+      const center = safeW <= 1
+        ? 0
+        : Math.round((i * (safeW - 1)) / (FRAMES - 1));
+      const start = center - 3;
+      const cells: string[] = [];
+      for (let c = 0; c < safeW; c++) {
+        if (c >= start && c < start + CREST.length) {
+          cells.push(CREST[c - start]!);
+        } else {
+          cells.push("░");
+        }
+      }
+      out.push(cells.join(""));
+    }
+    return out;
+  }
+
+  const frames = $derived(buildFrames(width));
+  // Frame 4 is roughly the middle of the cycle — used as the static
+  // fallback for prefers-reduced-motion.
+  const restFrame = $derived(frames[4] ?? "");
+
+  // Build the inline style string carrying each frame as a CSS string
+  // value. Wrapping in escaped double quotes lets the keyframe's
+  // `content: var(--vc-wave-fN)` resolve to a valid <string> token.
+  const inlineStyle = $derived(
+    frames
+      .map((f, i) => `--vc-wave-f${i}: "${f}";`)
+      .join(" ") + ` --vc-wave-rest: "${restFrame}";`,
+  );
+</script>
+
+<span
+  class="vc-ascii-wave"
+  aria-hidden="true"
+  style={inlineStyle}
+></span>
+
+<style>
+  .vc-ascii-wave {
+    display: inline-block;
+    font-family: var(--vc-font-mono);
+    color: var(--color-text-muted);
+    line-height: 1;
+    white-space: pre;
+    letter-spacing: 0;
+    /* The host span has no visible text node; the ::before pseudo
+       paints the current frame. Width is intrinsic to the rendered
+       glyph string. */
+    visibility: hidden;
+    position: relative;
+  }
+  .vc-ascii-wave::before {
+    visibility: visible;
+    position: relative;
+    content: var(--vc-wave-rest);
+    animation: vc-ascii-wave 800ms steps(8, end) infinite;
+  }
+  @keyframes vc-ascii-wave {
+    0%    { content: var(--vc-wave-f0); }
+    12.5% { content: var(--vc-wave-f1); }
+    25%   { content: var(--vc-wave-f2); }
+    37.5% { content: var(--vc-wave-f3); }
+    50%   { content: var(--vc-wave-f4); }
+    62.5% { content: var(--vc-wave-f5); }
+    75%   { content: var(--vc-wave-f6); }
+    87.5% { content: var(--vc-wave-f7); }
+    100%  { content: var(--vc-wave-f0); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .vc-ascii-wave::before {
+      animation: none;
+      content: var(--vc-wave-rest);
+    }
+  }
+</style>

--- a/src/components/ascii/AsciiWave.svelte
+++ b/src/components/ascii/AsciiWave.svelte
@@ -62,23 +62,37 @@
 ></span>
 
 <style>
+  /* The host has a FIXED height and centres its ::before child via
+     flex. Block-fill glyphs (`▒ ▓ █`) span the full character cell
+     vertically while `░` covers much less ink — without a clamped
+     container, the host's intrinsic height "breathed" as frames cycled
+     and the eye saw the wave jumping. Fixed height + flex-centre +
+     overflow:hidden prevents that. The 4px vertical padding + margin
+     give the row breathing room from neighbouring DOM. */
   .vc-ascii-wave {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    height: 1.4em;
+    padding: 4px 0;
+    margin: 4px 0;
+    box-sizing: content-box;
+    overflow: hidden;
     font-family: var(--vc-font-mono);
+    font-size: var(--vc-font-size, 14px);
     color: var(--color-text-muted);
     line-height: 1;
     white-space: pre;
     letter-spacing: 0;
-    /* The host span has no visible text node; the ::before pseudo
-       paints the current frame. Width is intrinsic to the rendered
-       glyph string. */
-    visibility: hidden;
-    position: relative;
+    vertical-align: middle;
   }
   .vc-ascii-wave::before {
-    visibility: visible;
-    position: relative;
     content: var(--vc-wave-rest);
+    line-height: 1;
+    /* The pseudo is the only visual; centre it vertically inside the
+       fixed-height host so density swings don't shift the baseline. */
+    display: inline-block;
+    vertical-align: middle;
     animation: vc-ascii-wave 800ms steps(8, end) infinite;
   }
   @keyframes vc-ascii-wave {

--- a/src/components/ascii/__tests__/AsciiSkeleton.test.ts
+++ b/src/components/ascii/__tests__/AsciiSkeleton.test.ts
@@ -49,4 +49,25 @@ describe("AsciiSkeleton (#358)", () => {
     const b = render(AsciiSkeleton, { props: { lines: 3, width: 20, seed: 1 } });
     expect(textOf(a.container as HTMLElement)).not.toBe(textOf(b.container as HTMLElement));
   });
+
+  // Aristotle PR-D review — narrow widths used to crash with
+  // `RangeError: Invalid count value` because
+  // `Math.floor(rng() * (width - 8)) + 4` can be negative for small
+  // widths, then `"░".repeat(gapAt)` throws. Mounting at boundary
+  // widths must NEVER throw.
+  it.each([0, 1, 5])("does not throw RangeError when width=%i", (width) => {
+    expect(() => {
+      render(AsciiSkeleton, { props: { lines: 2, width, seed: 0 } });
+    }).not.toThrow();
+  });
+
+  it("renders only ░, space, and newline chars even at narrow widths", () => {
+    for (const width of [1, 3, 5]) {
+      const { container } = render(AsciiSkeleton, {
+        props: { lines: 2, width, seed: 7 },
+      });
+      const text = textOf(container as HTMLElement);
+      expect(text).toMatch(/^[░ \n]*$/);
+    }
+  });
 });

--- a/src/components/ascii/__tests__/AsciiSkeleton.test.ts
+++ b/src/components/ascii/__tests__/AsciiSkeleton.test.ts
@@ -1,0 +1,52 @@
+// Issue #358 PR D — primitives layer.
+// AsciiSkeleton is a deterministic, static skeleton. Tests codify
+// §1.3 of the plan + Socrates v1 m3 (LCG seed-collision regression):
+//   - aria-hidden on the host <pre>
+//   - exact line count + line width
+//   - same seed → same output (determinism)
+//   - seed=0 vs seed=1 produce DIFFERENT output (regression for the
+//     `(s | 0) || 1` aliasing bug)
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+
+import AsciiSkeleton from "../AsciiSkeleton.svelte";
+
+function textOf(container: HTMLElement): string {
+  return container.querySelector("pre.vc-ascii-skel")?.textContent ?? "";
+}
+
+describe("AsciiSkeleton (#358)", () => {
+  it("the host <pre> carries aria-hidden=true", () => {
+    const { container } = render(AsciiSkeleton, {
+      props: { lines: 3, width: 20, seed: 1 },
+    });
+    const pre = container.querySelector("pre.vc-ascii-skel")!;
+    expect(pre.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("emits exactly `lines` lines, each `width` chars long", () => {
+    const { container } = render(AsciiSkeleton, {
+      props: { lines: 3, width: 20, seed: 42 },
+    });
+    const lines = textOf(container as HTMLElement).split("\n");
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect(line).toHaveLength(20);
+      // Lines must consist only of `░` and ASCII space.
+      expect(line).toMatch(/^[░ ]+$/);
+    }
+  });
+
+  it("the same seed yields the same output across two renders (determinism)", () => {
+    const a = render(AsciiSkeleton, { props: { lines: 3, width: 20, seed: 7 } });
+    const b = render(AsciiSkeleton, { props: { lines: 3, width: 20, seed: 7 } });
+    expect(textOf(a.container as HTMLElement)).toBe(textOf(b.container as HTMLElement));
+  });
+
+  it("seeds 0 and 1 produce DIFFERENT outputs (Socrates v1 m3 regression)", () => {
+    const a = render(AsciiSkeleton, { props: { lines: 3, width: 20, seed: 0 } });
+    const b = render(AsciiSkeleton, { props: { lines: 3, width: 20, seed: 1 } });
+    expect(textOf(a.container as HTMLElement)).not.toBe(textOf(b.container as HTMLElement));
+  });
+});

--- a/src/components/ascii/__tests__/AsciiWave.test.ts
+++ b/src/components/ascii/__tests__/AsciiWave.test.ts
@@ -1,0 +1,75 @@
+// Issue #358 PR D add-on — AsciiWave primitive.
+// A travelling block-density wave (`░ ▒ ▓ █`) cycled via CSS @keyframes
+// over an 8-frame steps() animation. No JS timer; aria-hidden; obeys
+// prefers-reduced-motion.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import AsciiWave from "../AsciiWave.svelte";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SOURCE_PATH = resolve(HERE, "../AsciiWave.svelte");
+
+describe("AsciiWave (#358 add-on)", () => {
+  let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+  let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setIntervalSpy = vi.spyOn(window, "setInterval");
+    setTimeoutSpy = vi.spyOn(window, "setTimeout");
+  });
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("renders an element with class vc-ascii-wave and aria-hidden=true", () => {
+    const { container } = render(AsciiWave);
+    const root = container.querySelector(".vc-ascii-wave");
+    expect(root).toBeTruthy();
+    expect(root!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not invoke setInterval or setTimeout on mount (CSS-only animation)", () => {
+    render(AsciiWave);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("source defines a @keyframes block driving the wave frames via CSS content:", () => {
+    const src = readFileSync(SOURCE_PATH, "utf8");
+    expect(src).toMatch(/@keyframes\s+vc-ascii-wave[^{]*\{[\s\S]*content:/);
+  });
+
+  it("source has a @media (prefers-reduced-motion: reduce) rule freezing the animation", () => {
+    const src = readFileSync(SOURCE_PATH, "utf8");
+    expect(src).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    // Inside that block, the wave's animation must be set to none.
+    const media = src.match(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]*?\}\s*\}/,
+    );
+    expect(media).toBeTruthy();
+    expect(media![0]).toMatch(/animation:\s*none/);
+  });
+
+  it("source palette is block-fills and box-drawing only — no ASCII slashes in any content: declaration", () => {
+    const src = readFileSync(SOURCE_PATH, "utf8");
+    const declarations = src.match(/content:\s*"([^"]*)"/g) ?? [];
+    // The component may pass frame strings via CSS custom properties;
+    // the @keyframes block then references content: var(--vc-wave-fN).
+    // In either form, the literal `content: "..."` declarations that
+    // do exist must not contain ASCII slashes.
+    for (const decl of declarations) {
+      expect(decl).not.toMatch(/[\\/]/);
+    }
+  });
+
+  it("source uses no braille characters (U+2800–U+28FF)", () => {
+    const src = readFileSync(SOURCE_PATH, "utf8");
+    expect(src).not.toMatch(/[⠀-⣿]/);
+  });
+});


### PR DESCRIPTION
Re-open of #371 after auto-closure when the stacked base branch was deleted on PR A merge.

## Summary
- New \`<AsciiSkeleton>\` primitive (deterministic LCG-driven static placeholder, kept for the deferred EditorPane noteLoading skeleton in #372).
- New \`<AsciiWave>\` primitive (8-frame travelling block-density wave, CSS-only animation, baseline-stabilised host).
- LocalGraphPanel: graph load → \`<AsciiSpinner /> Computing local graph\`. Boy-Scout aria-labels on no-note + no-links empty divs.
- OmniSearch: animated \`<AsciiWave>\` indicator during the content-mode debounce + in-flight RPC window. Replaces the static skeleton at this surface based on UAT feedback ("zeige eine Welle als Animation während gesucht wird").

## Test plan
- [x] \`pnpm vitest run src/components/ascii src/components/Graph src/components/Search/__tests__/OmniSearch.test.ts\` — 55/55
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vite build\` clean
- [x] User UAT on integration branch (wave redesign + baseline fix accepted)

EditorPane noteLoading skeleton (Plan §6 PR-D touchpoint 5) deferred to #372 to keep PR scope tight.
Both Aristotle review rounds approved the original work; the AsciiWave addition + baseline fix were UAT-accepted by the user. Replaces the closed #371.