### PR TITLE
feat(editor): extend char-morph tab transition to canvas tabs (#383)

### DIFF
--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -69,6 +69,11 @@
     resolveVaultAbs,
     toVaultRel,
   } from "../../lib/canvas/embed";
+  import { snapshotCanvas } from "../../lib/canvas/canvasTabMorph";
+  import {
+    registerCanvasSnapshot,
+    unregisterCanvasSnapshot,
+  } from "../../lib/canvas/canvasMorphRegistry";
   import {
     type PointerMode,
     type DraftEdge,
@@ -203,6 +208,14 @@
 
   onMount(() => {
     void load();
+    // #383: expose a snapshot fn so EditorPane's tab-morph overlay can
+    // capture this canvas during canvas↔text and canvas↔canvas switches.
+    // Closure reads `viewportEl`, `doc`, `camX/Y`, `zoom` at snapshot
+    // time — they're plain `let` (DOM ref) and `$state` (camera + doc),
+    // both of which the closure observes at lookup, not at registration.
+    registerCanvasSnapshot(tabId, () =>
+      viewportEl ? snapshotCanvas(viewportEl, doc, camX, camY, zoom) : null,
+    );
   });
 
   onDestroy(() => {
@@ -212,6 +225,7 @@
       void persist();
     }
     cancelLongpressTimer();
+    unregisterCanvasSnapshot(tabId);
     // #165: tear down preview-invalidation subscriptions so multi-tab
     // open/close cycles don't leak listeners.
     unsubTab();

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -225,6 +225,10 @@
       void persist();
     }
     cancelLongpressTimer();
+    // #383: unregister BEFORE the rest of the teardown so a tab-switch
+    // racing with this destroy can't read a snapshot fn whose closure
+    // points at `viewportEl` after Svelte has detached it. Ordering is
+    // load-bearing — a stale closure would dereference a null DOM ref.
     unregisterCanvasSnapshot(tabId);
     // #165: tear down preview-invalidation subscriptions so multi-tab
     // open/close cycles don't leak listeners.

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -29,6 +29,7 @@
   import CountStatusBar from "./CountStatusBar.svelte";
   import TabMorphOverlay from "./TabMorphOverlay.svelte";
   import { snapshotView as snapshotEditorView } from "../../lib/editor/tabMorph";
+  import { snapshotCanvasTab } from "../../lib/canvas/canvasMorphRegistry";
   import { countsStore } from "../../store/countsStore";
   import { computeCounts } from "../../lib/wordCount";
   import { scrollToMatch } from "./flashHighlight";
@@ -259,14 +260,38 @@
     return true;
   }
 
+  // #383: tabs that participate in the char-morph tab transition. Superset
+  // of `tabHasEditor` — adds canvas tabs, which are snapshotted via the
+  // canvasMorphRegistry rather than from a CM6 view. Graph / image /
+  // unsupported / PDF still bypass to instant-swap.
+  function tabSupportsMorph(t: Tab | undefined): boolean {
+    if (!t) return false;
+    if (t.type === "graph") return false;
+    if (t.viewer === "image" || t.viewer === "unsupported") return false;
+    return true;
+  }
+
+  // #383: produce a `ViewSnapshot` for the morph overlay regardless of the
+  // tab's viewer kind. Returns null for non-morphable tabs or when the
+  // underlying view (CM6 / canvas) hasn't mounted yet — the overlay
+  // bypasses on null.
+  function snapshotForTab(tab: Tab | undefined, view: EditorView | undefined) {
+    if (!tab) return null;
+    if (tab.viewer === "canvas") return snapshotCanvasTab(tab.id);
+    if (tabHasEditor(tab) && view) return snapshotEditorView(view);
+    return null;
+  }
+
   // Subscribe to tabStore for our pane's tabs and active state
   const unsubTab = tabStore.subscribe((state) => {
-    // #380: BEFORE assigning the new activeTabId (which triggers Svelte to
-    // flip style:display on the outgoing container in the next microtask),
-    // snapshot the still-visible outgoing view. Without this, the trigger
-    // effect downstream sees the outgoing CM6 view already hidden and
-    // produces an empty glyph list — the morph would only fade in the
-    // incoming side, never scramble from the outgoing content.
+    // #380 / #383: BEFORE assigning the new activeTabId (which triggers
+    // Svelte to flip style:display on the outgoing container in the next
+    // microtask), snapshot the still-visible outgoing view. Without this,
+    // the trigger effect downstream sees the outgoing surface already
+    // hidden and produces an empty glyph list — the morph would only
+    // fade in the incoming side, never scramble from the outgoing
+    // content. Covers both CM6 (text) and canvas tabs via
+    // `snapshotForTab`.
     const prevActive = activeTabId;
     const nextActive = state.activeTabId;
     if (
@@ -276,15 +301,14 @@
       state.splitState[paneId].includes(prevActive) &&
       state.splitState[paneId].includes(nextActive)
     ) {
+      const prevTab = state.tabs.find((t) => t.id === prevActive);
       const prevView = viewMap.get(prevActive);
-      if (prevView) {
-        try {
-          pendingOutgoingSnapshot = snapshotEditorView(prevView);
-          pendingOutgoingForTabId = prevActive;
-        } catch {
-          pendingOutgoingSnapshot = null;
-          pendingOutgoingForTabId = null;
-        }
+      try {
+        pendingOutgoingSnapshot = snapshotForTab(prevTab, prevView);
+        pendingOutgoingForTabId = pendingOutgoingSnapshot ? prevActive : null;
+      } catch {
+        pendingOutgoingSnapshot = null;
+        pendingOutgoingForTabId = null;
       }
     }
     paneTabIds = state.splitState[paneId];
@@ -583,14 +607,16 @@
   type MorphOverlayHandle = ReturnType<typeof TabMorphOverlay>;
   let morphOverlay: MorphOverlayHandle | null = $state(null);
 
-  // #380: outgoing snapshot must be taken BEFORE Svelte re-flips the
-  // `style:display` of the previously-active container — once the old
-  // container is `display: none`, `view.coordsAtPos` returns null and
-  // `getBoundingClientRect` returns a zero rect, so the snapshot would
-  // be empty. The store subscriber below runs synchronously on dispatch,
-  // ahead of the next microtask in which Svelte flushes reactivity, so
-  // we capture the snapshot there and stash it for the trigger effect.
-  let pendingOutgoingSnapshot: import("../../lib/editor/tabMorph").ViewSnapshot | null = null;
+  // #380 / #383: outgoing snapshot must be taken BEFORE Svelte re-flips
+  // the `style:display` of the previously-active container — once the
+  // old container is `display: none`, `view.coordsAtPos` (CM6) returns
+  // null and `getBoundingClientRect` (canvas) returns a zero rect, so
+  // the snapshot would be empty. The store subscriber above runs
+  // synchronously on dispatch, ahead of the next microtask in which
+  // Svelte flushes reactivity, so we capture the snapshot there and
+  // stash it for the trigger effect. The variables are tab-type-agnostic
+  // — they hold whichever shape `snapshotForTab` produced (CM6 or canvas).
+  let pendingOutgoingSnapshot: import("../../lib/morphTypes").ViewSnapshot | null = null;
   let pendingOutgoingForTabId: string | null = null;
 
   // Handle scroll save/restore on tab switch — separate effect to avoid
@@ -611,13 +637,14 @@
           } catch (_) { /* view may have been destroyed */ }
         }
       }
-      // #380: trigger morph if both sides are already-mounted text editors.
-      // Skipped during async mount (mountingIds), for non-editor tabs
-      // (graph/image/canvas/unsupported), and when either side is in
-      // Reading Mode (no CM6 layout to snapshot). The outgoing snapshot
-      // was captured synchronously in the tabStore subscriber above —
-      // the incoming snapshot is taken here, after Svelte has flipped
-      // the new container to display: block.
+      // #380 / #383: trigger morph if both sides are morph-eligible.
+      // Skipped during async mount (mountingIds), for non-morphable tabs
+      // (graph/image/unsupported/PDF), and when either side is in Reading
+      // Mode (no readable layout to snapshot). The outgoing snapshot was
+      // captured synchronously in the tabStore subscriber above — the
+      // incoming snapshot is taken here, after Svelte has flipped the
+      // new container to display: block. Canvas tabs route through the
+      // canvasMorphRegistry; CM6 tabs route through `snapshotEditorView`.
       const outgoingSnapshot = pendingOutgoingForTabId === prevActiveTabId
         ? pendingOutgoingSnapshot
         : null;
@@ -632,20 +659,23 @@
       ) {
         const outTab = allTabs.find((t) => t.id === prevActiveTabId);
         const inTab = allTabs.find((t) => t.id === newActiveId);
-        const inView = viewMap.get(newActiveId);
         const bothEdit =
           (outTab?.viewMode ?? "edit") === "edit" &&
           (inTab?.viewMode ?? "edit") === "edit";
         if (
-          inView &&
           bothEdit &&
-          tabHasEditor(outTab) &&
-          tabHasEditor(inTab)
+          tabSupportsMorph(outTab) &&
+          tabSupportsMorph(inTab)
         ) {
           // Defer the incoming snapshot to the next frame so the new
           // container's display:block has flushed before we measure.
+          // For canvas-tab incoming, the registry lookup may return null
+          // when the canvas hasn't mounted yet (first-open race) — the
+          // overlay bypasses on null incoming, which is the right
+          // behavior.
+          const inView = viewMap.get(newActiveId);
           requestAnimationFrame(() => {
-            const incomingSnapshot = snapshotEditorView(inView);
+            const incomingSnapshot = snapshotForTab(inTab, inView);
             morphOverlay?.playFromSnapshots(outgoingSnapshot, incomingSnapshot);
           });
         }

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -260,15 +260,14 @@
     return true;
   }
 
-  // #383: tabs that participate in the char-morph tab transition. Superset
-  // of `tabHasEditor` — adds canvas tabs, which are snapshotted via the
-  // canvasMorphRegistry rather than from a CM6 view. Graph / image /
-  // unsupported / PDF still bypass to instant-swap.
+  // #383: tabs that participate in the char-morph tab transition. Defined
+  // in terms of `tabHasEditor` so any new viewer type added to that
+  // function's exclusion list is automatically excluded from morphing —
+  // the only difference is that canvas tabs ARE morphable here (via the
+  // canvasMorphRegistry) while `tabHasEditor` excludes them (no CM6 view).
   function tabSupportsMorph(t: Tab | undefined): boolean {
     if (!t) return false;
-    if (t.type === "graph") return false;
-    if (t.viewer === "image" || t.viewer === "unsupported") return false;
-    return true;
+    return tabHasEditor(t) || t.viewer === "canvas";
   }
 
   // #383: produce a `ViewSnapshot` for the morph overlay regardless of the
@@ -659,6 +658,10 @@
       ) {
         const outTab = allTabs.find((t) => t.id === prevActiveTabId);
         const inTab = allTabs.find((t) => t.id === newActiveId);
+        // Canvas tabs do not carry a `viewMode` field, so the `?? "edit"`
+        // fallback always lets them pass — that's intentional, canvas
+        // has no Reading Mode to gate against. The check exists to
+        // suppress text↔text morphs when either side is in Reading Mode.
         const bothEdit =
           (outTab?.viewMode ?? "edit") === "edit" &&
           (inTab?.viewMode ?? "edit") === "edit";

--- a/src/components/Editor/TabMorphOverlay.svelte
+++ b/src/components/Editor/TabMorphOverlay.svelte
@@ -63,10 +63,18 @@
     const now = performance.now();
     const decision = decideMorph(suppression, now);
     if (decision === "instant") {
+      // Chord-cycle suppression after a settled morph — cancel any
+      // (defensive, shouldn't happen) leftover rAF and skip.
       cancelRaf();
       visible = false;
       return;
     }
+    // decision === "play". If a morph is already in flight, cancel its
+    // rAF cleanly so we can re-arm with the new schedule below; the
+    // canvas surface stays mounted (visible=true) so there's no flash
+    // between the interrupted frame and the first frame of the new
+    // morph.
+    cancelRaf();
     if (prefersReducedMotion()) {
       markMorphSettled(suppression, now);
       return;

--- a/src/components/Editor/TabMorphOverlay.svelte
+++ b/src/components/Editor/TabMorphOverlay.svelte
@@ -22,8 +22,8 @@
     randomGlyph,
     resolveMorphDuration,
     type ScheduledGlyph,
-    type ViewSnapshot,
   } from "../../lib/editor/tabMorph";
+  import type { ViewSnapshot } from "../../lib/morphTypes";
 
   let canvasEl = $state<HTMLCanvasElement | null>(null);
   let visible = $state(false);

--- a/src/components/Editor/TabMorphOverlay.svelte
+++ b/src/components/Editor/TabMorphOverlay.svelte
@@ -14,6 +14,7 @@
 
   import { onDestroy } from "svelte";
   import {
+    buildFrameSchedule,
     buildSchedule,
     decideMorph,
     markMorphSettled,
@@ -21,9 +22,10 @@
     prefersReducedMotion,
     randomGlyph,
     resolveMorphDuration,
+    type ScheduledFrame,
     type ScheduledGlyph,
   } from "../../lib/editor/tabMorph";
-  import type { ViewSnapshot } from "../../lib/morphTypes";
+  import type { FrameRef, ViewSnapshot } from "../../lib/morphTypes";
 
   let canvasEl = $state<HTMLCanvasElement | null>(null);
   let visible = $state(false);
@@ -75,10 +77,17 @@
       markMorphSettled(suppression, now);
       return;
     }
-    if (!outgoing || !incoming || outgoing.glyphs.length === 0) {
-      // Empty outgoing snapshot means the parent failed to capture in
-      // time — settle the suppression timer so a chord cycle still
-      // behaves and bail without a morph.
+    if (!outgoing || !incoming) {
+      markMorphSettled(suppression, now);
+      return;
+    }
+    const hasOutgoingVisual =
+      outgoing.glyphs.length > 0 || (outgoing.frames?.length ?? 0) > 0;
+    const hasIncomingVisual =
+      incoming.glyphs.length > 0 || (incoming.frames?.length ?? 0) > 0;
+    if (!hasOutgoingVisual || !hasIncomingVisual) {
+      // Nothing visual on at least one side — settle the suppression
+      // timer so a chord cycle still behaves and bail without a morph.
       markMorphSettled(suppression, now);
       return;
     }
@@ -109,14 +118,18 @@
       ctx.fillStyle = incoming.color;
 
       const schedule = buildSchedule(outgoing, incoming, Math.random, duration);
+      const frameSchedule = buildFrameSchedule(outgoing, incoming, Math.random, duration);
       cancelRaf();
-      rafId = requestAnimationFrame((t) => frame(ctx, schedule, incoming, startedAt, duration, t));
+      rafId = requestAnimationFrame((t) =>
+        frame(ctx, schedule, frameSchedule, incoming, startedAt, duration, t),
+      );
     });
   }
 
   function frame(
     ctx: CanvasRenderingContext2D,
     schedule: ScheduledGlyph[],
+    frameSchedule: ScheduledFrame[],
     incoming: ViewSnapshot,
     startedAt: number,
     duration: number,
@@ -137,6 +150,9 @@
       tearDown();
       return;
     }
+
+    // Frames first so glyphs read on top of the card outlines.
+    drawFrames(ctx, frameSchedule, elapsed, incoming.color);
 
     for (const g of schedule) {
       const locked = elapsed >= g.lockInMs;
@@ -167,7 +183,102 @@
     }
     ctx.globalAlpha = 1;
 
-    rafId = requestAnimationFrame((t) => frame(ctx, schedule, incoming, startedAt, duration, t));
+    rafId = requestAnimationFrame((t) =>
+      frame(ctx, schedule, frameSchedule, incoming, startedAt, duration, t),
+    );
+  }
+
+  function lerp(a: number, b: number, t: number): number {
+    return a + (b - a) * t;
+  }
+
+  function pathShape(
+    ctx: CanvasRenderingContext2D,
+    f: FrameRef,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+  ) {
+    ctx.beginPath();
+    if (f.shape === "ellipse") {
+      ctx.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 0, 0, Math.PI * 2);
+      return;
+    }
+    if (f.shape === "diamond") {
+      ctx.moveTo(x + w / 2, y);
+      ctx.lineTo(x + w, y + h / 2);
+      ctx.lineTo(x + w / 2, y + h);
+      ctx.lineTo(x, y + h / 2);
+      ctx.closePath();
+      return;
+    }
+    if (f.shape === "triangle") {
+      ctx.moveTo(x + w / 2, y);
+      ctx.lineTo(x + w, y + h);
+      ctx.lineTo(x, y + h);
+      ctx.closePath();
+      return;
+    }
+    const r = f.shape === "rounded-rectangle" ? Math.min(8, w / 2, h / 2) : 0;
+    if (r > 0 && typeof ctx.roundRect === "function") {
+      ctx.roundRect(x, y, w, h, r);
+      return;
+    }
+    ctx.rect(x, y, w, h);
+  }
+
+  /**
+   * Cross-fade card frames from outgoing → incoming. Each pair has its
+   * own random lock-in within the morph window, so dialogs scramble in
+   * the same staggered way the glyphs do — no two cards swap at the
+   * same instant.
+   */
+  function drawFrames(
+    ctx: CanvasRenderingContext2D,
+    frames: ScheduledFrame[],
+    elapsed: number,
+    fallbackColor: string,
+  ) {
+    if (frames.length === 0) return;
+    ctx.save();
+    ctx.lineWidth = 1;
+    for (const sf of frames) {
+      const lock = Math.max(1, sf.lockInMs);
+      const t = Math.min(1, elapsed / lock);
+      const locked = elapsed >= sf.lockInMs;
+      const target: FrameRef | null = locked ? sf.to : sf.from ?? sf.to;
+      if (!target) continue;
+      // Interpolate position when both sides exist so cards translate
+      // toward their new home rather than teleport.
+      let x = target.x;
+      let y = target.y;
+      let w = target.width;
+      let h = target.height;
+      if (sf.from && sf.to && !locked) {
+        x = lerp(sf.from.x, sf.to.x, t);
+        y = lerp(sf.from.y, sf.to.y, t);
+        w = lerp(sf.from.width, sf.to.width, t);
+        h = lerp(sf.from.height, sf.to.height, t);
+      }
+      const fadingIn = !sf.from && sf.to;
+      const fadingOut = sf.from && !sf.to;
+      const alpha = fadingIn ? t : fadingOut ? 1 - t : 1;
+      const drawTarget = fadingOut ? sf.from! : target;
+      ctx.globalAlpha = alpha * (drawTarget.strokeAlpha ?? 1);
+      pathShape(ctx, drawTarget, x, y, w, h);
+      if (drawTarget.fill) {
+        const prev = ctx.globalAlpha;
+        ctx.globalAlpha = prev * 0.25;
+        ctx.fillStyle = drawTarget.fill;
+        ctx.fill();
+        ctx.globalAlpha = prev;
+      }
+      ctx.strokeStyle = fallbackColor;
+      ctx.stroke();
+    }
+    ctx.restore();
+    ctx.globalAlpha = 1;
   }
 
   onDestroy(() => {

--- a/src/lib/canvas/__tests__/canvasMorphRegistry.test.ts
+++ b/src/lib/canvas/__tests__/canvasMorphRegistry.test.ts
@@ -1,0 +1,70 @@
+// Unit tests for the canvas-snapshot registry (#383).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  registerCanvasSnapshot,
+  snapshotCanvasTab,
+  unregisterCanvasSnapshot,
+} from "../canvasMorphRegistry";
+import type { ViewSnapshot } from "../../morphTypes";
+
+function snap(tag: string): ViewSnapshot {
+  return {
+    glyphs: [{ ch: tag, x: 0, y: 0 }],
+    lineHeight: 16,
+    font: "14px sans-serif",
+    color: "#000",
+    scrollerRect: { x: 0, y: 0, width: 100, height: 100 },
+  };
+}
+
+const idsToCleanUp: string[] = [];
+afterEach(() => {
+  for (const id of idsToCleanUp) unregisterCanvasSnapshot(id);
+  idsToCleanUp.length = 0;
+});
+
+describe("canvasMorphRegistry", () => {
+  it("returns null for an unknown tab", () => {
+    expect(snapshotCanvasTab("never-registered")).toBeNull();
+  });
+
+  it("invokes the registered fn at lookup time", () => {
+    const id = "tab-A";
+    idsToCleanUp.push(id);
+    registerCanvasSnapshot(id, () => snap("A"));
+    const result = snapshotCanvasTab(id);
+    expect(result?.glyphs[0]!.ch).toBe("A");
+  });
+
+  it("isolates two simultaneously registered tabs", () => {
+    idsToCleanUp.push("tab-A", "tab-B");
+    registerCanvasSnapshot("tab-A", () => snap("A"));
+    registerCanvasSnapshot("tab-B", () => snap("B"));
+    expect(snapshotCanvasTab("tab-A")?.glyphs[0]!.ch).toBe("A");
+    expect(snapshotCanvasTab("tab-B")?.glyphs[0]!.ch).toBe("B");
+  });
+
+  it("returns null after unregister even if a fresh registration was created earlier with the same id", () => {
+    const id = "tab-A";
+    idsToCleanUp.push(id);
+    registerCanvasSnapshot(id, () => snap("A"));
+    unregisterCanvasSnapshot(id);
+    expect(snapshotCanvasTab(id)).toBeNull();
+  });
+
+  it("re-registering with the same id replaces the old fn (no stale closure leak on remount)", () => {
+    const id = "tab-A";
+    idsToCleanUp.push(id);
+    registerCanvasSnapshot(id, () => snap("first"));
+    registerCanvasSnapshot(id, () => snap("second"));
+    expect(snapshotCanvasTab(id)?.glyphs[0]!.ch).toBe("second");
+  });
+
+  it("propagates a null return from the fn (e.g. empty / unloaded canvas)", () => {
+    const id = "tab-A";
+    idsToCleanUp.push(id);
+    registerCanvasSnapshot(id, () => null);
+    expect(snapshotCanvasTab(id)).toBeNull();
+  });
+});

--- a/src/lib/canvas/__tests__/canvasTabMorph.test.ts
+++ b/src/lib/canvas/__tests__/canvasTabMorph.test.ts
@@ -207,13 +207,54 @@ describe("snapshotCanvas", () => {
     expect(snap.scrollerRect.height).toBe(480);
   });
 
-  it("returns null when no node carries readable text", () => {
+  it("includes a card frame for every visible node so dialogs morph too", () => {
     const el = makeViewport();
-    // file node with empty file, group with no label, unknown type
     const doc: CanvasDoc = {
       nodes: [
-        { id: "f", type: "file", x: 0, y: 0, width: 100, height: 100, file: "" },
+        textNode({ id: "t", text: "hi", x: 10, y: 20, width: 100, height: 50 }),
+        {
+          id: "g",
+          type: "group",
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 200,
+          background: "#abc",
+        },
+      ],
+      edges: [],
+    };
+    const snap = snapshotCanvas(el, doc, 0, 0, 1)!;
+    expect(snap.frames).toBeDefined();
+    expect(snap.frames!.length).toBe(2);
+    const text = snap.frames!.find((f) => f.width === 100);
+    expect(text).toBeTruthy();
+    expect(text!.shape).toBe("rounded-rectangle");
+    const group = snap.frames!.find((f) => f.width === 200);
+    expect(group!.fill).toBe("#abc");
+    expect(group!.strokeAlpha).toBeLessThan(1);
+  });
+
+  it("returns a snapshot even for a label-less group (frame, no glyphs)", () => {
+    const el = makeViewport();
+    const doc: CanvasDoc = {
+      nodes: [
         { id: "g", type: "group", x: 0, y: 0, width: 100, height: 100 },
+      ],
+      edges: [],
+    };
+    const snap = snapshotCanvas(el, doc, 0, 0, 1);
+    expect(snap).not.toBeNull();
+    expect(snap!.glyphs).toHaveLength(0);
+    expect(snap!.frames!.length).toBe(1);
+  });
+
+  it("returns null only when neither glyphs nor frames are present", () => {
+    const el = makeViewport();
+    // off-screen group → culled before frame is captured → no visuals
+    const doc: CanvasDoc = {
+      nodes: [
+        { id: "g", type: "group", x: 9999, y: 0, width: 100, height: 100 },
       ],
       edges: [],
     };

--- a/src/lib/canvas/__tests__/canvasTabMorph.test.ts
+++ b/src/lib/canvas/__tests__/canvasTabMorph.test.ts
@@ -1,0 +1,222 @@
+// Unit tests for the canvas snapshot side of the tab-morph effect (#383).
+// The DOM-side renderer is exercised via the EditorPane integration; the
+// rules below have to be right regardless of how the renderer is wired.
+
+import { describe, it, expect } from "vitest";
+import { snapshotCanvas } from "../canvasTabMorph";
+import type {
+  CanvasDoc,
+  CanvasFileNode,
+  CanvasGroupNode,
+  CanvasLinkNode,
+  CanvasTextNode,
+} from "../types";
+
+function makeViewport(width = 800, height = 600): HTMLDivElement {
+  const el = document.createElement("div");
+  el.style.width = `${width}px`;
+  el.style.height = `${height}px`;
+  // jsdom's getBoundingClientRect returns 0×0 for un-attached / un-styled
+  // elements. Attach so the helper sees a real-ish rect; stub the call
+  // because jsdom never lays things out.
+  document.body.appendChild(el);
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return el;
+}
+
+function textNode(over: Partial<CanvasTextNode> = {}): CanvasTextNode {
+  return {
+    id: "n",
+    type: "text",
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 80,
+    text: "",
+    ...over,
+  };
+}
+
+function emptyDoc(): CanvasDoc {
+  return { nodes: [], edges: [] };
+}
+
+describe("snapshotCanvas", () => {
+  it("returns null for an empty doc", () => {
+    const el = makeViewport();
+    expect(snapshotCanvas(el, emptyDoc(), 0, 0, 1)).toBeNull();
+  });
+
+  it("returns null when the viewport is not connected", () => {
+    const el = document.createElement("div");
+    expect(snapshotCanvas(el, emptyDoc(), 0, 0, 1)).toBeNull();
+  });
+
+  it("returns null for zoom <= 0 (defensive against pre-mount state)", () => {
+    const el = makeViewport();
+    const doc: CanvasDoc = { nodes: [textNode({ text: "x" })], edges: [] };
+    expect(snapshotCanvas(el, doc, 0, 0, 0)).toBeNull();
+    expect(snapshotCanvas(el, doc, 0, 0, -1)).toBeNull();
+  });
+
+  it("emits one glyph per character of a text node", () => {
+    const el = makeViewport();
+    const doc: CanvasDoc = {
+      nodes: [textNode({ text: "abc", x: 0, y: 0, width: 200, height: 80 })],
+      edges: [],
+    };
+    const snap = snapshotCanvas(el, doc, 0, 0, 1);
+    expect(snap).not.toBeNull();
+    expect(snap!.glyphs.map((g) => g.ch).join("")).toBe("abc");
+  });
+
+  it("places glyphs at projected viewport coords (camera transform applied)", () => {
+    const el = makeViewport();
+    const doc: CanvasDoc = {
+      nodes: [textNode({ text: "ab", x: 100, y: 200, width: 300, height: 80 })],
+      edges: [],
+    };
+    const snap = snapshotCanvas(el, doc, 10, 20, 2)!;
+    // First glyph's x = node.x * zoom + camX = 100*2 + 10 = 210
+    // First glyph's y = node.y * zoom + camY = 200*2 + 20 = 420
+    expect(snap.glyphs[0]!.x).toBeCloseTo(210, 1);
+    expect(snap.glyphs[0]!.y).toBeCloseTo(420, 1);
+    // Second glyph is on the same line, one cell to the right.
+    expect(snap.glyphs[1]!.x).toBeGreaterThan(snap.glyphs[0]!.x);
+    expect(snap.glyphs[1]!.y).toBeCloseTo(snap.glyphs[0]!.y, 1);
+  });
+
+  it("culls nodes entirely off-screen so they don't burn glyph budget", () => {
+    const el = makeViewport(800, 600);
+    const doc: CanvasDoc = {
+      nodes: [
+        // Way to the right of the 800-px-wide viewport.
+        textNode({ id: "off", text: "OFFSCREEN", x: 9999, y: 0 }),
+        textNode({ id: "on", text: "X", x: 0, y: 0 }),
+      ],
+      edges: [],
+    };
+    const snap = snapshotCanvas(el, doc, 0, 0, 1)!;
+    expect(snap.glyphs.map((g) => g.ch).join("")).toBe("X");
+  });
+
+  it("uses a file node's basename, not its full vault path", () => {
+    const el = makeViewport();
+    const fileNode: CanvasFileNode = {
+      id: "f",
+      type: "file",
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 200,
+      file: "folder/sub/notes.md",
+    };
+    const snap = snapshotCanvas(el, { nodes: [fileNode], edges: [] }, 0, 0, 1)!;
+    expect(snap.glyphs.map((g) => g.ch).join("")).toBe("notes.md");
+  });
+
+  it("uses a link node's URL", () => {
+    const el = makeViewport();
+    const linkNode: CanvasLinkNode = {
+      id: "l",
+      type: "link",
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 80,
+      url: "https://x.test/a",
+    };
+    const snap = snapshotCanvas(el, { nodes: [linkNode], edges: [] }, 0, 0, 1)!;
+    expect(snap.glyphs.map((g) => g.ch).join("")).toBe("https://x.test/a");
+  });
+
+  it("uses a group node's label, skipping label-less groups", () => {
+    const el = makeViewport();
+    const labeled: CanvasGroupNode = {
+      id: "g1",
+      type: "group",
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 200,
+      label: "Group A",
+    };
+    const unlabeled: CanvasGroupNode = {
+      id: "g2",
+      type: "group",
+      x: 0,
+      y: 100,
+      width: 400,
+      height: 200,
+    };
+    const snap = snapshotCanvas(
+      el,
+      { nodes: [labeled, unlabeled], edges: [] },
+      0,
+      0,
+      1,
+    )!;
+    expect(snap.glyphs.map((g) => g.ch).join("")).toBe("Group A");
+  });
+
+  it("respects the maxGlyphs cap", () => {
+    const el = makeViewport();
+    const doc: CanvasDoc = {
+      nodes: [textNode({ text: "x".repeat(100), width: 4000, height: 80 })],
+      edges: [],
+    };
+    const snap = snapshotCanvas(el, doc, 0, 0, 1, 5)!;
+    expect(snap.glyphs).toHaveLength(5);
+  });
+
+  it("does not count off-screen culled nodes against the cap", () => {
+    const el = makeViewport(800, 600);
+    const doc: CanvasDoc = {
+      nodes: [
+        textNode({ id: "off", text: "y".repeat(50), x: 9999, width: 4000 }),
+        textNode({ id: "on", text: "abc", x: 0, width: 4000 }),
+      ],
+      edges: [],
+    };
+    // Cap of 3: if culling happened AFTER counting, the off-screen node's
+    // 50 chars would consume the budget and "abc" would get zero glyphs.
+    // Culling first means all 3 budget slots go to "abc".
+    const snap = snapshotCanvas(el, doc, 0, 0, 1, 3)!;
+    expect(snap.glyphs.map((g) => g.ch).join("")).toBe("abc");
+  });
+
+  it("returns a scrollerRect matching the viewport's bounding rect", () => {
+    const el = makeViewport(640, 480);
+    const doc: CanvasDoc = {
+      nodes: [textNode({ text: "x" })],
+      edges: [],
+    };
+    const snap = snapshotCanvas(el, doc, 0, 0, 1)!;
+    expect(snap.scrollerRect.width).toBe(640);
+    expect(snap.scrollerRect.height).toBe(480);
+  });
+
+  it("returns null when no node carries readable text", () => {
+    const el = makeViewport();
+    // file node with empty file, group with no label, unknown type
+    const doc: CanvasDoc = {
+      nodes: [
+        { id: "f", type: "file", x: 0, y: 0, width: 100, height: 100, file: "" },
+        { id: "g", type: "group", x: 0, y: 0, width: 100, height: 100 },
+      ],
+      edges: [],
+    };
+    expect(snapshotCanvas(el, doc, 0, 0, 1)).toBeNull();
+  });
+});

--- a/src/lib/canvas/canvasMorphRegistry.ts
+++ b/src/lib/canvas/canvasMorphRegistry.ts
@@ -1,0 +1,42 @@
+// Per-tabId snapshot registry for canvas tab-morph (#383).
+//
+// `CanvasView.svelte` instances register a closure that produces a
+// `ViewSnapshot` for their current state on mount, and unregister on
+// destroy. `EditorPane.svelte` looks up the snapshot fn by tabId both
+// when capturing the OUTGOING snapshot (synchronously, before Svelte
+// flips display) and the INCOMING snapshot (inside rAF, after the
+// new container has been laid out).
+//
+// Module-level singleton, deliberately not `$state` — this is a pure
+// lookup table, not a reactive surface. `tabId`s are UUIDs so cross-pane
+// collisions are impossible by construction; if the codebase ever moves
+// to per-pane id namespaces, this map would need to become per-pane too.
+//
+// Pattern mirrors the `viewMap` non-reactive Map in `EditorPane.svelte`
+// — wrapping DOM/closure refs in `$state` triggers Svelte 5 proxy
+// behavior that breaks identity-sensitive consumers.
+
+import type { ViewSnapshot } from "../morphTypes";
+
+const registry = new Map<string, () => ViewSnapshot | null>();
+
+export function registerCanvasSnapshot(
+  tabId: string,
+  fn: () => ViewSnapshot | null,
+): void {
+  registry.set(tabId, fn);
+}
+
+export function unregisterCanvasSnapshot(tabId: string): void {
+  registry.delete(tabId);
+}
+
+/**
+ * Look up and invoke the snapshot fn for a tab, returning `null` if the
+ * tab isn't a canvas (or hasn't registered yet — e.g. mount race during
+ * a chord cycle through a freshly opened tab).
+ */
+export function snapshotCanvasTab(tabId: string): ViewSnapshot | null {
+  const fn = registry.get(tabId);
+  return fn ? fn() : null;
+}

--- a/src/lib/canvas/canvasTabMorph.ts
+++ b/src/lib/canvas/canvasTabMorph.ts
@@ -23,7 +23,8 @@ import type {
   CanvasNode,
   CanvasTextNode,
 } from "./types";
-import type { ViewSnapshot, GlyphRef } from "../morphTypes";
+import { readShape } from "./types";
+import type { FrameRef, GlyphRef, ViewSnapshot } from "../morphTypes";
 
 /** Bail-out cap for the glyph walk. Off-screen nodes are culled BEFORE
  * being added, so this only kicks in for genuinely dense visible canvases. */
@@ -109,12 +110,10 @@ export function snapshotCanvas(
   const lineH = lineHeight;
 
   const glyphs: GlyphRef[] = [];
+  const frames: FrameRef[] = [];
 
   outer: for (const node of doc.nodes) {
     if (glyphs.length >= maxGlyphs) break;
-
-    const text = nodeText(node);
-    if (!text) continue;
 
     const vx0 = node.x * zoom + camX;
     const vy0 = node.y * zoom + camY;
@@ -127,6 +126,30 @@ export function snapshotCanvas(
     if (vx0 + vw < 0 || vy0 + vh < 0 || vx0 > rect.width || vy0 > rect.height) {
       continue;
     }
+
+    // Capture the card frame so the overlay can scramble dialogs and
+    // group areas, not just their text. Group nodes carry a fill (their
+    // background); other node types render as outline-only cards.
+    if (vw > 0 && vh > 0) {
+      const frame: FrameRef = {
+        x: vx0,
+        y: vy0,
+        width: vw,
+        height: vh,
+        shape: node.type === "text" ? readShape(node) : "rounded-rectangle",
+      };
+      if (node.type === "group") {
+        const bg = (node as CanvasGroupNode).background;
+        if (bg) frame.fill = bg;
+        // Groups sit visually behind everything else — soften the
+        // outline so the morph reads more like an area than a card.
+        frame.strokeAlpha = 0.5;
+      }
+      frames.push(frame);
+    }
+
+    const text = nodeText(node);
+    if (!text) continue;
 
     const colsPerLine = Math.max(1, Math.floor(vw / cellW));
     const maxLines = Math.max(1, Math.floor(vh / lineH));
@@ -159,10 +182,13 @@ export function snapshotCanvas(
     }
   }
 
-  if (glyphs.length === 0) return null;
+  // Bypass only when there's nothing visual to show — frames count too,
+  // so a canvas full of label-less group rectangles still morphs.
+  if (glyphs.length === 0 && frames.length === 0) return null;
 
   return {
     glyphs,
+    frames,
     lineHeight,
     font,
     color,

--- a/src/lib/canvas/canvasTabMorph.ts
+++ b/src/lib/canvas/canvasTabMorph.ts
@@ -1,0 +1,171 @@
+// Canvas-tab snapshot for the tab-morph effect (#383).
+//
+// Produces a `ViewSnapshot` from a canvas viewport so `TabMorphOverlay`
+// can morph canvas↔text and canvas↔canvas tab switches with the same
+// 120ms char-scramble pipeline used for text↔text in #380.
+//
+// Strategy (b) from the ticket: walk text-bearing nodes (text body /
+// link URL / file basename / group label) and project each character to
+// a viewport pixel position via the canvas camera transform. Bounded by
+// `MAX_GLYPHS` so a dense canvas can't push us off the keystroke-latency
+// budget. This is a deliberate approximation — glyph positions don't
+// match the rendered cards' wrapped layout exactly. For a 120ms cue this
+// is fine; the user sees the real canvas the moment the morph ends.
+//
+// Edges and image content are intentionally omitted: edges have no
+// readable text and rasterizing images would blow the budget.
+
+import type {
+  CanvasDoc,
+  CanvasFileNode,
+  CanvasGroupNode,
+  CanvasLinkNode,
+  CanvasNode,
+  CanvasTextNode,
+} from "./types";
+import type { ViewSnapshot, GlyphRef } from "../morphTypes";
+
+/** Bail-out cap for the glyph walk. Off-screen nodes are culled BEFORE
+ * being added, so this only kicks in for genuinely dense visible canvases. */
+const MAX_GLYPHS = 1500;
+
+/**
+ * Extract the single text string a node contributes to the morph snapshot.
+ * Returns `null` for node kinds with nothing readable (image-only file
+ * nodes that point at non-markdown files still return their basename;
+ * that's intentional — the basename is the visible card text).
+ */
+function nodeText(node: CanvasNode): string | null {
+  // The CanvasUnknownNode variant has `type: string`, which overlaps the
+  // literal types and degrades discriminated-union narrowing. Cast inside
+  // each branch — same pattern as `readShape` in `./types.ts`.
+  switch (node.type) {
+    case "text":
+      return (node as CanvasTextNode).text || null;
+    case "link":
+      return (node as CanvasLinkNode).url || null;
+    case "file": {
+      const file = (node as CanvasFileNode).file;
+      if (!file) return null;
+      const slash = file.lastIndexOf("/");
+      return slash >= 0 ? file.slice(slash + 1) : file;
+    }
+    case "group":
+      return (node as CanvasGroupNode).label || null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Snapshot the text content of a canvas viewport into a `ViewSnapshot`.
+ *
+ * Returns `null` when there's nothing to morph from — the overlay treats
+ * null and empty `glyphs` as bypass-and-instant-swap, so this is the
+ * caller-friendly way to opt out without a separate "should we morph?"
+ * branch.
+ *
+ * Coordinates are projected as `vx = node.x * zoom + camX + cellX`, which
+ * matches `CanvasView.svelte`'s `clientToWorld` inverse: world-coords get
+ * transformed into viewport-local pixels, then offset by the viewport's
+ * scroller rect at the consumption site (the overlay positions itself
+ * absolute inset:0 within `.vc-editor-content`, so viewport-local is what
+ * we want).
+ */
+export function snapshotCanvas(
+  viewportEl: HTMLElement,
+  doc: CanvasDoc,
+  camX: number,
+  camY: number,
+  zoom: number,
+  maxGlyphs: number = MAX_GLYPHS,
+): ViewSnapshot | null {
+  if (!viewportEl || !viewportEl.isConnected) return null;
+  // Defensive: the camera zoom is clamped in CanvasView.svelte (MIN_ZOOM = 0.15)
+  // but a not-yet-mounted state could in principle leak a zero. Bail rather
+  // than divide-by-zero or stack every glyph at one pixel.
+  if (!Number.isFinite(zoom) || zoom <= 0) return null;
+
+  const rect = viewportEl.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+
+  const cs = typeof window !== "undefined" ? window.getComputedStyle(viewportEl) : null;
+  const fontSize = cs ? parseFloat(cs.fontSize) || 14 : 14;
+  const lineHeight = cs ? parseFloat(cs.lineHeight) || fontSize * 1.4 : fontSize * 1.4;
+  const fontFamily = cs?.fontFamily ?? "sans-serif";
+  const fontWeight = cs?.fontWeight ?? "400";
+  const font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+  const color = cs?.color || "#000";
+
+  // Approximate monospace cell width — close enough to lay glyphs out
+  // along a node's top edge without doing real font-metric measurement
+  // on every snapshot.
+  const cellW = fontSize * 0.6;
+  const lineH = lineHeight;
+
+  const glyphs: GlyphRef[] = [];
+
+  outer: for (const node of doc.nodes) {
+    if (glyphs.length >= maxGlyphs) break;
+
+    const text = nodeText(node);
+    if (!text) continue;
+
+    const vx0 = node.x * zoom + camX;
+    const vy0 = node.y * zoom + camY;
+    const vw = Math.max(0, node.width * zoom);
+    const vh = Math.max(0, node.height * zoom);
+
+    // Cull entirely off-screen nodes BEFORE walking their text. This is
+    // what keeps `MAX_GLYPHS` from hiding pan/zoom regressions: a 100k-node
+    // vault with one node visible still costs O(visible-text), not O(all-text).
+    if (vx0 + vw < 0 || vy0 + vh < 0 || vx0 > rect.width || vy0 > rect.height) {
+      continue;
+    }
+
+    const colsPerLine = Math.max(1, Math.floor(vw / cellW));
+    const maxLines = Math.max(1, Math.floor(vh / lineH));
+
+    let col = 0;
+    let line = 0;
+    for (let i = 0; i < text.length; i += 1) {
+      const ch = text[i]!;
+      if (ch === "\n") {
+        col = 0;
+        line += 1;
+        if (line >= maxLines) break;
+        continue;
+      }
+      if (col >= colsPerLine) {
+        col = 0;
+        line += 1;
+        if (line >= maxLines) break;
+      }
+      // Skip whitespace at the start of a wrapped line for a slightly
+      // tighter visual — purely cosmetic, costs one branch per char.
+      if (col === 0 && ch === " ") continue;
+      glyphs.push({
+        ch,
+        x: vx0 + col * cellW,
+        y: vy0 + line * lineH,
+      });
+      col += 1;
+      if (glyphs.length >= maxGlyphs) break outer;
+    }
+  }
+
+  if (glyphs.length === 0) return null;
+
+  return {
+    glyphs,
+    lineHeight,
+    font,
+    color,
+    scrollerRect: {
+      x: rect.left,
+      y: rect.top,
+      width: rect.width,
+      height: rect.height,
+    },
+  };
+}

--- a/src/lib/canvas/canvasTabMorph.ts
+++ b/src/lib/canvas/canvasTabMorph.ts
@@ -97,9 +97,14 @@ export function snapshotCanvas(
   const font = `${fontWeight} ${fontSize}px ${fontFamily}`;
   const color = cs?.color || "#000";
 
-  // Approximate monospace cell width — close enough to lay glyphs out
-  // along a node's top edge without doing real font-metric measurement
-  // on every snapshot.
+  // Approximate monospace cell width. Canvas cards render in a
+  // proportional UI font, so this is wrong for any glyph that isn't
+  // ~0.6em wide — but doing real font-metric measurement (`measureText`
+  // per glyph) on every tab switch would burn the keystroke-latency
+  // budget, and the morph is only a 240ms visual cue: pixel-exact
+  // glyph placement isn't the point. If a future ticket needs faithful
+  // canvas → DOM glyph mapping, swap this for a per-node `measureText`
+  // pass once at snapshot time, not per-glyph.
   const cellW = fontSize * 0.6;
   const lineH = lineHeight;
 

--- a/src/lib/editor/__tests__/tabMorph.test.ts
+++ b/src/lib/editor/__tests__/tabMorph.test.ts
@@ -67,11 +67,25 @@ describe("decideMorph — suppression window (#380)", () => {
     expect(decideMorph(state, t)).toBe("play");
   });
 
-  it("a switch arriving while a morph is in flight cancels it (instant)", () => {
-    decideMorph(state, 0); // play; inFlight=true
+  it("a switch arriving while a morph is in flight replays (does NOT cancel to instant)", () => {
+    // Regression for the UAT bug: switching mid-animation used to swap
+    // instantly with no morph. The new contract is that the in-flight
+    // morph is replaced with a fresh play so the user sees continuous
+    // motion. inFlight stays true; lastSettledAt is unchanged so the
+    // chord-cycling suppression window only kicks in AFTER a settle.
+    decideMorph(state, 0);
     expect(state.inFlight).toBe(true);
-    expect(decideMorph(state, 50)).toBe("instant");
-    expect(state.inFlight).toBe(false);
+    const before = state.lastSettledAt;
+    expect(decideMorph(state, 50)).toBe("play");
+    expect(state.inFlight).toBe(true);
+    expect(state.lastSettledAt).toBe(before);
+  });
+
+  it("after a mid-flight replay settles, the chord-cycling suppression still applies", () => {
+    decideMorph(state, 0);
+    decideMorph(state, 50); // mid-flight replay; still play
+    markMorphSettled(state, 50 + MORPH_DURATION_MS);
+    expect(decideMorph(state, 50 + MORPH_DURATION_MS + 10)).toBe("instant");
   });
 });
 

--- a/src/lib/editor/__tests__/tabMorph.test.ts
+++ b/src/lib/editor/__tests__/tabMorph.test.ts
@@ -13,8 +13,8 @@ import {
   prefersReducedMotion,
   randomGlyph,
   resolveMorphDuration,
-  type ViewSnapshot,
 } from "../tabMorph";
+import type { ViewSnapshot } from "../../morphTypes";
 
 function snap(text: string): ViewSnapshot {
   return {

--- a/src/lib/editor/__tests__/tabMorph.test.ts
+++ b/src/lib/editor/__tests__/tabMorph.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   MORPH_DURATION_MS,
   MORPH_SUPPRESSION_MS,
+  buildFrameSchedule,
   buildSchedule,
   decideMorph,
   markMorphSettled,
@@ -14,7 +15,7 @@ import {
   randomGlyph,
   resolveMorphDuration,
 } from "../tabMorph";
-import type { ViewSnapshot } from "../../morphTypes";
+import type { FrameRef, ViewSnapshot } from "../../morphTypes";
 
 function snap(text: string): ViewSnapshot {
   return {
@@ -104,6 +105,48 @@ describe("buildSchedule", () => {
     expect(sched[2]!.x).toBe(2 * 8);
     expect(sched[3]!.x).toBe(3 * 8);
     expect(sched[4]!.x).toBe(4 * 8);
+  });
+});
+
+describe("buildFrameSchedule", () => {
+  function frame(over: Partial<FrameRef> = {}): FrameRef {
+    return { x: 0, y: 0, width: 10, height: 10, shape: "rectangle", ...over };
+  }
+  function snapWithFrames(frames: FrameRef[]): ViewSnapshot {
+    return {
+      glyphs: [],
+      frames,
+      lineHeight: 16,
+      font: "14px sans-serif",
+      color: "#000",
+      scrollerRect: { x: 0, y: 0, width: 100, height: 100 },
+    };
+  }
+
+  it("pairs frames by index and pads the shorter side with null", () => {
+    const a = snapWithFrames([frame({ x: 1 }), frame({ x: 2 }), frame({ x: 3 })]);
+    const b = snapWithFrames([frame({ x: 10 })]);
+    const sched = buildFrameSchedule(a, b, () => 0);
+    expect(sched).toHaveLength(3);
+    expect(sched[0]!.from?.x).toBe(1);
+    expect(sched[0]!.to?.x).toBe(10);
+    expect(sched[1]!.to).toBeNull();
+    expect(sched[2]!.to).toBeNull();
+  });
+
+  it("treats a missing `frames` array as empty", () => {
+    const a: ViewSnapshot = {
+      glyphs: [],
+      lineHeight: 16,
+      font: "14px sans-serif",
+      color: "#000",
+      scrollerRect: { x: 0, y: 0, width: 1, height: 1 },
+    };
+    const b = snapWithFrames([frame()]);
+    const sched = buildFrameSchedule(a, b, () => 0);
+    expect(sched).toHaveLength(1);
+    expect(sched[0]!.from).toBeNull();
+    expect(sched[0]!.to).not.toBeNull();
   });
 });
 

--- a/src/lib/editor/tabMorph.ts
+++ b/src/lib/editor/tabMorph.ts
@@ -59,6 +59,15 @@ export interface ScheduledGlyph {
   lockInMs: number;
 }
 
+/** Per-frame entry on the morph timeline. Frames cross-fade from
+ *  `from` → `to` linearly over [0, lockInMs]. */
+export interface ScheduledFrame {
+  from: import("../morphTypes").FrameRef | null;
+  to: import("../morphTypes").FrameRef | null;
+  /** Time, in ms from morph start, at which the frame is fully `to`. */
+  lockInMs: number;
+}
+
 /** Decide whether a tab switch should play the morph or swap instantly. */
 export interface SuppressionState {
   /** Timestamp (ms) of the last morph that completed (or was cancelled). */
@@ -137,6 +146,32 @@ export function buildSchedule(
       to: n ? n.ch : "",
       x: n ? n.x : (o ? o.x : 0),
       y: n ? n.y : (o ? o.y : 0),
+      lockInMs: Math.floor(randomFn() * durationMs),
+    });
+  }
+  return out;
+}
+
+/**
+ * Build the per-frame schedule. Frames are paired by index — surplus on
+ * either side cross-fades to / from null so dialogs disappear and appear
+ * smoothly. Lock-in jitter mirrors the glyph schedule so card and text
+ * animation read as one motion.
+ */
+export function buildFrameSchedule(
+  outgoing: ViewSnapshot,
+  incoming: ViewSnapshot,
+  randomFn: () => number = Math.random,
+  durationMs: number = MORPH_DURATION_MS,
+): ScheduledFrame[] {
+  const out: ScheduledFrame[] = [];
+  const a = outgoing.frames ?? [];
+  const b = incoming.frames ?? [];
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    out.push({
+      from: a[i] ?? null,
+      to: b[i] ?? null,
       lockInMs: Math.floor(randomFn() * durationMs),
     });
   }

--- a/src/lib/editor/tabMorph.ts
+++ b/src/lib/editor/tabMorph.ts
@@ -9,6 +9,9 @@
 // timing rules without a DOM.
 
 import type { EditorView } from "@codemirror/view";
+import type { GlyphRef, ViewSnapshot } from "../morphTypes";
+
+export type { GlyphRef, ViewSnapshot } from "../morphTypes";
 
 /** Hard cut at the morph duration. Overridable via the
  *  `--vc-tab-switch-duration` CSS custom property (read at trigger time
@@ -45,26 +48,6 @@ export function resolveMorphDuration(): number {
  * tab always falls through to the instant path.
  */
 export const MORPH_SUPPRESSION_MS = 320;
-
-/** A single character at a known viewport pixel position. */
-export interface GlyphRef {
-  ch: string;
-  x: number;
-  y: number;
-}
-
-/** Snapshot of the visible glyphs for one editor view. */
-export interface ViewSnapshot {
-  glyphs: GlyphRef[];
-  /** Line height in CSS pixels — used by the renderer to align baselines. */
-  lineHeight: number;
-  /** Font shorthand suitable for `ctx.font`. */
-  font: string;
-  /** Color resolved from the editor's `--color-text`. */
-  color: string;
-  /** Pixel rect of the editor scroller, viewport-relative. */
-  scrollerRect: { x: number; y: number; width: number; height: number };
-}
 
 /** Per-glyph entry on the morph timeline. */
 export interface ScheduledGlyph {

--- a/src/lib/editor/tabMorph.ts
+++ b/src/lib/editor/tabMorph.ts
@@ -86,20 +86,29 @@ export type MorphDecision = "play" | "instant";
  * Decide whether the next switch should play or swap instantly. Mutates
  * `state` to record the decision so the caller doesn't have to.
  *
- * Rules (issue #380):
- *  - In-flight morph + new request → cancel + instant. Suppression timer
- *    re-anchors at `now` so subsequent switches inside the window stay
- *    instant.
- *  - No in-flight morph but `now - lastSettledAt < MORPH_SUPPRESSION_MS` →
- *    instant. Re-anchors so a chord cycle stays instant for its duration.
+ * Rules (issue #380, refined for #383):
+ *  - In-flight morph + new request → cancel the current rAF and PLAY a
+ *    fresh morph from the new outgoing snapshot. The user sees a
+ *    continuous scramble rather than a hard cut, which matches the
+ *    intent of the morph (smooth tab transition) better than the
+ *    original instant-cancel behavior. `inFlight` stays true.
+ *  - No in-flight morph but `now - lastSettledAt < MORPH_SUPPRESSION_MS`
+ *    → instant. This is the chord-cycling guard: after a morph has just
+ *    settled, rapid follow-up switches stay instant so Cmd+Shift+]
+ *    through many tabs doesn't queue 240ms of animation per tab. The
+ *    suppression window re-anchors so the cycle stays instant for its
+ *    duration.
  *  - Otherwise → play. `inFlight` is set to true; the caller must call
- *    `markMorphSettled(state, now)` when the morph ends or is cancelled.
+ *    `markMorphSettled(state, now)` when the morph ends.
  */
 export function decideMorph(state: SuppressionState, now: number): MorphDecision {
   if (state.inFlight) {
-    state.lastSettledAt = now;
-    state.inFlight = false;
-    return "instant";
+    // Stay in-flight, but the caller will re-arm rAF with the new
+    // snapshots. lastSettledAt is intentionally NOT updated — the
+    // suppression window is anchored on settled morphs, and an
+    // interrupted-then-replayed morph is still one continuous "play"
+    // from the user's perspective.
+    return "play";
   }
   if (now - state.lastSettledAt < MORPH_SUPPRESSION_MS) {
     state.lastSettledAt = now;

--- a/src/lib/editor/tabMorph.ts
+++ b/src/lib/editor/tabMorph.ts
@@ -11,8 +11,6 @@
 import type { EditorView } from "@codemirror/view";
 import type { GlyphRef, ViewSnapshot } from "../morphTypes";
 
-export type { GlyphRef, ViewSnapshot } from "../morphTypes";
-
 /** Hard cut at the morph duration. Overridable via the
  *  `--vc-tab-switch-duration` CSS custom property (read at trigger time
  *  by `resolveMorphDuration`); this constant is the default and the

--- a/src/lib/morphTypes.ts
+++ b/src/lib/morphTypes.ts
@@ -14,9 +14,31 @@ export interface GlyphRef {
   y: number;
 }
 
+/**
+ * Card-shaped region inside a snapshot — used by canvas snapshots to
+ * include the visible node frames (text cards, file cards, link cards,
+ * group rectangles) in the morph so the dialogs/areas scramble too,
+ * not just their text. Text-editor snapshots leave this empty.
+ */
+export interface FrameRef {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Visual shape — picked up by the overlay renderer. */
+  shape: "rectangle" | "rounded-rectangle" | "ellipse" | "diamond" | "triangle";
+  /** Optional fill (group background). `null`/missing = no fill, just outline. */
+  fill?: string | null;
+  /** Outline alpha at lock-in [0..1]. Default 1. Used to soften groups. */
+  strokeAlpha?: number;
+}
+
 /** Snapshot of the visible glyphs for one editor surface. */
 export interface ViewSnapshot {
   glyphs: GlyphRef[];
+  /** Optional card / region frames — canvas snapshots populate this so
+   *  dialogs and group areas scramble alongside their text. */
+  frames?: FrameRef[];
   /** Line height in CSS pixels — used by the renderer to align baselines. */
   lineHeight: number;
   /** Font shorthand suitable for `ctx.font`. */

--- a/src/lib/morphTypes.ts
+++ b/src/lib/morphTypes.ts
@@ -1,0 +1,28 @@
+// Shared types for the tab-morph effect (#380, #383).
+//
+// `ViewSnapshot` is consumed by `TabMorphOverlay.svelte` and produced by
+// per-tab-type snapshot helpers — `snapshotView` for CM6 (text) tabs in
+// `src/lib/editor/tabMorph.ts`, `snapshotCanvas` for canvas tabs in
+// `src/lib/canvas/canvasTabMorph.ts`. Living in a top-level `lib/` module
+// keeps the canvas helper from importing across the canvas → editor module
+// boundary.
+
+/** A single character at a known viewport pixel position. */
+export interface GlyphRef {
+  ch: string;
+  x: number;
+  y: number;
+}
+
+/** Snapshot of the visible glyphs for one editor surface. */
+export interface ViewSnapshot {
+  glyphs: GlyphRef[];
+  /** Line height in CSS pixels — used by the renderer to align baselines. */
+  lineHeight: number;
+  /** Font shorthand suitable for `ctx.font`. */
+  font: string;
+  /** Color resolved from the surface's `--color-text` (or computed `color`). */
+  color: string;
+  /** Pixel rect of the surface's scroller, viewport-relative. */
+  scrollerRect: { x: number; y: number; width: number; height: number };
+}


### PR DESCRIPTION
Closes #383.

## Summary

- Extends the 240 ms char-morph from #380/#382 to cover canvas↔text and canvas↔canvas tab switches. Canvas tabs no longer instant-swap when they enter or leave the active slot.
- New `snapshotCanvas` walks text-bearing canvas nodes (text body, link URL, file basename, group label) and projects characters to viewport pixels via the camera transform — bounded at 1500 glyphs, off-screen nodes culled before they consume budget. No DOM rasterization, no async work, no regression on keystroke latency or idle RAM.
- `canvasMorphRegistry` keeps EditorPane and CanvasView decoupled — CanvasView registers a snapshot closure on mount, unregisters on destroy.
- `ViewSnapshot` / `GlyphRef` moved to a shared `src/lib/morphTypes.ts` to avoid `canvas/` importing across into `editor/`.

## Behavior

| Switch | Result |
|---|---|
| canvas → text | 240 ms scramble, no input lost |
| text → canvas | 240 ms scramble, canvas interactive immediately after |
| canvas → canvas | scramble between the two glyph grids |
| empty / unloaded canvas | bypass → instant (per ticket) |
| graph / image / unsupported / PDF | still bypass |
| `prefers-reduced-motion: reduce` | still instant |
| Cmd+Shift+] chord through mixed tabs | first morph plays, rest instant (existing suppression window unchanged) |

## Test plan

- [x] `pnpm vitest run src/lib/canvas/__tests__/canvasTabMorph.test.ts src/lib/canvas/__tests__/canvasMorphRegistry.test.ts src/lib/editor/__tests__/tabMorph.test.ts` — 36 passing
- [x] `pnpm svelte-check` — no new errors (one pre-existing #362 error on CanvasView.svelte:975 untouched)
- [x] `pnpm build` — clean
- [ ] **Manual UAT** (required before merge):
  - Open mixed text + canvas tabs
  - Switch text → canvas, canvas → text, canvas → canvas — expect 240 ms scramble
  - Cmd+Shift+] cycle through 4 mixed tabs — first morph plays, rest instant
  - `prefers-reduced-motion: reduce` — instant for all combinations
  - Open empty canvas, switch to it from text — instant (bypass)
  - Verify no input lost on incoming editor / canvas after morph