### PR TITLE
feat(mobile): viewport store + hit-target token sweep (#385)

### DIFF
--- a/src/components/Editor/Breadcrumbs.svelte
+++ b/src/components/Editor/Breadcrumbs.svelte
@@ -138,6 +138,8 @@
     align-items: center;
     gap: 6px;
     height: 28px;
+    /* #385 — bumps to 44px on coarse pointer (overrides `height`). */
+    min-height: var(--vc-hit-target, 28px);
     padding: 0 12px;
     background: var(--color-surface);
     border-bottom: 1px solid var(--color-border);
@@ -172,6 +174,9 @@
     justify-content: center;
     width: 24px;
     height: 22px;
+    /* #385 — square 44px touch target on coarse. */
+    min-width: var(--vc-hit-target, 24px);
+    min-height: var(--vc-hit-target, 22px);
     padding: 0;
     flex-shrink: 0;
     background: transparent;

--- a/src/components/Layout/RightSidebar.svelte
+++ b/src/components/Layout/RightSidebar.svelte
@@ -124,6 +124,8 @@
     align-items: center;
     justify-content: center;
     height: 36px;
+    /* #385 — coarse-pointer min-height overrides height per CSS spec. */
+    min-height: var(--vc-hit-target, 36px);
     background: transparent;
     border: none;
     cursor: pointer;

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -1064,6 +1064,10 @@
     justify-content: center;
     width: 32px;
     height: 32px;
+    /* #385 — bump to 44x44 on coarse pointer; both axes since the icon
+       button needs a square touch target. */
+    min-width: var(--vc-hit-target, 32px);
+    min-height: var(--vc-hit-target, 32px);
     background: none;
     border: none;
     border-radius: 4px;

--- a/src/components/Properties/PropertiesPanel.svelte
+++ b/src/components/Properties/PropertiesPanel.svelte
@@ -225,6 +225,9 @@
   .vc-props-add {
     width: 24px;
     height: 24px;
+    /* #385 — square 44px touch target on coarse. */
+    min-width: var(--vc-hit-target, 24px);
+    min-height: var(--vc-hit-target, 24px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -265,6 +268,8 @@
   .vc-props-key,
   .vc-props-value {
     height: 24px;
+    /* #385 — coarse pointer min-height overrides height per CSS spec. */
+    min-height: var(--vc-hit-target, 24px);
     font-size: 13px;
     color: var(--color-text);
     background: var(--color-surface);
@@ -290,7 +295,8 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 4px;
-    min-height: 24px;
+    /* #385 — desktop fallback preserves the 24px min-height. */
+    min-height: var(--vc-hit-target, 24px);
     padding: 2px 4px;
     background: var(--color-surface);
     border: 1px solid var(--color-border);

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -632,6 +632,9 @@
   .vc-settings-title { font-size: 14px; font-weight: 600; margin: 0; color: var(--color-text); }
   .vc-settings-close {
     width: 28px; height: 28px;
+    /* #385 — coarse-pointer touch target. */
+    min-width: var(--vc-hit-target, 28px);
+    min-height: var(--vc-hit-target, 28px);
     background: none; border: none; cursor: pointer;
     color: var(--color-text-muted);
     display: flex; align-items: center; justify-content: center;
@@ -655,6 +658,8 @@
   .vc-theme-radio-group { display: flex; gap: 8px; }
   .vc-theme-radio {
     flex: 1; height: 36px;
+    /* #385 — coarse pointer min-height overrides height per CSS spec. */
+    min-height: var(--vc-hit-target, 36px);
     display: flex; align-items: center; justify-content: center;
     border: 1px solid var(--color-border); border-radius: 6px;
     cursor: pointer;
@@ -715,6 +720,8 @@
   .vc-vault-switch-btn {
     flex-shrink: 0;
     height: 32px;
+    /* #385 — coarse pointer touch target. */
+    min-height: var(--vc-hit-target, 32px);
     padding: 0 12px;
     font-size: 13px;
     color: var(--color-text);
@@ -734,6 +741,8 @@
   .vc-settings-btn {
     flex-shrink: 0;
     height: 32px;
+    /* #385 — coarse pointer touch target. */
+    min-height: var(--vc-hit-target, 32px);
     padding: 0 12px;
     font-size: 13px;
     color: var(--color-text);

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -1038,6 +1038,8 @@
     cursor: pointer;
     background: var(--color-surface);
     color: var(--color-text);
+    /* #385 — desktop fallback `auto` preserves current padding-only size. */
+    min-height: var(--vc-hit-target, auto);
   }
 
   .vc-confirm-btn:hover {

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -610,7 +610,7 @@
     display: flex;
     align-items: center;
     gap: 4px;
-    min-height: 24px;
+    min-height: var(--vc-hit-target, 24px);
     padding-top: 2px;
     padding-bottom: 2px;
     padding-right: 8px;
@@ -734,6 +734,15 @@
     display: flex;
   }
 
+  /* #385 — touch devices have no hover; the kebab must always be visible
+     so the menu is reachable. (hover: none) is the inverse of (hover: hover)
+     and matches every fine-OR-no-hover-at-all device, including Android/iOS. */
+  @media (hover: none) {
+    .vc-tree-more {
+      display: flex;
+    }
+  }
+
   .vc-tree-more:hover {
     background: var(--color-accent-bg);
     color: var(--color-accent);
@@ -784,6 +793,9 @@
     cursor: pointer;
     background: var(--color-surface);
     color: var(--color-text);
+    /* #385 — desktop: token undefined → fallback `auto` → no effect
+       (byte-identical). Coarse: 44px. */
+    min-height: var(--vc-hit-target, auto);
   }
 
   .vc-confirm-btn:hover {

--- a/src/components/Tabs/Tab.svelte
+++ b/src/components/Tabs/Tab.svelte
@@ -112,6 +112,9 @@
     max-width: 160px;
     min-width: 80px;
     height: 36px;
+    /* #385 — keep `height` for desktop layout; min-height bumps to 44px
+       on coarse pointer (overrides height per CSS spec). */
+    min-height: var(--vc-hit-target, 36px);
     box-sizing: border-box;
     cursor: pointer;
     flex-shrink: 0;

--- a/src/components/Tabs/TabBar.svelte
+++ b/src/components/Tabs/TabBar.svelte
@@ -102,6 +102,9 @@
     flex-direction: row;
     width: 100%;
     height: 36px;
+    /* #385 — coarse pointer promotes to 44px without touching `height` on
+       desktop (var undefined → fallback 36 == height → no change). */
+    min-height: var(--vc-hit-target, 36px);
     background: var(--color-surface);
     border-bottom: 1px solid var(--color-border);
     overflow-x: auto;

--- a/src/components/Tags/TagRow.svelte
+++ b/src/components/Tags/TagRow.svelte
@@ -43,7 +43,8 @@
 </div>
 
 <style>
-  .vc-tag-row { display: flex; align-items: center; min-height: 28px; padding: 0 16px; }
+  /* #385 — desktop fallback preserves the 28px min-height; coarse → 44px. */
+  .vc-tag-row { display: flex; align-items: center; min-height: var(--vc-hit-target, 28px); padding: 0 16px; }
   .vc-tag-row--child { padding-left: 32px; }
   .vc-tag-row:hover { background: var(--color-accent-bg); }
   .vc-tag-chevron, .vc-tag-chevron-spacer { width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; color: var(--color-text-muted); cursor: pointer; transition: transform 120ms ease; }

--- a/src/components/Welcome/FileListRow.svelte
+++ b/src/components/Welcome/FileListRow.svelte
@@ -25,7 +25,8 @@
   .vc-file-row {
     display: block;
     width: 100%;
-    min-height: 32px;
+    /* #385 — desktop fallback preserves the 32px min-height; coarse → 44px. */
+    min-height: var(--vc-hit-target, 32px);
     padding: 8px 16px;
     background: transparent;
     border: none;

--- a/src/components/Welcome/RecentVaultRow.svelte
+++ b/src/components/Welcome/RecentVaultRow.svelte
@@ -32,7 +32,8 @@
     align-items: center;
     gap: 8px;
     width: 100%;
-    min-height: 32px;
+    /* #385 — desktop fallback preserves the 32px min-height; coarse → 44px. */
+    min-height: var(--vc-hit-target, 32px);
     padding: 8px 16px;
     background: transparent;
     border: none;

--- a/src/components/common/ContextMenu.svelte
+++ b/src/components/common/ContextMenu.svelte
@@ -105,6 +105,11 @@
     border: none;
     cursor: pointer;
     color: var(--color-text);
+    /* #385 — desktop: token undefined → fallback `auto` → no min-height
+       (current padding-only ~30px preserved). Coarse: 44px. Block display
+       is intentionally kept; the coarse-pointer text simply sits at the
+       top of the taller hit area until #386 polishes the layout. */
+    min-height: var(--vc-hit-target, auto);
   }
 
   :global(.vc-context-item:hover),

--- a/src/store/__tests__/viewportStore.test.ts
+++ b/src/store/__tests__/viewportStore.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { get } from "svelte/store";
+
+import { createViewportStore } from "../viewportStore";
+
+type MqlListener = (ev: MediaQueryListEvent) => void;
+
+interface FakeMql {
+  media: string;
+  matches: boolean;
+  listeners: Set<MqlListener>;
+  addEventListener: (type: "change", l: MqlListener) => void;
+  removeEventListener: (type: "change", l: MqlListener) => void;
+  // legacy (unused by our store but populated for compat)
+  addListener: (l: MqlListener) => void;
+  removeListener: (l: MqlListener) => void;
+  onchange: null;
+  dispatchEvent: () => boolean;
+}
+
+interface MqlHarness {
+  matchMedia: (q: string) => FakeMql;
+  mqls: Map<string, FakeMql>;
+  /** Flip `matches` on the MQL for `query` and dispatch `change`. */
+  set: (query: string, matches: boolean) => void;
+}
+
+function makeMqlHarness(initial: Record<string, boolean>): MqlHarness {
+  const mqls = new Map<string, FakeMql>();
+
+  function getOrCreate(query: string): FakeMql {
+    const existing = mqls.get(query);
+    if (existing) return existing;
+    const mql: FakeMql = {
+      media: query,
+      matches: initial[query] ?? false,
+      listeners: new Set(),
+      addEventListener: (type, l) => {
+        if (type === "change") mql.listeners.add(l);
+      },
+      removeEventListener: (type, l) => {
+        if (type === "change") mql.listeners.delete(l);
+      },
+      addListener: (l) => mql.listeners.add(l),
+      removeListener: (l) => mql.listeners.delete(l),
+      onchange: null,
+      dispatchEvent: () => false,
+    };
+    mqls.set(query, mql);
+    return mql;
+  }
+
+  return {
+    matchMedia: getOrCreate,
+    mqls,
+    set(query, matches) {
+      const mql = getOrCreate(query);
+      mql.matches = matches;
+      const ev = { matches, media: query } as MediaQueryListEvent;
+      for (const l of mql.listeners) l(ev);
+    },
+  };
+}
+
+const Q_MOBILE = "(max-width: 699px)";
+const Q_TABLET = "(max-width: 1023px)";
+const Q_COARSE = "(pointer: coarse)";
+
+describe("viewportStore", () => {
+  let harness: MqlHarness;
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerWidth = window.innerWidth;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  function installHarness(initial: Record<string, boolean>, width: number) {
+    harness = makeMqlHarness(initial);
+    vi.stubGlobal("matchMedia", harness.matchMedia);
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: harness.matchMedia,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width,
+    });
+  }
+
+  it("reports desktop mode when neither width query matches", () => {
+    installHarness({ [Q_MOBILE]: false, [Q_TABLET]: false, [Q_COARSE]: false }, 1280);
+    const store = createViewportStore();
+    const state = get(store);
+    expect(state.mode).toBe("desktop");
+    expect(state.isCoarsePointer).toBe(false);
+    expect(state.width).toBe(1280);
+  });
+
+  it("reports tablet mode when only the tablet query matches", () => {
+    installHarness({ [Q_MOBILE]: false, [Q_TABLET]: true, [Q_COARSE]: false }, 900);
+    const store = createViewportStore();
+    expect(get(store).mode).toBe("tablet");
+  });
+
+  it("reports mobile mode when both width queries match", () => {
+    installHarness({ [Q_MOBILE]: true, [Q_TABLET]: true, [Q_COARSE]: true }, 400);
+    const store = createViewportStore();
+    const state = get(store);
+    expect(state.mode).toBe("mobile");
+    expect(state.isCoarsePointer).toBe(true);
+  });
+
+  it("transitions desktop → tablet → mobile when width queries flip", () => {
+    installHarness({ [Q_MOBILE]: false, [Q_TABLET]: false, [Q_COARSE]: false }, 1280);
+    const store = createViewportStore();
+    expect(get(store).mode).toBe("desktop");
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 900 });
+    harness.set(Q_TABLET, true);
+    expect(get(store).mode).toBe("tablet");
+    expect(get(store).width).toBe(900);
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 400 });
+    harness.set(Q_MOBILE, true);
+    expect(get(store).mode).toBe("mobile");
+    expect(get(store).width).toBe(400);
+  });
+
+  it("toggles isCoarsePointer independent of width", () => {
+    installHarness({ [Q_MOBILE]: false, [Q_TABLET]: false, [Q_COARSE]: false }, 1280);
+    const store = createViewportStore();
+    expect(get(store).isCoarsePointer).toBe(false);
+
+    harness.set(Q_COARSE, true);
+    expect(get(store).isCoarsePointer).toBe(true);
+    expect(get(store).mode).toBe("desktop");
+    expect(get(store).width).toBe(1280);
+  });
+
+  it("delivers updates to multiple subscribers", () => {
+    installHarness({ [Q_MOBILE]: false, [Q_TABLET]: false, [Q_COARSE]: false }, 1280);
+    const store = createViewportStore();
+    const seenA: string[] = [];
+    const seenB: string[] = [];
+    const unsubA = store.subscribe((s) => seenA.push(s.mode));
+    const unsubB = store.subscribe((s) => seenB.push(s.mode));
+
+    harness.set(Q_TABLET, true);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+    harness.set(Q_TABLET, true); // re-fire to trigger width refresh
+
+    expect(seenA[seenA.length - 1]).toBe("tablet");
+    expect(seenB[seenB.length - 1]).toBe("tablet");
+    unsubA();
+    unsubB();
+  });
+
+  it("returns a stable default when window is undefined (SSR / non-browser)", () => {
+    vi.stubGlobal("window", undefined);
+    const store = createViewportStore();
+    const state = get(store);
+    expect(state.mode).toBe("desktop");
+    expect(state.isCoarsePointer).toBe(false);
+    expect(typeof state.width).toBe("number");
+  });
+});

--- a/src/store/viewportStore.ts
+++ b/src/store/viewportStore.ts
@@ -1,0 +1,70 @@
+/**
+ * viewportStore — exposes the current viewport mode and pointer-coarseness so
+ * mobile-aware components can branch without sprinkling matchMedia calls.
+ *
+ * Driven by three matchMedia listeners — width queries gate layout collapse,
+ * `(pointer: coarse)` gates hit-target bumps. The two are intentionally
+ * independent: a desktop with a touchscreen reports coarse pointer at full
+ * width, and that path must still apply 44px hit targets without collapsing
+ * the layout.
+ *
+ * Pattern: classic writable factory (D-06/RC-01 — see `themeStore.ts`).
+ *
+ * Exports a singleton `viewportStore` for app code and `createViewportStore`
+ * for tests so each test gets its own subscription set.
+ */
+import { writable, type Readable } from "svelte/store";
+
+export type ViewportMode = "desktop" | "tablet" | "mobile";
+
+export interface ViewportState {
+  mode: ViewportMode;
+  isCoarsePointer: boolean;
+  width: number;
+}
+
+const Q_MOBILE = "(max-width: 699px)";
+const Q_TABLET = "(max-width: 1023px)";
+const Q_COARSE = "(pointer: coarse)";
+
+const SSR_DEFAULT: ViewportState = {
+  mode: "desktop",
+  isCoarsePointer: false,
+  width: 1280,
+};
+
+function modeFor(mobile: boolean, tablet: boolean): ViewportMode {
+  if (mobile) return "mobile";
+  if (tablet) return "tablet";
+  return "desktop";
+}
+
+export function createViewportStore(): Readable<ViewportState> {
+  const _store = writable<ViewportState>(SSR_DEFAULT);
+
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return { subscribe: _store.subscribe };
+  }
+
+  const mqlMobile = window.matchMedia(Q_MOBILE);
+  const mqlTablet = window.matchMedia(Q_TABLET);
+  const mqlCoarse = window.matchMedia(Q_COARSE);
+
+  function read(): ViewportState {
+    return {
+      mode: modeFor(mqlMobile.matches, mqlTablet.matches),
+      isCoarsePointer: mqlCoarse.matches,
+      width: window.innerWidth,
+    };
+  }
+
+  _store.set(read());
+  const onChange = () => _store.set(read());
+  mqlMobile.addEventListener("change", onChange);
+  mqlTablet.addEventListener("change", onChange);
+  mqlCoarse.addEventListener("change", onChange);
+
+  return { subscribe: _store.subscribe };
+}
+
+export const viewportStore = createViewportStore();

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -29,6 +29,17 @@
   /* #380 — tab-morph transition duration. User snippets can override to 0ms
      to disable the effect entirely without touching the JS gate. */
   --vc-tab-switch-duration: 240ms;
+
+}
+
+/* #385 — touch hit-target token. The token is intentionally LEFT UNDEFINED
+   on desktop so `var(--vc-hit-target, <px>)` falls back to the literal
+   desktop value at every callsite (byte-identical desktop). Under coarse
+   pointer the token resolves to 44px and overrides the fallback. */
+@media (pointer: coarse) {
+  :root {
+    --vc-hit-target: 44px;
+  }
 }
 
 /* Light theme (explicit) — same values as the bare :root defaults. Allows the HTML

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -6,3 +6,24 @@ export function withFakeTimers() {
   vi.useFakeTimers();
   return () => vi.useRealTimers();
 }
+
+// jsdom does not implement matchMedia. Provide a controllable stub so tests
+// that touch viewport-aware code (viewportStore, tabMorph's
+// prefers-reduced-motion check, etc.) don't crash. Suites that need specific
+// matches/listener behavior override via vi.stubGlobal("matchMedia", ...).
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList,
+  });
+}


### PR DESCRIPTION
Foundation PR for mobile/tablet support — desktop must remain byte-identical. Refs #385, #74.

## Summary

- **New `src/store/viewportStore.ts`** — Svelte readable store `{ mode, isCoarsePointer, width }` driven by three `matchMedia` listeners: `(max-width: 699px)`, `(max-width: 1023px)`, `(pointer: coarse)`. Layout collapse gates on `mode`; hit-target bumps gate on `isCoarsePointer` (kept independent so a desktop with a touchscreen still gets 44px targets without collapsing the layout). Pattern mirrors `themeStore.ts` (classic writable factory, D-06/RC-01).
- **New `--vc-hit-target` CSS token** — intentionally **left undefined on desktop** so `min-height: var(--vc-hit-target, <px>)` falls back to the literal desktop value at every callsite. Under `@media (pointer: coarse)`, `:root` sets it to `44px` and the fallback is overridden.
- **Hit-target sweep** — TreeRow, Tab/TabBar, sidebar toggle, tree-kebab (also forced visible on `@media (hover: none)`), context-menu items, confirm buttons, right-sidebar tabs, breadcrumbs + mode toggle, settings controls (close, theme radio, vault switch, generic btn), properties panel rows + add button + chips, tag row, file-list row, recent-vault row. Each control adds `min-height: var(--vc-hit-target, <existing-px>)` (and `min-width` on icon-square buttons) **alongside** the existing `height` declaration. On desktop the var is undefined → fallback engages → exact same value as the existing `height` → byte-identical. On coarse, `min-height` becomes 44px and overrides `height` per CSS spec.
- **Boy Scout** — added a global controllable `matchMedia` stub in `src/test/setup.ts` (jsdom does not implement it). Existing per-suite `vi.stubGlobal('matchMedia', …)` overrides keep working.

## Why undefined-token-with-fallback

An earlier draft set `--vc-hit-target: auto` on `:root` and relied on `auto` being invalid for `min-height` to engage the `var()` fallback. That was wrong — `min-height: auto` is the property's initial value (valid). Leaving the custom property *undefined* on desktop is the only approach that guarantees the fallback engages.

## Out of scope (deferred per ticket)

- `@media (hover: hover)` guards on `:hover` selectors (cosmetic — ticket explicitly allows defer; will land in #386).
- Topbar / layout adjustments needed to host the larger toggle button on touch — belongs to #386.
- The `vc-context-item` flex-vs-block decision: kept `display: block` to avoid even cosmetic desktop change; on coarse the menu text sits at the top of a 44px row. Polish in #386.

## Test plan

- [x] `pnpm vitest run src/store/__tests__/viewportStore.test.ts` — 7/7 pass (mode transitions, isCoarsePointer independence, multiple subscribers, SSR fallback).
- [x] `pnpm vitest run` for every test that touches the swept components (Sidebar, Tabs, ContextMenu, Editor, Tags, modal theming) — 124/124 pass.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm build` — succeeds.
- [x] `svelte-check` — no new errors (one pre-existing CanvasView error on `main` is unaffected).
- [ ] **Visual desktop verification via `pnpm dev` was NOT run from this environment** — the change is mathematically byte-identical on desktop (token undefined → fallback engages literal px), but a manual visual pass before merge is recommended. Asking for it as part of UAT.
- [ ] Manual coarse-pointer verification (Chromium DevTools: emulate "Touch") — recommended in UAT.

Refs #385, #74.