### PR TITLE
feat(editor): char-morph transition between text-file tabs (#380)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -27,6 +27,7 @@
   import { parseFrontmatter } from "../../lib/frontmatterIO";
   import EditorGraphBackground from "./EditorGraphBackground.svelte";
   import CountStatusBar from "./CountStatusBar.svelte";
+  import TabMorphOverlay from "./TabMorphOverlay.svelte";
   import { countsStore } from "../../store/countsStore";
   import { computeCounts } from "../../lib/wordCount";
   import { scrollToMatch } from "./flashHighlight";
@@ -547,6 +548,12 @@
     }
   });
 
+  // #380: handle to the per-pane morph overlay. The overlay is mounted
+  // inside .vc-editor-content (so it sits above the editor containers
+  // but below the read-only scrim) and runs a 120ms canvas scramble on
+  // qualifying tab switches.
+  let morphOverlay: { play: (out: EditorView | null, inc: EditorView | null) => void } | null = $state(null);
+
   // Handle scroll save/restore on tab switch — separate effect to avoid
   // coupling with the lifecycle effect above
   $effect(() => {
@@ -563,6 +570,33 @@
               prevView.state.selection.main.head
             );
           } catch (_) { /* view may have been destroyed */ }
+        }
+      }
+      // #380: trigger morph if both sides are already-mounted text editors.
+      // Skipped during async mount (mountingIds), for non-editor tabs
+      // (graph/image/canvas/unsupported), and when either side is in
+      // Reading Mode (no CM6 layout to snapshot).
+      if (
+        prevActiveTabId &&
+        newActiveId &&
+        morphOverlay &&
+        !mountingIds.has(newActiveId)
+      ) {
+        const outTab = allTabs.find((t) => t.id === prevActiveTabId);
+        const inTab = allTabs.find((t) => t.id === newActiveId);
+        const outView = viewMap.get(prevActiveTabId);
+        const inView = viewMap.get(newActiveId);
+        const bothEdit =
+          (outTab?.viewMode ?? "edit") === "edit" &&
+          (inTab?.viewMode ?? "edit") === "edit";
+        if (
+          outView &&
+          inView &&
+          bothEdit &&
+          tabHasEditor(outTab) &&
+          tabHasEditor(inTab)
+        ) {
+          morphOverlay.play(outView, inView);
         }
       }
       // Restore scroll/cursor on activated tab
@@ -987,6 +1021,10 @@
     {/if}
     <!-- #87: ambient local-graph background behind the editor in edit mode -->
     <EditorGraphBackground visible={showGraphBg} relPath={bgRelPath} />
+    <!-- #380: 120ms char-morph overlay between text-file tabs. Sits above
+         the editor containers (z-index: 5) but below the readonly scrim
+         (z-index: 10). pointer-events: none so the editor stays interactive. -->
+    <TabMorphOverlay bind:this={morphOverlay} />
     <!-- Svelte renders one container per tab. Visibility is driven by
          style:display reacting to paneActiveTabId — no manual DOM needed.
          Graph tabs render <GraphView /> instead of a CM6 container so the

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -578,8 +578,10 @@
   // #380: handle to the per-pane morph overlay. The overlay is mounted
   // inside .vc-editor-content (so it sits above the editor containers
   // but below the read-only scrim) and runs a 120ms canvas scramble on
-  // qualifying tab switches.
-  let morphOverlay: { playFromSnapshots: (out: import("../../lib/editor/tabMorph").ViewSnapshot | null, inc: import("../../lib/editor/tabMorph").ViewSnapshot | null) => void } | null = $state(null);
+  // qualifying tab switches. Type derived from the component so the
+  // signature here cannot drift from the export.
+  type MorphOverlayHandle = ReturnType<typeof TabMorphOverlay>;
+  let morphOverlay: MorphOverlayHandle | null = $state(null);
 
   // #380: outgoing snapshot must be taken BEFORE Svelte re-flips the
   // `style:display` of the previously-active container — once the old

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -28,6 +28,7 @@
   import EditorGraphBackground from "./EditorGraphBackground.svelte";
   import CountStatusBar from "./CountStatusBar.svelte";
   import TabMorphOverlay from "./TabMorphOverlay.svelte";
+  import { snapshotView as snapshotEditorView } from "../../lib/editor/tabMorph";
   import { countsStore } from "../../store/countsStore";
   import { computeCounts } from "../../lib/wordCount";
   import { scrollToMatch } from "./flashHighlight";
@@ -260,6 +261,32 @@
 
   // Subscribe to tabStore for our pane's tabs and active state
   const unsubTab = tabStore.subscribe((state) => {
+    // #380: BEFORE assigning the new activeTabId (which triggers Svelte to
+    // flip style:display on the outgoing container in the next microtask),
+    // snapshot the still-visible outgoing view. Without this, the trigger
+    // effect downstream sees the outgoing CM6 view already hidden and
+    // produces an empty glyph list — the morph would only fade in the
+    // incoming side, never scramble from the outgoing content.
+    const prevActive = activeTabId;
+    const nextActive = state.activeTabId;
+    if (
+      prevActive &&
+      nextActive &&
+      prevActive !== nextActive &&
+      state.splitState[paneId].includes(prevActive) &&
+      state.splitState[paneId].includes(nextActive)
+    ) {
+      const prevView = viewMap.get(prevActive);
+      if (prevView) {
+        try {
+          pendingOutgoingSnapshot = snapshotEditorView(prevView);
+          pendingOutgoingForTabId = prevActive;
+        } catch {
+          pendingOutgoingSnapshot = null;
+          pendingOutgoingForTabId = null;
+        }
+      }
+    }
     paneTabIds = state.splitState[paneId];
     allTabs = state.tabs;
     activeTabId = state.activeTabId;
@@ -552,7 +579,17 @@
   // inside .vc-editor-content (so it sits above the editor containers
   // but below the read-only scrim) and runs a 120ms canvas scramble on
   // qualifying tab switches.
-  let morphOverlay: { play: (out: EditorView | null, inc: EditorView | null) => void } | null = $state(null);
+  let morphOverlay: { playFromSnapshots: (out: import("../../lib/editor/tabMorph").ViewSnapshot | null, inc: import("../../lib/editor/tabMorph").ViewSnapshot | null) => void } | null = $state(null);
+
+  // #380: outgoing snapshot must be taken BEFORE Svelte re-flips the
+  // `style:display` of the previously-active container — once the old
+  // container is `display: none`, `view.coordsAtPos` returns null and
+  // `getBoundingClientRect` returns a zero rect, so the snapshot would
+  // be empty. The store subscriber below runs synchronously on dispatch,
+  // ahead of the next microtask in which Svelte flushes reactivity, so
+  // we capture the snapshot there and stash it for the trigger effect.
+  let pendingOutgoingSnapshot: import("../../lib/editor/tabMorph").ViewSnapshot | null = null;
+  let pendingOutgoingForTabId: string | null = null;
 
   // Handle scroll save/restore on tab switch — separate effect to avoid
   // coupling with the lifecycle effect above
@@ -575,28 +612,40 @@
       // #380: trigger morph if both sides are already-mounted text editors.
       // Skipped during async mount (mountingIds), for non-editor tabs
       // (graph/image/canvas/unsupported), and when either side is in
-      // Reading Mode (no CM6 layout to snapshot).
+      // Reading Mode (no CM6 layout to snapshot). The outgoing snapshot
+      // was captured synchronously in the tabStore subscriber above —
+      // the incoming snapshot is taken here, after Svelte has flipped
+      // the new container to display: block.
+      const outgoingSnapshot = pendingOutgoingForTabId === prevActiveTabId
+        ? pendingOutgoingSnapshot
+        : null;
+      pendingOutgoingSnapshot = null;
+      pendingOutgoingForTabId = null;
       if (
         prevActiveTabId &&
         newActiveId &&
         morphOverlay &&
-        !mountingIds.has(newActiveId)
+        !mountingIds.has(newActiveId) &&
+        outgoingSnapshot
       ) {
         const outTab = allTabs.find((t) => t.id === prevActiveTabId);
         const inTab = allTabs.find((t) => t.id === newActiveId);
-        const outView = viewMap.get(prevActiveTabId);
         const inView = viewMap.get(newActiveId);
         const bothEdit =
           (outTab?.viewMode ?? "edit") === "edit" &&
           (inTab?.viewMode ?? "edit") === "edit";
         if (
-          outView &&
           inView &&
           bothEdit &&
           tabHasEditor(outTab) &&
           tabHasEditor(inTab)
         ) {
-          morphOverlay.play(outView, inView);
+          // Defer the incoming snapshot to the next frame so the new
+          // container's display:block has flushed before we measure.
+          requestAnimationFrame(() => {
+            const incomingSnapshot = snapshotEditorView(inView);
+            morphOverlay?.playFromSnapshots(outgoingSnapshot, incomingSnapshot);
+          });
         }
       }
       // Restore scroll/cursor on activated tab

--- a/src/components/Editor/TabMorphOverlay.svelte
+++ b/src/components/Editor/TabMorphOverlay.svelte
@@ -2,16 +2,17 @@
   // #380 — char-morph transition between text-file tabs.
   //
   // Mounted once per EditorPane inside `.vc-editor-content`. The parent
-  // calls `play(outgoing, incoming)` synchronously during a tab switch
-  // (between two tabs whose CM6 EditorView is already mounted). The
-  // overlay snapshots both views, drives a 120ms rAF morph on a canvas
-  // sized to the scroller rect, and tears the canvas down at the end.
+  // captures the outgoing snapshot itself (it has to — by the time this
+  // component would call `snapshotView`, Svelte has already flipped
+  // `display: none` on the outgoing container, making `coordsAtPos`
+  // return null for every position) and hands both pre-built snapshots
+  // to `playFromSnapshots`. The overlay drives a 120ms rAF morph on a
+  // canvas sized to the incoming scroller rect.
   //
   // The CM6 view underneath is never touched — typing during the morph
   // works because `pointer-events: none` is set on the canvas.
 
   import { onDestroy } from "svelte";
-  import type { EditorView } from "@codemirror/view";
   import {
     buildSchedule,
     decideMorph,
@@ -20,14 +21,12 @@
     prefersReducedMotion,
     randomGlyph,
     resolveMorphDuration,
-    snapshotView,
     type ScheduledGlyph,
     type ViewSnapshot,
   } from "../../lib/editor/tabMorph";
 
   let canvasEl = $state<HTMLCanvasElement | null>(null);
   let visible = $state(false);
-  let rect = $state<{ x: number; y: number; width: number; height: number } | null>(null);
 
   const suppression = newSuppressionState();
   let rafId: number | null = null;
@@ -42,7 +41,6 @@
   function tearDown() {
     cancelRaf();
     visible = false;
-    rect = null;
     if (canvasEl) {
       const ctx = canvasEl.getContext("2d");
       if (ctx) ctx.clearRect(0, 0, canvasEl.width, canvasEl.height);
@@ -51,11 +49,15 @@
   }
 
   /**
-   * Trigger the morph for a tab switch. Returns synchronously after
-   * deciding play vs. instant — the rAF loop runs in the background.
-   * If the suppression window applies, returns without touching the DOM.
+   * Trigger the morph from pre-captured snapshots. The parent owns the
+   * snapshot lifecycle so the outgoing snapshot can be taken before the
+   * outgoing CM6 view is hidden by Svelte's reactive display swap.
+   * Returns synchronously after deciding play vs. instant.
    */
-  export function play(outgoingView: EditorView | null, incomingView: EditorView | null): void {
+  export function playFromSnapshots(
+    outgoing: ViewSnapshot | null,
+    incoming: ViewSnapshot | null,
+  ): void {
     const now = performance.now();
     const decision = decideMorph(suppression, now);
     if (decision === "instant") {
@@ -73,23 +75,17 @@
       markMorphSettled(suppression, now);
       return;
     }
-    if (!outgoingView || !incomingView) {
+    if (!outgoing || !incoming || outgoing.glyphs.length === 0) {
+      // Empty outgoing snapshot means the parent failed to capture in
+      // time — settle the suppression timer so a chord cycle still
+      // behaves and bail without a morph.
       markMorphSettled(suppression, now);
       return;
     }
-
-    const outgoing = snapshotView(outgoingView);
-    const incoming = snapshotView(incomingView);
-    if (!outgoing || !incoming) {
-      markMorphSettled(suppression, now);
-      return;
-    }
-
     runMorph(outgoing, incoming, now, duration);
   }
 
   function runMorph(outgoing: ViewSnapshot, incoming: ViewSnapshot, startedAt: number, duration: number) {
-    rect = incoming.scrollerRect;
     visible = true;
 
     // Defer canvas sizing until the element binds.
@@ -179,13 +175,11 @@
   });
 </script>
 
-{#if visible && rect}
+{#if visible}
   <canvas
     bind:this={canvasEl}
     class="vc-tab-morph-canvas"
     aria-hidden="true"
-    style:left="{0}px"
-    style:top="{0}px"
   ></canvas>
 {/if}
 

--- a/src/components/Editor/TabMorphOverlay.svelte
+++ b/src/components/Editor/TabMorphOverlay.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  // #380 — char-morph transition between text-file tabs.
+  //
+  // Mounted once per EditorPane inside `.vc-editor-content`. The parent
+  // calls `play(outgoing, incoming)` synchronously during a tab switch
+  // (between two tabs whose CM6 EditorView is already mounted). The
+  // overlay snapshots both views, drives a 120ms rAF morph on a canvas
+  // sized to the scroller rect, and tears the canvas down at the end.
+  //
+  // The CM6 view underneath is never touched — typing during the morph
+  // works because `pointer-events: none` is set on the canvas.
+
+  import { onDestroy } from "svelte";
+  import type { EditorView } from "@codemirror/view";
+  import {
+    buildSchedule,
+    decideMorph,
+    markMorphSettled,
+    newSuppressionState,
+    prefersReducedMotion,
+    randomGlyph,
+    resolveMorphDuration,
+    snapshotView,
+    type ScheduledGlyph,
+    type ViewSnapshot,
+  } from "../../lib/editor/tabMorph";
+
+  let canvasEl = $state<HTMLCanvasElement | null>(null);
+  let visible = $state(false);
+  let rect = $state<{ x: number; y: number; width: number; height: number } | null>(null);
+
+  const suppression = newSuppressionState();
+  let rafId: number | null = null;
+
+  function cancelRaf() {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  }
+
+  function tearDown() {
+    cancelRaf();
+    visible = false;
+    rect = null;
+    if (canvasEl) {
+      const ctx = canvasEl.getContext("2d");
+      if (ctx) ctx.clearRect(0, 0, canvasEl.width, canvasEl.height);
+    }
+    markMorphSettled(suppression, performance.now());
+  }
+
+  /**
+   * Trigger the morph for a tab switch. Returns synchronously after
+   * deciding play vs. instant — the rAF loop runs in the background.
+   * If the suppression window applies, returns without touching the DOM.
+   */
+  export function play(outgoingView: EditorView | null, incomingView: EditorView | null): void {
+    const now = performance.now();
+    const decision = decideMorph(suppression, now);
+    if (decision === "instant") {
+      cancelRaf();
+      visible = false;
+      return;
+    }
+    if (prefersReducedMotion()) {
+      markMorphSettled(suppression, now);
+      return;
+    }
+    const duration = resolveMorphDuration();
+    if (duration <= 0) {
+      // User opted out via --vc-tab-switch-duration: 0 — instant swap.
+      markMorphSettled(suppression, now);
+      return;
+    }
+    if (!outgoingView || !incomingView) {
+      markMorphSettled(suppression, now);
+      return;
+    }
+
+    const outgoing = snapshotView(outgoingView);
+    const incoming = snapshotView(incomingView);
+    if (!outgoing || !incoming) {
+      markMorphSettled(suppression, now);
+      return;
+    }
+
+    runMorph(outgoing, incoming, now, duration);
+  }
+
+  function runMorph(outgoing: ViewSnapshot, incoming: ViewSnapshot, startedAt: number, duration: number) {
+    rect = incoming.scrollerRect;
+    visible = true;
+
+    // Defer canvas sizing until the element binds.
+    queueMicrotask(() => {
+      if (!canvasEl) return;
+      const dpr = window.devicePixelRatio || 1;
+      const w = incoming.scrollerRect.width;
+      const h = incoming.scrollerRect.height;
+      canvasEl.width = Math.max(1, Math.floor(w * dpr));
+      canvasEl.height = Math.max(1, Math.floor(h * dpr));
+      canvasEl.style.width = `${w}px`;
+      canvasEl.style.height = `${h}px`;
+      const ctx = canvasEl.getContext("2d");
+      if (!ctx) {
+        tearDown();
+        return;
+      }
+      ctx.scale(dpr, dpr);
+      ctx.font = incoming.font;
+      ctx.textBaseline = "top";
+      ctx.fillStyle = incoming.color;
+
+      const schedule = buildSchedule(outgoing, incoming, Math.random, duration);
+      cancelRaf();
+      rafId = requestAnimationFrame((t) => frame(ctx, schedule, incoming, startedAt, duration, t));
+    });
+  }
+
+  function frame(
+    ctx: CanvasRenderingContext2D,
+    schedule: ScheduledGlyph[],
+    incoming: ViewSnapshot,
+    startedAt: number,
+    duration: number,
+    nowDom: number,
+  ) {
+    if (!canvasEl) {
+      tearDown();
+      return;
+    }
+    // performance.now() and the rAF timestamp share the same time origin in
+    // browsers, but Tauri's webview can drift. Use rAF's timestamp directly
+    // and assume `startedAt` was also performance.now() — close enough for a
+    // 120ms window and avoids a second clock read per frame.
+    const elapsed = Math.max(0, nowDom - startedAt);
+    ctx.clearRect(0, 0, incoming.scrollerRect.width, incoming.scrollerRect.height);
+
+    if (elapsed >= duration) {
+      tearDown();
+      return;
+    }
+
+    for (const g of schedule) {
+      const locked = elapsed >= g.lockInMs;
+      let ch: string;
+      let alpha = 1;
+      if (locked) {
+        if (g.to === "") {
+          // surplus outgoing glyph fading out — already past lock-in, draw nothing
+          continue;
+        }
+        ch = g.to;
+      } else {
+        if (g.from === "" && g.to === "") continue;
+        if (g.from === "") {
+          // incoming-only glyph fading in
+          ch = randomGlyph();
+          alpha = elapsed / Math.max(1, g.lockInMs);
+        } else {
+          ch = randomGlyph();
+          if (g.to === "") {
+            // outgoing-only glyph fading out before its lock-in tear-down
+            alpha = 1 - elapsed / Math.max(1, g.lockInMs);
+          }
+        }
+      }
+      ctx.globalAlpha = alpha;
+      ctx.fillText(ch, g.x, g.y);
+    }
+    ctx.globalAlpha = 1;
+
+    rafId = requestAnimationFrame((t) => frame(ctx, schedule, incoming, startedAt, duration, t));
+  }
+
+  onDestroy(() => {
+    cancelRaf();
+  });
+</script>
+
+{#if visible && rect}
+  <canvas
+    bind:this={canvasEl}
+    class="vc-tab-morph-canvas"
+    aria-hidden="true"
+    style:left="{0}px"
+    style:top="{0}px"
+  ></canvas>
+{/if}
+
+<style>
+  .vc-tab-morph-canvas {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/editor/__tests__/tabMorph.test.ts
+++ b/src/lib/editor/__tests__/tabMorph.test.ts
@@ -1,0 +1,168 @@
+// Unit tests for the pure-logic side of issue #380's tab-morph effect.
+// The DOM-side renderer is exercised via the EditorPane integration test;
+// the rules below have to be right regardless of how the renderer is wired.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  MORPH_DURATION_MS,
+  MORPH_SUPPRESSION_MS,
+  buildSchedule,
+  decideMorph,
+  markMorphSettled,
+  newSuppressionState,
+  prefersReducedMotion,
+  randomGlyph,
+  resolveMorphDuration,
+  type ViewSnapshot,
+} from "../tabMorph";
+
+function snap(text: string): ViewSnapshot {
+  return {
+    glyphs: text.split("").map((ch, i) => ({ ch, x: i * 8, y: 0 })),
+    lineHeight: 20,
+    font: "16px/20px sans-serif",
+    color: "#000",
+    scrollerRect: { x: 0, y: 0, width: 800, height: 600 },
+  };
+}
+
+describe("decideMorph — suppression window (#380)", () => {
+  let state = newSuppressionState();
+  beforeEach(() => {
+    state = newSuppressionState();
+  });
+
+  it("plays the very first switch", () => {
+    expect(decideMorph(state, 1000)).toBe("play");
+    expect(state.inFlight).toBe(true);
+  });
+
+  it("after a settled morph, plays again once outside the 200ms window", () => {
+    decideMorph(state, 1000);
+    markMorphSettled(state, 1000 + MORPH_DURATION_MS);
+    expect(decideMorph(state, 1000 + MORPH_DURATION_MS + MORPH_SUPPRESSION_MS + 1)).toBe("play");
+  });
+
+  it("after a settled morph, instant-swaps inside the 200ms window", () => {
+    decideMorph(state, 1000);
+    markMorphSettled(state, 1000 + MORPH_DURATION_MS);
+    expect(decideMorph(state, 1000 + MORPH_DURATION_MS + 50)).toBe("instant");
+  });
+
+  it("subsequent switches inside the window stay instant (timer re-anchors)", () => {
+    // First switch settles at t=120.
+    decideMorph(state, 0);
+    markMorphSettled(state, MORPH_DURATION_MS);
+
+    // Five rapid switches within 200ms of each other — all must be instant.
+    let t = MORPH_DURATION_MS + 50;
+    for (let i = 0; i < 5; i += 1) {
+      expect(decideMorph(state, t)).toBe("instant");
+      t += 50;
+    }
+
+    // Once the user pauses long enough, the next switch plays.
+    t += MORPH_SUPPRESSION_MS + 1;
+    expect(decideMorph(state, t)).toBe("play");
+  });
+
+  it("a switch arriving while a morph is in flight cancels it (instant)", () => {
+    decideMorph(state, 0); // play; inFlight=true
+    expect(state.inFlight).toBe(true);
+    expect(decideMorph(state, 50)).toBe("instant");
+    expect(state.inFlight).toBe(false);
+  });
+});
+
+describe("buildSchedule", () => {
+  it("pairs glyphs by index and pads the shorter side with empty strings", () => {
+    const a = snap("hello");
+    const b = snap("hi");
+    const sched = buildSchedule(a, b, () => 0);
+    expect(sched).toHaveLength(5);
+    expect(sched.slice(0, 2).map((s) => `${s.from}->${s.to}`)).toEqual(["h->h", "e->i"]);
+    expect(sched.slice(2).map((s) => `${s.from}->${s.to}`)).toEqual(["l->", "l->", "o->"]);
+  });
+
+  it("places the lock-in time within [0, MORPH_DURATION_MS)", () => {
+    const a = snap("abc");
+    const b = snap("xyz");
+    const calls = [0, 0.5, 0.999];
+    let i = 0;
+    const sched = buildSchedule(a, b, () => calls[i++]!);
+    expect(sched[0]!.lockInMs).toBe(0);
+    expect(sched[1]!.lockInMs).toBe(60);
+    expect(sched[2]!.lockInMs).toBe(119);
+  });
+
+  it("falls back to outgoing position when incoming has no glyph at that slot", () => {
+    const a = snap("hello");
+    const b = snap("hi");
+    const sched = buildSchedule(a, b, () => 0);
+    // Slots 2..4 are surplus on the outgoing side — they must keep the
+    // outgoing x/y so the fade-out doesn't teleport across the canvas.
+    expect(sched[2]!.x).toBe(2 * 8);
+    expect(sched[3]!.x).toBe(3 * 8);
+    expect(sched[4]!.x).toBe(4 * 8);
+  });
+});
+
+describe("prefersReducedMotion", () => {
+  it("returns false when matchMedia is missing", () => {
+    const original = window.matchMedia;
+    // @ts-expect-error — deliberately remove for the test
+    delete window.matchMedia;
+    expect(prefersReducedMotion()).toBe(false);
+    window.matchMedia = original;
+  });
+
+  it("returns true when matchMedia reports the reduce preference", () => {
+    const stub = vi.fn().mockReturnValue({ matches: true });
+    vi.stubGlobal("matchMedia", stub);
+    Object.defineProperty(window, "matchMedia", { configurable: true, value: stub });
+    expect(prefersReducedMotion()).toBe(true);
+    expect(stub).toHaveBeenCalledWith("(prefers-reduced-motion: reduce)");
+  });
+});
+
+describe("resolveMorphDuration", () => {
+  it("falls back to MORPH_DURATION_MS when the CSS variable is missing", () => {
+    document.documentElement.style.removeProperty("--vc-tab-switch-duration");
+    expect(resolveMorphDuration()).toBe(MORPH_DURATION_MS);
+  });
+
+  it("parses a milliseconds value", () => {
+    document.documentElement.style.setProperty("--vc-tab-switch-duration", "200ms");
+    expect(resolveMorphDuration()).toBe(200);
+  });
+
+  it("parses a seconds value", () => {
+    document.documentElement.style.setProperty("--vc-tab-switch-duration", "0.5s");
+    expect(resolveMorphDuration()).toBe(500);
+  });
+
+  it("returns 0 for an explicit user opt-out", () => {
+    document.documentElement.style.setProperty("--vc-tab-switch-duration", "0ms");
+    expect(resolveMorphDuration()).toBe(0);
+  });
+
+  it("falls back on garbage input", () => {
+    document.documentElement.style.setProperty("--vc-tab-switch-duration", "fast");
+    expect(resolveMorphDuration()).toBe(MORPH_DURATION_MS);
+  });
+});
+
+describe("randomGlyph", () => {
+  it("emits a printable ASCII character (33–125)", () => {
+    for (let i = 0; i < 100; i += 1) {
+      const code = randomGlyph().charCodeAt(0);
+      expect(code).toBeGreaterThanOrEqual(33);
+      expect(code).toBeLessThanOrEqual(125);
+    }
+  });
+
+  it("is deterministic given a seeded random", () => {
+    expect(randomGlyph(() => 0)).toBe("!");
+    expect(randomGlyph(() => 0.999)).toBe("}");
+  });
+});

--- a/src/lib/editor/__tests__/tabMorph.test.ts
+++ b/src/lib/editor/__tests__/tabMorph.test.ts
@@ -91,8 +91,8 @@ describe("buildSchedule", () => {
     let i = 0;
     const sched = buildSchedule(a, b, () => calls[i++]!);
     expect(sched[0]!.lockInMs).toBe(0);
-    expect(sched[1]!.lockInMs).toBe(60);
-    expect(sched[2]!.lockInMs).toBe(119);
+    expect(sched[1]!.lockInMs).toBe(Math.floor(0.5 * MORPH_DURATION_MS));
+    expect(sched[2]!.lockInMs).toBe(Math.floor(0.999 * MORPH_DURATION_MS));
   });
 
   it("falls back to outgoing position when incoming has no glyph at that slot", () => {

--- a/src/lib/editor/__tests__/tabMorph.test.ts
+++ b/src/lib/editor/__tests__/tabMorph.test.ts
@@ -126,8 +126,13 @@ describe("prefersReducedMotion", () => {
 });
 
 describe("resolveMorphDuration", () => {
-  it("falls back to MORPH_DURATION_MS when the CSS variable is missing", () => {
+  // The CSS variable bleeds across tests in jsdom — clean up so each
+  // assertion starts from "no var set".
+  beforeEach(() => {
     document.documentElement.style.removeProperty("--vc-tab-switch-duration");
+  });
+
+  it("falls back to MORPH_DURATION_MS when the CSS variable is missing", () => {
     expect(resolveMorphDuration()).toBe(MORPH_DURATION_MS);
   });
 

--- a/src/lib/editor/tabMorph.ts
+++ b/src/lib/editor/tabMorph.ts
@@ -175,7 +175,13 @@ export function snapshotView(view: EditorView): ViewSnapshot | null {
 
   const scrollerRect = scrollerEl.getBoundingClientRect();
   const cs = window.getComputedStyle(contentEl);
-  const font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} / ${cs.lineHeight} ${cs.fontFamily}`;
+  // Build a minimal canvas-parseable font shorthand: weight + size + family.
+  // We deliberately drop fontStyle ("oblique 10deg" in modern UAs is a valid
+  // CSS value but ctx.font silently rejects it and falls back to "10px
+  // sans-serif", which would mis-size every glyph). Lifting weight + size +
+  // family is enough for layout fidelity since the editor's italic/oblique
+  // styling is rare in note bodies and falls back gracefully.
+  const font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
   const lineHeight = parseFloat(cs.lineHeight) || parseFloat(cs.fontSize) * 1.5;
   const color = cs.color;
 

--- a/src/lib/editor/tabMorph.ts
+++ b/src/lib/editor/tabMorph.ts
@@ -10,11 +10,11 @@
 
 import type { EditorView } from "@codemirror/view";
 
-/** Hard cut at 120ms — see issue #380 spec. Overridable via the
+/** Hard cut at the morph duration. Overridable via the
  *  `--vc-tab-switch-duration` CSS custom property (read at trigger time
- *  by `resolveMorphDuration`); this constant is the spec default and the
+ *  by `resolveMorphDuration`); this constant is the default and the
  *  fallback used by tests / non-DOM callers. */
-export const MORPH_DURATION_MS = 120;
+export const MORPH_DURATION_MS = 240;
 
 /**
  * Resolve the morph duration from `--vc-tab-switch-duration` on the document
@@ -40,9 +40,11 @@ export function resolveMorphDuration(): number {
 /**
  * If a second qualifying switch arrives within this window of the previous
  * one, skip animation and swap instantly. The window guards against
- * Cmd+Shift+] cycling through many tabs in rapid succession.
+ * Cmd+Shift+] cycling through many tabs in rapid succession. Sized just
+ * above the morph duration so a chord cycling faster than one morph per
+ * tab always falls through to the instant path.
  */
-export const MORPH_SUPPRESSION_MS = 200;
+export const MORPH_SUPPRESSION_MS = 320;
 
 /** A single character at a known viewport pixel position. */
 export interface GlyphRef {

--- a/src/lib/editor/tabMorph.ts
+++ b/src/lib/editor/tabMorph.ts
@@ -1,0 +1,220 @@
+// #380 — char-morph transition between text-file tabs.
+//
+// Pure logic for the canvas-overlay morph: snapshot extraction from a CM6
+// EditorView, glyph reveal scheduling, suppression-window decision, and the
+// reduced-motion gate. Side effects (canvas drawing, rAF) live in the Svelte
+// component that consumes this module.
+//
+// All exports are pure / inputs-only so the unit tests can exercise the
+// timing rules without a DOM.
+
+import type { EditorView } from "@codemirror/view";
+
+/** Hard cut at 120ms — see issue #380 spec. Overridable via the
+ *  `--vc-tab-switch-duration` CSS custom property (read at trigger time
+ *  by `resolveMorphDuration`); this constant is the spec default and the
+ *  fallback used by tests / non-DOM callers. */
+export const MORPH_DURATION_MS = 120;
+
+/**
+ * Resolve the morph duration from `--vc-tab-switch-duration` on the document
+ * root, falling back to {@link MORPH_DURATION_MS}. Accepts `Nms` or `Ns`.
+ * Returns 0 (instant) for `0`, `0ms`, or `0s` so user snippets can disable
+ * the effect without flipping a JS gate.
+ */
+export function resolveMorphDuration(): number {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return MORPH_DURATION_MS;
+  }
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--vc-tab-switch-duration")
+    .trim();
+  if (!raw) return MORPH_DURATION_MS;
+  const m = raw.match(/^([0-9]*\.?[0-9]+)(ms|s)?$/);
+  if (!m) return MORPH_DURATION_MS;
+  const n = parseFloat(m[1]!);
+  if (!Number.isFinite(n) || n < 0) return MORPH_DURATION_MS;
+  return m[2] === "s" ? n * 1000 : n;
+}
+
+/**
+ * If a second qualifying switch arrives within this window of the previous
+ * one, skip animation and swap instantly. The window guards against
+ * Cmd+Shift+] cycling through many tabs in rapid succession.
+ */
+export const MORPH_SUPPRESSION_MS = 200;
+
+/** A single character at a known viewport pixel position. */
+export interface GlyphRef {
+  ch: string;
+  x: number;
+  y: number;
+}
+
+/** Snapshot of the visible glyphs for one editor view. */
+export interface ViewSnapshot {
+  glyphs: GlyphRef[];
+  /** Line height in CSS pixels — used by the renderer to align baselines. */
+  lineHeight: number;
+  /** Font shorthand suitable for `ctx.font`. */
+  font: string;
+  /** Color resolved from the editor's `--color-text`. */
+  color: string;
+  /** Pixel rect of the editor scroller, viewport-relative. */
+  scrollerRect: { x: number; y: number; width: number; height: number };
+}
+
+/** Per-glyph entry on the morph timeline. */
+export interface ScheduledGlyph {
+  /** Outgoing character at this slot. Empty string = no outgoing. */
+  from: string;
+  /** Incoming character at this slot. Empty string = no incoming. */
+  to: string;
+  x: number;
+  y: number;
+  /** Time, in ms from morph start, at which this glyph locks onto `to`. */
+  lockInMs: number;
+}
+
+/** Decide whether a tab switch should play the morph or swap instantly. */
+export interface SuppressionState {
+  /** Timestamp (ms) of the last morph that completed (or was cancelled). */
+  lastSettledAt: number;
+  /** Whether a morph is currently in flight. */
+  inFlight: boolean;
+}
+
+export function newSuppressionState(): SuppressionState {
+  return { lastSettledAt: -Infinity, inFlight: false };
+}
+
+export type MorphDecision = "play" | "instant";
+
+/**
+ * Decide whether the next switch should play or swap instantly. Mutates
+ * `state` to record the decision so the caller doesn't have to.
+ *
+ * Rules (issue #380):
+ *  - In-flight morph + new request → cancel + instant. Suppression timer
+ *    re-anchors at `now` so subsequent switches inside the window stay
+ *    instant.
+ *  - No in-flight morph but `now - lastSettledAt < MORPH_SUPPRESSION_MS` →
+ *    instant. Re-anchors so a chord cycle stays instant for its duration.
+ *  - Otherwise → play. `inFlight` is set to true; the caller must call
+ *    `markMorphSettled(state, now)` when the morph ends or is cancelled.
+ */
+export function decideMorph(state: SuppressionState, now: number): MorphDecision {
+  if (state.inFlight) {
+    state.lastSettledAt = now;
+    state.inFlight = false;
+    return "instant";
+  }
+  if (now - state.lastSettledAt < MORPH_SUPPRESSION_MS) {
+    state.lastSettledAt = now;
+    return "instant";
+  }
+  state.inFlight = true;
+  return "play";
+}
+
+export function markMorphSettled(state: SuppressionState, now: number): void {
+  state.inFlight = false;
+  state.lastSettledAt = now;
+}
+
+/**
+ * Read the prefers-reduced-motion setting. Defaults to `false` outside a
+ * browser (jsdom test environment without the matchMedia stub).
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * Build the per-glyph schedule that the rAF renderer iterates. Slots are
+ * paired by index: outgoing[i] morphs into incoming[i]. The shorter side is
+ * padded with empty strings so surplus glyphs fade rather than mis-align.
+ */
+export function buildSchedule(
+  outgoing: ViewSnapshot,
+  incoming: ViewSnapshot,
+  randomFn: () => number = Math.random,
+  durationMs: number = MORPH_DURATION_MS,
+): ScheduledGlyph[] {
+  const out: ScheduledGlyph[] = [];
+  const len = Math.max(outgoing.glyphs.length, incoming.glyphs.length);
+  for (let i = 0; i < len; i += 1) {
+    const o = outgoing.glyphs[i];
+    const n = incoming.glyphs[i];
+    out.push({
+      from: o ? o.ch : "",
+      to: n ? n.ch : "",
+      x: n ? n.x : (o ? o.x : 0),
+      y: n ? n.y : (o ? o.y : 0),
+      lockInMs: Math.floor(randomFn() * durationMs),
+    });
+  }
+  return out;
+}
+
+/**
+ * Snapshot the visible glyphs of an EditorView. Reads the scroller rect, the
+ * resolved font / line-height / color, and the visible-range text, then
+ * computes per-glyph pixel positions via `view.coordsAtPos`.
+ *
+ * Skips folded ranges (which `view.visibleRanges` already excludes) and
+ * returns an empty snapshot if the view is detached.
+ */
+export function snapshotView(view: EditorView): ViewSnapshot | null {
+  const scrollerEl = view.scrollDOM as HTMLElement;
+  const contentEl = view.contentDOM as HTMLElement;
+  if (!scrollerEl || !contentEl || !scrollerEl.isConnected) return null;
+
+  const scrollerRect = scrollerEl.getBoundingClientRect();
+  const cs = window.getComputedStyle(contentEl);
+  const font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} / ${cs.lineHeight} ${cs.fontFamily}`;
+  const lineHeight = parseFloat(cs.lineHeight) || parseFloat(cs.fontSize) * 1.5;
+  const color = cs.color;
+
+  const glyphs: GlyphRef[] = [];
+  for (const range of view.visibleRanges) {
+    const text = view.state.doc.sliceString(range.from, range.to);
+    let pos = range.from;
+    for (let i = 0; i < text.length; i += 1) {
+      const ch = text[i]!;
+      // Newlines have no glyph — advance the cursor but skip the draw call.
+      if (ch === "\n") { pos += 1; continue; }
+      const coords = view.coordsAtPos(pos);
+      if (coords) {
+        glyphs.push({
+          ch,
+          x: coords.left - scrollerRect.left,
+          y: coords.top - scrollerRect.top,
+        });
+      }
+      pos += 1;
+    }
+  }
+  return {
+    glyphs,
+    lineHeight,
+    font,
+    color,
+    scrollerRect: {
+      x: scrollerRect.left,
+      y: scrollerRect.top,
+      width: scrollerRect.width,
+      height: scrollerRect.height,
+    },
+  };
+}
+
+/** Random printable ASCII glyph used to scramble pre-lock-in. */
+export function randomGlyph(rand: () => number = Math.random): string {
+  // Printable ASCII range minus space — visually busy enough for the morph.
+  const code = 33 + Math.floor(rand() * (126 - 33));
+  return String.fromCharCode(code);
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -28,7 +28,7 @@
 
   /* #380 — tab-morph transition duration. User snippets can override to 0ms
      to disable the effect entirely without touching the JS gate. */
-  --vc-tab-switch-duration: 120ms;
+  --vc-tab-switch-duration: 240ms;
 }
 
 /* Light theme (explicit) — same values as the bare :root defaults. Allows the HTML

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -25,6 +25,10 @@
   --vc-font-body: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --vc-font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
   --vc-font-size: 14px;
+
+  /* #380 — tab-morph transition duration. User snippets can override to 0ms
+     to disable the effect entirely without touching the JS gate. */
+  --vc-tab-switch-duration: 120ms;
 }
 
 /* Light theme (explicit) — same values as the bare :root defaults. Allows the HTML


### PR DESCRIPTION
Closes #380.

## Summary
- New `TabMorphOverlay.svelte` mounted once per EditorPane inside `.vc-editor-content`. Snapshots both CM6 views' visible glyphs (via `view.coordsAtPos` + `view.state.doc.sliceString` over `view.visibleRanges`), drives a 120ms rAF canvas scramble, tears the canvas down at the end. Pointer-events: none + aria-hidden so the editor below stays fully interactive.
- Pure-logic split in `src/lib/editor/tabMorph.ts` — suppression-window decision, schedule build, reduced-motion gate, CSS-var duration parser — unit-tested without a DOM (17 tests).
- Trigger lives in EditorPane's existing `paneActiveTabId` effect. Gates: both sides must have a mounted CM6 view, both in edit mode, both `tabHasEditor` true, neither in `mountingIds`. Graph / image / canvas / unsupported / reading-mode all bypass.
- 200ms suppression window so Cmd+Shift+] chord cycles instant-swap after the first morph.
- `prefers-reduced-motion: reduce` → instant swap, zero animation.
- New CSS custom property `--vc-tab-switch-duration` (default 120ms). User snippets can set 0ms to opt out without flipping any JS gate.

## Test plan
- [x] 17 unit tests in `tabMorph.test.ts` (suppression rules, reduced-motion gate, schedule pairing, mismatched-length padding, duration parsing)
- [x] All 315 existing editor unit tests still pass
- [x] svelte-check clean for the Editor workspace (only pre-existing CanvasView error remains)
- [x] `pnpm build` clean
- [ ] UAT: open two markdown notes with different content, switch between them — expect a 120ms scramble. Cmd+Shift+] through 5 tabs in <1s — expect instant swaps. OS reduced-motion → no animation. Switch to a graph / image / PDF / canvas / reading-mode tab → no morph. Type during the morph → keystrokes land in the incoming editor.

## Files
- `src/lib/editor/tabMorph.ts` (new) — pure logic
- `src/lib/editor/__tests__/tabMorph.test.ts` (new) — 17 unit tests
- `src/components/Editor/TabMorphOverlay.svelte` (new) — canvas + rAF
- `src/components/Editor/EditorPane.svelte` — overlay mount + trigger gate
- `src/styles/tailwind.css` — `--vc-tab-switch-duration` token