### PR TITLE
fix(sidebar): rename cascade dialog races with watcher tree re-flatten (#378)

### DIFF
--- a/e2e/specs/rename-cascade.spec.ts
+++ b/e2e/specs/rename-cascade.spec.ts
@@ -12,15 +12,7 @@ import { textOf, textsOf } from "../helpers/text.js";
  * WebKitWebDriver reports pointer clicks on .vc-context-item as intercepted
  * by the overlay (same pattern as inline-rename.spec.ts).
  */
-// SKIP: pre-existing race between `renameFile` completion and the watcher
-// event that re-flattens the virtualized tree (#336). The original TreeRow
-// instance unmounts before its `onConfirm` callback can mount the cascade
-// dialog, so `pendingRename` is set on a stale component and the dialog
-// never paints. Tracked in #378. Direct IPC probing confirms `rename_file`
-// correctly returns `linkCount: 3` for this fixture — the backend is fine.
-// The Vitest unit tests in `commands/links::tests` still cover the
-// rename-rewrite regex contract (#62 anchor preservation included).
-describe.skip("Rename cascade dialog", () => {
+describe("Rename cascade dialog", () => {
   let vault: TestVault;
 
   before(async () => {
@@ -83,10 +75,10 @@ describe.skip("Rename cascade dialog", () => {
     await setRenameValue("Welcome Renamed.md");
     await browser.keys(["Enter"]);
 
-    // Rename-input unmounts, cascade dialog appears. The dialog's
-    // `aria-labelledby` is suffixed with the row's path (per-row uniqueness)
-    // so a prefix match is the right selector — the bare-string variant has
-    // never matched since the tree virtualization landed.
+    // Rename-input unmounts, cascade dialog appears. After the #378 lift the
+    // dialog lives on the Sidebar (single owner, survives the watcher
+    // re-flatten that destroys the per-row TreeRow). The aria-labelledby is
+    // now a stable string; the prefix selector still matches.
     await input.waitForDisplayed({ timeout: 5000, reverse: true });
     const dialog = await browser.$('[aria-labelledby^="rename-heading"]');
     await dialog.waitForDisplayed({ timeout: 3000 });

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -38,7 +38,7 @@
   import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import type {
     RenameCascadeRequest,
-    MoveCascadeRequest,
+    MoveDropRequest,
     PendingRename,
     PendingMove,
   } from "../../types/sidebar";
@@ -561,15 +561,64 @@
     pendingRename = { ...req, fileCount };
   }
 
-  function handleRequestMoveCascade(req: MoveCascadeRequest) {
+  async function handleRequestMoveCascade(req: MoveDropRequest) {
+    // Modal precedence — same rule as rename cascade.
     if (pendingRename || pendingMove) return;
-    pendingMove = req;
+    const vault = $vaultStore.currentPath;
+    if (!vault) return;
+    const { sourcePath, targetDirPath } = req;
+    const sourceRelPath = sourcePath.startsWith(vault + "/")
+      ? sourcePath.slice(vault.length + 1)
+      : sourcePath;
+    const sourceFilename = sourcePath.split("/").pop() ?? sourcePath;
+    const newAbsPath = targetDirPath + "/" + sourceFilename;
+    const newRelPath = newAbsPath.startsWith(vault + "/")
+      ? newAbsPath.slice(vault.length + 1)
+      : newAbsPath;
+
+    let linkCount = 0;
+    let fileCount = 0;
+    try {
+      const backlinks = await getBacklinks(sourceRelPath);
+      linkCount = backlinks.length;
+      fileCount = new Set(backlinks.map((b) => b.sourcePath)).size;
+    } catch {
+      /* proceed without cascade */
+    }
+
+    if (linkCount > 0) {
+      pendingMove = {
+        sourcePath,
+        targetDirPath,
+        sourceRelPath,
+        newRelPath,
+        linkCount,
+        fileCount,
+      };
+      return;
+    }
+
+    // No-cascade direct move — was previously inside TreeRow.handleDrop.
+    try {
+      await moveFile(sourcePath, targetDirPath);
+      void bookmarksStore.renamePath(sourceRelPath, newRelPath, vault);
+      await refreshFolder(targetDirPath);
+      const parent = parentOf(sourcePath);
+      if (parent) await refreshFolder(parent);
+      resolvedLinksStore.requestReload();
+    } catch (err) {
+      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
   }
 
   async function confirmRenameWithLinks() {
     if (!pendingRename) return;
+    // Snapshot but DO NOT clear pendingRename yet — clearing before the
+    // IPC settles would let a second cascade request slip past the modal
+    // guard in handleRequest*Cascade and trigger concurrent link rewrites.
+    // Keep the dialog open while applying; clear only when the IPC resolves.
     const { oldPath, newPath, oldRelPath, newRelPath } = pendingRename;
-    pendingRename = null;
     handlePathChanged(oldPath, newPath);
     resolvedLinksStore.requestReload();
     try {
@@ -589,6 +638,8 @@
         variant: "error",
         message: "Links konnten nicht aktualisiert werden.",
       });
+    } finally {
+      pendingRename = null;
     }
   }
 
@@ -598,8 +649,9 @@
 
   async function confirmMoveWithLinks() {
     if (!pendingMove) return;
+    // Same re-entrancy reasoning as confirmRenameWithLinks — keep the modal
+    // guard armed across the whole IPC chain.
     const { sourcePath, targetDirPath, sourceRelPath, newRelPath } = pendingMove;
-    pendingMove = null;
     try {
       await moveFile(sourcePath, targetDirPath);
       const vaultForBookmarks = $vaultStore.currentPath;
@@ -624,6 +676,8 @@
     } catch (err) {
       const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    } finally {
+      pendingMove = null;
     }
   }
 

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -544,71 +544,88 @@
   // #378 — cascade-request handlers from TreeRow. The row hands the request
   // up the moment the IPC await resolves (synchronously, no further await),
   // so the closure capture cannot race the row's unmount. Sidebar then runs
-  // any post-IPC work (getBacklinks for fileCount, dialog rendering,
-  // updateLinksAfterRename on confirm) on its own always-mounted lifetime.
+  // any post-IPC work on its own always-mounted lifetime.
+  //
+  // `cascadeClaiming` is a synchronous slot reservation. The handler does an
+  // `await getBacklinks(...)` before it can populate the full `pendingRename`
+  // / `pendingMove` shape; checking only those state fields would let a second
+  // request pass the guard and race for the slot during that await window.
+  // `cascadeClaiming` is set before the await and the synthetic guard reads
+  // it, closing the re-entrancy window without flashing a half-populated
+  // dialog.
+  let cascadeClaiming = $state(false);
+
+  function cascadeBusy(): boolean {
+    return cascadeClaiming || pendingRename !== null || pendingMove !== null;
+  }
+
   async function handleRequestRenameCascade(req: RenameCascadeRequest) {
-    // Modal precedence: ignore overlapping cascade requests. Only one dialog
-    // open at a time. The user can re-trigger the suppressed action after
-    // resolving the first dialog.
-    if (pendingRename || pendingMove) return;
+    if (cascadeBusy()) return;
+    cascadeClaiming = true;
     let fileCount = 1;
     try {
       const backlinks = await getBacklinks(req.oldRelPath);
       fileCount = new Set(backlinks.map((b) => b.sourcePath)).size || 1;
     } catch {
       /* fall back to the linkCount/1 default */
+    } finally {
+      pendingRename = { ...req, fileCount };
+      cascadeClaiming = false;
     }
-    pendingRename = { ...req, fileCount };
   }
 
   async function handleRequestMoveCascade(req: MoveDropRequest) {
-    // Modal precedence — same rule as rename cascade.
-    if (pendingRename || pendingMove) return;
-    const vault = $vaultStore.currentPath;
-    if (!vault) return;
-    const { sourcePath, targetDirPath } = req;
-    const sourceRelPath = sourcePath.startsWith(vault + "/")
-      ? sourcePath.slice(vault.length + 1)
-      : sourcePath;
-    const sourceFilename = sourcePath.split("/").pop() ?? sourcePath;
-    const newAbsPath = targetDirPath + "/" + sourceFilename;
-    const newRelPath = newAbsPath.startsWith(vault + "/")
-      ? newAbsPath.slice(vault.length + 1)
-      : newAbsPath;
-
-    let linkCount = 0;
-    let fileCount = 0;
+    if (cascadeBusy()) return;
+    cascadeClaiming = true;
     try {
-      const backlinks = await getBacklinks(sourceRelPath);
-      linkCount = backlinks.length;
-      fileCount = new Set(backlinks.map((b) => b.sourcePath)).size;
-    } catch {
-      /* proceed without cascade */
-    }
+      const vault = $vaultStore.currentPath;
+      if (!vault) return;
+      const { sourcePath, targetDirPath } = req;
+      const sourceRelPath = sourcePath.startsWith(vault + "/")
+        ? sourcePath.slice(vault.length + 1)
+        : sourcePath;
+      const sourceFilename = sourcePath.split("/").pop() ?? sourcePath;
+      const newAbsPath = targetDirPath + "/" + sourceFilename;
+      const newRelPath = newAbsPath.startsWith(vault + "/")
+        ? newAbsPath.slice(vault.length + 1)
+        : newAbsPath;
 
-    if (linkCount > 0) {
-      pendingMove = {
-        sourcePath,
-        targetDirPath,
-        sourceRelPath,
-        newRelPath,
-        linkCount,
-        fileCount,
-      };
-      return;
-    }
+      let linkCount = 0;
+      let fileCount = 0;
+      try {
+        const backlinks = await getBacklinks(sourceRelPath);
+        linkCount = backlinks.length;
+        fileCount = new Set(backlinks.map((b) => b.sourcePath)).size;
+      } catch {
+        /* proceed without cascade */
+      }
 
-    // No-cascade direct move — was previously inside TreeRow.handleDrop.
-    try {
-      await moveFile(sourcePath, targetDirPath);
-      void bookmarksStore.renamePath(sourceRelPath, newRelPath, vault);
-      await refreshFolder(targetDirPath);
-      const parent = parentOf(sourcePath);
-      if (parent) await refreshFolder(parent);
-      resolvedLinksStore.requestReload();
-    } catch (err) {
-      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
-      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+      if (linkCount > 0) {
+        pendingMove = {
+          sourcePath,
+          targetDirPath,
+          sourceRelPath,
+          newRelPath,
+          linkCount,
+          fileCount,
+        };
+        return;
+      }
+
+      // No-cascade direct move — was previously inside TreeRow.handleDrop.
+      try {
+        await moveFile(sourcePath, targetDirPath);
+        void bookmarksStore.renamePath(sourceRelPath, newRelPath, vault);
+        await refreshFolder(targetDirPath);
+        const parent = parentOf(sourcePath);
+        if (parent) await refreshFolder(parent);
+        resolvedLinksStore.requestReload();
+      } catch (err) {
+        const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
+        toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+      }
+    } finally {
+      cascadeClaiming = false;
     }
   }
 

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from "svelte";
   import { FilePlus, FolderPlus, Network, ChevronDown, FileText, LayoutDashboard, BookOpen } from "lucide-svelte";
-  import { listDirectory, createFile, createFolder, writeFile } from "../../ipc/commands";
+  import {
+    listDirectory,
+    createFile,
+    createFolder,
+    writeFile,
+    getBacklinks,
+    moveFile,
+    updateLinksAfterRename,
+  } from "../../ipc/commands";
   import { serializeCanvas, emptyCanvas } from "../../lib/canvas/parse";
   import { commandRegistry } from "../../lib/commands/registry";
   import { CMD_IDS } from "../../lib/commands/defaultCommands";
@@ -26,6 +34,14 @@
   } from "../../ipc/events";
   import type { UnlistenFn } from "@tauri-apps/api/event";
   import { tabStore } from "../../store/tabStore";
+  import { tabReloadStore } from "../../store/tabReloadStore";
+  import { resolvedLinksStore } from "../../store/resolvedLinksStore";
+  import type {
+    RenameCascadeRequest,
+    MoveCascadeRequest,
+    PendingRename,
+    PendingMove,
+  } from "../../types/sidebar";
   import { openHomeCanvas } from "../../lib/homeCanvas";
   import { openDocsPage } from "../../lib/docsPage";
   import { searchStore } from "../../store/searchStore";
@@ -106,6 +122,12 @@
   // The row currently inline-renaming. We always keep it inside the window so
   // the InlineRename input never recycles out.
   let renamingPath = $state<string | null>(null);
+
+  // #378 — cascade-confirm dialog state. Owned by Sidebar so it survives the
+  // watcher-driven re-flatten that destroys the source TreeRow during rename
+  // or move. Per-row ownership was the original defect.
+  let pendingRename = $state<PendingRename | null>(null);
+  let pendingMove = $state<PendingMove | null>(null);
 
   const startIdx = $derived.by(() => {
     const first = Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN;
@@ -519,6 +541,96 @@
     else void loadRoot();
   }
 
+  // #378 — cascade-request handlers from TreeRow. The row hands the request
+  // up the moment the IPC await resolves (synchronously, no further await),
+  // so the closure capture cannot race the row's unmount. Sidebar then runs
+  // any post-IPC work (getBacklinks for fileCount, dialog rendering,
+  // updateLinksAfterRename on confirm) on its own always-mounted lifetime.
+  async function handleRequestRenameCascade(req: RenameCascadeRequest) {
+    // Modal precedence: ignore overlapping cascade requests. Only one dialog
+    // open at a time. The user can re-trigger the suppressed action after
+    // resolving the first dialog.
+    if (pendingRename || pendingMove) return;
+    let fileCount = 1;
+    try {
+      const backlinks = await getBacklinks(req.oldRelPath);
+      fileCount = new Set(backlinks.map((b) => b.sourcePath)).size || 1;
+    } catch {
+      /* fall back to the linkCount/1 default */
+    }
+    pendingRename = { ...req, fileCount };
+  }
+
+  function handleRequestMoveCascade(req: MoveCascadeRequest) {
+    if (pendingRename || pendingMove) return;
+    pendingMove = req;
+  }
+
+  async function confirmRenameWithLinks() {
+    if (!pendingRename) return;
+    const { oldPath, newPath, oldRelPath, newRelPath } = pendingRename;
+    pendingRename = null;
+    handlePathChanged(oldPath, newPath);
+    resolvedLinksStore.requestReload();
+    try {
+      const result = await updateLinksAfterRename(oldRelPath, newRelPath);
+      if (result.updatedPaths.length > 0) {
+        tabReloadStore.request(result.updatedPaths);
+      }
+      if (result.failedFiles.length > 0) {
+        const total = result.updatedLinks + result.failedFiles.length;
+        toastStore.push({
+          variant: "error",
+          message: `${result.updatedLinks} von ${total} Links aktualisiert. ${result.failedFiles.length} Dateien konnten nicht geändert werden.`,
+        });
+      }
+    } catch {
+      toastStore.push({
+        variant: "error",
+        message: "Links konnten nicht aktualisiert werden.",
+      });
+    }
+  }
+
+  function cancelRenameWithLinks() {
+    pendingRename = null;
+  }
+
+  async function confirmMoveWithLinks() {
+    if (!pendingMove) return;
+    const { sourcePath, targetDirPath, sourceRelPath, newRelPath } = pendingMove;
+    pendingMove = null;
+    try {
+      await moveFile(sourcePath, targetDirPath);
+      const vaultForBookmarks = $vaultStore.currentPath;
+      if (vaultForBookmarks) {
+        void bookmarksStore.renamePath(sourceRelPath, newRelPath, vaultForBookmarks);
+      }
+      await refreshFolder(targetDirPath);
+      const parent = parentOf(sourcePath);
+      if (parent) await refreshFolder(parent);
+      resolvedLinksStore.requestReload();
+      const result = await updateLinksAfterRename(sourceRelPath, newRelPath);
+      if (result.updatedPaths.length > 0) {
+        tabReloadStore.request(result.updatedPaths);
+      }
+      if (result.failedFiles.length > 0) {
+        const total = result.updatedLinks + result.failedFiles.length;
+        toastStore.push({
+          variant: "error",
+          message: `${result.updatedLinks} von ${total} Links aktualisiert. ${result.failedFiles.length} Dateien konnten nicht geändert werden.`,
+        });
+      }
+    } catch (err) {
+      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
+      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
+    }
+  }
+
+  function cancelMoveWithLinks() {
+    pendingMove = null;
+  }
+
   function parentOf(absPath: string): string | null {
     const i = absPath.lastIndexOf("/");
     if (i <= 0) return null;
@@ -747,15 +859,136 @@
             onRefreshFolder={refreshFolder}
             onPathChanged={handlePathChanged}
             {onRenameStateChange}
+            onRequestRenameCascade={handleRequestRenameCascade}
+            onRequestMoveCascade={handleRequestMoveCascade}
           />
         {/each}
       </ul>
     {/if}
   </div>
+
+  {#if pendingRename}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+      class="vc-confirm-overlay vc-modal-scrim"
+      onclick={cancelRenameWithLinks}
+      role="presentation"
+    ></div>
+    <div
+      class="vc-confirm-dialog vc-modal-surface"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="rename-heading"
+    >
+      <h2 id="rename-heading" class="vc-confirm-heading">Links aktualisieren?</h2>
+      <p class="vc-confirm-body">
+        {pendingRename.linkCount} Links in {pendingRename.fileCount} Dateien werden aktualisiert. Fortfahren?
+      </p>
+      <div class="vc-confirm-actions">
+        <button class="vc-confirm-btn vc-confirm-btn--cancel" onclick={cancelRenameWithLinks}>Abbrechen</button>
+        <button class="vc-confirm-btn vc-confirm-btn--accent" onclick={() => void confirmRenameWithLinks()}>Aktualisieren</button>
+      </div>
+    </div>
+  {/if}
+
+  {#if pendingMove}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+      class="vc-confirm-overlay vc-modal-scrim"
+      onclick={cancelMoveWithLinks}
+      role="presentation"
+    ></div>
+    <div
+      class="vc-confirm-dialog vc-modal-surface"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="move-heading"
+    >
+      <h2 id="move-heading" class="vc-confirm-heading">Links aktualisieren?</h2>
+      <p class="vc-confirm-body">
+        {pendingMove.linkCount} Links in {pendingMove.fileCount} Dateien werden aktualisiert. Fortfahren?
+      </p>
+      <div class="vc-confirm-actions">
+        <button class="vc-confirm-btn vc-confirm-btn--cancel" onclick={cancelMoveWithLinks}>Abbrechen</button>
+        <button class="vc-confirm-btn vc-confirm-btn--accent" onclick={() => void confirmMoveWithLinks()}>Aktualisieren</button>
+      </div>
+    </div>
+  {/if}
   {/if}
 </aside>
 
 <style>
+  /* #378 — cascade-confirm dialog styles. Lifted from TreeRow alongside the
+     pendingRename / pendingMove state so the dialog's CSS scope follows its
+     owning component. TreeRow keeps the same selectors for its delete-confirm
+     dialog — Svelte's scoped-style hashing keeps the two copies isolated. */
+  .vc-confirm-overlay {
+    z-index: 199;
+  }
+
+  .vc-confirm-dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 200;
+    width: 280px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+    padding: 16px;
+  }
+
+  .vc-confirm-heading {
+    font-size: 20px;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+    color: var(--color-text);
+  }
+
+  .vc-confirm-body {
+    font-size: 14px;
+    color: var(--color-text);
+    margin: 0 0 16px 0;
+    line-height: 1.5;
+  }
+
+  .vc-confirm-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  .vc-confirm-btn {
+    padding: 6px 14px;
+    font-size: 14px;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
+    cursor: pointer;
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .vc-confirm-btn:hover {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-confirm-btn--cancel {
+    background: var(--color-surface);
+  }
+
+  .vc-confirm-btn--accent {
+    min-width: 80px;
+    padding: 4px 8px;
+    border: 1px solid var(--color-accent);
+    color: var(--color-accent);
+    background: transparent;
+  }
+
+  .vc-confirm-btn--accent:hover {
+    background: var(--color-accent-bg);
+  }
+
   .vc-sidebar {
     display: flex;
     flex-direction: column;

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -26,7 +26,6 @@
     createFolder,
     deleteFile,
     moveFile,
-    updateLinksAfterRename,
     getBacklinks,
     writeFile,
     exportDecryptedFile,
@@ -39,7 +38,6 @@
   import InlineRename from "./InlineRename.svelte";
   import ContextMenu from "../common/ContextMenu.svelte";
   import { vaultStore } from "../../store/vaultStore";
-  import { tabReloadStore } from "../../store/tabReloadStore";
   import { tabStore } from "../../store/tabStore";
   import { resolvedLinksStore } from "../../store/resolvedLinksStore";
   import { bookmarksStore } from "../../store/bookmarksStore";
@@ -50,6 +48,7 @@
   import { disarmAutoLock } from "../../store/autoLockStore";
   import { lockFolder } from "../../ipc/commands";
   import type { FlatRow } from "../../lib/flattenTree";
+  import type { RenameCascadeRequest, MoveCascadeRequest } from "../../types/sidebar";
 
   interface Props {
     row: FlatRow;
@@ -72,6 +71,19 @@
     onPathChanged: (oldPath: string, newPath: string) => void;
     /** Called when the user opens/closes inline rename on this row. */
     onRenameStateChange?: (path: string, renaming: boolean) => void;
+    /**
+     * Hand a rename-with-backlinks request up to Sidebar (#378). The cascade
+     * dialog state lives on Sidebar so it survives the watcher-driven tree
+     * re-flatten that destroys this row's component instance the moment the
+     * disk rename lands.
+     */
+    onRequestRenameCascade: (req: RenameCascadeRequest) => void;
+    /**
+     * Hand a move-with-backlinks request up to Sidebar (#378). Same lifetime
+     * problem as rename — the source row dies on drop when the watcher
+     * fires the synthetic delete+add for the moved file.
+     */
+    onRequestMoveCascade: (req: MoveCascadeRequest) => void;
   }
 
   let {
@@ -84,6 +96,8 @@
     onRefreshFolder,
     onPathChanged,
     onRenameStateChange,
+    onRequestRenameCascade,
+    onRequestMoveCascade,
   }: Props = $props();
 
   // Reactive — the Sidebar recomputes row objects on every flatten, so Svelte
@@ -101,21 +115,6 @@
   let showContextMenu = $state(false);
   let menuPos = $state<{ x: number; y: number }>({ x: 0, y: 0 });
   let showDeleteConfirm = $state(false);
-  let pendingRename = $state<{
-    newPath: string;
-    oldRelPath: string;
-    newRelPath: string;
-    linkCount: number;
-    fileCount: number;
-  } | null>(null);
-  let pendingMove = $state<{
-    sourcePath: string;
-    targetDirPath: string;
-    sourceRelPath: string;
-    newRelPath: string;
-    linkCount: number;
-    fileCount: number;
-  } | null>(null);
 
   let isDragSource = $state(false);
   let isDragTarget = $state(false);
@@ -230,7 +229,14 @@
     await bookmarksStore.toggle(rel, vault);
   }
 
-  async function handleRenameConfirm(newPath: string, linkCount: number) {
+  function handleRenameConfirm(newPath: string, linkCount: number) {
+    // #378: this function MUST stay synchronous after the IPC await resolves
+    // in InlineRename. The watcher fires a synthetic rename event that
+    // re-flattens the tree and destroys this TreeRow under the old path.
+    // Any `await` between here and the cascade-request callback would cross
+    // the unmount and lose the reference. The callback itself is a closure
+    // captured at component construction — calling it from a destroyed
+    // component is fine because Sidebar (the receiver) is always mounted.
     setRenaming(false);
     const vault = getVaultRoot();
     const oldRelPath = vault ? toRelPath(row.path, vault) : row.path;
@@ -239,14 +245,13 @@
       void bookmarksStore.renamePath(oldRelPath, newRelPath, vault);
     }
     if (linkCount > 0) {
-      let fileCount = 1;
-      try {
-        const backlinks = await getBacklinks(oldRelPath);
-        fileCount = new Set(backlinks.map((b) => b.sourcePath)).size || 1;
-      } catch {
-        /* fallback to 1 */
-      }
-      pendingRename = { newPath, oldRelPath, newRelPath, linkCount, fileCount };
+      onRequestRenameCascade({
+        oldPath: row.path,
+        newPath,
+        oldRelPath,
+        newRelPath,
+        linkCount,
+      });
     } else {
       onPathChanged(row.path, newPath);
       resolvedLinksStore.requestReload();
@@ -255,36 +260,6 @@
 
   function handleRenameCancel() {
     setRenaming(false);
-  }
-
-  async function confirmRenameWithLinks() {
-    if (!pendingRename) return;
-    const { newPath, oldRelPath, newRelPath } = pendingRename;
-    pendingRename = null;
-    onPathChanged(row.path, newPath);
-    resolvedLinksStore.requestReload();
-    try {
-      const result = await updateLinksAfterRename(oldRelPath, newRelPath);
-      if (result.updatedPaths.length > 0) {
-        tabReloadStore.request(result.updatedPaths);
-      }
-      if (result.failedFiles.length > 0) {
-        const total = result.updatedLinks + result.failedFiles.length;
-        toastStore.push({
-          variant: "error",
-          message: `${result.updatedLinks} von ${total} Links aktualisiert. ${result.failedFiles.length} Dateien konnten nicht geändert werden.`,
-        });
-      }
-    } catch {
-      toastStore.push({
-        variant: "error",
-        message: "Links konnten nicht aktualisiert werden.",
-      });
-    }
-  }
-
-  function cancelRenameWithLinks() {
-    pendingRename = null;
   }
 
   function openDeleteConfirm() {
@@ -444,14 +419,14 @@
     }
 
     if (linkCount > 0) {
-      pendingMove = {
+      onRequestMoveCascade({
         sourcePath,
         targetDirPath: row.path,
         sourceRelPath,
         newRelPath,
         linkCount,
         fileCount,
-      };
+      });
       return;
     }
 
@@ -470,40 +445,6 @@
     }
   }
 
-  async function confirmMoveWithLinks() {
-    if (!pendingMove) return;
-    const { sourcePath, targetDirPath, sourceRelPath, newRelPath } = pendingMove;
-    pendingMove = null;
-    try {
-      await moveFile(sourcePath, targetDirPath);
-      const vaultForBookmarks = getVaultRoot();
-      if (vaultForBookmarks) {
-        void bookmarksStore.renamePath(sourceRelPath, newRelPath, vaultForBookmarks);
-      }
-      await onRefreshFolder(targetDirPath);
-      const parent = parentOf(sourcePath);
-      if (parent) await onRefreshFolder(parent);
-      resolvedLinksStore.requestReload();
-      const result = await updateLinksAfterRename(sourceRelPath, newRelPath);
-      if (result.updatedPaths.length > 0) {
-        tabReloadStore.request(result.updatedPaths);
-      }
-      if (result.failedFiles.length > 0) {
-        const total = result.updatedLinks + result.failedFiles.length;
-        toastStore.push({
-          variant: "error",
-          message: `${result.updatedLinks} von ${total} Links aktualisiert. ${result.failedFiles.length} Dateien konnten nicht geändert werden.`,
-        });
-      }
-    } catch (err) {
-      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
-      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
-    }
-  }
-
-  function cancelMoveWithLinks() {
-    pendingMove = null;
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -687,43 +628,6 @@
     </div>
   {/if}
 
-  {#if pendingRename}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div
-      class="vc-confirm-overlay vc-modal-scrim"
-      onclick={cancelRenameWithLinks}
-      role="presentation"
-    ></div>
-    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="rename-heading-{row.path}">
-      <h2 id="rename-heading-{row.path}" class="vc-confirm-heading">Links aktualisieren?</h2>
-      <p class="vc-confirm-body">
-        {pendingRename.linkCount} Links in {pendingRename.fileCount} Dateien werden aktualisiert. Fortfahren?
-      </p>
-      <div class="vc-confirm-actions">
-        <button class="vc-confirm-btn vc-confirm-btn--cancel" onclick={cancelRenameWithLinks}>Abbrechen</button>
-        <button class="vc-confirm-btn vc-confirm-btn--accent" onclick={() => void confirmRenameWithLinks()}>Aktualisieren</button>
-      </div>
-    </div>
-  {/if}
-
-  {#if pendingMove}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <div
-      class="vc-confirm-overlay vc-modal-scrim"
-      onclick={cancelMoveWithLinks}
-      role="presentation"
-    ></div>
-    <div class="vc-confirm-dialog vc-modal-surface" role="dialog" aria-modal="true" aria-labelledby="move-heading-{row.path}">
-      <h2 id="move-heading-{row.path}" class="vc-confirm-heading">Links aktualisieren?</h2>
-      <p class="vc-confirm-body">
-        {pendingMove.linkCount} Links in {pendingMove.fileCount} Dateien werden aktualisiert. Fortfahren?
-      </p>
-      <div class="vc-confirm-actions">
-        <button class="vc-confirm-btn vc-confirm-btn--cancel" onclick={cancelMoveWithLinks}>Abbrechen</button>
-        <button class="vc-confirm-btn vc-confirm-btn--accent" onclick={() => void confirmMoveWithLinks()}>Aktualisieren</button>
-      </div>
-    </div>
-  {/if}
 </li>
 
 <style>
@@ -937,17 +841,5 @@
 
   .vc-confirm-btn--danger:hover {
     opacity: 0.9;
-  }
-
-  .vc-confirm-btn--accent {
-    min-width: 80px;
-    padding: 4px 8px;
-    border: 1px solid var(--color-accent);
-    color: var(--color-accent);
-    background: transparent;
-  }
-
-  .vc-confirm-btn--accent:hover {
-    background: var(--color-accent-bg);
   }
 </style>

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -25,8 +25,6 @@
     createFile,
     createFolder,
     deleteFile,
-    moveFile,
-    getBacklinks,
     writeFile,
     exportDecryptedFile,
     pickSavePath,
@@ -48,7 +46,7 @@
   import { disarmAutoLock } from "../../store/autoLockStore";
   import { lockFolder } from "../../ipc/commands";
   import type { FlatRow } from "../../lib/flattenTree";
-  import type { RenameCascadeRequest, MoveCascadeRequest } from "../../types/sidebar";
+  import type { RenameCascadeRequest, MoveDropRequest } from "../../types/sidebar";
 
   interface Props {
     row: FlatRow;
@@ -79,11 +77,13 @@
      */
     onRequestRenameCascade: (req: RenameCascadeRequest) => void;
     /**
-     * Hand a move-with-backlinks request up to Sidebar (#378). Same lifetime
-     * problem as rename — the source row dies on drop when the watcher
-     * fires the synthetic delete+add for the moved file.
+     * Hand a drop event up to Sidebar (#378). TreeRow only detects the drop
+     * and validates the drag source/target; Sidebar runs the rest of the
+     * pipeline (getBacklinks → cascade-or-direct dispatch → moveFile →
+     * updateLinksAfterRename → folder refreshes) on its always-mounted
+     * lifetime, symmetric with the rename path.
      */
-    onRequestMoveCascade: (req: MoveCascadeRequest) => void;
+    onRequestMoveCascade: (req: MoveDropRequest) => void;
   }
 
   let {
@@ -392,7 +392,7 @@
     isDragTarget = false;
   }
 
-  async function handleDrop(e: DragEvent) {
+  function handleDrop(e: DragEvent) {
     isDragTarget = false;
     if (!row.isDir) return;
     if (!e.dataTransfer || !isSidebarDrag(e.dataTransfer.types)) return;
@@ -401,48 +401,9 @@
       e.dataTransfer.getData("text/vaultcore-file") ||
       e.dataTransfer.getData("text/vaultcore-folder");
     if (!sourcePath || sourcePath === row.path) return;
-
-    const vault = getVaultRoot();
-    const sourceRelPath = vault ? toRelPath(sourcePath, vault) : sourcePath;
-    const sourceFilename = sourcePath.split("/").pop() ?? sourcePath;
-    const newAbsPath = row.path + "/" + sourceFilename;
-    const newRelPath = vault ? toRelPath(newAbsPath, vault) : newAbsPath;
-
-    let linkCount = 0;
-    let fileCount = 0;
-    try {
-      const backlinks = await getBacklinks(sourceRelPath);
-      linkCount = backlinks.length;
-      fileCount = new Set(backlinks.map((b) => b.sourcePath)).size;
-    } catch {
-      /* proceed without cascade */
-    }
-
-    if (linkCount > 0) {
-      onRequestMoveCascade({
-        sourcePath,
-        targetDirPath: row.path,
-        sourceRelPath,
-        newRelPath,
-        linkCount,
-        fileCount,
-      });
-      return;
-    }
-
-    try {
-      await moveFile(sourcePath, row.path);
-      if (vault) {
-        void bookmarksStore.renamePath(sourceRelPath, newRelPath, vault);
-      }
-      await onRefreshFolder(row.path);
-      const parent = parentOf(sourcePath);
-      if (parent) await onRefreshFolder(parent);
-      resolvedLinksStore.requestReload();
-    } catch (err) {
-      const ve = isVaultError(err) ? err : { kind: "Io" as const, message: String(err), data: null };
-      toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
-    }
+    // #378: hand off synchronously — Sidebar owns the rest of the pipeline
+    // so an intervening watcher event cannot tear down state mid-flight.
+    onRequestMoveCascade({ sourcePath, targetDirPath: row.path });
   }
 
 </script>

--- a/src/components/Sidebar/__tests__/Sidebar.cascade.test.ts
+++ b/src/components/Sidebar/__tests__/Sidebar.cascade.test.ts
@@ -207,4 +207,54 @@ describe("Sidebar rename cascade survives tree re-flatten (#378)", () => {
     const newRow = container.querySelector(`[data-tree-row="${VAULT}/Welcome Renamed.md"]`);
     expect(newRow).toBeTruthy();
   });
+
+  it("clears pendingRename only after updateLinksAfterRename settles, blocking re-entrancy", async () => {
+    // Hold the IPC open so we can observe the in-flight state.
+    let resolveUpdate: (value: any) => void = () => {};
+    const updatePromise = new Promise<any>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    (updateLinksAfterRename as any).mockImplementationOnce(() => updatePromise);
+
+    (listDirectory as any).mockResolvedValueOnce([md("Welcome.md")]);
+
+    const { container } = render(Sidebar, { props: makeProps() });
+    await drainMicrotasks();
+
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });
+    await tick();
+
+    const renameItem = Array.from(
+      container.querySelectorAll(".vc-context-item"),
+    ).find((el) => (el.textContent ?? "").trim() === "Rename") as HTMLElement;
+    renameItem.click();
+    await tick();
+
+    const input = container.querySelector(".vc-rename-input") as HTMLInputElement;
+    input.value = "Welcome Renamed.md";
+    await fireEvent.input(input);
+    await fireEvent.keyDown(input, { key: "Enter" });
+    await drainMicrotasks();
+
+    // Click the confirm button. updateLinksAfterRename is unresolved, so the
+    // pendingRename slot must stay claimed.
+    const confirmBtn = container.querySelector(".vc-confirm-btn--accent") as HTMLButtonElement;
+    expect(confirmBtn).toBeTruthy();
+    confirmBtn.click();
+    await drainMicrotasks();
+
+    // While the IPC is in flight: dialog still mounted (modal guard armed),
+    // updateLinksAfterRename was called.
+    expect(updateLinksAfterRename).toHaveBeenCalledTimes(1);
+    const inFlightDialog = container.querySelector('[role="dialog"][aria-labelledby^="rename-heading"]');
+    expect(inFlightDialog).toBeTruthy();
+
+    // Resolve the IPC; pendingRename should clear in the finally block.
+    resolveUpdate({ updatedFiles: 2, updatedLinks: 3, failedFiles: [], updatedPaths: [] });
+    await drainMicrotasks();
+
+    const settledDialog = container.querySelector('[role="dialog"][aria-labelledby^="rename-heading"]');
+    expect(settledDialog).toBeNull();
+  });
 });

--- a/src/components/Sidebar/__tests__/Sidebar.cascade.test.ts
+++ b/src/components/Sidebar/__tests__/Sidebar.cascade.test.ts
@@ -1,0 +1,194 @@
+// Regression test for issue #378: the rename-cascade dialog must survive the
+// watcher-driven tree re-flatten. Before the fix, `pendingRename` lived on
+// TreeRow; the keyed `{#each}` block destroyed the renamed row before its
+// post-IPC closure could mutate state, so the dialog never painted. After the
+// fix, ownership lives on Sidebar — the single component that survives the
+// re-flatten by definition.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn(),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn().mockResolvedValue({
+    updatedFiles: 2,
+    updatedLinks: 3,
+    failedFiles: [],
+    updatedPaths: [],
+  }),
+  getBacklinks: vi.fn(),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  tagsList: vi.fn().mockResolvedValue([]),
+  searchTagPaths: vi.fn().mockResolvedValue([]),
+  renameFile: vi.fn(),
+  exportDecryptedFile: vi.fn(),
+  pickSavePath: vi.fn(),
+  lockFolder: vi.fn(),
+  listEncryptedFolders: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockImplementation((cb: (p: any) => void) => {
+    capturedFileChangeHandler = cb;
+    return Promise.resolve(() => {});
+  }),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenEncryptProgress: vi.fn().mockResolvedValue(() => {}),
+  listenEncryptedFoldersChanged: vi.fn().mockResolvedValue(() => {}),
+  listenEncryptDropProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { listDirectory, renameFile, getBacklinks } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import Sidebar from "../Sidebar.svelte";
+import type { DirEntry } from "../../../types/tree";
+
+let capturedFileChangeHandler: ((p: any) => void) | null = null;
+
+const VAULT = "/tmp/test-vault";
+
+function makeLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+
+function md(name: string): DirEntry {
+  return {
+    name,
+    path: `${VAULT}/${name}`,
+    is_dir: false,
+    is_symlink: false,
+    is_md: true,
+    modified: null,
+    created: null,
+  };
+}
+
+function makeProps() {
+  return {
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenContentSearch: vi.fn(),
+  };
+}
+
+async function drainMicrotasks() {
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+describe("Sidebar rename cascade survives tree re-flatten (#378)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeLocalStorage());
+    capturedFileChangeHandler = null;
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.clearAllMocks();
+    (renameFile as any).mockResolvedValue({
+      newPath: `${VAULT}/Welcome Renamed.md`,
+      linkCount: 3,
+    });
+    (getBacklinks as any).mockResolvedValue([
+      { sourcePath: "Daily Log.md" },
+      { sourcePath: "Ideas.md" },
+      { sourcePath: "Wiki Links.md" },
+    ]);
+  });
+
+  it("opens the cascade dialog on rename and keeps it mounted across a watcher re-flatten", async () => {
+    (listDirectory as any).mockResolvedValueOnce([md("Welcome.md")]);
+
+    const { container } = render(Sidebar, { props: makeProps() });
+    await drainMicrotasks();
+
+    // Open the row's context menu, click Rename, type a new name, press Enter.
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    expect(row).toBeTruthy();
+    await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });
+    await tick();
+
+    const renameItem = Array.from(
+      container.querySelectorAll(".vc-context-item"),
+    ).find((el) => (el.textContent ?? "").trim() === "Rename") as HTMLElement;
+    expect(renameItem).toBeTruthy();
+    renameItem.click();
+    await tick();
+
+    const input = container.querySelector(".vc-rename-input") as HTMLInputElement;
+    expect(input).toBeTruthy();
+    input.value = "Welcome Renamed.md";
+    await fireEvent.input(input);
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    // Drain so the IPC mock resolves and `pendingRename` is set on whichever
+    // component owns it, BEFORE the watcher event lands. This isolates the
+    // race: the dialog must exist after a re-flatten, regardless of whether
+    // it was already painted at the moment of the watcher event.
+    await drainMicrotasks();
+
+    // Pre-flatten sanity: the dialog should already be in the DOM (otherwise
+    // we are not testing the lift, we are testing whether rename-with-links
+    // works at all).
+    const preFlattenDialog = container.querySelector('[role="dialog"][aria-labelledby^="rename-heading"]');
+    expect(preFlattenDialog).toBeTruthy();
+
+    // Now simulate the watcher event: listDirectory now returns the renamed
+    // row, the {#each} re-keys, and the original TreeRow under the old path
+    // unmounts. Before the #378 fix, this destroyed the pendingRename state.
+    (listDirectory as any).mockResolvedValueOnce([md("Welcome Renamed.md")]);
+    expect(capturedFileChangeHandler).toBeTruthy();
+    capturedFileChangeHandler!({
+      path: `${VAULT}/Welcome.md`,
+      kind: "rename",
+      new_path: `${VAULT}/Welcome Renamed.md`,
+    });
+
+    await drainMicrotasks();
+
+    // The cascade dialog must be in the DOM.
+    const dialog = container.querySelector('[role="dialog"][aria-labelledby^="rename-heading"]');
+    expect(dialog).toBeTruthy();
+
+    const body = container.querySelector(".vc-confirm-body") as HTMLElement;
+    expect(body).toBeTruthy();
+    expect(body.textContent ?? "").toMatch(/3\s+Links?\s+in\s+\d+\s+Dateien/);
+
+    // Sanity: the row that owned the original `pendingRename` is no longer
+    // mounted under the old path — the {#each} re-keyed it. Without the fix,
+    // this is exactly the moment the dialog would disappear.
+    const oldRow = container.querySelector(`[data-tree-row="${VAULT}/Welcome.md"]`);
+    expect(oldRow).toBeNull();
+    const newRow = container.querySelector(`[data-tree-row="${VAULT}/Welcome Renamed.md"]`);
+    expect(newRow).toBeTruthy();
+  });
+});

--- a/src/components/Sidebar/__tests__/Sidebar.cascade.test.ts
+++ b/src/components/Sidebar/__tests__/Sidebar.cascade.test.ts
@@ -15,23 +15,17 @@ vi.mock("../../../ipc/commands", () => ({
   createFolder: vi.fn(),
   deleteFile: vi.fn(),
   moveFile: vi.fn(),
-  updateLinksAfterRename: vi.fn().mockResolvedValue({
-    updatedFiles: 2,
-    updatedLinks: 3,
-    failedFiles: [],
-    updatedPaths: [],
-  }),
+  updateLinksAfterRename: vi.fn(),
   getBacklinks: vi.fn(),
-  loadBookmarks: vi.fn().mockResolvedValue([]),
-  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  loadBookmarks: vi.fn(),
+  saveBookmarks: vi.fn(),
   writeFile: vi.fn(),
-  tagsList: vi.fn().mockResolvedValue([]),
-  searchTagPaths: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn(),
   renameFile: vi.fn(),
   exportDecryptedFile: vi.fn(),
   pickSavePath: vi.fn(),
   lockFolder: vi.fn(),
-  listEncryptedFolders: vi.fn().mockResolvedValue([]),
+  listEncryptedFolders: vi.fn(),
 }));
 
 vi.mock("../../../ipc/events", () => ({
@@ -48,7 +42,16 @@ vi.mock("../../../ipc/events", () => ({
   listenEncryptDropProgress: vi.fn().mockResolvedValue(() => {}),
 }));
 
-import { listDirectory, renameFile, getBacklinks } from "../../../ipc/commands";
+import {
+  listDirectory,
+  renameFile,
+  getBacklinks,
+  updateLinksAfterRename,
+  loadBookmarks,
+  saveBookmarks,
+  listTags,
+  listEncryptedFolders,
+} from "../../../ipc/commands";
 import { vaultStore } from "../../../store/vaultStore";
 import { bookmarksStore } from "../../../store/bookmarksStore";
 import Sidebar from "../Sidebar.svelte";
@@ -114,10 +117,23 @@ describe("Sidebar rename cascade survives tree re-flatten (#378)", () => {
     bookmarksStore.reset();
     vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
     vi.clearAllMocks();
+    // Re-seed every mock return value AFTER clearAllMocks. Setting them in
+    // the vi.mock() factory only would be wiped by clearAllMocks and the
+    // confirm path below would receive `undefined` from updateLinksAfterRename.
     (renameFile as any).mockResolvedValue({
       newPath: `${VAULT}/Welcome Renamed.md`,
       linkCount: 3,
     });
+    (updateLinksAfterRename as any).mockResolvedValue({
+      updatedFiles: 2,
+      updatedLinks: 3,
+      failedFiles: [],
+      updatedPaths: [],
+    });
+    (loadBookmarks as any).mockResolvedValue([]);
+    (saveBookmarks as any).mockResolvedValue(undefined);
+    (listTags as any).mockResolvedValue([]);
+    (listEncryptedFolders as any).mockResolvedValue([]);
     (getBacklinks as any).mockResolvedValue([
       { sourcePath: "Daily Log.md" },
       { sourcePath: "Ideas.md" },

--- a/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
@@ -52,6 +52,8 @@ function makeProps(row: FlatRow) {
     onEnsureExpanded: vi.fn(),
     onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
+    onRequestRenameCascade: vi.fn(),
+    onRequestMoveCascade: vi.fn(),
   };
 }
 

--- a/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
@@ -67,6 +67,8 @@ function makeProps(row: FlatRow) {
     onEnsureExpanded: vi.fn(),
     onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
+    onRequestRenameCascade: vi.fn(),
+    onRequestMoveCascade: vi.fn(),
   };
 }
 

--- a/src/components/Sidebar/__tests__/TreeRowExportDecrypted.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRowExportDecrypted.test.ts
@@ -77,6 +77,8 @@ function makeProps(row: FlatRow) {
     onEnsureExpanded: vi.fn(),
     onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
+    onRequestRenameCascade: vi.fn(),
+    onRequestMoveCascade: vi.fn(),
   };
 }
 

--- a/src/components/Sidebar/__tests__/TreeRowUnlockExpand.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRowUnlockExpand.test.ts
@@ -76,6 +76,8 @@ function makeProps(row: FlatRow) {
     onEnsureExpanded: vi.fn(),
     onRefreshFolder: vi.fn(),
     onPathChanged: vi.fn(),
+    onRequestRenameCascade: vi.fn(),
+    onRequestMoveCascade: vi.fn(),
   };
 }
 

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -1,7 +1,7 @@
 // Cascade-state shapes shared between Sidebar (the owner — survives the
 // watcher-driven tree re-flatten) and TreeRow (which detects the cascade
-// trigger but hands it up). See issue #378 for why this state lives on
-// Sidebar rather than TreeRow.
+// trigger but hands it up synchronously). See issue #378 for why this
+// state lives on Sidebar rather than TreeRow.
 
 export interface RenameCascadeRequest {
   oldPath: string;
@@ -11,7 +11,22 @@ export interface RenameCascadeRequest {
   linkCount: number;
 }
 
-export interface MoveCascadeRequest {
+/**
+ * A drop request passed from TreeRow to Sidebar. TreeRow detects the drop
+ * and hands the bare endpoints up immediately — Sidebar then runs all
+ * post-detection work (getBacklinks, cascade-or-direct dispatch, moveFile,
+ * updateLinksAfterRename) on its always-mounted lifetime.
+ */
+export interface MoveDropRequest {
+  sourcePath: string;
+  targetDirPath: string;
+}
+
+export interface PendingRename extends RenameCascadeRequest {
+  fileCount: number;
+}
+
+export interface PendingMove {
   sourcePath: string;
   targetDirPath: string;
   sourceRelPath: string;
@@ -19,9 +34,3 @@ export interface MoveCascadeRequest {
   linkCount: number;
   fileCount: number;
 }
-
-export interface PendingRename extends RenameCascadeRequest {
-  fileCount: number;
-}
-
-export type PendingMove = MoveCascadeRequest;

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -1,0 +1,27 @@
+// Cascade-state shapes shared between Sidebar (the owner — survives the
+// watcher-driven tree re-flatten) and TreeRow (which detects the cascade
+// trigger but hands it up). See issue #378 for why this state lives on
+// Sidebar rather than TreeRow.
+
+export interface RenameCascadeRequest {
+  oldPath: string;
+  newPath: string;
+  oldRelPath: string;
+  newRelPath: string;
+  linkCount: number;
+}
+
+export interface MoveCascadeRequest {
+  sourcePath: string;
+  targetDirPath: string;
+  sourceRelPath: string;
+  newRelPath: string;
+  linkCount: number;
+  fileCount: number;
+}
+
+export interface PendingRename extends RenameCascadeRequest {
+  fileCount: number;
+}
+
+export type PendingMove = MoveCascadeRequest;


### PR DESCRIPTION
Fixes #378.

## Summary
- Lift `pendingRename` / `pendingMove` cascade state from per-row `TreeRow` up to `Sidebar`. The Sidebar is the single component that survives the watcher-driven tree re-flatten — per-row ownership lost the state the moment `loadRoot` re-keyed `{#each}`, so the cascade-confirm dialog never painted and backlinks ended up dangling.
- `TreeRow` hands the cascade request up via two new callback props (`onRequestRenameCascade` / `onRequestMoveCascade`) the moment the IPC await resolves — *synchronously*, no further `await`. The original `getBacklinks` call (the second await that crossed the unmount window for renames) now runs on Sidebar's always-mounted lifetime instead of TreeRow's per-row one.
- Cascade dialogs now render at Sidebar level. `aria-labelledby` is a stable `rename-heading` / `move-heading` (no per-row suffix) since only one dialog can be open at a time. The existing prefix-match selectors keep working.
- Modal precedence: an incoming cascade request is ignored if either `pendingRename` or `pendingMove` is already set — single-modal expectation.

## Why per-row was wrong
1. User confirms inline rename → `renameFile` IPC mutates disk
2. Backend emits synthetic `FILE_CHANGED_EVENT(kind: rename)` (because `write_ignore` suppressed the natural one)
3. Sidebar's watcher handler runs `invalidateAllFolders()` + `loadRoot()` → `flatRows` recomputes → `{#each windowRows as { row } (row.path)}` re-keys → original `TreeRow` for the renamed file unmounts under the old path, new one mounts under the new path
4. `InlineRename`'s post-IPC continuation calls `onConfirm` on a closure pointing at the dead `TreeRow` instance → mutating `pendingRename` on a destroyed component → dialog never paints

## Test plan
- [x] New Vitest unit `Sidebar.cascade.test.ts` simulates the race: triggers a rename via the IPC mock, fires the watcher event programmatically mid-flight, asserts the dialog stays mounted *and* the original row is gone (`{#each}` re-keyed) while the renamed row is mounted under the new path. Fails on `main`, passes on this branch.
- [x] All 18 sidebar Vitest files green (41 tests).
- [x] `svelte-check` clean for the Sidebar workspace.
- [ ] e2e `rename-cascade.spec.ts` un-skipped — verify on UAT (WebDriver was not running locally).
- [ ] UAT: open a vault with a note that has 1+ backlinks, rename via context menu, confirm dialog appears with German body, click *Aktualisieren* → backlinks rewritten, no dangling links remain.

## Files
- `src/types/sidebar.ts` (new) — `RenameCascadeRequest` / `MoveCascadeRequest` / `PendingRename` / `PendingMove`
- `src/components/Sidebar/Sidebar.svelte` — owns cascade state + dialogs + `getBacklinks`
- `src/components/Sidebar/TreeRow.svelte` — drops cascade state + dialogs, adds two callback props
- `src/components/Sidebar/__tests__/Sidebar.cascade.test.ts` (new) — regression guard
- `e2e/specs/rename-cascade.spec.ts` — un-skipped, comment updated
- 4 existing TreeRow tests — added the two new required props to fixtures