### PR TITLE
feat: block references and heading anchors (#62)

### DIFF
--- a/e2e/helpers/vault.ts
+++ b/e2e/helpers/vault.ts
@@ -63,6 +63,43 @@ tags: [alpha, beta]
 ---
 # Tagged
 `,
+
+  // ── #62: block + heading anchor fixtures ──────────────────────────────
+  "Anchored.md": `# Anchored Source
+
+## Quick Recap
+
+This is the recap paragraph that the block-ref test scrolls to. ^recap
+
+## Multi Word Heading
+
+Body of the multi-word section. Slug is \`multi-word-heading\`.
+
+### Nested H3 inside Multi Word
+
+This nested heading sits inside the multi-word section embed.
+
+## Düsseldorf trip
+
+Unicode-slug section to exercise the parity fixture in a live test.
+
+## Final section
+
+Last section, embed runs to EOF.
+`,
+
+  "Anchor Refs.md": `# Anchor Refs
+
+Block ref: [[Anchored^recap]]
+
+Heading ref (multi-word slug): [[Anchored#Multi Word Heading]]
+
+Anchor missing: [[Anchored^does-not-exist]]
+
+Heading embed: ![[Anchored#Multi Word Heading]]
+
+Block embed: ![[Anchored^recap]]
+`,
 };
 
 export function createTestVault(): TestVault {

--- a/e2e/specs/block-references.spec.ts
+++ b/e2e/specs/block-references.spec.ts
@@ -1,0 +1,235 @@
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+import { textOf, textsOf } from "../helpers/text.js";
+
+/**
+ * #62 — block references and heading anchors, end-to-end.
+ *
+ * Coverage:
+ *   - resolved block-ref click opens target + applies the flash highlight
+ *   - resolved heading-ref (multi-word slug) opens target + applies flash
+ *   - anchor-missing click opens target + surfaces a `warning` toast and
+ *     decorates the link with `cm-wikilink-unresolved-anchor`
+ *   - heading-section embed renders only the section body (the H3 inside
+ *     the section is present, the next H2's body is not)
+ *   - block embed renders only the tagged paragraph (not the rest of
+ *     the source file)
+ */
+describe("Block references (#62)", () => {
+  let vault: TestVault;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+  });
+
+  after(() => {
+    vault.cleanup();
+  });
+
+  async function openTreeFile(name: string): Promise<void> {
+    const nodes = await browser.$$(".vc-tree-name");
+    for (const n of nodes) {
+      if ((await textOf(n)) === name) {
+        await n.click();
+        return;
+      }
+    }
+    throw new Error(`"${name}" not in tree`);
+  }
+
+  async function waitForVisibleEditor(): Promise<void> {
+    await browser.waitUntil(
+      async () => {
+        const els = await browser.$$(".cm-content");
+        for (const el of els) if (await el.isDisplayed()) return true;
+        return false;
+      },
+      { timeout: 5000, timeoutMsg: ".cm-content never became visible" },
+    );
+  }
+
+  async function waitForDecoration(selector: string, msg: string): Promise<void> {
+    await browser.waitUntil(
+      async () => (await browser.$$(selector)).length > 0,
+      { timeout: 5000, timeoutMsg: msg },
+    );
+  }
+
+  /**
+   * Click a wiki-link decoration matching `target` and (optionally) the
+   * given `data-wiki-anchor-value`. The CM6 plugin handles `mousedown`,
+   * not `click`, so we dispatch a real `mousedown` event.
+   */
+  async function clickWikiLink(
+    target: string,
+    anchorValue?: string,
+  ): Promise<boolean> {
+    return browser.execute(
+      (t: string, a: string | undefined) => {
+        const nodes = Array.from(
+          document.querySelectorAll<HTMLElement>("[data-wiki-target]"),
+        );
+        const match = nodes.find((el) => {
+          if (el.getAttribute("data-wiki-target") !== t) return false;
+          if (a !== undefined) {
+            return el.getAttribute("data-wiki-anchor-value") === a;
+          }
+          return true;
+        });
+        if (!match) return false;
+        match.dispatchEvent(
+          new MouseEvent("mousedown", { bubbles: true, cancelable: true, button: 0 }),
+        );
+        return true;
+      },
+      target,
+      anchorValue,
+    );
+  }
+
+  it("resolves a block-ref click and flashes the target paragraph", async () => {
+    await openTreeFile("Anchor Refs.md");
+    await waitForVisibleEditor();
+    await waitForDecoration(
+      ".cm-wikilink-resolved",
+      ".cm-wikilink-resolved never rendered",
+    );
+
+    const clicked = await clickWikiLink("Anchored", "recap");
+    expect(clicked).toBe(true);
+
+    // Anchored.md tab opens.
+    await browser.waitUntil(
+      async () => {
+        const titles = await textsOf(await browser.$$(".vc-tab-label"));
+        return titles.some((t) => t.includes("Anchored"));
+      },
+      { timeout: 3000, timeoutMsg: "Anchored tab never opened" },
+    );
+
+    // Flash decoration appears on the target range.
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-flash-highlight")).length > 0,
+      {
+        timeout: 3000,
+        timeoutMsg: ".vc-flash-highlight never appeared after anchor scroll",
+      },
+    );
+  });
+
+  it("resolves a multi-word heading-ref via the slug", async () => {
+    await openTreeFile("Anchor Refs.md");
+    await waitForVisibleEditor();
+    await waitForDecoration(
+      ".cm-wikilink-resolved",
+      ".cm-wikilink-resolved never rendered",
+    );
+
+    // The decoration's data-wiki-anchor-value preserves the raw value
+    // ("Multi Word Heading"); the slug step happens inside resolveAnchor.
+    const clicked = await clickWikiLink("Anchored", "Multi Word Heading");
+    expect(clicked).toBe(true);
+
+    await browser.waitUntil(
+      async () => (await browser.$$(".vc-flash-highlight")).length > 0,
+      {
+        timeout: 3000,
+        timeoutMsg: "heading-ref scroll did not flash the target",
+      },
+    );
+  });
+
+  it("renders missing anchors with the warning class and shows a toast on click", async () => {
+    await openTreeFile("Anchor Refs.md");
+    await waitForVisibleEditor();
+    await waitForDecoration(
+      ".cm-wikilink-unresolved-anchor",
+      ".cm-wikilink-unresolved-anchor never rendered",
+    );
+
+    const clicked = await clickWikiLink("Anchored", "does-not-exist");
+    expect(clicked).toBe(true);
+
+    // Warning toast surfaces with a message containing the anchor label.
+    await browser.waitUntil(
+      async () => {
+        const toasts = await browser.$$('[data-testid="toast"][data-variant="warning"]');
+        for (const t of toasts) {
+          const text = await textOf(t);
+          if (text.includes("does-not-exist")) return true;
+        }
+        return false;
+      },
+      {
+        timeout: 3000,
+        timeoutMsg: "warning toast for missing anchor never appeared",
+      },
+    );
+  });
+
+  it("renders a heading-section embed scoped to the section body only", async () => {
+    await openTreeFile("Anchor Refs.md");
+    await waitForVisibleEditor();
+
+    // Wait for at least one note-embed widget to render.
+    await browser.waitUntil(
+      async () => (await browser.$$(".cm-embed-note")).length > 0,
+      {
+        timeout: 5000,
+        timeoutMsg: ".cm-embed-note never rendered",
+      },
+    );
+
+    // Find the embed whose data-embed-path is Anchored.md AND that contains
+    // the multi-word heading text — there are two embeds in this file
+    // (heading + block) so we filter by content.
+    const sectionText = await browser.execute(() => {
+      const nodes = Array.from(document.querySelectorAll<HTMLElement>(".cm-embed-note"));
+      for (const n of nodes) {
+        if (n.getAttribute("data-embed-path") !== "Anchored.md") continue;
+        const t = n.textContent ?? "";
+        if (t.includes("Multi Word Heading")) return t;
+      }
+      return "";
+    });
+
+    expect(sectionText).toContain("Multi Word Heading");
+    expect(sectionText).toContain("Nested H3 inside Multi Word");
+    // Section embed must STOP at the next H2 — Düsseldorf and Final
+    // section are subsequent H2s and must not bleed in.
+    expect(sectionText).not.toContain("Düsseldorf trip");
+    expect(sectionText).not.toContain("Final section");
+  });
+
+  it("renders a block embed scoped to the tagged paragraph only", async () => {
+    await openTreeFile("Anchor Refs.md");
+    await waitForVisibleEditor();
+
+    await browser.waitUntil(
+      async () => (await browser.$$(".cm-embed-note")).length >= 2,
+      {
+        timeout: 5000,
+        timeoutMsg: "expected two .cm-embed-note widgets",
+      },
+    );
+
+    const blockText = await browser.execute(() => {
+      const nodes = Array.from(document.querySelectorAll<HTMLElement>(".cm-embed-note"));
+      for (const n of nodes) {
+        if (n.getAttribute("data-embed-path") !== "Anchored.md") continue;
+        const t = n.textContent ?? "";
+        // Block embed contains the recap line but not the heading.
+        if (t.includes("recap paragraph") && !t.includes("Multi Word Heading")) {
+          return t;
+        }
+      }
+      return "";
+    });
+
+    expect(blockText).toContain("recap paragraph");
+    // Other sections of Anchored.md must not leak into the block embed.
+    expect(blockText).not.toContain("Multi Word Heading");
+    expect(blockText).not.toContain("Final section");
+  });
+});

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 
 use crate::encryption::CanonicalPath;
 use crate::error::VaultError;
+use crate::indexer::anchors::AnchorKeySet;
 use crate::indexer::link_graph::{self, BacklinkEntry, LinkGraph, ParsedLink, UnresolvedLink};
 use crate::indexer::memory::FileIndex;
 use crate::indexer::tag_index::TagIndex;
@@ -136,8 +137,15 @@ pub struct RenameResult {
 /// internally consistent.
 ///
 /// `re` MUST be the pre-compiled rename regex
-/// (`\[\[<old_stem>(\|[^\]]*)?(\]\])`).  Compilation is hoisted to the
-/// caller so the `rayon` parallel loop reuses a single instance.
+/// (`\[\[<old_stem>(#[^\]\|\^]+)?(\^[A-Za-z0-9-]+)?(\|[^\]]*)?(\]\])`).
+/// Compilation is hoisted to the caller so the `rayon` parallel loop
+/// reuses a single instance.
+///
+/// #62: heading (`#H`) and block-id (`^id`) suffixes are preserved
+/// unchanged so a rename of `Note` → `NewNote` rewrites `[[Note#H]]` →
+/// `[[NewNote#H]]` and `[[Note^id]]` → `[[NewNote^id]]` instead of
+/// collapsing them to `[[NewNote]]` (which would silently drop the anchor
+/// and route every cascade'd link to the top of the renamed note).
 fn rewrite_wiki_links_respecting_templates(
     content: &str,
     re: &Regex,
@@ -152,8 +160,10 @@ fn rewrite_wiki_links_respecting_templates(
                 return whole.as_str().to_string();
             }
             link_count += 1;
-            let alias_part = caps.get(1).map(|m| m.as_str()).unwrap_or("");
-            format!("[[{}{}]]", new_stem, alias_part)
+            let heading_part = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+            let block_part = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+            let alias_part = caps.get(3).map(|m| m.as_str()).unwrap_or("");
+            format!("[[{}{}{}{}]]", new_stem, heading_part, block_part, alias_part)
         })
         .into_owned();
     (new_content, link_count)
@@ -421,8 +431,15 @@ pub async fn update_links_after_rename(
         .strip_suffix(".md")
         .unwrap_or(&new_path);
 
-    // Regex: [[old_stem]] or [[old_stem|alias]]
-    let pattern = format!(r"\[\[{}(\|[^\]]*)?(\]\])", regex::escape(old_stem));
+    // Regex: [[old_stem]], [[old_stem#H]], [[old_stem^id]], [[old_stem|alias]],
+    // [[old_stem#H|alias]], [[old_stem^id|alias]], or any combination thereof.
+    // #62: heading and block-id suffixes are captured separately so the
+    // rewriter preserves them on the rewritten link instead of collapsing
+    // every cascade'd link to a bare stem reference.
+    let pattern = format!(
+        r"\[\[{}(#[^\]\|\^]+)?(\^[A-Za-z0-9-]+)?(\|[^\]]*)?(\]\])",
+        regex::escape(old_stem)
+    );
     let re = Regex::new(&pattern).map_err(|e| {
         VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
@@ -673,6 +690,52 @@ pub async fn get_resolved_links(
         .filter(|(p, _)| !checker.is_locked(p))
         .collect();
     Ok(link_graph::resolved_map_with_aliases(&paths, &filtered_aliases))
+}
+
+// ── get_resolved_anchors ───────────────────────────────────────────────────────
+
+/// Return a `rel_path -> AnchorKeySet` map covering every indexed file that
+/// owns at least one block-id or heading anchor (#62).
+///
+/// Two design decisions baked in:
+///   1. **Keyed by rel_path**, not stem. Anchor data is unambiguous given the
+///      file's relative path; stems can collide across folders.
+///   2. **UTF-16 offsets are precomputed in Rust.** The frontend slices
+///      `noteContentCache` content (a JS string) directly with `js_start /
+///      js_end`, which avoids byte-vs-code-unit drift on multi-byte content
+///      (CJK, emoji). Byte offsets are still surfaced for tools and tests.
+///
+/// Empty entries are skipped so the wire payload stays bounded — most notes
+/// in a typical vault carry zero anchors.
+#[tauri::command]
+pub async fn get_resolved_anchors(
+    state: tauri::State<'_, VaultState>,
+) -> Result<HashMap<String, AnchorKeySet>, VaultError> {
+    let ai_arc = {
+        let guard = state
+            .index_coordinator
+            .lock()
+            .map_err(|_| VaultError::IndexCorrupt)?;
+        match guard.as_ref() {
+            Some(c) => c.anchor_index(),
+            None => return Ok(HashMap::new()),
+        }
+    };
+
+    let snapshot = {
+        let ai = ai_arc.lock().map_err(|_| VaultError::IndexCorrupt)?;
+        ai.snapshot_payload()
+    };
+
+    // #345 parity with `get_resolved_links`: drop entries whose path lives
+    // inside a locked encrypted root so anchor data doesn't leak.
+    let checker = LockedRelChecker::new(&state);
+    Ok(snapshot
+        .into_iter()
+        .filter(|(rel, ks)| {
+            !checker.is_locked(rel) && (!ks.blocks.is_empty() || !ks.headings.is_empty())
+        })
+        .collect())
 }
 
 // ── get_resolved_attachments ───────────────────────────────────────────────────
@@ -1243,7 +1306,10 @@ mod tests {
     // render and the user may not notice until much later.
 
     fn build_rename_regex(old_stem: &str) -> regex::Regex {
-        let pattern = format!(r"\[\[{}(\|[^\]]*)?(\]\])", regex::escape(old_stem));
+        let pattern = format!(
+            r"\[\[{}(#[^\]\|\^]+)?(\^[A-Za-z0-9-]+)?(\|[^\]]*)?(\]\])",
+            regex::escape(old_stem)
+        );
         regex::Regex::new(&pattern).expect("test regex must compile")
     }
 
@@ -1284,6 +1350,44 @@ mod tests {
         let (out, count) = rewrite_wiki_links_respecting_templates(content, &re, "bar");
         assert_eq!(count, 0);
         assert_eq!(out, content);
+    }
+
+    // ── #62: rename cascade preserves block-id and heading suffixes ────────
+
+    #[test]
+    fn rewrite_preserves_heading_anchor_on_rename() {
+        let re = build_rename_regex("foo");
+        let content = "see [[foo#Section Title]] for more";
+        let (out, count) = rewrite_wiki_links_respecting_templates(content, &re, "bar");
+        assert_eq!(count, 1);
+        assert_eq!(out, "see [[bar#Section Title]] for more");
+    }
+
+    #[test]
+    fn rewrite_preserves_block_anchor_on_rename() {
+        let re = build_rename_regex("foo");
+        let content = "see [[foo^para1]] then [[foo^para2]]";
+        let (out, count) = rewrite_wiki_links_respecting_templates(content, &re, "bar");
+        assert_eq!(count, 2);
+        assert_eq!(out, "see [[bar^para1]] then [[bar^para2]]");
+    }
+
+    #[test]
+    fn rewrite_preserves_heading_plus_alias() {
+        let re = build_rename_regex("foo");
+        let content = "[[foo#Heading|Display]]";
+        let (out, count) = rewrite_wiki_links_respecting_templates(content, &re, "bar");
+        assert_eq!(count, 1);
+        assert_eq!(out, "[[bar#Heading|Display]]");
+    }
+
+    #[test]
+    fn rewrite_preserves_block_plus_alias() {
+        let re = build_rename_regex("foo");
+        let content = "[[foo^id|caption]]";
+        let (out, count) = rewrite_wiki_links_respecting_templates(content, &re, "bar");
+        assert_eq!(count, 1);
+        assert_eq!(out, "[[bar^id|caption]]");
     }
 
     #[test]

--- a/src-tauri/src/indexer/anchor_index.rs
+++ b/src-tauri/src/indexer/anchor_index.rs
@@ -13,11 +13,9 @@ use super::anchors::{build_anchor_key_set, AnchorKeySet, AnchorTable};
 
 #[derive(Debug, Default)]
 pub struct AnchorIndex {
-    by_path: HashMap<String, AnchorTable>,
-    /// Pre-built wire-format payload kept in lock-step with `by_path`. The
-    /// hot get_resolved_anchors path returns this without re-walking the
-    /// table on every IPC, mirroring the prebuilt-cache idea behind
-    /// `StemIndex` for the link-resolution path.
+    /// Pre-built wire-format payload — what `get_resolved_anchors` returns.
+    /// We don't keep `AnchorTable` separately: only the payload is read
+    /// downstream, and storing both doubles memory + risks drift.
     payload: HashMap<String, AnchorKeySet>,
 }
 
@@ -26,34 +24,25 @@ impl AnchorIndex {
         Self::default()
     }
 
-    /// Replace the anchor data for a single file. Idempotent: a second call
-    /// for the same path overwrites the first.
+    /// Replace the anchor data for a single file via raw inputs. Idempotent.
+    /// Used by the watcher path (`UpdateLinks`) which holds the AnchorTable
+    /// directly. Cold-start uses `update_file_with_payload` to skip the
+    /// table-keeping that would balloon the cold-start buffer.
     pub fn update_file(&mut self, rel_path: &str, content: &str, table: AnchorTable) {
         let payload = build_anchor_key_set(content, &table);
+        self.update_file_with_payload(rel_path, payload);
+    }
+
+    /// Replace the anchor data for a single file with a precomputed payload.
+    /// Used by the cold-start flush so we never carry raw file contents
+    /// past the per-file loop body.
+    pub fn update_file_with_payload(&mut self, rel_path: &str, payload: AnchorKeySet) {
         self.payload.insert(rel_path.to_string(), payload);
-        self.by_path.insert(rel_path.to_string(), table);
     }
 
     /// Drop every anchor entry for a file (used on delete and rename-old).
     pub fn remove_file(&mut self, rel_path: &str) {
-        self.by_path.remove(rel_path);
         self.payload.remove(rel_path);
-    }
-
-    /// Re-key an existing entry on rename — anchor data is keyed by rel_path
-    /// only (anchor content is independent of filename), so rename does not
-    /// invalidate the table itself. Cheaper than removing + re-extracting.
-    pub fn rename_file(&mut self, old_rel: &str, new_rel: &str) {
-        if let Some(table) = self.by_path.remove(old_rel) {
-            self.by_path.insert(new_rel.to_string(), table);
-        }
-        if let Some(payload) = self.payload.remove(old_rel) {
-            self.payload.insert(new_rel.to_string(), payload);
-        }
-    }
-
-    pub fn anchors_for(&self, rel_path: &str) -> Option<&AnchorTable> {
-        self.by_path.get(rel_path)
     }
 
     /// Snapshot for the wire payload — clones the precomputed map, no
@@ -69,38 +58,36 @@ mod tests {
     use crate::indexer::anchors::extract_anchors;
 
     #[test]
-    fn rename_moves_entry_without_recomputing() {
-        let mut idx = AnchorIndex::new();
-        let md = "para ^id1\n";
-        let table = extract_anchors(md);
-        idx.update_file("old.md", md, table);
-        idx.rename_file("old.md", "new.md");
-        assert!(idx.anchors_for("old.md").is_none());
-        assert!(idx.anchors_for("new.md").is_some());
-        let payload = idx.snapshot_payload();
-        assert!(payload.contains_key("new.md"));
-        assert!(!payload.contains_key("old.md"));
-    }
-
-    #[test]
     fn update_overwrites_previous_entry() {
         let mut idx = AnchorIndex::new();
         let md1 = "first ^a\n";
         let md2 = "second ^b\n";
         idx.update_file("note.md", md1, extract_anchors(md1));
         idx.update_file("note.md", md2, extract_anchors(md2));
-        let table = idx.anchors_for("note.md").unwrap();
-        assert_eq!(table.blocks.len(), 1);
-        assert_eq!(table.blocks[0].id, "b");
+        let payload = idx.snapshot_payload();
+        let entry = payload.get("note.md").expect("entry must exist");
+        assert_eq!(entry.blocks.len(), 1);
+        assert_eq!(entry.blocks[0].id, "b");
     }
 
     #[test]
-    fn remove_drops_both_table_and_payload() {
+    fn remove_drops_payload() {
         let mut idx = AnchorIndex::new();
         let md = "para ^id\n";
         idx.update_file("n.md", md, extract_anchors(md));
         idx.remove_file("n.md");
-        assert!(idx.anchors_for("n.md").is_none());
         assert!(!idx.snapshot_payload().contains_key("n.md"));
+    }
+
+    #[test]
+    fn update_file_with_payload_round_trips() {
+        let mut idx = AnchorIndex::new();
+        let md = "para ^id\n";
+        let table = extract_anchors(md);
+        let payload = super::super::anchors::build_anchor_key_set(md, &table);
+        idx.update_file_with_payload("n.md", payload);
+        let snap = idx.snapshot_payload();
+        assert!(snap.contains_key("n.md"));
+        assert_eq!(snap["n.md"].blocks[0].id, "id");
     }
 }

--- a/src-tauri/src/indexer/anchor_index.rs
+++ b/src-tauri/src/indexer/anchor_index.rs
@@ -1,0 +1,106 @@
+// Per-vault anchor index — maps `rel_path -> AnchorTable` for every indexed
+// `.md` file. Sibling to `LinkGraph` and `TagIndex` so the same Arc<Mutex<>>
+// + accessor pattern carries over.
+//
+// Two consumers:
+//   - `get_resolved_anchors` (Tauri command) returns a snapshot per vault open.
+//   - `resolve_anchor` is called by the rename-cascade Rust path so anchors
+//     survive a rename without a frontend round-trip.
+
+use std::collections::HashMap;
+
+use super::anchors::{build_anchor_key_set, AnchorKeySet, AnchorTable};
+
+#[derive(Debug, Default)]
+pub struct AnchorIndex {
+    by_path: HashMap<String, AnchorTable>,
+    /// Pre-built wire-format payload kept in lock-step with `by_path`. The
+    /// hot get_resolved_anchors path returns this without re-walking the
+    /// table on every IPC, mirroring the prebuilt-cache idea behind
+    /// `StemIndex` for the link-resolution path.
+    payload: HashMap<String, AnchorKeySet>,
+}
+
+impl AnchorIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the anchor data for a single file. Idempotent: a second call
+    /// for the same path overwrites the first.
+    pub fn update_file(&mut self, rel_path: &str, content: &str, table: AnchorTable) {
+        let payload = build_anchor_key_set(content, &table);
+        self.payload.insert(rel_path.to_string(), payload);
+        self.by_path.insert(rel_path.to_string(), table);
+    }
+
+    /// Drop every anchor entry for a file (used on delete and rename-old).
+    pub fn remove_file(&mut self, rel_path: &str) {
+        self.by_path.remove(rel_path);
+        self.payload.remove(rel_path);
+    }
+
+    /// Re-key an existing entry on rename — anchor data is keyed by rel_path
+    /// only (anchor content is independent of filename), so rename does not
+    /// invalidate the table itself. Cheaper than removing + re-extracting.
+    pub fn rename_file(&mut self, old_rel: &str, new_rel: &str) {
+        if let Some(table) = self.by_path.remove(old_rel) {
+            self.by_path.insert(new_rel.to_string(), table);
+        }
+        if let Some(payload) = self.payload.remove(old_rel) {
+            self.payload.insert(new_rel.to_string(), payload);
+        }
+    }
+
+    pub fn anchors_for(&self, rel_path: &str) -> Option<&AnchorTable> {
+        self.by_path.get(rel_path)
+    }
+
+    /// Snapshot for the wire payload — clones the precomputed map, no
+    /// re-walking. Drop this guard before any await point.
+    pub fn snapshot_payload(&self) -> HashMap<String, AnchorKeySet> {
+        self.payload.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::anchors::extract_anchors;
+
+    #[test]
+    fn rename_moves_entry_without_recomputing() {
+        let mut idx = AnchorIndex::new();
+        let md = "para ^id1\n";
+        let table = extract_anchors(md);
+        idx.update_file("old.md", md, table);
+        idx.rename_file("old.md", "new.md");
+        assert!(idx.anchors_for("old.md").is_none());
+        assert!(idx.anchors_for("new.md").is_some());
+        let payload = idx.snapshot_payload();
+        assert!(payload.contains_key("new.md"));
+        assert!(!payload.contains_key("old.md"));
+    }
+
+    #[test]
+    fn update_overwrites_previous_entry() {
+        let mut idx = AnchorIndex::new();
+        let md1 = "first ^a\n";
+        let md2 = "second ^b\n";
+        idx.update_file("note.md", md1, extract_anchors(md1));
+        idx.update_file("note.md", md2, extract_anchors(md2));
+        let table = idx.anchors_for("note.md").unwrap();
+        assert_eq!(table.blocks.len(), 1);
+        assert_eq!(table.blocks[0].id, "b");
+    }
+
+    #[test]
+    fn remove_drops_both_table_and_payload() {
+        let mut idx = AnchorIndex::new();
+        let md = "para ^id\n";
+        idx.update_file("n.md", md, extract_anchors(md));
+        idx.remove_file("n.md");
+        assert!(idx.anchors_for("n.md").is_none());
+        assert!(!idx.snapshot_payload().contains_key("n.md"));
+    }
+}

--- a/src-tauri/src/indexer/anchors.rs
+++ b/src-tauri/src/indexer/anchors.rs
@@ -728,4 +728,38 @@ mod tests {
         assert!(table.blocks.is_empty());
         assert!(table.headings.is_empty());
     }
+
+    // ── Cross-language parity (#62) ────────────────────────────────────────
+    //
+    // Same shape as `template_expr_regex_matches_shared_fixture`: the JSON
+    // fixture lives next to the Rust crate root and is consumed by both
+    // sides. Drift in the slug algorithm would silently break every
+    // multi-word heading anchor — keep them in lockstep.
+
+    #[derive(serde::Deserialize)]
+    struct SlugCase {
+        name: String,
+        input: String,
+        expected: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct SlugFixture {
+        cases: Vec<SlugCase>,
+    }
+
+    #[test]
+    fn slugify_parity_fixture() {
+        const FIXTURE: &str = include_str!("../../../test-fixtures/slug_parity.json");
+        let fixture: SlugFixture = serde_json::from_str(FIXTURE)
+            .expect("slug_parity.json is valid JSON");
+        for case in &fixture.cases {
+            assert_eq!(
+                slugify(&case.input),
+                case.expected,
+                "parity mismatch on case {:?}",
+                case.name,
+            );
+        }
+    }
 }

--- a/src-tauri/src/indexer/anchors.rs
+++ b/src-tauri/src/indexer/anchors.rs
@@ -1,0 +1,731 @@
+// Per-file anchor extraction (#62).
+//
+// Walks Markdown content with `pulldown-cmark` and emits two anchor tables:
+//
+//   - block anchors: `^blockid` tags trailing a paragraph, list item,
+//     heading, or callout. The `id` is lowercased; `byte_end` excludes the
+//     trailing tag so renderers can slice the block content cleanly.
+//   - heading anchors: every heading, with a GFM-style slug derived from
+//     the heading text (after stripping a trailing `^id`). `byte_end` is
+//     the end of the heading section — the byte offset of the next heading
+//     at the same or higher level, or the document end.
+//
+// Single source of truth for both Rust-side resolution (`resolve_anchor`)
+// and the wire payload consumed by the frontend (`AnchorEntry::js_start /
+// js_end` for direct slicing of UTF-16 JS strings).
+//
+// Anchor extraction is suppressed inside fenced/indented code blocks and
+// inside `{{ ... }}` template-expression bodies — both would otherwise
+// produce phantom anchors from source code that resembles a tag.
+
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use regex::Regex;
+use serde::Serialize;
+use std::sync::OnceLock;
+
+use super::link_graph::{overlaps_any, template_expr_ranges};
+
+// ── Public types ───────────────────────────────────────────────────────────────
+
+/// Logical block kind that owns the trailing `^blockid` tag. Headings and
+/// callouts are first-class so the embed-slice path can shape the rendered
+/// content per the design brief without a second pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BlockKind {
+    Paragraph,
+    ListItem,
+    Heading,
+    Callout,
+}
+
+/// One block anchor (`^blockid`) extracted from a Markdown file.
+#[derive(Debug, Clone)]
+pub struct BlockAnchor {
+    /// Lowercased id without the leading caret.
+    pub id: String,
+    /// 0-based line of the block's first line.
+    pub line: u32,
+    /// Byte offset (in the original UTF-8 content) of the block's first byte.
+    pub byte_start: usize,
+    /// Byte offset just past the last content byte of the block, **excluding**
+    /// the trailing whitespace + `^id` tag. This is what slicers consume.
+    pub byte_end: usize,
+    pub kind: BlockKind,
+}
+
+/// One heading anchor — emitted for every heading in the document.
+#[derive(Debug, Clone)]
+pub struct HeadingAnchor {
+    /// GFM-style slug, lowercased; collisions get `-1`, `-2`, ... in document
+    /// order so each slug is unique within the file.
+    pub slug: String,
+    /// Original heading text (with `^id` trimmed if present).
+    pub text: String,
+    pub level: u8,
+    pub line: u32,
+    /// Byte offset of the heading's first byte.
+    pub byte_start: usize,
+    /// Byte offset of the **section** end: next heading at the same or higher
+    /// level, or the document length. Heading-embed renderers slice
+    /// `[byte_start..byte_end)` to show the heading + its body (per Vitruvius).
+    pub byte_end: usize,
+}
+
+/// All anchors inside one file.
+#[derive(Debug, Clone, Default)]
+pub struct AnchorTable {
+    pub blocks: Vec<BlockAnchor>,
+    pub headings: Vec<HeadingAnchor>,
+}
+
+// ── Wire format (frontend payload) ─────────────────────────────────────────────
+//
+// `AnchorEntry` is what `get_resolved_anchors` returns. Two pairs of offsets:
+//
+//   - `byte_start` / `byte_end` — UTF-8 byte offsets, kept for tools and
+//     tests that operate on raw bytes.
+//   - `js_start` / `js_end`     — UTF-16 code-unit offsets. JS strings are
+//     UTF-16 indexed; precomputing the conversion here lets the frontend
+//     slice `noteContentCache` content directly with `String.prototype.slice`
+//     without ever decoding bytes (Socrates B2). Multi-byte content (CJK,
+//     emoji) would otherwise produce wrong slices.
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnchorEntry {
+    /// `id` for blocks, `slug` for headings.
+    pub id: String,
+    pub byte_start: u32,
+    pub byte_end: u32,
+    pub js_start: u32,
+    pub js_end: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnchorKeySet {
+    pub blocks: Vec<AnchorEntry>,
+    pub headings: Vec<AnchorEntry>,
+}
+
+// ── Block-id regex ─────────────────────────────────────────────────────────────
+
+fn block_id_trailer_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // Anchored to the line end so mid-paragraph `^foo` doesn't false-match.
+        // `\s` includes CR so CRLF endings are absorbed before `\s*$`.
+        Regex::new(r"(?m)\s\^([A-Za-z0-9-]+)\s*$").expect("invalid block-id regex")
+    })
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/// Extract all anchors from `content`. Single pass over the markdown tree.
+pub fn extract_anchors(content: &str) -> AnchorTable {
+    let template_ranges = template_expr_ranges(content);
+    let mut state = ExtractState::new(content, template_ranges);
+    let parser = Parser::new_ext(content, Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TABLES);
+    for (event, range) in parser.into_offset_iter() {
+        state.feed(event, range);
+    }
+    state.finish()
+}
+
+// ── Extraction state machine ───────────────────────────────────────────────────
+
+struct ExtractState<'a> {
+    content: &'a str,
+    template_ranges: Vec<(usize, usize)>,
+    blocks: Vec<BlockAnchor>,
+    headings: Vec<HeadingAnchor>,
+    /// Tracks whether we are currently inside a fenced/indented code block.
+    /// `pulldown-cmark` events for `Tag::CodeBlock` bracket the contents.
+    in_code_block: bool,
+    /// Stack of open block-quote starts (byte offsets). The outermost open
+    /// block quote whose first paragraph begins with `[!type]` is treated as
+    /// a callout and tagged when its End fires.
+    block_quote_stack: Vec<usize>,
+    /// Open list-item ranges so a `^id` on the last line of a nested list
+    /// item binds to its full `[byte_start..byte_end)`.
+    list_item_stack: Vec<usize>,
+    /// Open paragraph range — captured so a `^id` on a paragraph's last
+    /// line gets the paragraph byte range, not the inline text range.
+    paragraph_start: Option<usize>,
+    /// Open heading state — `(byte_start, level, line)`.
+    heading_stack: Vec<(usize, HeadingLevel, u32)>,
+    /// Carry slugs already emitted to apply collision suffixes (-1, -2, ...).
+    slug_counts: std::collections::HashMap<String, u32>,
+}
+
+impl<'a> ExtractState<'a> {
+    fn new(content: &'a str, template_ranges: Vec<(usize, usize)>) -> Self {
+        Self {
+            content,
+            template_ranges,
+            blocks: Vec::new(),
+            headings: Vec::new(),
+            in_code_block: false,
+            block_quote_stack: Vec::new(),
+            list_item_stack: Vec::new(),
+            paragraph_start: None,
+            heading_stack: Vec::new(),
+            slug_counts: std::collections::HashMap::new(),
+        }
+    }
+
+    fn feed(&mut self, event: Event<'_>, range: std::ops::Range<usize>) {
+        match event {
+            Event::Start(Tag::CodeBlock(_)) => {
+                self.in_code_block = true;
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                self.in_code_block = false;
+            }
+            Event::Start(Tag::BlockQuote(_)) => {
+                self.block_quote_stack.push(range.start);
+            }
+            Event::End(TagEnd::BlockQuote(_)) => {
+                let start = self.block_quote_stack.pop().unwrap_or(range.start);
+                if self.in_code_block {
+                    return;
+                }
+                if !self.is_callout_quote(start, range.end) {
+                    return;
+                }
+                self.try_emit_block_anchor(start, range.end, BlockKind::Callout);
+            }
+            Event::Start(Tag::Item) => {
+                self.list_item_stack.push(range.start);
+            }
+            Event::End(TagEnd::Item) => {
+                let start = self.list_item_stack.pop().unwrap_or(range.start);
+                if self.in_code_block {
+                    return;
+                }
+                self.try_emit_block_anchor(start, range.end, BlockKind::ListItem);
+            }
+            Event::Start(Tag::Paragraph) => {
+                self.paragraph_start = Some(range.start);
+            }
+            Event::End(TagEnd::Paragraph) => {
+                let start = self.paragraph_start.take().unwrap_or(range.start);
+                if self.in_code_block {
+                    return;
+                }
+                // A paragraph that lives directly inside a list item or
+                // block quote has its own block-id binding deferred to the
+                // outer container's End event. Skip emission here so the
+                // tag binds to the list-item or callout, not the inner
+                // paragraph fragment.
+                if !self.list_item_stack.is_empty() || !self.block_quote_stack.is_empty() {
+                    return;
+                }
+                self.try_emit_block_anchor(start, range.end, BlockKind::Paragraph);
+            }
+            Event::Start(Tag::Heading { level, .. }) => {
+                let line = self.line_of(range.start);
+                self.heading_stack.push((range.start, level, line));
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                let (start, level, line) = match self.heading_stack.pop() {
+                    Some(v) => v,
+                    None => return,
+                };
+                if self.in_code_block {
+                    return;
+                }
+                // A heading may carry both a `^id` (block anchor) and a
+                // slug (heading anchor). Emit both so `[[note^id]]` and
+                // `[[note#Heading]]` resolve independently per the AC.
+                let heading_slice = &self.content[start..range.end];
+                let (text_no_id, block_id) = split_trailing_block_id(heading_slice);
+                if let Some(id) = block_id {
+                    let tag_len = trailing_block_id_byte_len(heading_slice);
+                    let id_start = range.end - tag_len;
+                    if !overlaps_any(&self.template_ranges, id_start, range.end) {
+                        self.blocks.push(BlockAnchor {
+                            id: id.to_lowercase(),
+                            line,
+                            byte_start: start,
+                            byte_end: id_start,
+                            kind: BlockKind::Heading,
+                        });
+                    }
+                }
+                let heading_text = strip_heading_markers(text_no_id);
+                let raw_slug = slugify(&heading_text);
+                let slug = self.disambiguate_slug(raw_slug);
+                self.headings.push(HeadingAnchor {
+                    slug,
+                    text: heading_text,
+                    level: heading_level_to_u8(level),
+                    line,
+                    byte_start: start,
+                    // byte_end is patched in `finish()` once the next-sibling
+                    // heading position is known.
+                    byte_end: range.end,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    fn try_emit_block_anchor(&mut self, start: usize, end: usize, kind: BlockKind) {
+        let slice = &self.content[start..end];
+        let (text_no_id, block_id) = split_trailing_block_id(slice);
+        let _ = text_no_id;
+        let id = match block_id {
+            Some(s) => s,
+            None => return,
+        };
+        let id_byte_len = trailing_block_id_byte_len(slice);
+        let trimmed_end = end.saturating_sub(id_byte_len);
+        // Template-overlap is checked against the tag's own byte range, not
+        // the whole block — a paragraph may legitimately reference a template
+        // body in its middle while still carrying a real `^id` tag at its
+        // end. Only the tag location decides whether emission is suppressed.
+        if overlaps_any(&self.template_ranges, trimmed_end, end) {
+            return;
+        }
+        let line = self.line_of(start);
+        // First-wins on duplicate ids within one file. Mirrors the
+        // alias-collision pattern in link_graph.rs.
+        if self.blocks.iter().any(|b| b.id == id.to_lowercase()) {
+            log::info!(
+                "duplicate block-id '{}' encountered; keeping first occurrence",
+                id
+            );
+            return;
+        }
+        self.blocks.push(BlockAnchor {
+            id: id.to_lowercase(),
+            line,
+            byte_start: start,
+            byte_end: trimmed_end,
+            kind,
+        });
+    }
+
+    fn is_callout_quote(&self, start: usize, end: usize) -> bool {
+        // Callouts open the blockquote with `> [!type]` on the first line.
+        // Detection mirrors the frontend `parseCallout`: a blockquote whose
+        // stripped first non-empty line begins with `[!`.
+        let slice = &self.content[start..end];
+        for raw_line in slice.lines() {
+            let line = raw_line.trim_start();
+            let after_quote = match line.strip_prefix('>') {
+                Some(rest) => rest.trim_start(),
+                None => continue,
+            };
+            if after_quote.is_empty() {
+                continue;
+            }
+            return after_quote.starts_with("[!");
+        }
+        false
+    }
+
+    fn line_of(&self, byte: usize) -> u32 {
+        if byte == 0 {
+            return 0;
+        }
+        let count = self.content[..byte].bytes().filter(|&b| b == b'\n').count();
+        count as u32
+    }
+
+    fn disambiguate_slug(&mut self, raw: String) -> String {
+        let count = self.slug_counts.entry(raw.clone()).or_insert(0);
+        let result = if *count == 0 {
+            raw.clone()
+        } else {
+            format!("{}-{}", raw, count)
+        };
+        *count += 1;
+        result
+    }
+
+    fn finish(mut self) -> AnchorTable {
+        // Patch heading byte_end to the next-sibling heading start (same or
+        // higher level) so heading-embed slicing covers heading + section
+        // body up to (not including) the next heading at the same or higher
+        // level. Last heading covers to EOF.
+        let total = self.headings.len();
+        let doc_end = self.content.len();
+        for i in 0..total {
+            let level_i = self.headings[i].level;
+            let mut end = doc_end;
+            for j in (i + 1)..total {
+                if self.headings[j].level <= level_i {
+                    end = self.headings[j].byte_start;
+                    break;
+                }
+            }
+            self.headings[i].byte_end = end;
+        }
+        AnchorTable {
+            blocks: self.blocks,
+            headings: self.headings,
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/// Split a block's text slice into `(text_without_trailing_id, Some(id))` if
+/// it ends with `<whitespace>^<id><optional whitespace>`; `(slice, None)`
+/// otherwise.
+fn split_trailing_block_id(slice: &str) -> (&str, Option<String>) {
+    let re = block_id_trailer_re();
+    if let Some(cap) = re.captures(slice) {
+        let m = cap.get(0).expect("capture 0 always present");
+        let id = cap.get(1).expect("capture 1 always present").as_str().to_string();
+        return (&slice[..m.start()], Some(id));
+    }
+    (slice, None)
+}
+
+/// Number of bytes consumed by the trailing `<ws>^id<ws>` tag, or 0 when no
+/// tag is present. Used to compute `byte_end` exclusive of the tag.
+fn trailing_block_id_byte_len(slice: &str) -> usize {
+    let re = block_id_trailer_re();
+    re.captures(slice)
+        .and_then(|c| c.get(0))
+        .map(|m| slice.len() - m.start())
+        .unwrap_or(0)
+}
+
+/// Strip leading `#` markers + surrounding whitespace from a raw heading slice.
+fn strip_heading_markers(slice: &str) -> String {
+    let trimmed = slice.trim();
+    let stripped = trimmed.trim_start_matches('#').trim();
+    stripped.to_string()
+}
+
+fn heading_level_to_u8(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+/// GFM-style slugify with Obsidian-parity Unicode handling:
+///   - lowercase (Unicode-aware via `str::to_lowercase`)
+///   - whitespace runs → single `-`
+///   - keep alphanumerics (Unicode), `-`, `_`; drop everything else
+///   - collapse repeated `-`, trim ends
+pub fn slugify(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut last_was_dash = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if !last_was_dash && !out.is_empty() {
+                out.push('-');
+                last_was_dash = true;
+            }
+            continue;
+        }
+        if ch.is_alphanumeric() || ch == '-' || ch == '_' {
+            for low in ch.to_lowercase() {
+                out.push(low);
+            }
+            last_was_dash = false;
+            continue;
+        }
+        // punctuation / emoji / other: drop, but treat consecutive drops as
+        // potential dash boundaries only if separated by a space, which is
+        // already handled by the whitespace branch above.
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    while out.starts_with('-') {
+        out.remove(0);
+    }
+    out
+}
+
+// ── Wire-format conversion ─────────────────────────────────────────────────────
+
+/// Build the camelCase wire payload for one file. UTF-16 offsets are
+/// computed by walking the content once and maintaining a running counter.
+pub fn build_anchor_key_set(content: &str, table: &AnchorTable) -> AnchorKeySet {
+    if table.blocks.is_empty() && table.headings.is_empty() {
+        return AnchorKeySet::default();
+    }
+    let mut offsets: Vec<(usize, u32)> = Vec::new();
+    // Collect every byte offset we need to translate, dedup, sort, then walk.
+    for b in &table.blocks {
+        offsets.push((b.byte_start, 0));
+        offsets.push((b.byte_end, 0));
+    }
+    for h in &table.headings {
+        offsets.push((h.byte_start, 0));
+        offsets.push((h.byte_end, 0));
+    }
+    offsets.sort_by_key(|(b, _)| *b);
+    offsets.dedup_by_key(|(b, _)| *b);
+
+    let mut byte_to_js: std::collections::HashMap<usize, u32> =
+        std::collections::HashMap::with_capacity(offsets.len());
+    let mut js: u32 = 0;
+    let mut byte_idx: usize = 0;
+    let mut cursor = 0usize;
+    let bytes = content.as_bytes();
+    while byte_idx < offsets.len() {
+        let target = offsets[byte_idx].0;
+        if target == cursor {
+            byte_to_js.insert(target, js);
+            byte_idx += 1;
+            continue;
+        }
+        if target < cursor || target > bytes.len() {
+            // Out-of-range or already past — pin to current js position.
+            byte_to_js.insert(target, js);
+            byte_idx += 1;
+            continue;
+        }
+        // Walk one Unicode scalar from `cursor`.
+        let ch_len = utf8_char_len(bytes[cursor]);
+        if cursor + ch_len > bytes.len() {
+            byte_to_js.insert(target, js);
+            byte_idx += 1;
+            continue;
+        }
+        // SAFETY: we walked Unicode boundaries via `utf8_char_len`.
+        let ch = std::str::from_utf8(&bytes[cursor..cursor + ch_len])
+            .ok()
+            .and_then(|s| s.chars().next());
+        match ch {
+            Some(c) => {
+                js += c.len_utf16() as u32;
+                cursor += ch_len;
+            }
+            None => {
+                cursor += 1;
+            }
+        }
+    }
+
+    let mk = |id: &str, bs: usize, be: usize| -> AnchorEntry {
+        AnchorEntry {
+            id: id.to_string(),
+            byte_start: bs as u32,
+            byte_end: be as u32,
+            js_start: byte_to_js.get(&bs).copied().unwrap_or(js),
+            js_end: byte_to_js.get(&be).copied().unwrap_or(js),
+        }
+    };
+
+    AnchorKeySet {
+        blocks: table.blocks.iter().map(|b| mk(&b.id, b.byte_start, b.byte_end)).collect(),
+        headings: table.headings.iter().map(|h| mk(&h.slug, h.byte_start, h.byte_end)).collect(),
+    }
+}
+
+fn utf8_char_len(first_byte: u8) -> usize {
+    match first_byte {
+        0x00..=0x7F => 1,
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => 1,
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(table: &AnchorTable) -> Vec<&str> {
+        table.blocks.iter().map(|b| b.id.as_str()).collect()
+    }
+
+    fn slugs(table: &AnchorTable) -> Vec<&str> {
+        table.headings.iter().map(|h| h.slug.as_str()).collect()
+    }
+
+    #[test]
+    fn paragraph_block_id_extracted() {
+        let md = "Some paragraph text. ^para1\n";
+        let table = extract_anchors(md);
+        assert_eq!(ids(&table), vec!["para1"]);
+        assert_eq!(table.blocks[0].kind, BlockKind::Paragraph);
+        // byte_end excludes the trailing tag
+        let slice = &md[table.blocks[0].byte_start..table.blocks[0].byte_end];
+        assert_eq!(slice.trim_end(), "Some paragraph text.");
+    }
+
+    #[test]
+    fn list_item_block_id_extracted_with_children() {
+        let md = "- top item ^itemA\n  - nested\n  - nested two\n";
+        let table = extract_anchors(md);
+        assert_eq!(ids(&table), vec!["itema"]);
+        let b = &table.blocks[0];
+        let slice = &md[b.byte_start..b.byte_end];
+        // Slice covers the top-level list item content, sans trailing tag.
+        // (Nested items render as their own list-item containers in
+        // pulldown-cmark's offset map; the embed-side renderer relies on
+        // adjacent list-item ranges, not on the parent containing the
+        // children byte-wise.)
+        assert!(slice.contains("top item"));
+        assert!(!slice.contains("^itemA"));
+    }
+
+
+    #[test]
+    fn heading_emits_both_block_and_heading_anchor_when_tagged() {
+        let md = "## Section ^sec1\n\nbody\n";
+        let table = extract_anchors(md);
+        assert_eq!(ids(&table), vec!["sec1"]);
+        assert_eq!(slugs(&table), vec!["section"]);
+        assert_eq!(table.blocks[0].kind, BlockKind::Heading);
+    }
+
+    #[test]
+    fn callout_block_id_covers_whole_quote() {
+        let md = "> [!note]\n> body line one\n> body line two ^callout1\n\nafter\n";
+        let table = extract_anchors(md);
+        assert_eq!(ids(&table), vec!["callout1"]);
+        assert_eq!(table.blocks[0].kind, BlockKind::Callout);
+        let slice = &md[table.blocks[0].byte_start..table.blocks[0].byte_end];
+        assert!(slice.contains("[!note]"));
+        assert!(slice.contains("body line one"));
+        assert!(!slice.contains("^callout1"));
+    }
+
+    #[test]
+    fn block_id_inside_code_fence_is_ignored() {
+        let md = "```\nparagraph ^fake\n```\nreal paragraph ^real\n";
+        let table = extract_anchors(md);
+        assert_eq!(ids(&table), vec!["real"]);
+    }
+
+    #[test]
+    fn block_id_inside_template_body_is_ignored() {
+        let md = "{{ vault.notes.where(n => n.name == \"x ^fake\") }}\nreal text ^real\n";
+        let table = extract_anchors(md);
+        assert_eq!(ids(&table), vec!["real"]);
+    }
+
+    #[test]
+    fn duplicate_block_ids_first_wins() {
+        let md = "first ^dup\n\nsecond ^dup\n";
+        let table = extract_anchors(md);
+        assert_eq!(table.blocks.len(), 1);
+        assert_eq!(table.blocks[0].id, "dup");
+        // Ensure it's the first paragraph by checking line.
+        assert_eq!(table.blocks[0].line, 0);
+    }
+
+    #[test]
+    fn slug_collision_suffixes_in_document_order() {
+        let md = "# Section\n\n# Section\n\n# Section\n";
+        let table = extract_anchors(md);
+        assert_eq!(slugs(&table), vec!["section", "section-1", "section-2"]);
+    }
+
+    #[test]
+    fn unicode_slug_preserves_non_ascii_letters() {
+        let md = "# Düsseldorf trip\n";
+        let table = extract_anchors(md);
+        assert_eq!(slugs(&table), vec!["düsseldorf-trip"]);
+    }
+
+    #[test]
+    fn block_id_mid_text_is_not_extracted() {
+        let md = "math: 2^3 = 8 and that's all\n";
+        let table = extract_anchors(md);
+        assert!(table.blocks.is_empty(), "got {:?}", table.blocks);
+    }
+
+    #[test]
+    fn block_id_requires_leading_whitespace() {
+        // `^foo` at line start (no leading whitespace) is not a tag.
+        let md = "^notatag\n\ntext ^valid\n";
+        let table = extract_anchors(md);
+        assert_eq!(ids(&table), vec!["valid"]);
+    }
+
+    #[test]
+    fn block_id_with_crlf_line_endings() {
+        let md = "paragraph one ^id1\r\n\r\nparagraph two ^id2\r\n";
+        let table = extract_anchors(md);
+        let extracted: Vec<&str> = table.blocks.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(extracted, vec!["id1", "id2"]);
+    }
+
+    #[test]
+    fn wikilink_with_block_anchor_in_paragraph_is_not_a_tag() {
+        // `[[Note^id]]` text in a paragraph must not be mistaken for a
+        // block-id tag — the tag is anchored to line end and `[[Note^id]]`
+        // never sits at line end without `]]`.
+        let md = "Reference: [[Note^id]] and that's the link.\n";
+        let table = extract_anchors(md);
+        assert!(table.blocks.is_empty());
+    }
+
+    #[test]
+    fn heading_section_byte_end_stops_at_next_same_or_higher() {
+        let md = "# A\n\nbody A\n\n## A1\n\nsub\n\n# B\n\nbody B\n";
+        let table = extract_anchors(md);
+        assert_eq!(slugs(&table), vec!["a", "a1", "b"]);
+        let h_a = &table.headings[0];
+        let slice = &md[h_a.byte_start..h_a.byte_end];
+        // # A's section runs through # A1's body but stops before # B.
+        assert!(slice.contains("body A"));
+        assert!(slice.contains("## A1"));
+        assert!(!slice.contains("# B"));
+        let h_a1 = &table.headings[1];
+        let slice = &md[h_a1.byte_start..h_a1.byte_end];
+        // ## A1 stops at # B (higher-level heading).
+        assert!(slice.contains("sub"));
+        assert!(!slice.contains("# B"));
+    }
+
+    #[test]
+    fn build_anchor_key_set_translates_byte_to_utf16() {
+        // `é` is 2 bytes in UTF-8, 1 UTF-16 code unit. Emoji `🎉` is 4 bytes,
+        // 2 UTF-16 code units (surrogate pair). The wire payload's
+        // js_start/js_end must reflect these positions so JS string slicing
+        // works correctly.
+        let md = "café 🎉 paragraph ^p1\n";
+        let table = extract_anchors(md);
+        assert_eq!(table.blocks.len(), 1);
+        let key_set = build_anchor_key_set(md, &table);
+        assert_eq!(key_set.blocks.len(), 1);
+        let entry = &key_set.blocks[0];
+        // byte_start == 0 (paragraph starts at beginning); js_start == 0.
+        assert_eq!(entry.byte_start, 0);
+        assert_eq!(entry.js_start, 0);
+        // byte_end excludes the trailing tag. Its corresponding JS index
+        // must be the same character count to that point: c-a-f-é-space-🎉
+        // -space-p-a-r-a-g-r-a-p-h-space.
+        let prefix_text = &md[..entry.byte_end as usize];
+        let expected_utf16: u32 = prefix_text.chars().map(|c| c.len_utf16() as u32).sum();
+        assert_eq!(entry.js_end, expected_utf16);
+    }
+
+    #[test]
+    fn slugify_strips_punctuation_keeps_unicode() {
+        assert_eq!(slugify("Hello, World!"), "hello-world");
+        assert_eq!(slugify("**Bold** heading"), "bold-heading");
+        assert_eq!(slugify("Düsseldorf 2026 — 一月"), "düsseldorf-2026-一月");
+        assert_eq!(slugify("multi   space"), "multi-space");
+        assert_eq!(slugify("---trim---"), "trim");
+    }
+
+    #[test]
+    fn empty_content_returns_empty_table() {
+        let table = extract_anchors("");
+        assert!(table.blocks.is_empty());
+        assert!(table.headings.is_empty());
+    }
+}

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -31,7 +31,7 @@ use std::time::{Duration, Instant};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anchor_index::AnchorIndex;
-use anchors::{extract_anchors, AnchorTable};
+use anchors::{build_anchor_key_set, extract_anchors, AnchorKeySet};
 use link_graph::{LinkGraph, ParsedLink, StemIndex, extract_links};
 use tag_index::{TagIndex, extract_inline_tag_occurrences};
 use frontmatter::parse_frontmatter;
@@ -402,10 +402,13 @@ impl IndexCoordinator {
         // their first step, so any iteration order yields the same end state.
         let mut link_buffer: Vec<(String, Vec<ParsedLink>)> = Vec::with_capacity(total);
         let mut tag_buffer: Vec<(String, Vec<String>)> = Vec::with_capacity(total);
-        // Anchor buffer (#62). Holds `(rel_path, content, AnchorTable)` so the
-        // wire-format payload (UTF-16 offsets) can be precomputed under the
-        // anchor_index mutex without re-reading any file.
-        let mut anchor_buffer: Vec<(String, String, AnchorTable)> = Vec::with_capacity(total);
+        // Anchor buffer (#62). Holds the small wire-format payload, NOT the
+        // raw file content — the latter would balloon the buffer to several
+        // hundred MB on a 100k-note vault and overrun the 250 MB active-RAM
+        // budget. The UTF-16 offsets are computed inline against the
+        // already-borrowed `content` String, which is dropped as soon as
+        // the loop body completes.
+        let mut anchor_buffer: Vec<(String, AnchorKeySet)> = Vec::with_capacity(total);
 
         for (i, abs_path) in md_paths.iter().enumerate() {
             // Read file — skip non-UTF-8 silently (IDX-08). THE ONLY read of
@@ -451,7 +454,8 @@ impl IndexCoordinator {
             let tags = extract_inline_tag_occurrences(&content);
             tag_buffer.push((relative_path.clone(), tags));
             let anchor_table = extract_anchors(&content);
-            anchor_buffer.push((relative_path.clone(), content.clone(), anchor_table));
+            let anchor_payload = build_anchor_key_set(&content, &anchor_table);
+            anchor_buffer.push((relative_path.clone(), anchor_payload));
 
             if !already_current {
                 let body = parser::strip_markdown(&content);
@@ -529,8 +533,8 @@ impl IndexCoordinator {
                 }
             }
             if let Ok(mut ai) = self.anchor_index.lock() {
-                for (rel, content, table) in anchor_buffer {
-                    ai.update_file(&rel, &content, table);
+                for (rel, payload) in anchor_buffer {
+                    ai.update_file_with_payload(&rel, payload);
                 }
             }
         }

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -19,6 +19,8 @@ pub mod parser;
 pub mod link_graph;
 pub mod tag_index;
 pub mod frontmatter;
+pub mod anchors;
+pub mod anchor_index;
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -28,6 +30,8 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use anchor_index::AnchorIndex;
+use anchors::{extract_anchors, AnchorTable};
 use link_graph::{LinkGraph, ParsedLink, StemIndex, extract_links};
 use tag_index::{TagIndex, extract_inline_tag_occurrences};
 use frontmatter::parse_frontmatter;
@@ -172,6 +176,10 @@ pub struct IndexCoordinator {
     link_graph: Arc<Mutex<LinkGraph>>,
     /// In-memory tag index — shared with tag IPC commands.
     tag_index: Arc<Mutex<TagIndex>>,
+    /// In-memory anchor index (#62) — `rel_path -> AnchorTable`. Populated
+    /// during cold-start and on every `UpdateLinks` so block-ref / heading-
+    /// ref resolution works without an extra IPC round-trip.
+    anchor_index: Arc<Mutex<AnchorIndex>>,
     /// #345: registry of locked encrypted roots. When populated, the
     /// cold-start walker prunes their subtrees so ciphertext is neither
     /// tokenized into Tantivy (garbage hits) nor traversed for links /
@@ -258,6 +266,7 @@ impl IndexCoordinator {
         )));
         let link_graph = Arc::new(Mutex::new(LinkGraph::new()));
         let tag_index = Arc::new(Mutex::new(TagIndex::new()));
+        let anchor_index = Arc::new(Mutex::new(AnchorIndex::new()));
 
         let (tx, rx) = mpsc::channel::<IndexCmd>(CHANNEL_CAPACITY);
 
@@ -276,6 +285,7 @@ impl IndexCoordinator {
         let file_index_clone = Arc::clone(&file_index);
         let link_graph_clone = Arc::clone(&link_graph);
         let tag_index_clone = Arc::clone(&tag_index);
+        let anchor_index_clone = Arc::clone(&anchor_index);
         tokio::task::spawn_blocking(move || {
             run_queue_consumer(
                 writer,
@@ -284,6 +294,7 @@ impl IndexCoordinator {
                 file_index_clone,
                 link_graph_clone,
                 tag_index_clone,
+                anchor_index_clone,
                 schema,
                 path_field,
                 title_field,
@@ -305,6 +316,7 @@ impl IndexCoordinator {
             index,
             link_graph,
             tag_index,
+            anchor_index,
             locked_paths: Arc::new(crate::encryption::LockedPathRegistry::new()),
         })
     }
@@ -333,6 +345,11 @@ impl IndexCoordinator {
     /// Clone the tag_index Arc for use in IPC commands.
     pub fn tag_index(&self) -> Arc<Mutex<TagIndex>> {
         Arc::clone(&self.tag_index)
+    }
+
+    /// Clone the anchor_index Arc for use in IPC commands (#62).
+    pub fn anchor_index(&self) -> Arc<Mutex<AnchorIndex>> {
+        Arc::clone(&self.anchor_index)
     }
 
     /// Index all `.md` files in `vault_path` and return a `VaultInfo`.
@@ -385,6 +402,10 @@ impl IndexCoordinator {
         // their first step, so any iteration order yields the same end state.
         let mut link_buffer: Vec<(String, Vec<ParsedLink>)> = Vec::with_capacity(total);
         let mut tag_buffer: Vec<(String, Vec<String>)> = Vec::with_capacity(total);
+        // Anchor buffer (#62). Holds `(rel_path, content, AnchorTable)` so the
+        // wire-format payload (UTF-16 offsets) can be precomputed under the
+        // anchor_index mutex without re-reading any file.
+        let mut anchor_buffer: Vec<(String, String, AnchorTable)> = Vec::with_capacity(total);
 
         for (i, abs_path) in md_paths.iter().enumerate() {
             // Read file — skip non-UTF-8 silently (IDX-08). THE ONLY read of
@@ -429,6 +450,8 @@ impl IndexCoordinator {
             link_buffer.push((relative_path.clone(), links));
             let tags = extract_inline_tag_occurrences(&content);
             tag_buffer.push((relative_path.clone(), tags));
+            let anchor_table = extract_anchors(&content);
+            anchor_buffer.push((relative_path.clone(), content.clone(), anchor_table));
 
             if !already_current {
                 let body = parser::strip_markdown(&content);
@@ -505,6 +528,11 @@ impl IndexCoordinator {
                     ti.update_file_with_tags(&rel, tags);
                 }
             }
+            if let Ok(mut ai) = self.anchor_index.lock() {
+                for (rel, content, table) in anchor_buffer {
+                    ai.update_file(&rel, &content, table);
+                }
+            }
         }
 
         file_list.sort();
@@ -527,6 +555,7 @@ fn run_queue_consumer(
     file_index: Arc<RwLock<FileIndex>>,
     link_graph: Arc<Mutex<LinkGraph>>,
     tag_index: Arc<Mutex<TagIndex>>,
+    anchor_index: Arc<Mutex<AnchorIndex>>,
     _schema: Schema,
     path_field: tantivy::schema::Field,
     title_field: tantivy::schema::Field,
@@ -628,6 +657,13 @@ fn run_queue_consumer(
                 if let Ok(mut fi) = file_index.write() {
                     fi.set_aliases_for_rel(&rel_path, aliases);
                 }
+                // Issue #62: same content read powers anchor extraction —
+                // refresh the anchor index alongside links so block-ref
+                // resolution stays current after every save / external edit.
+                let anchor_table = anchors::extract_anchors(&content);
+                if let Ok(mut ai) = anchor_index.lock() {
+                    ai.update_file(&rel_path, &content, anchor_table);
+                }
             }
             IndexCmd::RemoveLinks { rel_path } => {
                 // Remove link-graph entries for a deleted file (LINK-08).
@@ -639,6 +675,10 @@ fn run_queue_consumer(
                 // clear here. RemoveLinks fires on rename-old too — the rename's
                 // new-side UpdateLinks command repopulates aliases under the new
                 // rel_path.
+                // Issue #62: drop anchor entries with the deleted file.
+                if let Ok(mut ai) = anchor_index.lock() {
+                    ai.remove_file(&rel_path);
+                }
             }
             IndexCmd::UpdateTags { rel_path, content } => {
                 // Incrementally update tag-index entries for a file (TAG-01/02).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,6 +153,7 @@ pub fn run() {
             commands::links::suggest_links,
             commands::links::update_links_after_rename,
             commands::links::get_resolved_links,
+            commands::links::get_resolved_anchors,
             commands::links::get_resolved_attachments,
             commands::links::get_local_graph,
             commands::links::get_link_graph,

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -826,6 +826,23 @@
     // mount is still in-flight (issue #41).
     tabStore.setLastSavedContent(tabId, content);
 
+    // #62: an anchor click that opened this tab via `tabStore.openTab` will
+    // have queued a `scrollStore.requestScrollToRange` BEFORE the view
+    // existed. The scrollStore subscriber only fires on store changes and
+    // bails when the view isn't in `viewMap`, so without this peek the
+    // request stays pending forever. Consume it now that the view is
+    // ready and the file path matches.
+    {
+      const pending = get(scrollStore).pending;
+      if (pending && pending.filePath === tabFilePath && pending.range) {
+        const docLen = view.state.doc.length;
+        const from = Math.min(pending.range.from, docLen);
+        const to = Math.min(pending.range.to, docLen);
+        if (from < to) scrollToMatch(view, from, to);
+        scrollStore.clearPending();
+      }
+    }
+
     // Attach wiki-link-click listener only on editable markdown tabs —
     // read-only previews don't have the wiki-link plugin loaded so no
     // wiki-link-click events would ever fire from them anyway.

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -15,7 +15,7 @@
   import { vaultStore } from "../../store/vaultStore";
   import { editorStore } from "../../store/editorStore";
   import { activeViewStore } from "../../store/activeViewStore";
-  import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
+  import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAnchors, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
   import { openFileAsTab } from "../../lib/openFileAsTab";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
@@ -35,7 +35,14 @@
   import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { tagsStore } from "../../store/tagsStore";
   import { tabReloadStore } from "../../store/tabReloadStore";
-  import { setResolvedLinks, resolveTarget, refreshWikiLinks } from "./wikiLink";
+  import {
+    setResolvedAnchors,
+    setResolvedLinks,
+    resolveAnchor,
+    resolveTarget,
+    refreshWikiLinks,
+    type WikiLinkClickDetail,
+  } from "./wikiLink";
   import { setResolvedAttachments } from "./embeds";
   import { decideExternalModifyAction, sha256Hex } from "./externalChangeHandler";
   import { listenFileChange, listenVaultStatus, type FileChangePayload } from "../../ipc/events";
@@ -276,11 +283,13 @@
    */
   async function reloadResolvedLinks(): Promise<void> {
     try {
-      const [linksMap, attachmentsMap] = await Promise.all([
+      const [linksMap, anchorsMap, attachmentsMap] = await Promise.all([
         getResolvedLinks(),
+        getResolvedAnchors(),
         getResolvedAttachments(),
       ]);
       setResolvedLinks(linksMap);
+      setResolvedAnchors(anchorsMap);
       setResolvedAttachments(attachmentsMap);
       for (const view of viewMap.values()) {
         refreshWikiLinks(view);
@@ -288,6 +297,7 @@
     } catch {
       // Soft-fail: all links/embeds render as unresolved until next reload
       setResolvedLinks(new Map());
+      setResolvedAnchors(new Map());
       setResolvedAttachments(new Map());
     }
     // #309 — bump readyToken AFTER the map has been swapped in (success or
@@ -300,62 +310,84 @@
 
   /**
    * Handle wiki-link-click CustomEvent dispatched by the CM6 wikiLink plugin.
-   * Resolved clicks open the target in a tab (zero IPC at click time).
-   * Unresolved clicks create the note, open it, and refresh the resolution map.
+   *
+   * Three resolution paths (#62):
+   *   - "resolved"       — open the target tab; if an anchor is attached,
+   *                        scroll to the anchor's `[jsStart, jsEnd)` range.
+   *   - "anchor-missing" — open the target tab and surface a warning toast;
+   *                        do not scroll (no usable target range).
+   *   - "unresolved"     — click-to-create at vault root, same as before.
+   *
+   * Even on "resolved" we re-check the live map (#309) so a stale decoration
+   * doesn't route a now-broken link into the wrong branch.
    */
   function handleWikiLinkClick(event: Event): void {
-    const detail = (event as CustomEvent).detail as { target: string; resolved: boolean };
+    const detail = (event as CustomEvent<WikiLinkClickDetail>).detail;
     const vault = get(vaultStore).currentPath;
     if (!vault) return;
 
-    // #309 — the decoration's `data-wiki-resolved` attribute reflects the
-    // resolved-links map at decoration-build time. When a file is created or
-    // moved between render and click (e.g. template re-renders on vaultStore
-    // tick before the async resolvedLinks refetch lands), the attribute can
-    // be stale-`false` while the live map now resolves the target. Re-check
-    // synchronously here so a stale decoration never routes into the
-    // create-at-root fallback. Zero IPC — `resolveTarget` is a `Map.get`.
+    // #309 kept verbatim: re-check the live map so a stale decoration
+    // (`resolved` baked in at decoration time, file came/went between then
+    // and click) doesn't route the wrong way.
     const liveRelPath = resolveTarget(detail.target);
 
-    if (detail.resolved || liveRelPath !== null) {
-      if (!liveRelPath) {
-        // Map out of sync (rare: file deleted between decoration and click)
-        void reloadResolvedLinks();
-        return;
-      }
+    if (liveRelPath) {
       const relPath = liveRelPath;
       const absPath = `${vault}/${relPath}`;
-      // #147 — `.canvas` targets need the canvas viewer; plain notes keep
-      // the synchronous `openTab` fast path so markdown clicks stay on the
-      // "zero IPC" path.
       if (relPath.endsWith(".canvas")) {
         tabStore.openFileTab(absPath, "canvas");
-      } else {
-        tabStore.openTab(absPath);
+        return;
       }
-    } else {
-      // LINK-04, D-08: click-to-create at vault root
-      const filename = detail.target.endsWith(".md")
-        ? detail.target
-        : `${detail.target}.md`;
-      const vaultPath = vault as string;
-      createFile(vaultPath, filename)
-        .then(async (newAbsPath) => {
-          tabStore.openTab(newAbsPath);
-          // Refresh map so the new file now resolves in future decorations
-          await reloadResolvedLinks();
-          // Signal sidebar to re-fetch its tree — the watcher suppresses
-          // backend-initiated writes via write_ignore, so the tree won't
-          // otherwise learn that this file exists.
-          treeRefreshStore.requestRefresh();
-        })
-        .catch(() =>
+      tabStore.openTab(absPath);
+      if (detail.anchor) {
+        // #62: prefer a fresh anchor lookup over the decoration-time
+        // `resolution` so an anchor newly indexed between render and click
+        // navigates correctly instead of toasting "not found".
+        const entry = resolveAnchor(relPath, detail.anchor);
+        if (entry) {
+          // Same store the OmniSearch flow uses — pane-agnostic routing keeps
+          // anchor scrolls working when the target tab opens in the other
+          // pane. Range may also fire before the view is mounted; the
+          // subscriber clamps to doc length and the request stays pending
+          // until consumed.
+          scrollStore.requestScrollToRange(absPath, entry.jsStart, entry.jsEnd);
+        } else {
+          const anchorLabel =
+            detail.anchor.kind === "block" ? `^${detail.anchor.value}` : `#${detail.anchor.value}`;
           toastStore.push({
-            variant: "error",
-            message: "Notiz konnte nicht erstellt werden.",
-          })
-        );
+            variant: "warning",
+            message: `Anker ${anchorLabel} in ${relPath} nicht gefunden`,
+          });
+        }
+      }
+      return;
     }
+
+    // No live entry. If the decoration thought the target resolved (or had
+    // an anchor on a now-missing note), short-circuit into a reload — the
+    // map is stale, not the user's intent.
+    if (detail.resolution === "resolved" || detail.resolution === "anchor-missing") {
+      void reloadResolvedLinks();
+      return;
+    }
+
+    // Truly unresolved — click-to-create at vault root.
+    const filename = detail.target.endsWith(".md")
+      ? detail.target
+      : `${detail.target}.md`;
+    const vaultPath = vault as string;
+    createFile(vaultPath, filename)
+      .then(async (newAbsPath) => {
+        tabStore.openTab(newAbsPath);
+        await reloadResolvedLinks();
+        treeRefreshStore.requestRefresh();
+      })
+      .catch(() =>
+        toastStore.push({
+          variant: "error",
+          message: "Notiz konnte nicht erstellt werden.",
+        })
+      );
   }
 
   // Track vault open transitions to reload the resolution map
@@ -418,16 +450,25 @@
   });
 
   // Subscribe to scrollStore — execute scroll-to-match when a request targets a file in this pane.
-  // Uses doc.toString().indexOf() to find the first occurrence (no @codemirror/search dep needed).
+  // Two paths: an explicit `range` (anchor navigation #62) wins; otherwise
+  // fall back to the legacy string search OmniSearch uses.
   const unsubScroll = scrollStore.subscribe((state) => {
     if (!state.pending) return;
-    const { filePath, searchText } = state.pending;
-    // Find which tab in this pane has this file
+    const { filePath, searchText, range } = state.pending;
     const tab = allTabs.find((t) => t.filePath === filePath && paneTabIds.includes(t.id));
     if (!tab) return;
     const view = viewMap.get(tab.id);
     if (!view) return;
-    // Find first occurrence of searchText using plain string search (case-insensitive)
+    if (range) {
+      // Clamp to current document length — the anchor index can lag a hot
+      // edit by one save cycle, and a stale range past EOF would crash CM6.
+      const docLen = view.state.doc.length;
+      const from = Math.min(range.from, docLen);
+      const to = Math.min(range.to, docLen);
+      if (from < to) scrollToMatch(view, from, to);
+      scrollStore.clearPending();
+      return;
+    }
     const docText = view.state.doc.toString();
     const lowerDoc = docText.toLowerCase();
     const lowerSearch = searchText.toLowerCase();

--- a/src/components/Editor/ReadingView.svelte
+++ b/src/components/Editor/ReadingView.svelte
@@ -246,11 +246,16 @@
     if (wikiAnchor) {
       event.preventDefault();
       const wikiTarget = wikiAnchor.getAttribute("data-wiki-target") ?? "";
-      const resolved = wikiAnchor.getAttribute("data-wiki-resolved") === "true";
+      // Three-valued resolution (#62). Reading view never emits anchor
+      // information, so the click always carries `anchor: null`; the
+      // EditorPane handler still re-checks the live map per #309.
+      const raw = wikiAnchor.getAttribute("data-wiki-resolved") ?? "unresolved";
+      const resolution: "resolved" | "anchor-missing" | "unresolved" =
+        raw === "resolved" || raw === "anchor-missing" ? raw : "unresolved";
       containerEl?.dispatchEvent(
         new CustomEvent("wiki-link-click", {
           bubbles: true,
-          detail: { target: wikiTarget, resolved },
+          detail: { target: wikiTarget, resolution, anchor: null },
         }),
       );
       return;

--- a/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
+++ b/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
@@ -17,10 +17,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/svelte";
 import { tick } from "svelte";
 
-const { readFile, createFile, getResolvedLinks, getResolvedAttachments } = vi.hoisted(() => ({
+const { readFile, createFile, getResolvedLinks, getResolvedAnchors, getResolvedAttachments } = vi.hoisted(() => ({
   readFile: vi.fn().mockResolvedValue(""),
   createFile: vi.fn().mockResolvedValue(""),
   getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAnchors: vi.fn().mockResolvedValue(new Map()),
   getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
 }));
 
@@ -31,6 +32,7 @@ vi.mock("../../../ipc/commands", () => ({
   getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
   mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
   getResolvedLinks,
+  getResolvedAnchors,
   getResolvedAttachments,
   getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
   getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
@@ -73,7 +75,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 import { tabStore } from "../../../store/tabStore";
 import { vaultStore } from "../../../store/vaultStore";
-import { setResolvedLinks } from "../wikiLink";
+import { setResolvedAnchors, setResolvedLinks } from "../wikiLink";
 import EditorPane from "../EditorPane.svelte";
 
 async function flushAsync(): Promise<void> {
@@ -89,8 +91,10 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     vaultStore.reset();
     createFile.mockReset().mockResolvedValue("");
     getResolvedLinks.mockReset().mockResolvedValue(new Map());
+    getResolvedAnchors.mockReset().mockResolvedValue(new Map());
     getResolvedAttachments.mockReset().mockResolvedValue(new Map());
     setResolvedLinks(new Map());
+    setResolvedAnchors(new Map());
   });
 
   afterEach(() => {
@@ -134,7 +138,7 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     cm.dispatchEvent(
       new CustomEvent("wiki-link-click", {
         bubbles: true,
-        detail: { target: "Untitled", resolved: false },
+        detail: { target: "Untitled", resolution: "unresolved", anchor: null },
       }),
     );
     await flushAsync();
@@ -165,7 +169,7 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     cm.dispatchEvent(
       new CustomEvent("wiki-link-click", {
         bubbles: true,
-        detail: { target: "DeletedNote", resolved: true },
+        detail: { target: "DeletedNote", resolution: "resolved", anchor: null },
       }),
     );
     await flushAsync();
@@ -191,11 +195,94 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     cm.dispatchEvent(
       new CustomEvent("wiki-link-click", {
         bubbles: true,
-        detail: { target: "Ghost", resolved: false },
+        detail: { target: "Ghost", resolution: "unresolved", anchor: null },
       }),
     );
     await flushAsync();
 
     expect(createFile).toHaveBeenCalledWith("/vault", "Ghost.md");
+  });
+
+  // ── #62: anchor navigation ─────────────────────────────────────────────
+
+  it("scrolls to the resolved anchor range after opening the target tab", async () => {
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md", "target.md"],
+      fileCount: 2,
+    });
+    const cm = await mountMarkdownTabAndGetCm();
+
+    setResolvedLinks(new Map([["target", "target.md"]]));
+    setResolvedAnchors(
+      new Map([
+        [
+          "target.md",
+          {
+            blocks: [
+              { id: "para1", byteStart: 0, byteEnd: 12, jsStart: 100, jsEnd: 130 },
+            ],
+            headings: [],
+          },
+        ],
+      ]),
+    );
+
+    const { scrollStore } = await import("../../../store/scrollStore");
+    const requestRangeSpy = vi.spyOn(scrollStore, "requestScrollToRange");
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: {
+          target: "target",
+          resolution: "resolved",
+          anchor: { kind: "block", value: "para1" },
+        },
+      }),
+    );
+    await flushAsync();
+
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md");
+    expect(requestRangeSpy).toHaveBeenCalledWith("/vault/target.md", 100, 130);
+  });
+
+  it("opens the tab and warns via toast when the anchor is missing", async () => {
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md", "target.md"],
+      fileCount: 2,
+    });
+    const cm = await mountMarkdownTabAndGetCm();
+
+    setResolvedLinks(new Map([["target", "target.md"]]));
+    setResolvedAnchors(
+      new Map([
+        ["target.md", { blocks: [], headings: [] }],
+      ]),
+    );
+
+    const { toastStore } = await import("../../../store/toastStore");
+    const toastSpy = vi.spyOn(toastStore, "push");
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: {
+          target: "target",
+          resolution: "anchor-missing",
+          anchor: { kind: "block", value: "missing" },
+        },
+      }),
+    );
+    await flushAsync();
+
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md");
+    expect(toastSpy).toHaveBeenCalled();
+    const toastArg = toastSpy.mock.calls[0]?.[0] as { variant: string; message: string };
+    expect(toastArg.variant).toBe("warning");
+    expect(toastArg.message).toContain("^missing");
   });
 });

--- a/src/components/Editor/__tests__/embedAnchorRegex.test.ts
+++ b/src/components/Editor/__tests__/embedAnchorRegex.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #62 — the WIKI_EMBED_RE regex must capture (target, heading?, blockId?,
+ * sizing?). These tests exercise every legal combination and pin the
+ * capture-group positions so the buildDecorations consumer keeps reading
+ * the right index.
+ *
+ * The regex itself is module-internal; the test imports the source file as
+ * raw text and rebuilds the regex from the literal. This avoids exporting
+ * a test-only handle while still locking down behaviour.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const SOURCE = readFileSync(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../embedPlugin.ts"),
+  "utf-8",
+);
+
+function extractRegex(): RegExp {
+  // Anchor on the comment block + the line that defines WIKI_EMBED_RE so the
+  // wrong literal isn't matched if another regex is added later.
+  const m = SOURCE.match(/const WIKI_EMBED_RE = (\/[^/]+\/g);/);
+  if (!m || !m[1]) throw new Error("WIKI_EMBED_RE not found in source");
+  // eslint-disable-next-line no-eval
+  return eval(m[1]) as RegExp;
+}
+
+const RE = extractRegex();
+
+function execAll(re: RegExp, input: string): RegExpExecArray[] {
+  re.lastIndex = 0;
+  const out: RegExpExecArray[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(input)) !== null) out.push(m);
+  return out;
+}
+
+describe("WIKI_EMBED_RE captures", () => {
+  it("plain note embed", () => {
+    const m = execAll(RE, "![[Note]]")[0]!;
+    expect(m[1]).toBe("Note");
+    expect(m[2]).toBeUndefined();
+    expect(m[3]).toBeUndefined();
+    expect(m[4]).toBeUndefined();
+  });
+
+  it("heading embed", () => {
+    const m = execAll(RE, "![[Note#Section]]")[0]!;
+    expect(m[1]).toBe("Note");
+    expect(m[2]).toBe("Section");
+    expect(m[3]).toBeUndefined();
+    expect(m[4]).toBeUndefined();
+  });
+
+  it("block embed", () => {
+    const m = execAll(RE, "![[Note^para1]]")[0]!;
+    expect(m[1]).toBe("Note");
+    expect(m[2]).toBeUndefined();
+    expect(m[3]).toBe("para1");
+    expect(m[4]).toBeUndefined();
+  });
+
+  it("heading + sizing", () => {
+    const m = execAll(RE, "![[Note#Section|300]]")[0]!;
+    expect(m[1]).toBe("Note");
+    expect(m[2]).toBe("Section");
+    expect(m[3]).toBeUndefined();
+    expect(m[4]).toBe("300");
+  });
+
+  it("block + alias", () => {
+    const m = execAll(RE, "![[Note^id|caption]]")[0]!;
+    expect(m[1]).toBe("Note");
+    expect(m[2]).toBeUndefined();
+    expect(m[3]).toBe("id");
+    expect(m[4]).toBe("caption");
+  });
+
+  it("plain image embed with sizing keeps capture 4", () => {
+    const m = execAll(RE, "![[image.png|300]]")[0]!;
+    expect(m[1]).toBe("image.png");
+    expect(m[2]).toBeUndefined();
+    expect(m[3]).toBeUndefined();
+    expect(m[4]).toBe("300");
+  });
+
+  it("does not falsely match a wiki-link without `!`", () => {
+    expect(execAll(RE, "[[Note^id]]")).toHaveLength(0);
+  });
+});

--- a/src/components/Editor/__tests__/markdownRenderer.test.ts
+++ b/src/components/Editor/__tests__/markdownRenderer.test.ts
@@ -57,14 +57,14 @@ describe("renderMarkdownToHtml (#63)", () => {
   it("renders resolved wiki-links as anchors carrying target + resolved attributes", () => {
     setResolvedLinks(new Map([["foo", "notes/foo.md"]]));
     const html = renderMarkdownToHtml("Link: [[Foo]]");
-    expect(html).toMatch(/<a[^>]*data-wiki-target="Foo"[^>]*data-wiki-resolved="true"[^>]*>/);
+    expect(html).toMatch(/<a[^>]*data-wiki-target="Foo"[^>]*data-wiki-resolved="resolved"[^>]*>/);
     expect(html).toContain("vc-reading-wikilink--resolved");
   });
 
   it("renders unresolved wiki-links with the unresolved class", () => {
     const html = renderMarkdownToHtml("Link: [[Missing]]");
     expect(html).toContain("vc-reading-wikilink--unresolved");
-    expect(html).toMatch(/data-wiki-resolved="false"/);
+    expect(html).toMatch(/data-wiki-resolved="unresolved"/);
   });
 
   it("honours wiki-link aliases for display text", () => {

--- a/src/components/Editor/__tests__/templateLivePreview.test.ts
+++ b/src/components/Editor/__tests__/templateLivePreview.test.ts
@@ -172,7 +172,7 @@ describe("templateLivePlugin — rendering", () => {
     const anchor = view.dom.querySelector(".vc-template-rendered [data-wiki-target]");
     expect(anchor).not.toBeNull();
     expect(anchor!.getAttribute("data-wiki-target")).toBe("first");
-    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("true");
+    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("resolved");
     expect(anchor!.classList.contains("cm-wikilink-resolved")).toBe(true);
     expect(anchor!.textContent).toBe("first");
   });
@@ -184,7 +184,7 @@ describe("templateLivePlugin — rendering", () => {
 
     const anchor = view.dom.querySelector(".vc-template-rendered [data-wiki-target]");
     expect(anchor).not.toBeNull();
-    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("false");
+    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("unresolved");
     expect(anchor!.classList.contains("cm-wikilink-unresolved")).toBe(true);
   });
 
@@ -197,7 +197,7 @@ describe("templateLivePlugin — rendering", () => {
     expect(anchor).not.toBeNull();
     expect(anchor!.textContent).toBe("Display");
     expect(anchor!.getAttribute("data-wiki-target")).toBe("real");
-    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("true");
+    expect(anchor!.getAttribute("data-wiki-resolved")).toBe("resolved");
   });
 
   // #303 — multi-segment `{{ ... ; ... }}` bodies.
@@ -291,7 +291,7 @@ describe("templateLivePlugin — rendering", () => {
       );
       expect(anchor).not.toBeNull();
       expect(anchor!.getAttribute("data-wiki-target")).toBe("first");
-      expect(anchor!.getAttribute("data-wiki-resolved")).toBe("true");
+      expect(anchor!.getAttribute("data-wiki-resolved")).toBe("resolved");
     });
   });
 
@@ -342,7 +342,7 @@ describe("templateLivePlugin — rendering", () => {
       );
       expect(link).not.toBeNull();
       expect(link!.getAttribute("data-wiki-target")).toBe("first");
-      expect(link!.getAttribute("data-wiki-resolved")).toBe("true");
+      expect(link!.getAttribute("data-wiki-resolved")).toBe("resolved");
       expect(link!.classList.contains("cm-wikilink-resolved")).toBe(true);
     });
 
@@ -461,7 +461,7 @@ describe("templateLivePlugin — rendering", () => {
     );
     expect(before).not.toBeNull();
     const beforeNode = before as HTMLElement;
-    expect(beforeNode.getAttribute("data-wiki-resolved")).toBe("false");
+    expect(beforeNode.getAttribute("data-wiki-resolved")).toBe("unresolved");
 
     // Simulate the stale-edge only — the map is NOT updated.
     resolvedLinksStore.requestReload();
@@ -471,7 +471,7 @@ describe("templateLivePlugin — rendering", () => {
       ".vc-template-rendered [data-wiki-target]",
     );
     expect(after).toBe(beforeNode);
-    expect(after!.getAttribute("data-wiki-resolved")).toBe("false");
+    expect(after!.getAttribute("data-wiki-resolved")).toBe("unresolved");
   });
 
   // #309 — regression: a file created between render and click left the
@@ -489,7 +489,7 @@ describe("templateLivePlugin — rendering", () => {
       ".vc-template-rendered [data-wiki-target]",
     );
     expect(initialAnchor).not.toBeNull();
-    expect(initialAnchor!.getAttribute("data-wiki-resolved")).toBe("false");
+    expect(initialAnchor!.getAttribute("data-wiki-resolved")).toBe("unresolved");
 
     // Simulate the flow after a sidebar "New note": EditorPane's async
     // reloadResolvedLinks lands, setResolvedLinks is called, then markReady()
@@ -501,7 +501,7 @@ describe("templateLivePlugin — rendering", () => {
       ".vc-template-rendered [data-wiki-target]",
     );
     expect(refreshedAnchor).not.toBeNull();
-    expect(refreshedAnchor!.getAttribute("data-wiki-resolved")).toBe("true");
+    expect(refreshedAnchor!.getAttribute("data-wiki-resolved")).toBe("resolved");
     expect(refreshedAnchor!.classList.contains("cm-wikilink-resolved")).toBe(true);
   });
 });

--- a/src/components/Editor/__tests__/wikiLinkAnchorParse.test.ts
+++ b/src/components/Editor/__tests__/wikiLinkAnchorParse.test.ts
@@ -1,0 +1,82 @@
+/**
+ * #62 — `parseLinkTarget` is the single chokepoint that splits a raw
+ * wiki-link target like `[[Note^id]]` / `[[Note#H]]` into its stem +
+ * optional anchor. These tests pin precedence (block-id beats heading
+ * when both are present), grammar (block id is `[A-Za-z0-9-]+`), case
+ * folding (block ids lowercased; heading slugs preserved at parse time
+ * so the consumer can compare against Rust's slugged value).
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseLinkTarget } from "../wikiLink";
+
+describe("parseLinkTarget", () => {
+  it("returns stem only when there is no anchor", () => {
+    expect(parseLinkTarget("Note")).toEqual({ stem: "Note", anchor: null });
+    expect(parseLinkTarget("folder/Note")).toEqual({
+      stem: "folder/Note",
+      anchor: null,
+    });
+  });
+
+  it("strips known extensions", () => {
+    expect(parseLinkTarget("Note.md").stem).toBe("Note");
+    expect(parseLinkTarget("foo.canvas").stem).toBe("foo");
+  });
+
+  it("splits a block-id suffix", () => {
+    expect(parseLinkTarget("Note^para1")).toEqual({
+      stem: "Note",
+      anchor: { kind: "block", value: "para1" },
+    });
+  });
+
+  it("lowercases the block-id value (Obsidian parity)", () => {
+    expect(parseLinkTarget("Note^MixedCase").anchor).toEqual({
+      kind: "block",
+      value: "mixedcase",
+    });
+  });
+
+  it("rejects a `^foo bar` block-id (whitespace not in grammar)", () => {
+    // `^` followed by non-`[A-Za-z0-9-]` is not a valid block id; treat
+    // the whole string as a stem.
+    expect(parseLinkTarget("Note^bad token")).toEqual({
+      stem: "Note^bad token",
+      anchor: null,
+    });
+  });
+
+  it("splits a heading suffix", () => {
+    expect(parseLinkTarget("Note#Section")).toEqual({
+      stem: "Note",
+      anchor: { kind: "heading", value: "Section" },
+    });
+  });
+
+  it("preserves heading case at parse time (slug lookup folds it)", () => {
+    expect(parseLinkTarget("Note#Mixed Case").anchor).toEqual({
+      kind: "heading",
+      value: "Mixed Case",
+    });
+  });
+
+  it("treats block-id as winning when both `#` and `^` are present", () => {
+    // Obsidian rejects `[[Note#H^id]]`; we match its precedence by
+    // anchoring on the trailing `^id`.
+    expect(parseLinkTarget("Note#Heading^id")).toEqual({
+      stem: "Note#Heading",
+      anchor: { kind: "block", value: "id" },
+    });
+  });
+
+  it("handles `Note^id|alias` style — alias is stripped earlier so this never sees pipes", () => {
+    // `parseLinkTarget` operates on the regex group 1 capture; the alias
+    // pipe and what follows is captured separately and never reaches
+    // here. Pin behaviour for the `^` + no-pipe case.
+    expect(parseLinkTarget("Note^id")).toEqual({
+      stem: "Note",
+      anchor: { kind: "block", value: "id" },
+    });
+  });
+});

--- a/src/components/Editor/__tests__/wikiLinkAnchorParse.test.ts
+++ b/src/components/Editor/__tests__/wikiLinkAnchorParse.test.ts
@@ -7,8 +7,8 @@
  * so the consumer can compare against Rust's slugged value).
  */
 
-import { describe, it, expect } from "vitest";
-import { parseLinkTarget } from "../wikiLink";
+import { describe, it, expect, beforeEach } from "vitest";
+import { parseLinkTarget, resolveAnchor, setResolvedAnchors } from "../wikiLink";
 
 describe("parseLinkTarget", () => {
   it("returns stem only when there is no anchor", () => {
@@ -78,5 +78,46 @@ describe("parseLinkTarget", () => {
       stem: "Note",
       anchor: { kind: "block", value: "id" },
     });
+  });
+});
+
+describe("resolveAnchor — heading slug parity (#62)", () => {
+  beforeEach(() => {
+    setResolvedAnchors(
+      new Map([
+        [
+          "doc.md",
+          {
+            blocks: [],
+            // `id` is the slug Rust stored at index time.
+            headings: [
+              { id: "multi-word-heading", byteStart: 0, byteEnd: 50, jsStart: 0, jsEnd: 50 },
+              { id: "düsseldorf", byteStart: 60, byteEnd: 100, jsStart: 60, jsEnd: 100 },
+            ],
+          },
+        ],
+      ]),
+    );
+  });
+
+  it("resolves a multi-word heading link via the slug", () => {
+    // The user types `[[doc#Multi Word Heading]]` — the parsed value is
+    // the raw heading text. Without slugify the comparison would compare
+    // `"multi word heading"` to `"multi-word-heading"` and fail.
+    const entry = resolveAnchor("doc.md", { kind: "heading", value: "Multi Word Heading" });
+    expect(entry).not.toBeNull();
+    expect(entry!.id).toBe("multi-word-heading");
+  });
+
+  it("preserves non-ASCII letters during slug lookup", () => {
+    const entry = resolveAnchor("doc.md", { kind: "heading", value: "DÜSSELDORF" });
+    expect(entry).not.toBeNull();
+    expect(entry!.id).toBe("düsseldorf");
+  });
+
+  it("returns null when the heading slug is unknown", () => {
+    expect(
+      resolveAnchor("doc.md", { kind: "heading", value: "Missing Heading" }),
+    ).toBeNull();
   });
 });

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -27,7 +27,8 @@ import { mount, unmount } from "svelte";
 
 import { resolveAttachment } from "./embeds";
 import { resolveAttachmentSrc, releaseAttachmentSrc } from "./attachmentSource";
-import { resolveTarget } from "./wikiLink";
+import { resolveAnchor, resolveTarget } from "./wikiLink";
+import type { AnchorEntry } from "../../types/links";
 import {
   findTemplateExprRanges,
   isInsideTemplateExpr,
@@ -52,18 +53,43 @@ import CanvasRenderer from "../Canvas/CanvasRenderer.svelte";
 // ── Regex ──────────────────────────────────────────────────────────────────────
 
 /**
- * Matches `![[target]]`, `![[target|sizing]]`, `![[target#heading]]`, and the
- * combined `![[target#heading|sizing]]`. Captures:
- *   1 — target (path/filename, no `]`, `|`, or `#`)
- *   2 — heading (optional, after `#`)
- *   3 — sizing/alias text (optional, after `|`)
- *
- * The heading capture is parsed but not yet used for slicing — see PR notes.
+ * Matches `![[target]]`, `![[target|sizing]]`, `![[target#heading]]`,
+ * `![[target^blockid]]` (#62), and any combination thereof. Captures:
+ *   1 — target (path/filename, no `]`, `|`, `#`, or `^`)
+ *   2 — heading slug (optional, after `#`)
+ *   3 — block id (optional, after `^`) — `[A-Za-z0-9-]+` per Obsidian
+ *   4 — sizing/alias text (optional, after `|`)
  */
-const WIKI_EMBED_RE = /!\[\[([^\]|#]+?)(?:#([^\]|]+))?(?:\|([^\]]*))?\]\]/g;
+const WIKI_EMBED_RE = /!\[\[([^\]|#^]+?)(?:#([^\]|^]+))?(?:\^([A-Za-z0-9-]+))?(?:\|([^\]]*))?\]\]/g;
 
 /** Matches `![alt](path)` — captures the path. */
 const MD_IMAGE_RE = /!\[[^\]]*\]\(([^)]+)\)/g;
+
+/**
+ * Look up the anchor entry the embed regex captured.
+ *
+ * Returns:
+ *   - `null`      — no anchor was requested (whole-note embed).
+ *   - `"missing"` — anchor was requested but doesn't resolve. Caller renders
+ *                   `BrokenEmbedWidget` with a "not found" label.
+ *   - `AnchorEntry` — anchor resolved; caller slices `cached.slice(jsStart,
+ *                     jsEnd)` to render only that block's content.
+ */
+function resolveEmbedAnchor(
+  relPath: string,
+  headingSlug: string | undefined,
+  blockId: string | undefined,
+): AnchorEntry | "missing" | null {
+  if (blockId !== undefined) {
+    const found = resolveAnchor(relPath, { kind: "block", value: blockId.toLowerCase() });
+    return found ?? "missing";
+  }
+  if (headingSlug !== undefined) {
+    const found = resolveAnchor(relPath, { kind: "heading", value: headingSlug });
+    return found ?? "missing";
+  }
+  return null;
+}
 
 // ── Cache for canvas-embed content ────────────────────────────────────────────
 //
@@ -616,7 +642,9 @@ function buildDecorations(view: EditorView): DecorationSet {
     if (head >= from && head <= to) continue;
 
     const target = rawTarget.trim();
-    const sizePx = parseSizePx(m[3]);
+    const headingSlug = m[2];
+    const blockId = m[3];
+    const sizePx = parseSizePx(m[4]);
 
     let deco: Decoration;
     if (isImageFilename(target)) {
@@ -627,15 +655,14 @@ function buildDecorations(view: EditorView): DecorationSet {
         deco = Decoration.replace({ widget: new BrokenEmbedWidget(target) });
       }
     } else {
-      // Note / canvas embed. We intentionally ignore the #heading capture for
-      // now and render the entire target; heading slicing is a follow-up.
+      // Note / canvas embed. #62: optional `#H` / `^id` anchor selects a
+      // sub-slice of the target file's content; missing anchors fall through
+      // to BrokenEmbedWidget so the user sees an explicit "not found" cue.
       const rel = resolveTarget(target);
       if (rel !== null) {
         if (rel.endsWith(".canvas")) {
           // #147 — route canvas targets through the SVG preview widget.
-          // #154 — bundle the cached JSON into the widget so edits to the
-          // source canvas produce a value-different widget and CM6 swaps
-          // the DOM; a miss schedules a fetch with a null-content placeholder.
+          // Anchor suffixes don't apply to canvases — keep behaviour stable.
           const cachedCanvas = canvasContentCache.get(rel);
           if (cachedCanvas === undefined) {
             scheduleCanvasFetch(view, rel);
@@ -648,11 +675,22 @@ function buildDecorations(view: EditorView): DecorationSet {
           const cached = readCachedNote(rel);
           if (cached === null) {
             requestLoadNote(rel);
-            // Show a muted placeholder while the fetch is in flight so the UI
-            // doesn't flash with a stale version of the target note.
             deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, "…") });
           } else {
-            deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, cached) });
+            const anchorEntry = resolveEmbedAnchor(rel, headingSlug, blockId);
+            if (anchorEntry === "missing") {
+              const label = blockId
+                ? `${target}^${blockId}`
+                : headingSlug
+                  ? `${target}#${headingSlug}`
+                  : target;
+              deco = Decoration.replace({ widget: new BrokenEmbedWidget(label) });
+            } else if (anchorEntry !== null) {
+              const sliced = cached.slice(anchorEntry.jsStart, anchorEntry.jsEnd);
+              deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, sliced) });
+            } else {
+              deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, cached) });
+            }
           }
         }
       } else {

--- a/src/components/Editor/embedPlugin.ts
+++ b/src/components/Editor/embedPlugin.ts
@@ -68,6 +68,10 @@ const MD_IMAGE_RE = /!\[[^\]]*\]\(([^)]+)\)/g;
 /**
  * Look up the anchor entry the embed regex captured.
  *
+ * `headingText` is the raw text written between `#` and the next pipe / end
+ * — NOT a pre-slugified value. `resolveAnchor` slugifies it internally so
+ * `![[Note#Multi Word Heading]]` matches the index-time slug.
+ *
  * Returns:
  *   - `null`      — no anchor was requested (whole-note embed).
  *   - `"missing"` — anchor was requested but doesn't resolve. Caller renders
@@ -77,15 +81,15 @@ const MD_IMAGE_RE = /!\[[^\]]*\]\(([^)]+)\)/g;
  */
 function resolveEmbedAnchor(
   relPath: string,
-  headingSlug: string | undefined,
+  headingText: string | undefined,
   blockId: string | undefined,
 ): AnchorEntry | "missing" | null {
   if (blockId !== undefined) {
     const found = resolveAnchor(relPath, { kind: "block", value: blockId.toLowerCase() });
     return found ?? "missing";
   }
-  if (headingSlug !== undefined) {
-    const found = resolveAnchor(relPath, { kind: "heading", value: headingSlug });
+  if (headingText !== undefined) {
+    const found = resolveAnchor(relPath, { kind: "heading", value: headingText });
     return found ?? "missing";
   }
   return null;
@@ -642,7 +646,7 @@ function buildDecorations(view: EditorView): DecorationSet {
     if (head >= from && head <= to) continue;
 
     const target = rawTarget.trim();
-    const headingSlug = m[2];
+    const headingText = m[2];
     const blockId = m[3];
     const sizePx = parseSizePx(m[4]);
 
@@ -677,12 +681,12 @@ function buildDecorations(view: EditorView): DecorationSet {
             requestLoadNote(rel);
             deco = Decoration.replace({ widget: new NoteEmbedWidget(rel, "…") });
           } else {
-            const anchorEntry = resolveEmbedAnchor(rel, headingSlug, blockId);
+            const anchorEntry = resolveEmbedAnchor(rel, headingText, blockId);
             if (anchorEntry === "missing") {
               const label = blockId
                 ? `${target}^${blockId}`
-                : headingSlug
-                  ? `${target}#${headingSlug}`
+                : headingText
+                  ? `${target}#${headingText}`
                   : target;
               deco = Decoration.replace({ widget: new BrokenEmbedWidget(label) });
             } else if (anchorEntry !== null) {

--- a/src/components/Editor/reading/markdownRenderer.ts
+++ b/src/components/Editor/reading/markdownRenderer.ts
@@ -163,7 +163,10 @@ md.renderer.rules["wiki_link"] = (tokens, idx) => {
   const label = md.utils.escapeHtml(alias ?? target);
   const escapedTarget = md.utils.escapeHtml(target);
   const cls = resolved ? "vc-reading-wikilink vc-reading-wikilink--resolved" : "vc-reading-wikilink vc-reading-wikilink--unresolved";
-  return `<a class="${cls}" href="#" data-wiki-target="${escapedTarget}" data-wiki-resolved="${resolved ? "true" : "false"}">${label}</a>`;
+  // #62: three-valued resolution attribute. The reading-view markdown
+  // renderer doesn't track anchors, so the only outcomes are
+  // "resolved" / "unresolved" — never "anchor-missing".
+  return `<a class="${cls}" href="#" data-wiki-target="${escapedTarget}" data-wiki-resolved="${resolved ? "resolved" : "unresolved"}">${label}</a>`;
 };
 
 // ── Heading slug IDs ─────────────────────────────────────────────────────────

--- a/src/components/Editor/templateLivePreview.ts
+++ b/src/components/Editor/templateLivePreview.ts
@@ -188,7 +188,10 @@ function appendValueWithWikiLinks(parent: HTMLElement, value: string): void {
     const link = document.createElement("span");
     link.className = resolved ? "cm-wikilink-resolved" : "cm-wikilink-unresolved";
     link.setAttribute("data-wiki-target", stem);
-    link.setAttribute("data-wiki-resolved", resolved ? "true" : "false");
+    // #62: three-valued resolution attribute. Template live-preview never
+    // emits anchor info, so a resolved target maps to "resolved" and a
+    // missing one to "unresolved" — there is no anchor-missing case here.
+    link.setAttribute("data-wiki-resolved", resolved ? "resolved" : "unresolved");
     link.textContent = alias !== undefined ? alias : rawTarget;
     parent.appendChild(link);
     cursor = m.index + m[0].length;

--- a/src/components/Editor/wikiLink.ts
+++ b/src/components/Editor/wikiLink.ts
@@ -24,6 +24,7 @@ import type { EditorState } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 
 import type { AnchorEntry, AnchorKeySet } from "../../types/links";
+import { slugify } from "../../lib/headingSlug";
 import {
   findTemplateExprRanges,
   isInsideTemplateExpr,
@@ -133,9 +134,13 @@ export function stripKnownExt(target: string): string {
 
 /**
  * Look up the anchor entry for `(relPath, anchor)`, or `null` when the file
- * has no anchors registered or the anchor doesn't match. Slug comparison is
- * case-insensitive for headings; block ids compare byte-for-byte against the
- * lowercased value already produced by `parseLinkTarget`.
+ * has no anchors registered or the anchor doesn't match.
+ *
+ * Block ids compare byte-for-byte against the lowercased value already
+ * produced by `parseLinkTarget`. Heading lookups slugify the raw heading
+ * text first so `[[Note#Multi Word Heading]]` matches the index-time slug
+ * `multi-word-heading`. The slug algorithm is the same on both sides —
+ * see `test-fixtures/slug_parity.json`.
  */
 export function resolveAnchor(relPath: string, anchor: ParsedAnchor): AnchorEntry | null {
   const set = resolvedAnchors.get(relPath);
@@ -143,8 +148,8 @@ export function resolveAnchor(relPath: string, anchor: ParsedAnchor): AnchorEntr
   if (anchor.kind === "block") {
     return set.blocks.find((b) => b.id === anchor.value) ?? null;
   }
-  const target = anchor.value.toLowerCase();
-  return set.headings.find((h) => h.id.toLowerCase() === target) ?? null;
+  const targetSlug = slugify(anchor.value);
+  return set.headings.find((h) => h.id === targetSlug) ?? null;
 }
 
 /** Three-valued resolution state for wiki-links carrying optional anchors (#62). */

--- a/src/components/Editor/wikiLink.ts
+++ b/src/components/Editor/wikiLink.ts
@@ -1,13 +1,21 @@
-// Wiki-link CM6 ViewPlugin — Phase 4 Plan 02
+// Wiki-link CM6 ViewPlugin — Phase 4 Plan 02 / Issue #62 anchor support.
 //
 // Architecture:
 //   - Module-level `resolvedLinks: Map<stem, relPath>` populated once per vault
 //     open via EditorPane calling setResolvedLinks(await getResolvedLinks()).
+//   - Module-level `resolvedAnchors: Map<relPath, AnchorKeySet>` (#62) added
+//     alongside so block-ref / heading-ref decoration is also a sync Map.get().
 //   - Every decoration + click lookup is a synchronous Map.get() — zero IPC
 //     inside the CM6 render loop, zero IPC at click time.
 //   - Click events are dispatched as CustomEvent("wiki-link-click") on the
 //     EditorView DOM so the Svelte layer handles navigation without coupling
 //     the CM6 extension to Svelte stores.
+//
+// Resolution model (#62):
+//   "resolved"       — note exists, anchor (if any) matches.
+//   "anchor-missing" — note exists, anchor does NOT match. Click opens note,
+//                      Svelte side surfaces a toast.
+//   "unresolved"     — note does not exist. Click creates the note.
 
 import { ViewPlugin, Decoration, EditorView } from "@codemirror/view";
 import type { DecorationSet, ViewUpdate } from "@codemirror/view";
@@ -15,6 +23,7 @@ import { RangeSetBuilder } from "@codemirror/state";
 import type { EditorState } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 
+import type { AnchorEntry, AnchorKeySet } from "../../types/links";
 import {
   findTemplateExprRanges,
   isInsideTemplateExpr,
@@ -24,39 +33,96 @@ const HIDE = Decoration.replace({});
 
 // ── Wiki-link regex ────────────────────────────────────────────────────────────
 
-/** Matches [[target]] and [[target|alias]]. Global flag — reset lastIndex before use. */
+/**
+ * Matches `[[target]]`, `[[target|alias]]`, `[[target#H]]`, `[[target^id]]`,
+ * and any `target` + heading + block + alias combination.
+ *
+ * Capture groups are intentionally NOT used for anchor splitting — the regex
+ * captures the full target including any `#H` / `^id` suffix in group 1; the
+ * runtime parser (`parseLinkTarget`) splits stem / heading / block-id with
+ * the same precedence rule the rename-cascade regex uses on the Rust side.
+ * Single-source-of-truth for the parsing rule lives in `parseLinkTarget`.
+ */
 const WIKI_LINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]*))?\]\]/g;
 
-// ── Resolution map ─────────────────────────────────────────────────────────────
+// ── Resolution state ───────────────────────────────────────────────────────────
 
 /**
- * Stem (lowercased) → vault-relative path.
- * Populated once per vault open via EditorPane calling
- * `setResolvedLinks(await getResolvedLinks())`.
- * Incrementally updated on file create/delete/rename by EditorPane.
+ * Stem (lowercased) → vault-relative path. Populated by EditorPane on vault
+ * open (and on every `resolvedLinksStore.requestReload()` after rename/move).
  */
 let resolvedLinks: Map<string, string> = new Map();
 
 /**
- * Replace the resolution map. Called by EditorPane after `get_resolved_links`
- * IPC returns on vault open, and on incremental file create/delete/rename events.
+ * Vault-relative path → anchor table (#62). Populated alongside
+ * `resolvedLinks` by EditorPane. Empty until `setResolvedAnchors` fires.
  */
+let resolvedAnchors: Map<string, AnchorKeySet> = new Map();
+
 export function setResolvedLinks(map: Map<string, string>): void {
   resolvedLinks = map;
 }
 
 /**
- * Synchronous lookup used by both the ViewPlugin (decoration) and the
- * EditorPane click handler.
- *
- * @param target - Raw link target from `[[target]]` (may include a `.md` or
- *   `.canvas` suffix — #147; alias is already stripped by the caller via
- *   the regex group 1 capture).
- * @returns Vault-relative path, or `null` if the target is not resolved.
+ * Replace the per-vault anchor map. Called by EditorPane right after
+ * `setResolvedLinks` in `reloadResolvedLinks`.
+ */
+export function setResolvedAnchors(map: Map<string, AnchorKeySet>): void {
+  resolvedAnchors = map;
+}
+
+/**
+ * Parsed wiki-link suffix. Block-id wins when both `^` and `#` are present —
+ * a malformed `[[Note#H^id]]` is treated as a block ref because Obsidian's
+ * own parser anchors on the trailing `^id`. The exact precedence is locked
+ * in by the test suite.
+ */
+export interface ParsedAnchor {
+  kind: "block" | "heading";
+  /** Lowercased for blocks, original case (slug-case folded) for headings. */
+  value: string;
+}
+
+export interface ParsedTarget {
+  stem: string;
+  anchor: ParsedAnchor | null;
+}
+
+/**
+ * Split a raw wiki-link target into `(stem, anchor?)`. Pure function — does
+ * not consult any resolution map. Single source of truth for anchor-suffix
+ * parsing on the frontend; the Rust side parses anchors at index time.
+ */
+export function parseLinkTarget(raw: string): ParsedTarget {
+  const stripped = stripKnownExt(raw);
+  // Block-id wins: scan for the LAST `^` and accept it only when the suffix
+  // is a valid block-id ([A-Za-z0-9-]+) and contains no `#`. This means
+  // `[[Note#H^id]]` resolves as `^id` (matches Rust-side block-id grammar).
+  const caretIdx = stripped.lastIndexOf("^");
+  if (caretIdx > 0) {
+    const id = stripped.slice(caretIdx + 1);
+    if (/^[A-Za-z0-9-]+$/.test(id)) {
+      return { stem: stripped.slice(0, caretIdx), anchor: { kind: "block", value: id.toLowerCase() } };
+    }
+  }
+  const hashIdx = stripped.indexOf("#");
+  if (hashIdx > 0) {
+    return {
+      stem: stripped.slice(0, hashIdx),
+      anchor: { kind: "heading", value: stripped.slice(hashIdx + 1) },
+    };
+  }
+  return { stem: stripped, anchor: null };
+}
+
+/**
+ * Synchronous lookup of `[[target]]` → vault-relative path. Strips any
+ * `#H` / `^id` suffix before consulting the stem map so legacy callers that
+ * pass the full link text still receive a match for the underlying note.
  */
 export function resolveTarget(target: string): string | null {
-  const stem = stripKnownExt(target).toLowerCase();
-  return resolvedLinks.get(stem) ?? null;
+  const { stem } = parseLinkTarget(target);
+  return resolvedLinks.get(stem.toLowerCase()) ?? null;
 }
 
 export function stripKnownExt(target: string): string {
@@ -65,16 +131,42 @@ export function stripKnownExt(target: string): string {
   return target;
 }
 
+/**
+ * Look up the anchor entry for `(relPath, anchor)`, or `null` when the file
+ * has no anchors registered or the anchor doesn't match. Slug comparison is
+ * case-insensitive for headings; block ids compare byte-for-byte against the
+ * lowercased value already produced by `parseLinkTarget`.
+ */
+export function resolveAnchor(relPath: string, anchor: ParsedAnchor): AnchorEntry | null {
+  const set = resolvedAnchors.get(relPath);
+  if (!set) return null;
+  if (anchor.kind === "block") {
+    return set.blocks.find((b) => b.id === anchor.value) ?? null;
+  }
+  const target = anchor.value.toLowerCase();
+  return set.headings.find((h) => h.id.toLowerCase() === target) ?? null;
+}
+
+/** Three-valued resolution state for wiki-links carrying optional anchors (#62). */
+export type LinkResolution = "resolved" | "anchor-missing" | "unresolved";
+
+function resolveLink(parsed: ParsedTarget): { resolution: LinkResolution; relPath: string | null } {
+  const relPath = resolvedLinks.get(parsed.stem.toLowerCase()) ?? null;
+  if (relPath === null) {
+    return { resolution: "unresolved", relPath: null };
+  }
+  if (parsed.anchor === null) {
+    return { resolution: "resolved", relPath };
+  }
+  const anchor = resolveAnchor(relPath, parsed.anchor);
+  return {
+    resolution: anchor !== null ? "resolved" : "anchor-missing",
+    relPath,
+  };
+}
+
 // ── Code block detection ───────────────────────────────────────────────────────
 
-/**
- * Returns true when `pos` is inside a fenced code block, indented code block,
- * or inline code span. Uses the lezer syntax tree to check node ancestry.
- *
- * Node names are based on `@lezer/markdown`'s grammar. If a vault's content
- * triggers a different node name (e.g. language-specific embedding), the
- * decoration is skipped safely — a false positive here is always safe.
- */
 function isInsideCodeBlock(state: EditorState, pos: number): boolean {
   const node = syntaxTree(state).resolve(pos, 1);
   let cur: typeof node | null = node;
@@ -98,8 +190,12 @@ function isInsideCodeBlock(state: EditorState, pos: number): boolean {
 interface WikiMatch {
   from: number;
   to: number;
+  /** Stem (without anchor and without alias). */
   target: string;
-  resolved: boolean;
+  resolution: LinkResolution;
+  /** Parsed anchor suffix or `null`. Carried so the click event can dispatch
+   * navigation without re-parsing. */
+  anchor: ParsedAnchor | null;
   aliasStart: number | null;
   aliasEnd: number | null;
 }
@@ -110,33 +206,40 @@ interface DecoratedRange {
   decoration: Decoration;
 }
 
-/**
- * Bytes to extend on each side of `view.viewport` so wiki-links and
- * `{{ ... }}` template bodies that straddle the viewport boundary are still
- * detected by the scan (#247). Wiki-links are tiny; templates can be
- * multi-line but rarely exceed a few hundred bytes in practice. 512 is
- * comfortably above both.
- */
 const VIEWPORT_WIDEN_BYTES = 512;
+
+function classFor(resolution: LinkResolution): string {
+  switch (resolution) {
+    case "resolved":
+      return "cm-wikilink-resolved";
+    case "anchor-missing":
+      return "cm-wikilink-unresolved-anchor";
+    case "unresolved":
+      return "cm-wikilink-unresolved";
+  }
+}
+
+function attrsFor(match: WikiMatch): Record<string, string> {
+  const attrs: Record<string, string> = {
+    "data-wiki-target": match.target,
+    "data-wiki-resolved": match.resolution,
+  };
+  if (match.anchor) {
+    attrs["data-wiki-anchor-kind"] = match.anchor.kind;
+    attrs["data-wiki-anchor-value"] = match.anchor.value;
+  }
+  return attrs;
+}
 
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
   const state = view.state;
   const docLength = state.doc.length;
 
-  // #247 — viewport-bounded scan. The old full-doc serialisation allocated
-  // O(doc length) per keystroke and burned the 16ms budget on medium+ notes.
-  // Slice only the visible region (± VIEWPORT_WIDEN_BYTES so straddling
-  // wiki-links and template bodies still match) and offset absolute positions
-  // by `windowFrom`. Code-block detection keeps using `syntaxTree(state)` with
-  // absolute coordinates — the slice is a scanning input, not an index space.
   const windowFrom = Math.max(0, view.viewport.from - VIEWPORT_WIDEN_BYTES);
   const windowTo = Math.min(docLength, view.viewport.to + VIEWPORT_WIDEN_BYTES);
   const text = state.sliceDoc(windowFrom, windowTo);
   const head = state.selection.main.head;
-  // Template ranges MUST be offset by windowFrom — otherwise every
-  // `{{ ... }}` exclusion breaks and literal `[[...]]` inside an expression
-  // gets decorated.
   const exprRanges = findTemplateExprRanges(text, windowFrom);
 
   const matches: WikiMatch[] = [];
@@ -153,15 +256,13 @@ function buildDecorations(view: EditorView): DecorationSet {
     if (isInsideCodeBlock(state, from)) continue;
     if (isInsideTemplateExpr(exprRanges, from, to)) continue;
 
-    const stem: string = stripKnownExt(rawTarget);
-    const resolved = resolvedLinks.has(stem.toLowerCase());
+    const parsed = parseLinkTarget(rawTarget);
+    const { resolution } = resolveLink(parsed);
 
     const aliasText = m[2];
     let aliasStart: number | null = null;
     let aliasEnd: number | null = null;
     if (aliasText !== undefined) {
-      // `text` is the widened-window slice; searching for `|` in it and
-      // translating back via windowFrom keeps absolute coordinates correct.
       const pipePosInSlice = text.indexOf("|", m.index + 2);
       if (pipePosInSlice !== -1) {
         aliasStart = windowFrom + pipePosInSlice;
@@ -169,7 +270,15 @@ function buildDecorations(view: EditorView): DecorationSet {
       }
     }
 
-    matches.push({ from, to, target: stem, resolved, aliasStart, aliasEnd });
+    matches.push({
+      from,
+      to,
+      target: parsed.stem,
+      resolution,
+      anchor: parsed.anchor,
+      aliasStart,
+      aliasEnd,
+    });
   }
 
   matches.sort((a, b) => a.from - b.from);
@@ -178,18 +287,14 @@ function buildDecorations(view: EditorView): DecorationSet {
 
   for (const match of matches) {
     const cursorInLink = head >= match.from && head <= match.to;
+    const cls = classFor(match.resolution);
+    const attrs = attrsFor(match);
 
     if (cursorInLink) {
       allRanges.push({
         from: match.from,
         to: match.to,
-        decoration: Decoration.mark({
-          class: match.resolved ? "cm-wikilink-resolved" : "cm-wikilink-unresolved",
-          attributes: {
-            "data-wiki-target": match.target,
-            "data-wiki-resolved": match.resolved ? "true" : "false",
-          },
-        }),
+        decoration: Decoration.mark({ class: cls, attributes: attrs }),
       });
     } else {
       allRanges.push({ from: match.from, to: match.from + 2, decoration: HIDE });
@@ -202,13 +307,7 @@ function buildDecorations(view: EditorView): DecorationSet {
         allRanges.push({
           from: visibleFrom,
           to: visibleTo,
-          decoration: Decoration.mark({
-            class: match.resolved ? "cm-wikilink-resolved" : "cm-wikilink-unresolved",
-            attributes: {
-              "data-wiki-target": match.target,
-              "data-wiki-resolved": match.resolved ? "true" : "false",
-            },
-          }),
+          decoration: Decoration.mark({ class: cls, attributes: attrs }),
         });
       } else {
         const visibleFrom = match.from + 2;
@@ -217,13 +316,7 @@ function buildDecorations(view: EditorView): DecorationSet {
           allRanges.push({
             from: visibleFrom,
             to: visibleTo,
-            decoration: Decoration.mark({
-              class: match.resolved ? "cm-wikilink-resolved" : "cm-wikilink-unresolved",
-              attributes: {
-                "data-wiki-target": match.target,
-                "data-wiki-resolved": match.resolved ? "true" : "false",
-              },
-            }),
+            decoration: Decoration.mark({ class: cls, attributes: attrs }),
           });
         }
       }
@@ -240,6 +333,17 @@ function buildDecorations(view: EditorView): DecorationSet {
 }
 
 // ── ViewPlugin ─────────────────────────────────────────────────────────────────
+
+/** Detail payload for the `wiki-link-click` CustomEvent. */
+export interface WikiLinkClickDetail {
+  /** Stem only — anchor / alias are stripped. */
+  target: string;
+  /** Three-valued resolution state. */
+  resolution: LinkResolution;
+  /** Anchor suffix (if any) — pre-parsed so the Svelte handler can route
+   * straight to scroll-to-block / scroll-to-heading without reparsing. */
+  anchor: ParsedAnchor | null;
+}
 
 export const wikiLinkPlugin = ViewPlugin.fromClass(
   class {
@@ -264,19 +368,27 @@ export const wikiLinkPlugin = ViewPlugin.fromClass(
         if (!wikiTarget) return false;
 
         const linkTarget = wikiTarget.getAttribute("data-wiki-target");
-        const isResolved = wikiTarget.getAttribute("data-wiki-resolved") === "true";
         if (!linkTarget) return false;
+        const rawResolution = wikiTarget.getAttribute("data-wiki-resolved") ?? "unresolved";
+        const resolution: LinkResolution =
+          rawResolution === "resolved" || rawResolution === "anchor-missing"
+            ? rawResolution
+            : "unresolved";
+        const kind = wikiTarget.getAttribute("data-wiki-anchor-kind");
+        const value = wikiTarget.getAttribute("data-wiki-anchor-value");
+        const anchor: ParsedAnchor | null =
+          kind === "block" || kind === "heading"
+            ? { kind, value: value ?? "" }
+            : null;
 
         event.preventDefault();
         event.stopPropagation();
 
-        // Dispatch custom event for the Svelte layer to handle navigation.
-        // The listener calls resolveTarget(linkTarget) for resolved links to
-        // get the vault-relative path — no flat-vault stub, no IPC at click time.
+        const detail: WikiLinkClickDetail = { target: linkTarget, resolution, anchor };
         view.dom.dispatchEvent(
-          new CustomEvent("wiki-link-click", {
+          new CustomEvent<WikiLinkClickDetail>("wiki-link-click", {
             bubbles: true,
-            detail: { target: linkTarget, resolved: isResolved },
+            detail,
           }),
         );
 
@@ -291,9 +403,6 @@ export const wikiLinkPlugin = ViewPlugin.fromClass(
 /**
  * Force decoration rebuild on all open EditorViews after `setResolvedLinks`
  * is called. Dispatches a no-op transaction to trigger `update()`.
- *
- * EditorPane calls this on every mounted EditorView after vault open so
- * decorations reflect the fresh resolution map immediately.
  */
 export function refreshWikiLinks(view: EditorView): void {
   view.dispatch({ effects: [] });

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -11,7 +11,14 @@ import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
 import type { DirEntry } from "../types/tree";
 import type { SearchResult, FileMatch } from "../types/search";
-import type { BacklinkEntry, ParsedLink, UnresolvedLink, RenameResult, LocalGraph } from "../types/links";
+import type {
+  AnchorKeySet,
+  BacklinkEntry,
+  ParsedLink,
+  UnresolvedLink,
+  RenameResult,
+  LocalGraph,
+} from "../types/links";
 import type { TagUsage, TagOccurrence } from "../types/tags";
 import type { EncryptedFolderView } from "../types/encryption";
 
@@ -331,6 +338,23 @@ export async function updateLinksAfterRename(
 export async function getResolvedLinks(): Promise<Map<string, string>> {
   try {
     const record = await invoke<Record<string, string>>("get_resolved_links");
+    return new Map(Object.entries(record));
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+/**
+ * Return a `rel_path → AnchorKeySet` map covering every indexed file with at
+ * least one block-id or heading anchor (#62).
+ *
+ * UTF-16 offsets (`jsStart` / `jsEnd`) are precomputed in Rust so the
+ * frontend can slice JS strings (`noteContentCache` content) directly without
+ * worrying about UTF-8 vs. UTF-16 drift on multi-byte content.
+ */
+export async function getResolvedAnchors(): Promise<Map<string, AnchorKeySet>> {
+  try {
+    const record = await invoke<Record<string, AnchorKeySet>>("get_resolved_anchors");
     return new Map(Object.entries(record));
   } catch (e) {
     throw normalizeError(e);

--- a/src/lib/__tests__/headingSlugParity.test.ts
+++ b/src/lib/__tests__/headingSlugParity.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Cross-language parity fixture for the heading-slug algorithm (#62).
+ *
+ * The Rust counterpart in `src-tauri/src/indexer/anchors.rs::tests::
+ * slugify_parity_fixture` reads the SAME JSON file and asserts identical
+ * output. Drift between the two implementations would silently break
+ * every multi-word heading anchor — the parity test is the safety net.
+ */
+
+import { describe, it, expect } from "vitest";
+import fixture from "../../../test-fixtures/slug_parity.json";
+import { slugify } from "../headingSlug";
+
+interface Case {
+  name: string;
+  input: string;
+  expected: string;
+}
+
+describe("headingSlug parity (#62)", () => {
+  for (const c of (fixture as { cases: Case[] }).cases) {
+    it(c.name, () => {
+      expect(slugify(c.input)).toBe(c.expected);
+    });
+  }
+});

--- a/src/lib/headingSlug.ts
+++ b/src/lib/headingSlug.ts
@@ -15,10 +15,16 @@
 // We do NOT collapse adjacent dashes from dropped characters because Rust
 // doesn't either — only whitespace creates dashes.
 
-/** Re-exported alphanumeric test that stays in sync with Rust's
- * `char::is_alphanumeric`. JS `\p{L}\p{N}` matches the same Unicode
- * categories. */
-const ALNUM_RE = /[\p{L}\p{N}]/u;
+/** Alphanumeric test that stays in sync with Rust's `char::is_alphanumeric`.
+ *
+ * `is_alphanumeric` is `is_alphabetic || is_numeric`, where `is_alphabetic`
+ * uses the Unicode **Alphabetic** property — a superset of `General_Category
+ * = Letter` that also includes combining marks with `Alphabetic = true`
+ * (e.g. Devanagari vowel signs U+093E / U+0902, Arabic fathatan). The
+ * naive `\p{L}\p{N}` regex misses those, so a heading written in Hindi
+ * with vowel diacritics would slug differently on each side. `\p{Alphabetic}`
+ * matches Rust exactly. */
+const ALNUM_RE = /[\p{Alphabetic}\p{N}]/u;
 
 export function slugify(text: string): string {
   let out = "";

--- a/src/lib/headingSlug.ts
+++ b/src/lib/headingSlug.ts
@@ -1,0 +1,44 @@
+// Heading-slug algorithm — mirror of `src-tauri/src/indexer/anchors.rs::slugify`.
+//
+// Used by the wiki-link click handler and the embed plugin to compare a
+// heading-ref's raw value (e.g. `Multi Word`) against the slug Rust stored
+// at index time (`multi-word`). The two sides MUST stay in lockstep —
+// `test-fixtures/slug_parity.json` pins identical output for every case
+// across both languages.
+//
+// Algorithm (matches Rust):
+//   1. lowercase (Unicode-aware via `String.prototype.toLowerCase`)
+//   2. whitespace runs → single `-` (only when boundary makes sense)
+//   3. keep `\p{L}\p{N}` plus `-` and `_`; drop everything else
+//   4. trim leading / trailing `-`
+//
+// We do NOT collapse adjacent dashes from dropped characters because Rust
+// doesn't either — only whitespace creates dashes.
+
+/** Re-exported alphanumeric test that stays in sync with Rust's
+ * `char::is_alphanumeric`. JS `\p{L}\p{N}` matches the same Unicode
+ * categories. */
+const ALNUM_RE = /[\p{L}\p{N}]/u;
+
+export function slugify(text: string): string {
+  let out = "";
+  let lastWasDash = false;
+  for (const ch of text) {
+    if (/\s/.test(ch)) {
+      if (!lastWasDash && out.length > 0) {
+        out += "-";
+        lastWasDash = true;
+      }
+      continue;
+    }
+    if (ALNUM_RE.test(ch) || ch === "-" || ch === "_") {
+      out += ch.toLowerCase();
+      lastWasDash = false;
+      continue;
+    }
+    // punctuation / emoji / other — drop without breaking dash-state
+  }
+  while (out.endsWith("-")) out = out.slice(0, -1);
+  while (out.startsWith("-")) out = out.slice(1);
+  return out;
+}

--- a/src/store/scrollStore.ts
+++ b/src/store/scrollStore.ts
@@ -4,14 +4,25 @@
 //
 // This is a one-shot event store: EditorPane consumes the request immediately after
 // executing it to prevent re-triggering on tab switches.
+//
+// #62: a wiki-link click on `[[Note^id]]` / `[[Note#H]]` produces a
+// `ScrollRequest` with an explicit `range` instead of a `searchText` —
+// EditorPane uses the precomputed JS code-unit offsets directly so the
+// scroll is exact (no string-search fallback that could hit the wrong
+// occurrence in the document).
 
 import { writable } from "svelte/store";
 
 export interface ScrollRequest {
   /** Absolute file path to scroll in. */
   filePath: string;
-  /** Plain text to search for in the CM6 document (first occurrence). */
+  /** Plain text to search for. Used when `range` is omitted (legacy
+   * OmniSearch flow). */
   searchText: string;
+  /** Optional explicit JS code-unit range — when present, EditorPane scrolls
+   * directly to `[from, to)` instead of running a string search. Anchor
+   * navigation (#62) populates this. */
+  range?: { from: number; to: number };
   /** Unique token to detect new requests (crypto.randomUUID()). */
   token: string;
 }
@@ -31,6 +42,17 @@ export const scrollStore = {
    */
   requestScrollToMatch(filePath: string, searchText: string): void {
     _store.set({ pending: { filePath, searchText, token: crypto.randomUUID() } });
+  },
+
+  /**
+   * Request a scroll to an explicit JS code-unit range — used by the
+   * wiki-link click handler when an anchor (`^id` / `#H`) resolved (#62).
+   * `searchText` is left empty because the range is authoritative.
+   */
+  requestScrollToRange(filePath: string, from: number, to: number): void {
+    _store.set({
+      pending: { filePath, searchText: "", range: { from, to }, token: crypto.randomUUID() },
+    });
   },
 
   /**

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -192,6 +192,20 @@ html, body, #app {
 .cm-wikilink-unresolved:hover {
   text-decoration: underline;
 }
+/* #62: note exists but the anchor (^id / #H) does not. Vitruvius briefed
+ * this third state with #92400E light-mode (≈7:1 vs surface white,
+ * passes WCAG AA) and the existing `--color-warning` dark-mode value. */
+.cm-wikilink-unresolved-anchor {
+  color: #92400E;
+  cursor: pointer;
+  text-decoration: none;
+}
+.cm-wikilink-unresolved-anchor:hover {
+  text-decoration: underline;
+}
+:root.dark .cm-wikilink-unresolved-anchor {
+  color: var(--color-warning, #FCD34D);
+}
 
 /* Phase 4 Plan 03: Wiki-link autocomplete popup styling */
 .cm-tooltip-autocomplete {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -164,15 +164,18 @@ html, body, #app {
   animation: vc-spin 1s linear infinite;
 }
 
-/* Phase 3 — Flash highlight for scroll-to-match */
+/* Phase 3 — Flash highlight for scroll-to-match.
+ * Only the background fades — fading `opacity` would also fade the text
+ * itself, making the user briefly stare at an invisible block before it
+ * pops back. Background-only keeps the surrounding paragraph readable
+ * the entire time. */
 .vc-flash-highlight {
   background: #FEF9C3;
-  transition: background 2500ms ease-out, opacity 2500ms ease-out;
+  transition: background 2500ms ease-out;
   border-radius: 2px;
 }
 .vc-flash-highlight.vc-flash-done {
   background: transparent;
-  opacity: 0;
 }
 
 /* Phase 4: Wiki-link decoration in CM6 editor */

--- a/src/types/links.ts
+++ b/src/types/links.ts
@@ -71,6 +71,29 @@ export interface LocalGraph {
   edges: GraphEdge[];
 }
 
+/**
+ * One anchor entry returned by `get_resolved_anchors` (#62).
+ *
+ * `byteStart`/`byteEnd` are UTF-8 byte offsets — kept for completeness but
+ * the frontend never slices by them. `jsStart`/`jsEnd` are UTF-16 code-unit
+ * offsets, precomputed in Rust so JS string slicing on `noteContentCache`
+ * content is correct for multi-byte content (CJK, emoji, surrogate pairs).
+ */
+export interface AnchorEntry {
+  /** Block id (lowercased) for blocks; heading slug for headings. */
+  id: string;
+  byteStart: number;
+  byteEnd: number;
+  jsStart: number;
+  jsEnd: number;
+}
+
+/** All anchors discovered in one file, returned by `get_resolved_anchors`. */
+export interface AnchorKeySet {
+  blocks: AnchorEntry[];
+  headings: AnchorEntry[];
+}
+
 /** Result returned by update_links_after_rename. */
 export interface RenameResult {
   /** Number of files that had their links rewritten. */

--- a/test-fixtures/slug_parity.json
+++ b/test-fixtures/slug_parity.json
@@ -1,0 +1,18 @@
+{
+  "_description": "Cross-language parity fixture for the heading-slug algorithm (#62). Both src-tauri/src/indexer/anchors.rs::slugify and src/lib/headingSlug.ts::slugify MUST produce the same output for every case. The frontend slugifies a heading-ref's `value` at click time; the Rust side slugifies at index time. Drift produces silently-broken anchor navigation for every multi-word heading.",
+  "cases": [
+    { "name": "ascii basic", "input": "Section", "expected": "section" },
+    { "name": "multi-word", "input": "Multi Word Heading", "expected": "multi-word-heading" },
+    { "name": "trim outer dashes", "input": "---Trim---", "expected": "trim" },
+    { "name": "collapse repeated whitespace", "input": "multi   space", "expected": "multi-space" },
+    { "name": "drop punctuation", "input": "Hello, World!", "expected": "hello-world" },
+    { "name": "strip markdown emphasis", "input": "**Bold** heading", "expected": "bold-heading" },
+    { "name": "preserves underscore", "input": "with_under_score", "expected": "with_under_score" },
+    { "name": "preserves dash", "input": "kebab-case", "expected": "kebab-case" },
+    { "name": "unicode preserves non-ascii letters", "input": "Düsseldorf", "expected": "düsseldorf" },
+    { "name": "unicode mixed", "input": "Düsseldorf 2026 — 一月", "expected": "düsseldorf-2026-一月" },
+    { "name": "drops leading and trailing punctuation", "input": "  ! Hello !  ", "expected": "hello" },
+    { "name": "empty", "input": "", "expected": "" },
+    { "name": "punctuation only", "input": "!!! ??? ...", "expected": "" }
+  ]
+}

--- a/test-fixtures/slug_parity.json
+++ b/test-fixtures/slug_parity.json
@@ -13,6 +13,9 @@
     { "name": "unicode mixed", "input": "Düsseldorf 2026 — 一月", "expected": "düsseldorf-2026-一月" },
     { "name": "drops leading and trailing punctuation", "input": "  ! Hello !  ", "expected": "hello" },
     { "name": "empty", "input": "", "expected": "" },
-    { "name": "punctuation only", "input": "!!! ??? ...", "expected": "" }
+    { "name": "punctuation only", "input": "!!! ??? ...", "expected": "" },
+    { "name": "devanagari vowel signs survive, virama drops (Mn non-Alphabetic)", "input": "हिन्दी पाठ", "expected": "हिनदी-पाठ" },
+    { "name": "arabic damma diacritic survives (Mn Alphabetic)", "input": "النصُ العربي", "expected": "النصُ-العربي" },
+    { "name": "combining marks survive", "input": "café", "expected": "café" }
   ]
 }


### PR DESCRIPTION
## Summary

Implements Obsidian-style **block references** (`[[note^blockid]]`, `![[note^blockid]]`) and **heading anchors** (`[[note#Heading]]`, `![[note#Heading]]`) end-to-end. Closes #62.

## What's new

**Rust**
- `indexer::anchors` extracts per-file block-id and heading anchors via `pulldown-cmark` offset iteration — paragraphs, list items, headings, callouts.
- `indexer::anchor_index` holds the per-vault map plus precomputed UTF-16 offsets for direct JS-string slicing on the frontend.
- New Tauri command `get_resolved_anchors`; locked-folder filtered like `get_resolved_links`.
- Rename-cascade regex preserves `#H` and `^id` suffixes.

**Frontend**
- `wikiLink.ts`: three-valued resolution (`resolved | anchor-missing | unresolved`), `parseLinkTarget` chokepoint, anchor in click event detail.
- `embedPlugin.ts`: regex extended to capture `^id`; slices cached content by `jsStart/jsEnd`; `BrokenEmbedWidget` for missing anchors.
- `EditorPane`: scrolls anchor matches through the existing `scrollStore` (now optionally carries a `range`); warning toast on anchor-missing.
- New CSS `cm-wikilink-unresolved-anchor` — `#92400E` light (~7:1 contrast), `--color-warning` dark.

## Why this shape

Per Socrates plan review, the design avoids five originally-blocking issues:
1. UTF-16 vs UTF-8 drift — Rust precomputes JS offsets.
2. Three-valued attribute routes correctly through the click handler (no false-create on anchor-missing).
3. Rename cascade preserves anchor suffixes.
4. `resolvedAnchors` keyed by rel_path (unambiguous).
5. `WIKI_EMBED_RE` capture-group shift accounted for in all call sites.

Vitruvius constraints all met: only one new CSS class, no new IPC inside the render loop, single-source slug rules in Rust, `BrokenEmbedWidget` reuse.

## Test plan
- [x] `cargo test --lib` — 381 passed, 0 failed
- [x] `npx vitest run` (excl. flaky pre-existing `largeFile` perf timer) — 1288 passed
- [x] `npm run typecheck` clean
- [ ] Manual UAT: open a vault with `[[note^id]]` content; verify decoration colors, anchor scroll, anchor-missing toast, embed slicing for blocks + heading sections, rename-cascade preserves suffixes.

## Out of scope (per ticket)
- Block-id autogeneration UX
- Transclusion edit-in-place
- Cross-vault references
- Anchor-aware backlinks