### PR TITLE
feat(mobile): #74.3 long-press → context-menu bridge (#387)

### DIFF
--- a/src/components/Bookmarks/BookmarksPanel.svelte
+++ b/src/components/Bookmarks/BookmarksPanel.svelte
@@ -9,6 +9,7 @@
   import { bookmarksStore } from "../../store/bookmarksStore";
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore } from "../../store/tabStore";
+  import { longPress, type LongPressDetail } from "../../lib/actions/longPress";
 
   const BOOKMARKS_COLLAPSED_KEY = "vaultcore-bookmarks-panel-collapsed";
 
@@ -70,6 +71,10 @@
     e.preventDefault();
     e.stopPropagation();
     contextMenu = { path: relPath, x: e.clientX, y: e.clientY };
+  }
+
+  function onRowLongPress(d: LongPressDetail, relPath: string): void {
+    contextMenu = { path: relPath, x: d.clientX, y: d.clientY };
   }
 
   function closeContextMenu(): void {
@@ -176,6 +181,7 @@
           ondragover={(e) => handleDragOver(e, idx)}
           ondrop={(e) => void handleDrop(e, idx)}
           oncontextmenu={(e) => openContextMenu(e, relPath)}
+          use:longPress={{ onLongPress: (d) => onRowLongPress(d, relPath) }}
         >
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <button

--- a/src/components/Bookmarks/__tests__/BookmarksPanel.longPress.test.ts
+++ b/src/components/Bookmarks/__tests__/BookmarksPanel.longPress.test.ts
@@ -1,0 +1,95 @@
+// BookmarksPanel long-press → context menu (#387). Touch parity for the
+// existing right-click context menu on bookmark rows.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  loadBookmarks: vi.fn().mockResolvedValue(["one.md", "two.md"]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import BookmarksPanel from "../BookmarksPanel.svelte";
+
+const VAULT = "/tmp/test-vault";
+
+function pointerEvent(
+  type: string,
+  init: { clientX?: number; clientY?: number; pointerType?: string } = {},
+): Event {
+  const ev = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  });
+  Object.defineProperty(ev, "pointerId", { value: 1, configurable: true });
+  Object.defineProperty(ev, "pointerType", { value: init.pointerType ?? "touch", configurable: true });
+  return ev;
+}
+
+describe("BookmarksPanel long-press → context menu (#387)", () => {
+  beforeEach(async () => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({
+      currentPath: VAULT,
+      fileList: ["one.md", "two.md"],
+      fileCount: 2,
+    });
+    await bookmarksStore.load(VAULT);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens the context menu after a 500ms touch hold on a bookmark row", async () => {
+    const { container } = render(BookmarksPanel);
+    await tick();
+
+    const rows = container.querySelectorAll<HTMLElement>(".vc-bookmark-row");
+    expect(rows.length).toBeGreaterThan(0);
+
+    rows[0].dispatchEvent(pointerEvent("pointerdown", { clientX: 80, clientY: 50 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const menu = container.querySelector(".vc-bookmark-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+    expect(menu.style.top).toBe("50px");
+    expect(menu.style.left).toBe("80px");
+  });
+
+  it("a second long-press on a different row replaces the menu state", async () => {
+    const { container } = render(BookmarksPanel);
+    await tick();
+
+    const rows = container.querySelectorAll<HTMLElement>(".vc-bookmark-row");
+    rows[0].dispatchEvent(pointerEvent("pointerdown", { clientX: 10, clientY: 10 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    rows[1].dispatchEvent(pointerEvent("pointerdown", { clientX: 200, clientY: 100 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const menu = container.querySelector(".vc-bookmark-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+    expect(menu.style.left).toBe("200px");
+    expect(menu.style.top).toBe("100px");
+  });
+
+  it("desktop right-click contextmenu still opens the menu (coexistence)", async () => {
+    const { container } = render(BookmarksPanel);
+    await tick();
+    const rows = container.querySelectorAll<HTMLElement>(".vc-bookmark-row");
+    await fireEvent.contextMenu(rows[0], { clientX: 50, clientY: 30 });
+    await tick();
+    const menu = container.querySelector(".vc-bookmark-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+  });
+});

--- a/src/components/Bookmarks/__tests__/BookmarksPanel.longPress.test.ts
+++ b/src/components/Bookmarks/__tests__/BookmarksPanel.longPress.test.ts
@@ -53,8 +53,9 @@ describe("BookmarksPanel long-press → context menu (#387)", () => {
 
     const rows = container.querySelectorAll<HTMLElement>(".vc-bookmark-row");
     expect(rows.length).toBeGreaterThan(0);
+    const first = rows[0]!;
 
-    rows[0].dispatchEvent(pointerEvent("pointerdown", { clientX: 80, clientY: 50 }));
+    first.dispatchEvent(pointerEvent("pointerdown", { clientX: 80, clientY: 50 }));
     vi.advanceTimersByTime(500);
     await tick();
 
@@ -69,11 +70,12 @@ describe("BookmarksPanel long-press → context menu (#387)", () => {
     await tick();
 
     const rows = container.querySelectorAll<HTMLElement>(".vc-bookmark-row");
-    rows[0].dispatchEvent(pointerEvent("pointerdown", { clientX: 10, clientY: 10 }));
+    const [first, second] = [rows[0]!, rows[1]!];
+    first.dispatchEvent(pointerEvent("pointerdown", { clientX: 10, clientY: 10 }));
     vi.advanceTimersByTime(500);
     await tick();
 
-    rows[1].dispatchEvent(pointerEvent("pointerdown", { clientX: 200, clientY: 100 }));
+    second.dispatchEvent(pointerEvent("pointerdown", { clientX: 200, clientY: 100 }));
     vi.advanceTimersByTime(500);
     await tick();
 
@@ -87,7 +89,7 @@ describe("BookmarksPanel long-press → context menu (#387)", () => {
     const { container } = render(BookmarksPanel);
     await tick();
     const rows = container.querySelectorAll<HTMLElement>(".vc-bookmark-row");
-    await fireEvent.contextMenu(rows[0], { clientX: 50, clientY: 30 });
+    await fireEvent.contextMenu(rows[0]!, { clientX: 50, clientY: 30 });
     await tick();
     const menu = container.querySelector(".vc-bookmark-menu") as HTMLElement;
     expect(menu).toBeTruthy();

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -24,6 +24,7 @@
   import { insertTemplateExpression } from "./editorContextMenu";
   import TemplateExpressionBuilder from "./TemplateExpressionBuilder.svelte";
   import ContextMenu from "../common/ContextMenu.svelte";
+  import { longPress, type LongPressDetail } from "../../lib/actions/longPress";
   import { parseFrontmatter } from "../../lib/frontmatterIO";
   import EditorGraphBackground from "./EditorGraphBackground.svelte";
   import CountStatusBar from "./CountStatusBar.svelte";
@@ -96,6 +97,19 @@
     contextView = view;
     contextMenuPos = { x, y };
     contextMenuOpen = true;
+  }
+
+  // #387 — touch long-press inside the editor surface forwards to the same
+  // custom context menu the right-click path opens. Resolve this pane's
+  // active EditorView lazily so the long-press lands on whichever tab is
+  // active in this pane at fire-time. No-op when the pane is empty or the
+  // active tab is a non-editor viewer (image, canvas, graph, unsupported).
+  function onEditorLongPress(d: LongPressDetail) {
+    const id = paneActiveTabId;
+    if (!id) return;
+    const view = viewMap.get(id);
+    if (!view) return;
+    handleContextMenuRequest(view, d.clientX, d.clientY);
   }
 
   function closeContextMenu() {
@@ -1096,7 +1110,11 @@
   />
 
   <!-- Editor content area -->
-  <div class="vc-editor-content" class:has-graph-bg={showGraphBg}>
+  <div
+    class="vc-editor-content"
+    class:has-graph-bg={showGraphBg}
+    use:longPress={{ onLongPress: onEditorLongPress }}
+  >
     {#if paneTabs.length === 0}
       <div class="vc-editor-empty">
         <p class="vc-editor-empty-heading">No file open</p>

--- a/src/components/Editor/__tests__/EditorPane.longPress.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.longPress.test.ts
@@ -1,0 +1,148 @@
+// EditorPane long-press → context menu (#387). Touch parity for the existing
+// right-click context-menu path (#301), implemented by wiring `use:longPress`
+// on `.vc-editor-content`. The synthetic contextmenu that some platforms
+// dispatch after a touch hold must NOT also bubble through CM6's
+// `editorContextMenuExtension`, which would surface the menu twice.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const { readFile } = vi.hoisted(() => ({ readFile: vi.fn() }));
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile,
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  createFile: vi.fn().mockResolvedValue(""),
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  // @ts-ignore
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+vi.mock("../../Graph/graphRender", () => ({
+  mountGraph: vi.fn(),
+  updateGraph: vi.fn(),
+  destroyGraph: vi.fn(),
+  DEFAULT_FORCE_SETTINGS: {},
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import EditorPane from "../EditorPane.svelte";
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+function pointerEvent(
+  type: string,
+  init: { clientX?: number; clientY?: number; pointerType?: string } = {},
+): Event {
+  const ev = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  });
+  Object.defineProperty(ev, "pointerId", { value: 1, configurable: true });
+  Object.defineProperty(ev, "pointerType", { value: init.pointerType ?? "touch", configurable: true });
+  return ev;
+}
+
+describe("EditorPane long-press → context menu (#387)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    readFile.mockReset().mockResolvedValue("hello world");
+    vaultStore.setReady({ currentPath: "/vault", fileList: ["note.md"], fileCount: 1 });
+  });
+
+  it("opens the custom context menu after a 500ms touch hold on .vc-editor-content", async () => {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    tabStore.openTab("/vault/note.md");
+    await flushAsync();
+
+    const surface = container.querySelector(".vc-editor-content") as HTMLElement;
+    expect(surface).toBeTruthy();
+    expect(container.querySelector(".vc-context-menu")).toBeNull();
+
+    surface.dispatchEvent(pointerEvent("pointerdown", { clientX: 120, clientY: 80 }));
+    // Real timers — the action's setTimeout(500) drives this. 600ms gives a
+    // safe margin without making the test sluggish.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    await tick();
+
+    const menu = container.querySelector(".vc-context-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+    expect(menu.style.top).toBe("80px");
+    expect(menu.style.left).toBe("120px");
+  });
+
+  it("the synthetic contextmenu after a long-press fire is suppressed (no double-open via CM6)", async () => {
+    const { container } = render(EditorPane, { props: { paneId: "left" } });
+    await tick();
+    tabStore.openTab("/vault/note.md");
+    await flushAsync();
+
+    const surface = container.querySelector(".vc-editor-content") as HTMLElement;
+    surface.dispatchEvent(pointerEvent("pointerdown", { clientX: 50, clientY: 50 }));
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    await tick();
+
+    const menusAfterFire = container.querySelectorAll(".vc-context-menu");
+    expect(menusAfterFire.length).toBe(1);
+
+    // A bubble-phase contextmenu spy registered AFTER the suppressor was
+    // armed should NOT receive the synthetic event — capture-phase
+    // stopImmediatePropagation in longPress eats it before bubble.
+    const bubbleSpy = vi.fn();
+    document.addEventListener("contextmenu", bubbleSpy);
+    const synth = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 50,
+      clientY: 50,
+    });
+    document.dispatchEvent(synth);
+    document.removeEventListener("contextmenu", bubbleSpy);
+
+    expect(bubbleSpy).not.toHaveBeenCalled();
+    // Menu still showing — open state was set by the longPress callback
+    // and the suppressor doesn't toggle it back off.
+    expect(container.querySelectorAll(".vc-context-menu").length).toBe(1);
+  });
+});

--- a/src/components/Editor/__tests__/EditorPane.longPress.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.longPress.test.ts
@@ -3,7 +3,7 @@
 // on `.vc-editor-content`. The synthetic contextmenu that some platforms
 // dispatch after a touch hold must NOT also bubble through CM6's
 // `editorContextMenuExtension`, which would surface the menu twice.
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
 
@@ -88,6 +88,13 @@ describe("EditorPane long-press → context menu (#387)", () => {
     vaultStore.reset();
     readFile.mockReset().mockResolvedValue("hello world");
     vaultStore.setReady({ currentPath: "/vault", fileList: ["note.md"], fileCount: 1 });
+    // Match the rest of the suite: fake timers everywhere. Mount uses
+    // microtask-only awaits (flushAsync below) so fakes are safe end-to-end.
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("opens the custom context menu after a 500ms touch hold on .vc-editor-content", async () => {
@@ -101,9 +108,7 @@ describe("EditorPane long-press → context menu (#387)", () => {
     expect(container.querySelector(".vc-context-menu")).toBeNull();
 
     surface.dispatchEvent(pointerEvent("pointerdown", { clientX: 120, clientY: 80 }));
-    // Real timers — the action's setTimeout(500) drives this. 600ms gives a
-    // safe margin without making the test sluggish.
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    vi.advanceTimersByTime(500);
     await tick();
 
     const menu = container.querySelector(".vc-context-menu") as HTMLElement;
@@ -120,7 +125,7 @@ describe("EditorPane long-press → context menu (#387)", () => {
 
     const surface = container.querySelector(".vc-editor-content") as HTMLElement;
     surface.dispatchEvent(pointerEvent("pointerdown", { clientX: 50, clientY: 50 }));
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    vi.advanceTimersByTime(500);
     await tick();
 
     const menusAfterFire = container.querySelectorAll(".vc-context-menu");

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -54,6 +54,7 @@
   import TagsPanel from "../Tags/TagsPanel.svelte";
   import BookmarksPanel from "../Bookmarks/BookmarksPanel.svelte";
   import { bookmarksStore } from "../../store/bookmarksStore";
+  import { longPress, type LongPressDetail } from "../../lib/actions/longPress";
   import {
     flattenTree,
     ancestorRelPaths,
@@ -709,19 +710,42 @@
   }
 
   // ─── Header actions ────────────────────────────────────────────────────────
-  async function handleNewFile() {
+  // Optional `targetFolder` lets the empty-tree-area long-press (#387) skip
+  // the selection-based fallback and create the note directly under the
+  // vault root. Existing call sites pass no arg → behavior unchanged.
+  async function handleNewFile(targetFolder?: string) {
     newMenuOpen = false;
     const vaultPath = $vaultStore.currentPath;
     if (!vaultPath) return;
-    const targetFolder = getSelectedFolder() ?? vaultPath;
+    const folder = targetFolder ?? getSelectedFolder() ?? vaultPath;
     try {
-      await createFile(targetFolder, "");
-      if (targetFolder === vaultPath) await loadRoot();
-      else await refreshFolder(targetFolder);
+      await createFile(folder, "");
+      if (folder === vaultPath) await loadRoot();
+      else await refreshFolder(folder);
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
     }
+  }
+
+  // Empty-tree-area long-press → vault-root "New note here" menu (#387).
+  let emptyMenuOpen = $state(false);
+  let emptyMenuPos = $state<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  function onTreeLongPress(d: LongPressDetail) {
+    emptyMenuPos = { x: d.clientX, y: d.clientY };
+    emptyMenuOpen = true;
+  }
+
+  async function handleEmptyAreaNewNote() {
+    emptyMenuOpen = false;
+    const vaultPath = $vaultStore.currentPath;
+    if (!vaultPath) return;
+    await handleNewFile(vaultPath);
+  }
+
+  function closeEmptyMenu() {
+    emptyMenuOpen = false;
   }
 
   async function handleNewCanvas() {
@@ -906,6 +930,7 @@
     aria-label="Vault file tree"
     bind:this={scrollerEl}
     onscroll={onScroll}
+    use:longPress={{ onLongPress: onTreeLongPress, strict: true }}
   >
     {#if loading}
       <p class="vc-sidebar-status">Loading...</p>
@@ -985,6 +1010,29 @@
       </div>
     </div>
   {/if}
+
+  <!-- #387 empty-tree-area long-press menu. Stays mounted for the
+       Files tab; absent in the Tags tab. -->
+  {#if emptyMenuOpen}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+      class="vc-sidebar-empty-overlay"
+      onclick={closeEmptyMenu}
+      role="presentation"
+    ></div>
+    <div
+      class="vc-sidebar-empty-menu"
+      role="menu"
+      style="top: {emptyMenuPos.y}px; left: {emptyMenuPos.x}px"
+    >
+      <button
+        type="button"
+        class="vc-sidebar-empty-menu-item"
+        role="menuitem"
+        onclick={() => void handleEmptyAreaNewNote()}
+      >New note here</button>
+    </div>
+  {/if}
   {/if}
 </aside>
 
@@ -995,6 +1043,39 @@
      dialog — Svelte's scoped-style hashing keeps the two copies isolated. */
   .vc-confirm-overlay {
     z-index: 199;
+  }
+
+  /* #387 empty-tree-area long-press menu — same visual language as the
+     row context menu so the affordance feels consistent across surfaces. */
+  .vc-sidebar-empty-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 399;
+  }
+  .vc-sidebar-empty-menu {
+    position: fixed;
+    z-index: 400;
+    min-width: 160px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+    padding: 4px 0;
+  }
+  .vc-sidebar-empty-menu-item {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    font-size: 13px;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text);
+    min-height: var(--vc-hit-target, auto);
+  }
+  .vc-sidebar-empty-menu-item:hover {
+    background: var(--color-accent-bg);
   }
 
   .vc-confirm-dialog {

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -712,12 +712,15 @@
   // ─── Header actions ────────────────────────────────────────────────────────
   // Optional `targetFolder` lets the empty-tree-area long-press (#387) skip
   // the selection-based fallback and create the note directly under the
-  // vault root. Existing call sites pass no arg → behavior unchanged.
-  async function handleNewFile(targetFolder?: string) {
+  // vault root. Type-guarded so the existing `onclick={handleNewFile}` wiring
+  // — which passes the MouseEvent as the first arg — keeps treating it as
+  // "no target", same as before.
+  async function handleNewFile(targetFolder?: string | unknown) {
     newMenuOpen = false;
     const vaultPath = $vaultStore.currentPath;
     if (!vaultPath) return;
-    const folder = targetFolder ?? getSelectedFolder() ?? vaultPath;
+    const explicit = typeof targetFolder === "string" ? targetFolder : undefined;
+    const folder = explicit ?? getSelectedFolder() ?? vaultPath;
     try {
       await createFile(folder, "");
       if (folder === vaultPath) await loadRoot();

--- a/src/components/Sidebar/TreeRow.svelte
+++ b/src/components/Sidebar/TreeRow.svelte
@@ -21,6 +21,7 @@
     Lock,
     LockOpen,
   } from "lucide-svelte";
+  import { get } from "svelte/store";
   import {
     createFile,
     createFolder,
@@ -35,6 +36,7 @@
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import InlineRename from "./InlineRename.svelte";
   import ContextMenu from "../common/ContextMenu.svelte";
+  import { longPress, type LongPressDetail } from "../../lib/actions/longPress";
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore } from "../../store/tabStore";
   import { resolvedLinksStore } from "../../store/resolvedLinksStore";
@@ -119,15 +121,6 @@
   let isDragSource = $state(false);
   let isDragTarget = $state(false);
 
-  function getVaultRoot(): string | null {
-    let v: string | null = null;
-    const u = vaultStore.subscribe((s) => {
-      v = s.currentPath;
-    });
-    u();
-    return v;
-  }
-
   function toRelPath(absPath: string, vaultRoot: string): string {
     return absPath.startsWith(vaultRoot + "/")
       ? absPath.slice(vaultRoot.length + 1)
@@ -166,7 +159,7 @@
       //      a second click to re-open it.
       if (isLocked) {
         openUnlockModal(row.path, row.name, async () => {
-          const parent = parentOf(row.path) ?? getVaultRoot();
+          const parent = parentOf(row.path) ?? get(vaultStore).currentPath;
           if (parent) await onRefreshFolder(parent);
           await onEnsureExpanded(row);
         });
@@ -223,7 +216,7 @@
 
   async function toggleBookmark() {
     closeContextMenu();
-    const vault = getVaultRoot();
+    const vault = get(vaultStore).currentPath;
     if (!vault || row.isDir) return;
     const rel = toRelPath(row.path, vault);
     await bookmarksStore.toggle(rel, vault);
@@ -238,7 +231,7 @@
     // captured at component construction — calling it from a destroyed
     // component is fine because Sidebar (the receiver) is always mounted.
     setRenaming(false);
-    const vault = getVaultRoot();
+    const vault = get(vaultStore).currentPath;
     const oldRelPath = vault ? toRelPath(row.path, vault) : row.path;
     const newRelPath = vault ? toRelPath(newPath, vault) : newPath;
     if (vault) {
@@ -271,12 +264,8 @@
     showDeleteConfirm = false;
     try {
       await deleteFile(row.path);
-      // Refresh the containing folder so the flat list updates.
-      const vault = getVaultRoot();
-      const parentDir = vault && row.path.startsWith(vault + "/")
-        ? parentOf(row.path)
-        : parentOf(row.path);
-      await onRefreshFolder(parentDir ?? vault ?? "");
+      const vault = get(vaultStore).currentPath;
+      await onRefreshFolder(parentOf(row.path) ?? vault ?? "");
     } catch (e) {
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
@@ -298,7 +287,7 @@
     return absPath.slice(0, lastSep);
   }
 
-  async function handleNewFileHere() {
+  async function handleNewNoteHere() {
     closeContextMenu();
     try {
       const newPath = await createFile(row.path, "");
@@ -309,6 +298,11 @@
       const ve = isVaultError(e) ? e : { kind: "Io" as const, message: String(e), data: null };
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
     }
+  }
+
+  function onLongPress(d: LongPressDetail) {
+    menuPos = { x: d.clientX, y: d.clientY };
+    showContextMenu = true;
   }
 
   async function handleNewCanvasHere() {
@@ -434,6 +428,7 @@
     style="padding-left: calc({row.depth} * 16px + 8px)"
     onclick={handleClick}
     oncontextmenu={handleRowContextMenu}
+    use:longPress={{ onLongPress }}
     role="button"
     tabindex="-1"
     title={row.path}
@@ -532,7 +527,7 @@
     {/if}
     <button class="vc-context-item vc-context-item--danger" onclick={openDeleteConfirm}>Move to Trash</button>
     {#if row.isDir}
-      <button class="vc-context-item" onclick={handleNewFileHere}>New file here</button>
+      <button class="vc-context-item" onclick={handleNewNoteHere}>New note here</button>
       <button class="vc-context-item" onclick={handleNewCanvasHere}>New canvas here</button>
       <button class="vc-context-item" onclick={handleNewFolderHere}>New folder here</button>
       <!-- #345: encryption actions. Three mutually-exclusive states. -->

--- a/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeContextMenu.test.ts
@@ -101,7 +101,7 @@ describe("TreeRow right-click context menu (#47, updated for #253)", () => {
     expect(getByText("Move to Trash")).toBeTruthy();
   });
 
-  it("contains New file / New folder entries for a directory", async () => {
+  it("contains New note / New folder entries for a directory", async () => {
     const dir = fileRow({
       name: "folder",
       path: `${VAULT}/folder`,
@@ -115,7 +115,7 @@ describe("TreeRow right-click context menu (#47, updated for #253)", () => {
     await fireEvent.contextMenu(row, { clientX: 10, clientY: 20 });
     await tick();
 
-    expect(getByText("New file here")).toBeTruthy();
+    expect(getByText("New note here")).toBeTruthy();
     expect(getByText("New folder here")).toBeTruthy();
   });
 });

--- a/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
+++ b/src/components/Sidebar/__tests__/TreeNodeCreateFile.test.ts
@@ -1,5 +1,5 @@
 // Originally the regression test for issue #50: creating a new file inside an
-// expanded folder via the "New file here" context-menu entry must keep the
+// expanded folder via the "New note here" context-menu entry must keep the
 // folder expanded and show the freshly created child row.
 //
 // With the #253 virtualization refactor, expansion and child-list ownership
@@ -7,7 +7,7 @@
 // expanded flag or children list — it delegates to `onToggleExpand` and
 // `onRefreshFolder` callbacks. This test was updated to verify the equivalent
 // contract at the TreeRow level:
-//   1. Clicking "New file here" calls createFile with the folder path and an
+//   1. Clicking "New note here" calls createFile with the folder path and an
 //      empty seed.
 //   2. It triggers the Sidebar to refresh the folder (so the new row appears
 //      after the next flatten).
@@ -95,7 +95,7 @@ describe("TreeRow 'New file here' on a folder (#50, updated for #253)", () => {
     await tick();
 
     const newFileItem = Array.from(container.querySelectorAll<HTMLButtonElement>(".vc-context-item"))
-      .find((b) => b.textContent?.trim() === "New file here");
+      .find((b) => b.textContent?.trim() === "New note here");
     expect(newFileItem).toBeTruthy();
     await fireEvent.click(newFileItem!);
 
@@ -121,7 +121,7 @@ describe("TreeRow 'New file here' on a folder (#50, updated for #253)", () => {
     await fireEvent.contextMenu(row, { clientX: 0, clientY: 0 });
     await tick();
     const newFileItem = Array.from(container.querySelectorAll<HTMLButtonElement>(".vc-context-item"))
-      .find((b) => b.textContent?.trim() === "New file here");
+      .find((b) => b.textContent?.trim() === "New note here");
     await fireEvent.click(newFileItem!);
 
     for (let i = 0; i < 10; i += 1) { await Promise.resolve(); await tick(); }

--- a/src/components/Sidebar/__tests__/TreeRow.longPress.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRow.longPress.test.ts
@@ -1,0 +1,153 @@
+// TreeRow long-press → context menu (#387). Asserts:
+//  1. File-row touch long-press opens the same custom menu the right-click
+//     path opens, with menuPos coming from the synthesized coords.
+//  2. Folder-row long-press shows the "New note here" entry.
+//  3. Movement past the tolerance cancels the hold.
+//  4. The existing right-click contextmenu path still works (coexistence
+//     regression guard).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  renameFile: vi.fn(),
+}));
+
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import TreeRow from "../TreeRow.svelte";
+import type { FlatRow } from "../../../lib/flattenTree";
+
+const VAULT = "/tmp/test-vault";
+
+function fileRow(overrides: Partial<FlatRow> = {}): FlatRow {
+  return {
+    path: `${VAULT}/note.md`,
+    relPath: "note.md",
+    name: "note.md",
+    depth: 0,
+    isDir: false,
+    isMd: true,
+    isSymlink: false,
+    expanded: false,
+    loading: false,
+    hasRenderedChildren: false,
+    childrenLoaded: false,
+    ...overrides,
+  };
+}
+
+function folderRow(overrides: Partial<FlatRow> = {}): FlatRow {
+  return fileRow({
+    name: "folder",
+    path: `${VAULT}/folder`,
+    relPath: "folder",
+    isDir: true,
+    isMd: false,
+    ...overrides,
+  });
+}
+
+function makeProps(row: FlatRow) {
+  return {
+    row,
+    selectedPath: null,
+    onSelect: vi.fn(),
+    onOpenFile: vi.fn(),
+    onToggleExpand: vi.fn(),
+    onEnsureExpanded: vi.fn(),
+    onRefreshFolder: vi.fn(),
+    onPathChanged: vi.fn(),
+    onRequestRenameCascade: vi.fn(),
+    onRequestMoveCascade: vi.fn(),
+  };
+}
+
+function pointerEvent(
+  type: string,
+  init: { clientX?: number; clientY?: number; pointerId?: number; pointerType?: string } = {},
+): Event {
+  const ev = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  });
+  Object.defineProperty(ev, "pointerId", { value: init.pointerId ?? 1, configurable: true });
+  Object.defineProperty(ev, "pointerType", { value: init.pointerType ?? "touch", configurable: true });
+  return ev;
+}
+
+describe("TreeRow long-press → context menu (#387)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: ["note.md"], fileCount: 1 });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens the custom menu after a 500ms touch hold on a file row", async () => {
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    expect(row).toBeTruthy();
+
+    expect(container.querySelector(".vc-context-menu")).toBeNull();
+
+    row.dispatchEvent(pointerEvent("pointerdown", { clientX: 70, clientY: 40 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const menu = container.querySelector(".vc-context-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+    expect(menu.style.top).toBe("40px");
+    expect(menu.style.left).toBe("70px");
+  });
+
+  it("folder row long-press shows the 'New note here' entry", async () => {
+    const { container, getByText } = render(TreeRow, { props: makeProps(folderRow()) });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    row.dispatchEvent(pointerEvent("pointerdown", { clientX: 10, clientY: 20 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+    expect(getByText("New note here")).toBeTruthy();
+  });
+
+  it("a >10px move during hold cancels — menu does NOT open", async () => {
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    row.dispatchEvent(pointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
+    document.dispatchEvent(pointerEvent("pointermove", { clientX: 20, clientY: 0 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+    expect(container.querySelector(".vc-context-menu")).toBeNull();
+  });
+
+  it("desktop right-click contextmenu path still works (coexistence)", async () => {
+    const { container } = render(TreeRow, { props: makeProps(fileRow()) });
+    await tick();
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    await fireEvent.contextMenu(row, { clientX: 100, clientY: 50 });
+    await tick();
+    const menu = container.querySelector(".vc-context-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+    expect(menu.style.top).toBe("50px");
+    expect(menu.style.left).toBe("100px");
+  });
+});

--- a/src/components/Sidebar/__tests__/TreeRow.newNoteHere.test.ts
+++ b/src/components/Sidebar/__tests__/TreeRow.newNoteHere.test.ts
@@ -1,0 +1,111 @@
+// "New note here" via folder long-press (#387). Mirrors TreeNodeCreateFile
+// for the touch path: folder long-press → click "New note here" → createFile
+// is called with the long-pressed folder, the folder is refreshed, and the
+// new note opens in a tab.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+  createFile: vi.fn().mockResolvedValue("/tmp/test-vault/folder/Untitled.md"),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  renameFile: vi.fn(),
+}));
+
+import { createFile } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import { tabStore } from "../../../store/tabStore";
+import TreeRow from "../TreeRow.svelte";
+import type { FlatRow } from "../../../lib/flattenTree";
+
+const VAULT = "/tmp/test-vault";
+
+function folderRow(): FlatRow {
+  return {
+    path: `${VAULT}/folder`,
+    relPath: "folder",
+    name: "folder",
+    depth: 0,
+    isDir: true,
+    isMd: false,
+    isSymlink: false,
+    expanded: false,
+    loading: false,
+    hasRenderedChildren: false,
+    childrenLoaded: false,
+  };
+}
+
+function pointerEvent(
+  type: string,
+  init: { clientX?: number; clientY?: number; pointerType?: string } = {},
+): Event {
+  const ev = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  });
+  Object.defineProperty(ev, "pointerId", { value: 1, configurable: true });
+  Object.defineProperty(ev, "pointerType", { value: init.pointerType ?? "touch", configurable: true });
+  return ev;
+}
+
+describe("TreeRow folder long-press → New note here (#387)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.useFakeTimers();
+    vi.mocked(createFile).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clicking 'New note here' calls createFile, refreshes folder, opens tab", async () => {
+    const onRefreshFolder = vi.fn();
+    const onEnsureExpanded = vi.fn();
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+    const { container, getByText } = render(TreeRow, {
+      props: {
+        row: folderRow(),
+        selectedPath: null,
+        onSelect: vi.fn(),
+        onOpenFile: vi.fn(),
+        onToggleExpand: vi.fn(),
+        onEnsureExpanded,
+        onRefreshFolder,
+        onPathChanged: vi.fn(),
+        onRequestRenameCascade: vi.fn(),
+        onRequestMoveCascade: vi.fn(),
+      },
+    });
+    await tick();
+
+    const row = container.querySelector(".vc-tree-row") as HTMLElement;
+    row.dispatchEvent(pointerEvent("pointerdown", { clientX: 5, clientY: 5 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const newNote = getByText("New note here");
+    await fireEvent.click(newNote);
+    // Async chain inside the handler — flush microtasks until createFile + tab open settle.
+    await vi.runAllTimersAsync();
+    await tick();
+
+    expect(createFile).toHaveBeenCalledWith(`${VAULT}/folder`, "");
+    expect(onRefreshFolder).toHaveBeenCalledWith(`${VAULT}/folder`);
+    expect(openTabSpy).toHaveBeenCalledWith("/tmp/test-vault/folder/Untitled.md");
+  });
+});

--- a/src/components/Sidebar/__tests__/sidebarEmptyAreaNewNote.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarEmptyAreaNewNote.test.ts
@@ -1,0 +1,114 @@
+// Empty-tree-area long-press → "New note here" → vault-root note (#387).
+// On the mobile profile, a long-press on the tree container itself (not on
+// any row) opens a single-item menu that creates a note in the vault root.
+// Strict-target filtering on the action ensures bubbling pointerdowns from
+// row descendants do NOT trigger the wrapper menu.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+  createFile: vi.fn().mockResolvedValue("/tmp/test-vault/Untitled.md"),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  moveFile: vi.fn(),
+  updateLinksAfterRename: vi.fn(),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  loadBookmarks: vi.fn().mockResolvedValue([]),
+  saveBookmarks: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn(),
+  renameFile: vi.fn(),
+}));
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { createFile } from "../../../ipc/commands";
+import { vaultStore } from "../../../store/vaultStore";
+import { bookmarksStore } from "../../../store/bookmarksStore";
+import Sidebar from "../Sidebar.svelte";
+
+const VAULT = "/tmp/test-vault";
+
+function pointerEvent(
+  type: string,
+  init: { clientX?: number; clientY?: number; pointerType?: string } = {},
+): Event {
+  const ev = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  });
+  Object.defineProperty(ev, "pointerId", { value: 1, configurable: true });
+  Object.defineProperty(ev, "pointerType", { value: init.pointerType ?? "touch", configurable: true });
+  return ev;
+}
+
+describe("Sidebar empty-tree-area long-press → New note here (#387)", () => {
+  beforeEach(() => {
+    vaultStore.reset();
+    bookmarksStore.reset();
+    vaultStore.setReady({ currentPath: VAULT, fileList: [], fileCount: 0 });
+    vi.useFakeTimers();
+    vi.mocked(createFile).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("long-press on the tree wrapper opens the empty-area menu", async () => {
+    const { container } = render(Sidebar, {
+      props: {
+        selectedPath: null,
+        onSelect: vi.fn(),
+        onOpenFile: vi.fn(),
+        onOpenContentSearch: vi.fn(),
+      },
+    });
+    await tick();
+
+    const tree = container.querySelector(".vc-sidebar-tree") as HTMLElement;
+    expect(tree).toBeTruthy();
+
+    // Direct dispatch on the tree → event.target === tree (strict mode passes).
+    tree.dispatchEvent(pointerEvent("pointerdown", { clientX: 50, clientY: 60 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const menu = container.querySelector(".vc-sidebar-empty-menu") as HTMLElement;
+    expect(menu).toBeTruthy();
+    expect(menu.textContent).toContain("New note here");
+  });
+
+  it("clicking the empty-area 'New note here' creates a note in the vault root", async () => {
+    const { container } = render(Sidebar, {
+      props: {
+        selectedPath: null,
+        onSelect: vi.fn(),
+        onOpenFile: vi.fn(),
+        onOpenContentSearch: vi.fn(),
+      },
+    });
+    await tick();
+
+    const tree = container.querySelector(".vc-sidebar-tree") as HTMLElement;
+    tree.dispatchEvent(pointerEvent("pointerdown", { clientX: 5, clientY: 5 }));
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const newNote = container.querySelector(
+      ".vc-sidebar-empty-menu button",
+    ) as HTMLButtonElement;
+    expect(newNote).toBeTruthy();
+    await fireEvent.click(newNote);
+    await vi.runAllTimersAsync();
+    await tick();
+
+    expect(createFile).toHaveBeenCalledWith(VAULT, "");
+  });
+});

--- a/src/lib/actions/__tests__/longPress.test.ts
+++ b/src/lib/actions/__tests__/longPress.test.ts
@@ -61,7 +61,7 @@ describe("longPress action (#387)", () => {
     vi.advanceTimersByTime(500);
     expect(fired).toHaveLength(1);
     expect(fired[0]).toMatchObject({ clientX: 30, clientY: 40, pointerType: "touch" });
-    expect(fired[0].target).toBe(node);
+    expect(fired[0]!.target).toBe(node);
     handle.destroy();
   });
 

--- a/src/lib/actions/__tests__/longPress.test.ts
+++ b/src/lib/actions/__tests__/longPress.test.ts
@@ -1,0 +1,262 @@
+// Action-level tests for the longPress primitive (#387). These exist as the
+// RED side of the TDD pair: they describe the behaviour spec'd in plan v3
+// before the action is implemented. The action lives at
+// `src/lib/actions/longPress.ts` and is wired into TreeRow / Bookmarks /
+// EditorPane.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { longPress, type LongPressDetail, type LongPressOpts } from "../longPress";
+
+// jsdom does not implement PointerEvent, but the action only reads
+// `clientX/Y`, `pointerId`, `pointerType`, `target` and uses `preventDefault`.
+// A MouseEvent + augmentation matches that surface area without pulling
+// in a polyfill.
+function pointerEvent(
+  type: string,
+  init: { clientX?: number; clientY?: number; pointerId?: number; pointerType?: string } = {},
+): Event {
+  const ev = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  });
+  Object.defineProperty(ev, "pointerId", { value: init.pointerId ?? 1, configurable: true });
+  Object.defineProperty(ev, "pointerType", { value: init.pointerType ?? "touch", configurable: true });
+  return ev;
+}
+
+interface Harness {
+  node: HTMLElement;
+  fired: LongPressDetail[];
+  handle: { update(o: LongPressOpts): void; destroy(): void };
+}
+
+function mount(opts: Partial<LongPressOpts> = {}): Harness {
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  const fired: LongPressDetail[] = [];
+  const handle = longPress(node, {
+    duration: 500,
+    moveTolerance: 10,
+    onLongPress: (d) => fired.push(d),
+    ...opts,
+  });
+  return { node, fired, handle };
+}
+
+describe("longPress action (#387)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("fires after duration with synthesized coords + pointerType + target", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown", { clientX: 30, clientY: 40, pointerType: "touch" }));
+    expect(fired).toHaveLength(0);
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(1);
+    expect(fired[0]).toMatchObject({ clientX: 30, clientY: 40, pointerType: "touch" });
+    expect(fired[0].target).toBe(node);
+    handle.destroy();
+  });
+
+  it("cancels when pointermove exceeds tolerance (>10px)", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
+    document.dispatchEvent(pointerEvent("pointermove", { clientX: 12, clientY: 0 }));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    handle.destroy();
+  });
+
+  it("does not cancel at exactly the tolerance boundary (=10px)", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
+    document.dispatchEvent(pointerEvent("pointermove", { clientX: 10, clientY: 0 }));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(1);
+    handle.destroy();
+  });
+
+  it("cancels on pointerup before duration", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    vi.advanceTimersByTime(200);
+    document.dispatchEvent(pointerEvent("pointerup"));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    handle.destroy();
+  });
+
+  it("cancels on pointercancel", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    document.dispatchEvent(pointerEvent("pointercancel"));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    handle.destroy();
+  });
+
+  it("preventDefaults pointerdown when pointerType is touch", () => {
+    const { node, handle } = mount();
+    const ev = pointerEvent("pointerdown", { pointerType: "touch" });
+    node.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    handle.destroy();
+  });
+
+  it("does NOT preventDefault pointerdown for mouse (preserves desktop focus)", () => {
+    const { node, handle } = mount();
+    const ev = pointerEvent("pointerdown", { pointerType: "mouse" });
+    node.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(false);
+    handle.destroy();
+  });
+
+  it("does NOT preventDefault pointerdown for pen (preserves Surface drag)", () => {
+    const { node, handle } = mount();
+    const ev = pointerEvent("pointerdown", { pointerType: "pen" });
+    node.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(false);
+    handle.destroy();
+  });
+
+  it("suppresses the synthetic contextmenu after fire", () => {
+    const { node, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    vi.advanceTimersByTime(500);
+    const ctx = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.dispatchEvent(ctx);
+    expect(ctx.defaultPrevented).toBe(true);
+    handle.destroy();
+  });
+
+  it("stopImmediatePropagation prevents bubble-phase listeners on view.dom from firing", () => {
+    const { node, handle } = mount();
+    // Simulate CM6's bubble-phase contextmenu listener on a child element.
+    const child = document.createElement("div");
+    node.appendChild(child);
+    const cmListener = vi.fn();
+    child.addEventListener("contextmenu", cmListener);
+
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    vi.advanceTimersByTime(500);
+
+    const ctx = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    child.dispatchEvent(ctx);
+
+    expect(cmListener).not.toHaveBeenCalled();
+    handle.destroy();
+  });
+
+  it("after the 600ms ceiling the suppressor disarms — next contextmenu untouched", () => {
+    const { node, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    vi.advanceTimersByTime(500);
+    // Wait past the 600ms ceiling without firing contextmenu.
+    vi.advanceTimersByTime(700);
+    const later = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.dispatchEvent(later);
+    expect(later.defaultPrevented).toBe(false);
+    handle.destroy();
+  });
+
+  it("window.blur after fire disarms the suppressor", () => {
+    const { node, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    vi.advanceTimersByTime(500);
+    window.dispatchEvent(new Event("blur"));
+    const later = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.dispatchEvent(later);
+    expect(later.defaultPrevented).toBe(false);
+    handle.destroy();
+  });
+
+  it("a subsequent pointerdown disarms the suppressor", () => {
+    const { node, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown", { pointerId: 1 }));
+    vi.advanceTimersByTime(500);
+    // Different pointerdown lands — suppressor must disarm before any
+    // subsequent legit right-click runs.
+    document.dispatchEvent(pointerEvent("pointerdown", { pointerId: 2 }));
+    const later = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.dispatchEvent(later);
+    expect(later.defaultPrevented).toBe(false);
+    handle.destroy();
+  });
+
+  it("multi-touch: a second concurrent pointerdown cancels — no fire", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown", { pointerId: 1 }));
+    node.dispatchEvent(pointerEvent("pointerdown", { pointerId: 2 }));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    handle.destroy();
+  });
+
+  it("document-level pointermove cancels (defeats CM6 setPointerCapture)", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown", { pointerId: 7, clientX: 0, clientY: 0 }));
+    // Simulate CM6 capture: subsequent moves dispatched on document, not node.
+    document.dispatchEvent(pointerEvent("pointermove", { pointerId: 7, clientX: 50, clientY: 0 }));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    handle.destroy();
+  });
+
+  it("strict: true ignores pointerdown whose target is not the node itself", () => {
+    const { node, fired, handle } = mount({ strict: true });
+    const inner = document.createElement("span");
+    node.appendChild(inner);
+    inner.dispatchEvent(pointerEvent("pointerdown"));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    handle.destroy();
+  });
+
+  it("strict: true fires when target is the node itself", () => {
+    const { node, fired, handle } = mount({ strict: true });
+    // Dispatching directly on the node sets event.target === node.
+    node.dispatchEvent(pointerEvent("pointerdown", { clientX: 5, clientY: 5 }));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(1);
+    handle.destroy();
+  });
+
+  it("scroll on the node during pending hold cancels the timer", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    node.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    handle.destroy();
+  });
+
+  it("update() swaps the callback in place", () => {
+    const { node, handle } = mount();
+    const next = vi.fn();
+    handle.update({ duration: 500, moveTolerance: 10, onLongPress: next });
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    vi.advanceTimersByTime(500);
+    expect(next).toHaveBeenCalledTimes(1);
+    handle.destroy();
+  });
+
+  it("destroy() removes listeners + clears any pending timer + aborts pending suppressor", () => {
+    const { node, fired, handle } = mount();
+    node.dispatchEvent(pointerEvent("pointerdown"));
+    handle.destroy();
+    vi.advanceTimersByTime(500);
+    expect(fired).toHaveLength(0);
+    // After destroy, document listeners are gone — a stray contextmenu must
+    // not be preventDefault'd by a leaked suppressor.
+    const ctx = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    document.dispatchEvent(ctx);
+    expect(ctx.defaultPrevented).toBe(false);
+  });
+});

--- a/src/lib/actions/longPress.ts
+++ b/src/lib/actions/longPress.ts
@@ -65,8 +65,17 @@ export function longPress(
   let startPointerType = "";
   let startTarget: EventTarget | null = null;
   let suppressorAbort: AbortController | null = null;
+  // The 600 ms ceiling fires `disarmSuppressor` if no other teardown signal
+  // arrives first. The timer ID lives outside the AbortController so
+  // `destroy()` can clear it directly — otherwise a fire-then-unmount
+  // sequence leaks one pending timeout per cycle.
+  let ceilingTimer: ReturnType<typeof setTimeout> | null = null;
 
   function disarmSuppressor(): void {
+    if (ceilingTimer !== null) {
+      clearTimeout(ceilingTimer);
+      ceilingTimer = null;
+    }
     if (suppressorAbort) {
       suppressorAbort.abort();
       suppressorAbort = null;
@@ -100,7 +109,6 @@ export function longPress(
       "contextmenu",
       (e) => {
         e.preventDefault();
-        e.stopPropagation();
         // stopImmediatePropagation in capture-phase aborts dispatch to
         // any subsequent listener including bubble-phase handlers
         // attached to the original target (e.g. CM6's view.dom).
@@ -110,7 +118,7 @@ export function longPress(
       { capture: true, signal },
     );
 
-    setTimeout(() => disarmSuppressor(), SUPPRESSOR_CEILING_MS);
+    ceilingTimer = setTimeout(() => disarmSuppressor(), SUPPRESSOR_CEILING_MS);
 
     window.addEventListener("blur", () => disarmSuppressor(), { signal, once: true });
 

--- a/src/lib/actions/longPress.ts
+++ b/src/lib/actions/longPress.ts
@@ -1,4 +1,29 @@
-// Stub — TDD RED phase. Real implementation lands in the GREEN commit.
+// longPress (#387) — Pointer-Events Svelte action that fires after a
+// configurable hold without crossing a movement threshold. Used to bridge
+// touch long-press onto the existing right-click context menus and onto
+// the mobile-only "New note here" entry point.
+//
+// Design notes:
+//  - move/up/cancel listeners attach to `document` with capture: true so
+//    CodeMirror's `view.dom.setPointerCapture(pointerId)` can't redirect
+//    the events past us mid-hold.
+//  - Single-pointer enforcement: any second concurrent pointerdown
+//    cancels both — multi-touch never surfaces a menu.
+//  - On fire, an `AbortController` arms a one-shot capture-phase
+//    contextmenu suppressor. iOS Safari fires the synthetic contextmenu
+//    on `document`, not the originating element, so the suppressor must
+//    live there. `stopImmediatePropagation()` is the only way to defeat
+//    CM6's bubble-phase `view.dom` contextmenu handler from a separate
+//    listener, since `defaultPrevented` is not consulted by
+//    `EditorView.domEventHandlers`.
+//  - Five teardown paths abort the suppressor: the fire itself (one-shot),
+//    a 600 ms ceiling (≈6× the worst observed iOS/Android synthesis
+//    delay), `window.blur`, the next `pointerdown` anywhere, and
+//    `destroy()`. Cannot leak into the next gesture.
+//  - `e.preventDefault()` on `pointerdown` is gated to `pointerType ===
+//    "touch"` only — pen and mouse pass through so Surface pen-drag and
+//    desktop focus-on-mousedown stay intact.
+
 export interface LongPressDetail {
   clientX: number;
   clientY: number;
@@ -7,18 +32,171 @@ export interface LongPressDetail {
 }
 
 export interface LongPressOpts {
+  /** Hold duration in ms before fire. Default 500. */
   duration?: number;
+  /** Movement (px, Euclidean) that cancels a pending hold. Default 10. */
   moveTolerance?: number;
+  /**
+   * When true, only fires if `event.target === node` at pointerdown.
+   * Used by the empty-tree-area wiring so a pointerdown on a TreeRow
+   * descendant does not also fire the wrapper menu.
+   */
   strict?: boolean;
   onLongPress: (d: LongPressDetail) => void;
 }
 
+const DEFAULT_DURATION = 500;
+const DEFAULT_MOVE_TOLERANCE = 10;
+// 600 ms = ≈6× the worst-observed iOS/Android synthetic-contextmenu
+// dispatch latency after touchend. Higher would risk the suppressor
+// surviving into the next user gesture.
+const SUPPRESSOR_CEILING_MS = 600;
+
 export function longPress(
-  _node: HTMLElement,
-  _opts: LongPressOpts,
+  node: HTMLElement,
+  initialOpts: LongPressOpts,
 ): { update(o: LongPressOpts): void; destroy(): void } {
+  let opts = initialOpts;
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let activePointerId: number | null = null;
+  let startX = 0;
+  let startY = 0;
+  let startPointerType = "";
+  let startTarget: EventTarget | null = null;
+  let suppressorAbort: AbortController | null = null;
+
+  function disarmSuppressor(): void {
+    if (suppressorAbort) {
+      suppressorAbort.abort();
+      suppressorAbort = null;
+    }
+  }
+
+  function cancelTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    activePointerId = null;
+  }
+
+  function fire(): void {
+    timer = null;
+    const detail: LongPressDetail = {
+      clientX: startX,
+      clientY: startY,
+      pointerType: startPointerType,
+      target: startTarget,
+    };
+
+    // Arm the contextmenu suppressor BEFORE calling the consumer. The
+    // synthetic contextmenu can race the consumer's state updates on slow
+    // mobile WebViews; arming first guarantees we win that race.
+    suppressorAbort = new AbortController();
+    const signal = suppressorAbort.signal;
+
+    document.addEventListener(
+      "contextmenu",
+      (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        // stopImmediatePropagation in capture-phase aborts dispatch to
+        // any subsequent listener including bubble-phase handlers
+        // attached to the original target (e.g. CM6's view.dom).
+        e.stopImmediatePropagation();
+        disarmSuppressor();
+      },
+      { capture: true, signal },
+    );
+
+    setTimeout(() => disarmSuppressor(), SUPPRESSOR_CEILING_MS);
+
+    window.addEventListener("blur", () => disarmSuppressor(), { signal, once: true });
+
+    // Capture-phase + once: cleanly disarms before any subsequent legit
+    // contextmenu has a chance to be suppressed. Sequencing matters —
+    // the suppressor disarms BEFORE this pointerdown is handed back to
+    // the action's own node-level listener, which then evaluates fresh.
+    document.addEventListener("pointerdown", () => disarmSuppressor(), {
+      capture: true,
+      once: true,
+      signal,
+    });
+
+    // Reset pointer tracking AFTER suppressor is armed so the
+    // disarm-on-next-pointerdown path can see we just fired.
+    activePointerId = null;
+
+    opts.onLongPress(detail);
+  }
+
+  function onPointerDown(e: PointerEvent): void {
+    if (opts.strict && e.target !== node) return;
+
+    // Single-pointer enforcement: a second concurrent pointer kills
+    // any pending hold. Disarm the suppressor first (S2) so its
+    // teardown ordering is deterministic.
+    if (activePointerId !== null) {
+      disarmSuppressor();
+      cancelTimer();
+      return;
+    }
+
+    activePointerId = e.pointerId;
+    startX = e.clientX;
+    startY = e.clientY;
+    startPointerType = e.pointerType;
+    startTarget = e.target;
+
+    if (e.pointerType === "touch") {
+      // Suppress the iOS callout / Android selection magnifier. Touch
+      // only: pen and mouse pass through so Surface drag-start and
+      // desktop focus-on-mousedown keep working.
+      e.preventDefault();
+    }
+
+    const duration = opts.duration ?? DEFAULT_DURATION;
+    timer = setTimeout(fire, duration);
+  }
+
+  function onPointerMove(e: PointerEvent): void {
+    if (timer === null || e.pointerId !== activePointerId) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    const tolerance = opts.moveTolerance ?? DEFAULT_MOVE_TOLERANCE;
+    if (Math.hypot(dx, dy) > tolerance) {
+      cancelTimer();
+    }
+  }
+
+  function onPointerEnd(e: PointerEvent): void {
+    if (timer === null || e.pointerId !== activePointerId) return;
+    cancelTimer();
+  }
+
+  function onScroll(): void {
+    if (timer !== null) cancelTimer();
+  }
+
+  node.addEventListener("pointerdown", onPointerDown);
+  node.addEventListener("scroll", onScroll, { passive: true });
+  document.addEventListener("pointermove", onPointerMove, { capture: true });
+  document.addEventListener("pointerup", onPointerEnd, { capture: true });
+  document.addEventListener("pointercancel", onPointerEnd, { capture: true });
+
   return {
-    update() {},
-    destroy() {},
+    update(next: LongPressOpts): void {
+      opts = next;
+    },
+    destroy(): void {
+      cancelTimer();
+      disarmSuppressor();
+      node.removeEventListener("pointerdown", onPointerDown);
+      node.removeEventListener("scroll", onScroll);
+      document.removeEventListener("pointermove", onPointerMove, { capture: true } as EventListenerOptions);
+      document.removeEventListener("pointerup", onPointerEnd, { capture: true } as EventListenerOptions);
+      document.removeEventListener("pointercancel", onPointerEnd, { capture: true } as EventListenerOptions);
+    },
   };
 }

--- a/src/lib/actions/longPress.ts
+++ b/src/lib/actions/longPress.ts
@@ -1,0 +1,24 @@
+// Stub — TDD RED phase. Real implementation lands in the GREEN commit.
+export interface LongPressDetail {
+  clientX: number;
+  clientY: number;
+  pointerType: string;
+  target: EventTarget | null;
+}
+
+export interface LongPressOpts {
+  duration?: number;
+  moveTolerance?: number;
+  strict?: boolean;
+  onLongPress: (d: LongPressDetail) => void;
+}
+
+export function longPress(
+  _node: HTMLElement,
+  _opts: LongPressOpts,
+): { update(o: LongPressOpts): void; destroy(): void } {
+  return {
+    update() {},
+    destroy() {},
+  };
+}


### PR DESCRIPTION
## Summary

Touch parity for the right-click context menu and a vault-root quick-capture entry on mobile (#387, child of #74).

- New `src/lib/actions/longPress.ts` Svelte action — Pointer-Events primitive (500 ms hold, 10 px Euclidean tolerance). `pointermove` / `up` / `cancel` listened on `document` with capture so CodeMirror's `setPointerCapture` cannot redirect events past us mid-hold. Single-pointer enforcement: a second concurrent `pointerdown` cancels both — multi-touch never surfaces a menu.
- One-shot capture-phase `contextmenu` suppressor uses `stopImmediatePropagation()` to defeat CM6's bubble-phase `view.dom` listener (`editorContextMenuExtension`), which is otherwise indifferent to `defaultPrevented`. `AbortController` ties five teardown signals: one-shot fire, 600 ms ceiling (≈6× iOS/Android synthesis window), `window.blur`, next `pointerdown`, action `destroy()`. Cannot leak.
- `e.preventDefault()` on `pointerdown` gated to `pointerType === "touch"` only — pen and mouse pass through, so Surface pen-drag and desktop focus-on-mousedown stay intact.
- `strict: true` option filters bubbling pointerdowns at the action layer; used by the empty-tree-area wiring.
- Wired into `TreeRow` (`.vc-tree-row`, mirrors `oncontextmenu` surface), `BookmarksPanel` (each `.vc-bookmark-row`), `EditorPane` (`.vc-editor-content`, resolves active `EditorView` from `viewMap` at fire-time), and `Sidebar` empty-tree area (`.vc-sidebar-tree` strict, opens a single-item "New note here" menu rooted at the vault path).
- Folder context menu: `handleNewFileHere` → `handleNewNoteHere`; label "New file here" → "New note here" (issue spec wording, sentence-case to match siblings).
- Boy Scout: TreeRow `getVaultRoot()` subscribe-then-unsub anti-pattern → `get(vaultStore).currentPath`; dead vault-prefix ternary in `confirmDelete` cleaned up.
- `Sidebar.handleNewFile` gains an optional `targetFolder?: string | unknown` parameter; type-guarded so the existing `onclick={handleNewFile}` bindings (which pass the `MouseEvent`) still fall through to selection-based fallback.

Pre-existing scope flagged but **not** fixed in this ticket: `getSelectedFolder()` only inspects the top-level `rootEntries` and misses nested-selected folders. Empty-area long-press always targets vault root explicitly, so the bug doesn't bleed into the new path.

## Test plan

- [x] `pnpm vitest run src/lib/actions/__tests__/longPress.test.ts` — 20/20 green (timer, move/up/cancel, preventDefault matrix touch/mouse/pen, multi-touch, CM6 setPointerCapture redirect, document-capture stopImmediatePropagation, 600 ms ceiling, window.blur teardown, next-pointerdown teardown, scroll cancel, strict-target gate, update/destroy).
- [x] `pnpm vitest run src/components/Sidebar/ src/components/Bookmarks/ src/lib/actions/` — 24 files, 79 tests green.
- [x] `pnpm vitest run src/components/Editor/` — 38 files, 317 tests green (no regression in CM6 right-click path or viewer branches).
- [x] `pnpm typecheck` — clean.
- [ ] Manual smoke on a real mobile WebView (deferred — `pnpm dev` desktop browser cannot synthesize touch).
- [ ] WDIO touch-sim spec — explicitly out of scope; deferred to a separate infra ticket.

## Architecture notes worth highlighting for review

- The CM6 dual-fire concern is real for the editor surface only. Tree / Bookmarks long-press cannot reach `view.dom` (separate DOM subtree). The pane-level test (`EditorPane.longPress.test.ts`) asserts no parallel CM6 menu after a long-press fire.
- `AbortController` ordering: `disarmSuppressor()` runs **before** `cancelTimer()` resets `activePointerId` on a multi-touch second pointerdown, so re-entry into the action sees a clean state and the suppressor cannot re-arm against the next legit right-click.