### PR TITLE
fix(ascii): tighten AsciiWave palette test + centre rest frame (#358)

### DIFF
--- a/src/components/ascii/AsciiWave.svelte
+++ b/src/components/ascii/AsciiWave.svelte
@@ -41,9 +41,25 @@
   }
 
   const frames = $derived(buildFrames(width));
-  // Frame 4 is roughly the middle of the cycle — used as the static
-  // fallback for prefers-reduced-motion.
-  const restFrame = $derived(frames[4] ?? "");
+
+  function buildCentredFrame(w: number): string {
+    const safeW = Math.max(0, w | 0);
+    const start = Math.floor((safeW - CREST.length) / 2);
+    const cells: string[] = [];
+    for (let c = 0; c < safeW; c++) {
+      if (c >= start && c < start + CREST.length) {
+        cells.push(CREST[c - start]!);
+      } else {
+        cells.push("░");
+      }
+    }
+    return cells.join("");
+  }
+
+  // Static fallback for prefers-reduced-motion: crest pinned at the
+  // visual centre of the strip (independent of the 8-frame cycle, whose
+  // discrete steps don't land exactly mid-strip).
+  const restFrame = $derived(buildCentredFrame(width));
 
   // Build the inline style string carrying each frame as a CSS string
   // value. Wrapping in escaped double quotes lets the keyframe's

--- a/src/components/ascii/__tests__/AsciiWave.test.ts
+++ b/src/components/ascii/__tests__/AsciiWave.test.ts
@@ -56,16 +56,20 @@ describe("AsciiWave (#358 add-on)", () => {
     expect(media![0]).toMatch(/animation:\s*none/);
   });
 
-  it("source palette is block-fills and box-drawing only — no ASCII slashes in any content: declaration", () => {
+  it("CREST constant uses only block-fill glyphs — no ASCII slashes, no braille", () => {
+    // The wave's only source of glyph variation is the CREST constant;
+    // every frame is built by sliding it across a `░` field. Asserting
+    // directly on CREST is the regression guard for palette violations.
+    // (A previous form scanned `content: "…"` literals, but the
+    // component injects frames via inline CSS custom properties, so no
+    // such literals exist and the scan was inert.)
     const src = readFileSync(SOURCE_PATH, "utf8");
-    const declarations = src.match(/content:\s*"([^"]*)"/g) ?? [];
-    // The component may pass frame strings via CSS custom properties;
-    // the @keyframes block then references content: var(--vc-wave-fN).
-    // In either form, the literal `content: "..."` declarations that
-    // do exist must not contain ASCII slashes.
-    for (const decl of declarations) {
-      expect(decl).not.toMatch(/[\\/]/);
-    }
+    const crestMatch = src.match(/const\s+CREST\s*=\s*"([^"]*)"/);
+    expect(crestMatch).toBeTruthy();
+    const crest = crestMatch![1]!;
+    expect(crest).not.toMatch(/[\\/]/);
+    expect(crest).not.toMatch(/[⠀-⣿]/);
+    expect(crest).toMatch(/^[░▒▓█]+$/);
   });
 
   it("source uses no braille characters (U+2800–U+28FF)", () => {


### PR DESCRIPTION
## Summary
Late Aristotle review on the AsciiWave addition (post-merge of #374) surfaced two issues:

- **Inert palette regression test**: scanned `content: \"...\"` literals, but the component injects every frame via inline CSS custom properties — the regex matched zero declarations and the loop never ran. A CREST mutation to ASCII slashes or braille would have slipped through silently. Replaced with a direct assertion on the CREST constant in source.
- **Off-centre rest frame**: \`frames[4]\` placed the crest at column 20 of a 36-wide strip, not the visual midpoint. Added \`buildCentredFrame\` so the \`prefers-reduced-motion\` static fallback pins the crest at the actual centre regardless of the 8-frame cycle's discrete positions.

## Test plan
- [x] \`pnpm vitest run src/components/ascii/__tests__/AsciiWave.test.ts src/components/Search/__tests__/OmniSearch.test.ts\` — 32/32
- [x] \`pnpm typecheck\` clean
- [ ] Visual UAT in Tauri (rest frame is only visible in reduced-motion mode)