### PR TITLE
feat(mobile): mobile shell — drawer + responsive layout (#386)

### DIFF
--- a/e2e/specs/mobile-layout.spec.ts
+++ b/e2e/specs/mobile-layout.spec.ts
@@ -1,0 +1,85 @@
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+
+/**
+ * #386 — mobile-shell e2e coverage.
+ *
+ * The layout collapses below 700px so we resize the WebKitWebDriver window
+ * to 600x900 in `before` and restore the original size in `after`. tauri.conf
+ * carries no minWidth/minHeight, so the resize succeeds.
+ *
+ * Pointer-event swipe gestures are NOT covered here — synthetic touch via
+ * webdriver `performActions` is tauri-driver dependent and noisy. The vitest
+ * spec covers the gesture logic; the swipe-to-open/close behaviour stays
+ * manual UAT for this slice.
+ */
+describe("Mobile layout (#386)", () => {
+  let vault: TestVault;
+  let restoreSize: { width: number; height: number } | null = null;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+    restoreSize = await browser.getWindowSize();
+    await browser.setWindowSize(600, 900);
+  });
+
+  after(async () => {
+    if (restoreSize) {
+      await browser.setWindowSize(restoreSize.width, restoreSize.height);
+    }
+    vault.cleanup();
+  });
+
+  async function isDrawerOpen(): Promise<boolean> {
+    const drawer = await browser.$(".vc-layout-sidebar");
+    const cls = (await drawer.getAttribute("class")) ?? "";
+    return cls.includes("vc-layout-sidebar--mobile-open");
+  }
+
+  it("hides the drawer on initial mobile load", async () => {
+    expect(await isDrawerOpen()).toBe(false);
+  });
+
+  it("opens the drawer when the hamburger trigger is clicked", async () => {
+    const trigger = await browser.$('button[aria-controls="vc-mobile-drawer"]');
+    await trigger.waitForDisplayed({ timeout: 3000 });
+    await browser.execute(() => {
+      (document.querySelector('button[aria-controls="vc-mobile-drawer"]') as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(isDrawerOpen, {
+      timeout: 3000,
+      timeoutMsg: "Drawer never opened after hamburger click",
+    });
+  });
+
+  it("closes the drawer when the scrim is clicked", async () => {
+    expect(await isDrawerOpen()).toBe(true);
+    await browser.execute(() => {
+      (document.querySelector(".vc-mobile-scrim") as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(async () => !(await isDrawerOpen()), {
+      timeout: 3000,
+      timeoutMsg: "Drawer never closed after scrim click",
+    });
+  });
+
+  it("Escape closes an open drawer", async () => {
+    await browser.execute(() => {
+      (document.querySelector('button[aria-controls="vc-mobile-drawer"]') as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(isDrawerOpen, { timeout: 3000 });
+    await browser.keys(["Escape"]);
+    await browser.waitUntil(async () => !(await isDrawerOpen()), {
+      timeout: 3000,
+      timeoutMsg: "Drawer never closed after Escape",
+    });
+  });
+
+  it("removes the right sidebar / backlinks toggle from the DOM on mobile", async () => {
+    const right = await browser.$$(".vc-layout-right-sidebar");
+    expect(right.length).toBe(0);
+    const backlinksBtn = await browser.$$(".vc-backlinks-toggle-btn");
+    expect(backlinksBtn.length).toBe(0);
+  });
+});

--- a/e2e/specs/mobile-layout.spec.ts
+++ b/e2e/specs/mobile-layout.spec.ts
@@ -37,11 +37,7 @@ describe("Mobile layout (#386)", () => {
     return cls.includes("vc-layout-sidebar--mobile-open");
   }
 
-  it("hides the drawer on initial mobile load", async () => {
-    expect(await isDrawerOpen()).toBe(false);
-  });
-
-  it("opens the drawer when the hamburger trigger is clicked", async () => {
+  async function openDrawer(): Promise<void> {
     const trigger = await browser.$('button[aria-controls="vc-mobile-drawer"]');
     await trigger.waitForDisplayed({ timeout: 3000 });
     await browser.execute(() => {
@@ -51,9 +47,29 @@ describe("Mobile layout (#386)", () => {
       timeout: 3000,
       timeoutMsg: "Drawer never opened after hamburger click",
     });
+  }
+
+  // Each test starts and ends with the drawer closed. afterEach cleans up
+  // any drawer state the test left behind so tests stay independent.
+  afterEach(async () => {
+    if (await isDrawerOpen()) {
+      await browser.keys(["Escape"]);
+      await browser.waitUntil(async () => !(await isDrawerOpen()), { timeout: 3000 }).catch(() => {});
+    }
+  });
+
+  it("hides the drawer on initial mobile load", async () => {
+    expect(await isDrawerOpen()).toBe(false);
+  });
+
+  it("opens the drawer when the hamburger trigger is clicked", async () => {
+    expect(await isDrawerOpen()).toBe(false);
+    await openDrawer();
+    expect(await isDrawerOpen()).toBe(true);
   });
 
   it("closes the drawer when the scrim is clicked", async () => {
+    await openDrawer();
     expect(await isDrawerOpen()).toBe(true);
     await browser.execute(() => {
       (document.querySelector(".vc-mobile-scrim") as HTMLElement | null)?.click();
@@ -65,10 +81,8 @@ describe("Mobile layout (#386)", () => {
   });
 
   it("Escape closes an open drawer", async () => {
-    await browser.execute(() => {
-      (document.querySelector('button[aria-controls="vc-mobile-drawer"]') as HTMLElement | null)?.click();
-    });
-    await browser.waitUntil(isDrawerOpen, { timeout: 3000 });
+    await openDrawer();
+    expect(await isDrawerOpen()).toBe(true);
     await browser.keys(["Escape"]);
     await browser.waitUntil(async () => !(await isDrawerOpen()), {
       timeout: 3000,

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -58,6 +58,8 @@
   import { resolveRevealRelPath } from "../../lib/activeTabReveal";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
   import { settingsStore } from "../../store/settingsStore";
+  import { viewportStore } from "../../store/viewportStore";
+  import { swipeGesture } from "../../lib/actions/swipeGesture";
   import {
     DEFAULT_DAILY_DATE_FORMAT,
     dailyNoteFilename,
@@ -100,6 +102,41 @@
   // Sidebar selection state
   let selectedPath = $state<string | null>(null);
 
+  // #386 mobile shell — drawer state. The drawer reuses the existing
+  // `.vc-layout-sidebar` container (width-driven on desktop, transform-driven
+  // via `.vc-layout-sidebar--mobile-open` on mobile via the @media block).
+  let mobileDrawerOpen = $state(false);
+  let triggerRef: HTMLButtonElement | undefined = $state(undefined);
+  let drawerEl: HTMLDivElement | undefined = $state(undefined);
+  const isMobile = $derived($viewportStore.mode === "mobile");
+
+  // Resize-to-desktop forces the drawer closed so re-entering mobile starts
+  // from a known state.
+  $effect(() => {
+    if (!isMobile) mobileDrawerOpen = false;
+  });
+
+  // Focus management: when the drawer opens, focus the first focusable inside
+  // (sidebar action buttons are bumped to 44px on coarse pointers — they are
+  // the empty-vault fallback). On close, return focus to the trigger.
+  // The `wasOpen` latch keeps the spurious mount-time focus dispatch from
+  // firing when the drawer starts closed.
+  let wasOpen = $state(false);
+  $effect(() => {
+    if (mobileDrawerOpen) {
+      wasOpen = true;
+      queueMicrotask(() => {
+        const first = drawerEl?.querySelector<HTMLElement>(
+          '[tabindex="0"], button:not([tabindex="-1"]), a:not([tabindex="-1"]), input:not([tabindex="-1"])'
+        );
+        first?.focus();
+      });
+    } else if (wasOpen) {
+      triggerRef?.focus();
+      wasOpen = false;
+    }
+  });
+
   const unsubTab = tabStore.subscribe((state) => {
     rightPaneIds = state.splitState.right;
   });
@@ -120,6 +157,7 @@
 
   // Sidebar divider drag-to-resize
   function handleDividerMousedown(e: MouseEvent) {
+    if (isMobile) return;
     e.preventDefault();
     isDragging = true;
     dragStartX = e.clientX;
@@ -127,6 +165,7 @@
   }
 
   function handleMousemove(e: MouseEvent) {
+    if (isMobile) return;
     if (isDragging) {
       const delta = e.clientX - dragStartX;
       const newWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, dragStartWidth + delta));
@@ -143,6 +182,7 @@
   }
 
   function handleMouseup() {
+    if (isMobile) return;
     if (isDragging) {
       isDragging = false;
       persistWidth(sidebarWidth);
@@ -156,6 +196,7 @@
   }
 
   function handleRightDividerMousedown(e: MouseEvent) {
+    if (isMobile) return;
     e.preventDefault();
     isRightDragging = true;
     rightDragStartX = e.clientX;
@@ -166,6 +207,7 @@
 
   // Split pane divider drag
   function handleSplitDividerMousedown(e: MouseEvent) {
+    if (isMobile) return;
     e.preventDefault();
     isSplitDragging = true;
     splitDragStartX = e.clientX;
@@ -173,6 +215,7 @@
   }
 
   function handleSplitDragMove(e: MouseEvent) {
+    if (isMobile) return;
     if (!isSplitDragging) return;
     const editorAreaEl = document.querySelector(".vc-layout-editor") as HTMLElement;
     if (!editorAreaEl) return;
@@ -553,7 +596,14 @@
         omniSearchOpen = true;
       },
       toggleSidebar: () => { toggleSidebar(); },
-      openBacklinks: () => { backlinksStore.toggle(); },
+      openBacklinks: () => {
+        // #386 — right sidebar is suppressed entirely on mobile (its content
+        // routes through #397's burger sheet). Snapshot the store with `get`
+        // because commands are imperative — `$viewportStore` reactive sugar
+        // isn't available inside this callback.
+        if (get(viewportStore).mode === "mobile") return;
+        backlinksStore.toggle();
+      },
       activateSearchTab: () => {
         omniSearchMode = "content";
         omniSearchPrefill = undefined;
@@ -679,6 +729,16 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
+    // #386 — drawer-Escape branch sits ABOVE the modal-open guard so a
+    // simultaneously open settings/palette doesn't swallow Escape that should
+    // ALSO close the drawer. The chosen ordering (drawer first, modal next)
+    // matches user intent: pressing Escape on a phone unstacks the drawer
+    // without forcing the user to dismiss whatever happens to be on top.
+    if (e.key === "Escape" && isMobile && mobileDrawerOpen) {
+      e.preventDefault();
+      mobileDrawerOpen = false;
+      return;
+    }
     if (settingsOpen || inlineRenameActive()) return;
     if (commandPaletteOpen) return; // palette handles its own keys
     if (omniSearchOpen) return; // omni-search handles its own keys
@@ -713,12 +773,33 @@
   class="vc-vault-layout"
   class:vc-vault-layout--dragging={isDragging || isSplitDragging || isRightDragging}
   style="--sidebar-width: {sidebarCollapsed ? 0 : sidebarWidth}px; --right-sidebar-width: {backlinksOpen ? backlinksWidth : 0}px; --vc-editor-max-width: {sidebarCollapsed ? 1100 : 720}px"
+  use:swipeGesture={{
+    direction: "right",
+    edge: "left",
+    edgeSize: 24,
+    onSwipe: () => { if (isMobile) mobileDrawerOpen = true; }
+  }}
 >
-  <!-- Sidebar column -->
+  <!-- Sidebar column.
+       On desktop this is a regular grid column (width-driven). On mobile
+       (@media max-width: 699px) it becomes a fixed-position drawer that
+       slides in from the left via `transform: translateX(...)`. The
+       `aria-hidden` ternary keeps off-screen content out of the AT tree on
+       both axes. -->
   <div
     class="vc-layout-sidebar"
     class:vc-layout-sidebar--collapsed={sidebarCollapsed}
-    aria-hidden={sidebarCollapsed}
+    class:vc-layout-sidebar--mobile-open={isMobile && mobileDrawerOpen}
+    id="vc-mobile-drawer"
+    bind:this={drawerEl}
+    aria-hidden={isMobile ? !mobileDrawerOpen : sidebarCollapsed}
+    role={isMobile && mobileDrawerOpen ? "dialog" : undefined}
+    aria-modal={isMobile && mobileDrawerOpen ? "true" : undefined}
+    aria-label={isMobile && mobileDrawerOpen ? "File tree" : undefined}
+    use:swipeGesture={{
+      direction: "left",
+      onSwipe: () => { if (mobileDrawerOpen) mobileDrawerOpen = false; }
+    }}
   >
     <Sidebar
       {selectedPath}
@@ -727,6 +808,21 @@
       onOpenContentSearch={openContentSearchWith}
     />
   </div>
+
+  {#if isMobile && mobileDrawerOpen}
+    <!-- Drawer scrim. `vc-modal-scrim` provides the backdrop colour and
+         `inset: 0`; `vc-mobile-scrim` overrides z-index so it stacks
+         BELOW all real modals (drawer 50, modals ≥199) — see Socrates v2
+         z-index audit in #386. -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="vc-modal-scrim vc-mobile-scrim"
+      aria-hidden="true"
+      tabindex="-1"
+      onclick={() => (mobileDrawerOpen = false)}
+    ></div>
+  {/if}
 
   <!-- Resize divider (column 2). Always rendered — a missing element would
        let CSS grid auto-placement slide every subsequent child one column
@@ -756,26 +852,42 @@
          settings) don't vanish together with the sidebar (issue #112). The
          sidebar toggle morphs between collapse / expand based on state. -->
     <div class="vc-editor-topbar">
-      <button
-        class="vc-sidebar-toggle-btn"
-        onclick={toggleSidebar}
-        aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-        aria-expanded={!sidebarCollapsed}
-        title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-      >
-        {#if sidebarCollapsed}&#9654;{:else}&#9664;{/if}
-      </button>
+      {#if isMobile}
+        <button
+          bind:this={triggerRef}
+          class="vc-sidebar-toggle-btn"
+          onclick={() => (mobileDrawerOpen = !mobileDrawerOpen)}
+          aria-label={mobileDrawerOpen ? "Close file tree" : "Open file tree"}
+          aria-expanded={mobileDrawerOpen}
+          aria-controls="vc-mobile-drawer"
+          title={mobileDrawerOpen ? "Close file tree" : "Open file tree"}
+        >
+          &#9776;
+        </button>
+      {:else}
+        <button
+          class="vc-sidebar-toggle-btn"
+          onclick={toggleSidebar}
+          aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          aria-expanded={!sidebarCollapsed}
+          title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          {#if sidebarCollapsed}&#9654;{:else}&#9664;{/if}
+        </button>
+      {/if}
       <div class="vc-editor-topbar-spacer"></div>
-      <button
-        class="vc-sidebar-toggle-btn vc-backlinks-toggle-btn"
-        class:vc-backlinks-toggle-btn--active={backlinksOpen}
-        onclick={() => backlinksStore.toggle()}
-        aria-label="Backlinks-Panel umschalten"
-        aria-pressed={backlinksOpen}
-        title="Backlinks-Panel umschalten (Cmd/Ctrl+Shift+B)"
-      >
-        <PanelRight size={16} />
-      </button>
+      {#if !isMobile}
+        <button
+          class="vc-sidebar-toggle-btn vc-backlinks-toggle-btn"
+          class:vc-backlinks-toggle-btn--active={backlinksOpen}
+          onclick={() => backlinksStore.toggle()}
+          aria-label="Backlinks-Panel umschalten"
+          aria-pressed={backlinksOpen}
+          title="Backlinks-Panel umschalten (Cmd/Ctrl+Shift+B)"
+        >
+          <PanelRight size={16} />
+        </button>
+      {/if}
       <button
         class="vc-sidebar-toggle-btn"
         class:vc-backlinks-toggle-btn--active={settingsOpen}
@@ -831,28 +943,33 @@
   <!-- Right resize divider (4th column).
        role="separator" is the correct ARIA pattern for a drag-to-resize
        handle; no standard keyboard activation applies to mouse-drag
-       resizing. -->
-  {#if backlinksOpen}
-    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-    <div
-      class="vc-layout-divider-right"
-      class:vc-layout-divider-right--active={isRightDragging}
-      role="separator"
-      aria-label="Resize backlinks sidebar"
-      aria-orientation="vertical"
-      onmousedown={handleRightDividerMousedown}
-    ></div>
-  {:else}
-    <div class="vc-layout-divider-right-hidden"></div>
-  {/if}
+       resizing.
+       #386: on mobile, both the divider and the right sidebar drop out of
+       the DOM entirely — backlinks content routes through the mobile burger
+       sheet (#397). -->
+  {#if !isMobile}
+    {#if backlinksOpen}
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div
+        class="vc-layout-divider-right"
+        class:vc-layout-divider-right--active={isRightDragging}
+        role="separator"
+        aria-label="Resize backlinks sidebar"
+        aria-orientation="vertical"
+        onmousedown={handleRightDividerMousedown}
+      ></div>
+    {:else}
+      <div class="vc-layout-divider-right-hidden"></div>
+    {/if}
 
-  <!-- Right sidebar (5th column) -->
-  <div
-    class="vc-layout-right-sidebar"
-    class:vc-layout-right-sidebar--hidden={!backlinksOpen}
-  >
-    <RightSidebar />
-  </div>
+    <!-- Right sidebar (5th column) -->
+    <div
+      class="vc-layout-right-sidebar"
+      class:vc-layout-right-sidebar--hidden={!backlinksOpen}
+    >
+      <RightSidebar />
+    </div>
+  {/if}
 </div>
 
 <!-- #174 — Omni-search (Spotlight-style) rendered outside the grid at body level -->
@@ -1109,5 +1226,43 @@
     width: 0;
     border-left: none;
     overflow: hidden;
+  }
+
+  /* #386 — mobile shell. Below 700px the layout collapses to a single
+     editor pane; the left sidebar becomes a drawer that slides in from the
+     left edge. The right sidebar / backlinks toggle drop out of the DOM
+     entirely (see {#if !isMobile} above) — its content routes through the
+     mobile burger sheet (#397). */
+  @media (max-width: 699px) {
+    .vc-vault-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .vc-layout-sidebar {
+      position: fixed;
+      inset: 0 auto 0 0;
+      width: min(var(--sidebar-width-mobile, 240px), 85vw);
+      transform: translateX(-100%);
+      /* Vitruvius spec: 240ms cubic-bezier(0.25, 0.46, 0.45, 0.94).
+         Overrides the desktop 200ms ease — different breakpoints, no
+         desync between the two. */
+      transition: transform 240ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+      z-index: 50;
+      padding-top: env(safe-area-inset-top);
+      padding-bottom: env(safe-area-inset-bottom);
+      padding-left: env(safe-area-inset-left);
+    }
+
+    .vc-layout-sidebar--mobile-open {
+      transform: translateX(0);
+    }
+
+    .vc-layout-divider,
+    .vc-layout-divider-right,
+    .vc-layout-divider-hidden,
+    .vc-layout-divider-right-hidden,
+    .vc-split-divider {
+      display: none;
+    }
   }
 </style>

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -302,8 +302,9 @@
     unsubTab();
     unsubBacklinksTab?.();
     unsubActiveTabReveal?.();
-    document.removeEventListener("mousemove", handleMousemove);
-    document.removeEventListener("mouseup", handleMouseup);
+    // mousemove/mouseup are torn down by the onMount return above; calling
+    // removeEventListener again here is a no-op (handler refs match) but
+    // misleads readers into thinking the listeners are owned by both hooks.
     // #345: tear down timers + activity listeners + visibility
     // listener so a subsequent mount starts clean (vault switch,
     // HMR, etc.).

--- a/src/components/Layout/__tests__/VaultLayout.responsiveCollapse.test.ts
+++ b/src/components/Layout/__tests__/VaultLayout.responsiveCollapse.test.ts
@@ -11,13 +11,19 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { tick } from "svelte";
-import { writable } from "svelte/store";
 
 // ---- viewportStore mock ----------------------------------------------------
-// A writable so tests can flip the mode mid-render.
-const viewportWritable = writable<{ mode: "mobile" | "desktop" | "tablet"; isCoarsePointer: boolean }>({
-  mode: "mobile",
-  isCoarsePointer: true,
+// A writable so tests can flip the mode mid-render. The `await` form of
+// `vi.hoisted` lets us pull `writable` from svelte/store before any test-file
+// imports run — `vi.mock` factories are hoisted to the very top.
+const { viewportWritable } = await vi.hoisted(async () => {
+  const { writable } = await import("svelte/store");
+  return {
+    viewportWritable: writable<{ mode: "mobile" | "desktop" | "tablet"; isCoarsePointer: boolean }>({
+      mode: "mobile",
+      isCoarsePointer: true,
+    }),
+  };
 });
 vi.mock("../../../store/viewportStore", () => ({
   viewportStore: viewportWritable,

--- a/src/components/Layout/__tests__/VaultLayout.responsiveCollapse.test.ts
+++ b/src/components/Layout/__tests__/VaultLayout.responsiveCollapse.test.ts
@@ -1,0 +1,219 @@
+/**
+ * VaultLayout responsive-collapse spec (#386).
+ *
+ * Most of the VaultLayout surface (IPC, encryption, autoLock listeners,
+ * file-watcher streams) is mocked away — these tests only care about the
+ * mobile-shell branch: drawer open/close, ARIA mirroring, mode reset on
+ * resize, and the backlinks-command early-return on mobile.
+ *
+ * The viewportStore mock uses a writable store so individual tests can
+ * flip mode between "mobile" and "desktop" mid-test.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tick } from "svelte";
+import { writable } from "svelte/store";
+
+// ---- viewportStore mock ----------------------------------------------------
+// A writable so tests can flip the mode mid-render.
+const viewportWritable = writable<{ mode: "mobile" | "desktop" | "tablet"; isCoarsePointer: boolean }>({
+  mode: "mobile",
+  isCoarsePointer: true,
+});
+vi.mock("../../../store/viewportStore", () => ({
+  viewportStore: viewportWritable,
+  createViewportStore: () => viewportWritable,
+}));
+
+// ---- IPC + event mocks (VaultLayout imports these at module scope) ---------
+vi.mock("../../../ipc/commands", () => ({
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  exportNoteHtml: vi.fn(),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  pickSavePath: vi.fn(),
+  readFile: vi.fn(),
+  renderNoteHtml: vi.fn(),
+  writeFile: vi.fn(),
+  encryptFolder: vi.fn(),
+  unlockFolder: vi.fn(),
+  lockAllFolders: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenEncryptDropProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("../../../store/autoLockStore", () => ({
+  attachAutoLockListeners: vi.fn(),
+  armAutoLock: vi.fn(),
+  disarmAutoLock: vi.fn(),
+  resetAutoLockStore: vi.fn(),
+}));
+
+// EditorPane drags in the entire CodeMirror stack — replace it with a stub
+// so the test mount stays cheap.
+vi.mock("../../Editor/EditorPane.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Sidebar/Sidebar.svelte", async () => {
+  const Stub = (await import("./testStubs/SidebarStub.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Search/OmniSearch.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../CommandPalette/CommandPalette.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../TemplatePicker/TemplatePicker.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../RightSidebar.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Settings/SettingsModal.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Statusbar/EncryptionStatusbar.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+
+import { render } from "@testing-library/svelte";
+import VaultLayout from "../VaultLayout.svelte";
+import { backlinksStore } from "../../../store/backlinksStore";
+import { commandRegistry } from "../../../lib/commands/registry";
+import { CMD_IDS } from "../../../lib/commands/defaultCommands";
+
+beforeEach(() => {
+  viewportWritable.set({ mode: "mobile", isCoarsePointer: true });
+  // jsdom in this vitest config does not always wire `localStorage` onto the
+  // global before $effect fires inside Svelte 5 component init. Stub a tiny
+  // in-memory implementation so VaultLayout's onMount localStorage reads
+  // don't crash the mount.
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+describe("VaultLayout — mobile drawer (#386)", () => {
+  it("does not apply the mobile-open class until the trigger is clicked", async () => {
+    const { container } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    const drawer = container.querySelector(".vc-layout-sidebar");
+    expect(drawer).not.toBeNull();
+    expect(drawer!.classList.contains("vc-layout-sidebar--mobile-open")).toBe(false);
+  });
+
+  it("opens the drawer when the hamburger trigger is clicked, closes via the scrim", async () => {
+    const { container } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-controls="vc-mobile-drawer"]');
+    expect(trigger).not.toBeNull();
+    trigger!.click();
+    await tick();
+
+    const drawer = container.querySelector(".vc-layout-sidebar")!;
+    expect(drawer.classList.contains("vc-layout-sidebar--mobile-open")).toBe(true);
+
+    const scrim = container.querySelector<HTMLElement>(".vc-mobile-scrim");
+    expect(scrim).not.toBeNull();
+    scrim!.click();
+    await tick();
+
+    expect(drawer.classList.contains("vc-layout-sidebar--mobile-open")).toBe(false);
+  });
+
+  it("resets mobileDrawerOpen when viewport flips from mobile to desktop", async () => {
+    const { container } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-controls="vc-mobile-drawer"]');
+    trigger!.click();
+    await tick();
+    const drawer = container.querySelector(".vc-layout-sidebar")!;
+    expect(drawer.classList.contains("vc-layout-sidebar--mobile-open")).toBe(true);
+
+    viewportWritable.set({ mode: "desktop", isCoarsePointer: false });
+    await tick();
+    await tick();
+    expect(drawer.classList.contains("vc-layout-sidebar--mobile-open")).toBe(false);
+  });
+
+  it("Escape closes an open drawer", async () => {
+    const { container } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-controls="vc-mobile-drawer"]');
+    trigger!.click();
+    await tick();
+    const drawer = container.querySelector(".vc-layout-sidebar")!;
+    expect(drawer.classList.contains("vc-layout-sidebar--mobile-open")).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await tick();
+
+    expect(drawer.classList.contains("vc-layout-sidebar--mobile-open")).toBe(false);
+  });
+
+  it("aria-hidden mirrors !mobileDrawerOpen on mobile, falls back to sidebarCollapsed otherwise", async () => {
+    const { container } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    const drawer = container.querySelector(".vc-layout-sidebar")!;
+    // Mobile + drawer closed → aria-hidden true.
+    expect(drawer.getAttribute("aria-hidden")).toBe("true");
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-controls="vc-mobile-drawer"]');
+    trigger!.click();
+    await tick();
+    expect(drawer.getAttribute("aria-hidden")).toBe("false");
+
+    // Desktop: aria-hidden follows sidebarCollapsed (default false).
+    viewportWritable.set({ mode: "desktop", isCoarsePointer: false });
+    await tick();
+    await tick();
+    expect(drawer.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("hides the right sidebar entirely on mobile (DOM absent)", async () => {
+    const { container } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+    expect(container.querySelector(".vc-layout-right-sidebar")).toBeNull();
+    expect(container.querySelector(".vc-backlinks-toggle-btn")).toBeNull();
+  });
+
+  it("backlinks-toggle command is a no-op on mobile", async () => {
+    render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    let snapshotOpen = false;
+    const unsub = backlinksStore.subscribe((s) => {
+      snapshotOpen = s.open;
+    });
+    const before = snapshotOpen;
+    commandRegistry.execute(CMD_IDS.BACKLINKS_TOGGLE);
+    expect(snapshotOpen).toBe(before);
+    unsub();
+  });
+});

--- a/src/components/Layout/__tests__/testStubs/EmptyComponent.svelte
+++ b/src/components/Layout/__tests__/testStubs/EmptyComponent.svelte
@@ -1,0 +1,2 @@
+<!-- Empty stub used by VaultLayout.responsiveCollapse.test.ts to swap out
+     heavy children that drag in the IPC / CodeMirror / encryption stack. -->

--- a/src/components/Layout/__tests__/testStubs/SidebarStub.svelte
+++ b/src/components/Layout/__tests__/testStubs/SidebarStub.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  // Minimal Sidebar stub: the responsive-collapse test asserts on the
+  // drawer container, not on tree internals. A single focusable button is
+  // enough to satisfy the focus-first-focusable querySelector.
+  let { selectedPath, onSelect, onOpenFile, onOpenContentSearch } = $props<{
+    selectedPath: string | null;
+    onSelect: (path: string) => void;
+    onOpenFile: (path: string, opts?: unknown) => void;
+    onOpenContentSearch: (q: string) => void;
+  }>();
+</script>
+
+<button class="vc-sidebar-action-btn" type="button" aria-label="stub-focus-target">stub</button>

--- a/src/lib/actions/__tests__/swipeGesture.test.ts
+++ b/src/lib/actions/__tests__/swipeGesture.test.ts
@@ -172,4 +172,55 @@ describe("swipeGesture action", () => {
     node.dispatchEvent(pointer("pointerup", 70, 110));
     expect(onSwipe).not.toHaveBeenCalled();
   });
+
+  it("nested instances coexist — child's left swipe fires without being stolen by the parent", () => {
+    // Regression for the WebKit-only bug: an earlier setPointerCapture on
+    // pointerdown made the layout-root listener (right + edge=left) steal
+    // every subsequent pointermove/up from the drawer's nested left-swipe
+    // listener, breaking swipe-to-close.
+    //
+    // The geometry below mirrors the production wiring: drawer is a 240px
+    // child of the layout root, the user starts inside the drawer (x=200),
+    // and swipes left by 60px to close it. The parent's right + edge=left
+    // gate must NOT fire on this gesture, and the child's left listener
+    // MUST fire — both events bubble to both listeners, and the child's
+    // listener sees the move first (capture+bubble order is identical
+    // when both are bubble-phase, but DOM ordering puts the inner target
+    // first via ancestor traversal).
+    const parentOnSwipe = vi.fn();
+    const childOnSwipe = vi.fn();
+
+    const parent = makeHost(800);
+    const child = document.createElement("div");
+    Object.defineProperty(child, "getBoundingClientRect", {
+      value: () => ({
+        left: 0, right: 240, top: 0, bottom: 800,
+        width: 240, height: 800, x: 0, y: 0, toJSON: () => ({}),
+      }),
+    });
+    parent.appendChild(child);
+
+    const parentAction = swipeGesture(parent, {
+      direction: "right",
+      edge: "left",
+      edgeSize: 24,
+      onSwipe: parentOnSwipe,
+    });
+    const childAction = swipeGesture(child, {
+      direction: "left",
+      onSwipe: childOnSwipe,
+    });
+
+    try {
+      child.dispatchEvent(pointer("pointerdown", 200, 100));
+      child.dispatchEvent(pointer("pointermove", 140, 110));
+      child.dispatchEvent(pointer("pointerup", 140, 110));
+      expect(childOnSwipe).toHaveBeenCalledTimes(1);
+      expect(parentOnSwipe).not.toHaveBeenCalled();
+    } finally {
+      childAction.destroy?.();
+      parentAction.destroy?.();
+      child.remove();
+    }
+  });
 });

--- a/src/lib/actions/__tests__/swipeGesture.test.ts
+++ b/src/lib/actions/__tests__/swipeGesture.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { swipeGesture, __pickSwipe } from "../swipeGesture";
+
+describe("__pickSwipe", () => {
+  // The decision-only helper — pure, no DOM. Authoritative coverage for
+  // the gesture-recognition logic. The action-level test below exercises
+  // the wiring; if jsdom proves flaky on PointerEvent, this layer remains
+  // correct.
+
+  it("accepts a right-direction swipe within the left edge zone", () => {
+    expect(
+      __pickSwipe(
+        { x: 10, y: 100, t: 0 },
+        { x: 70, y: 110, t: 200 },
+        { direction: "right", edge: "left", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects when start is outside the left edge zone", () => {
+    expect(
+      __pickSwipe(
+        { x: 200, y: 100, t: 0 },
+        { x: 260, y: 110, t: 200 },
+        { direction: "right", edge: "left", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a left-direction swipe with no edge constraint (full mode)", () => {
+    expect(
+      __pickSwipe(
+        { x: 200, y: 100, t: 0 },
+        { x: 100, y: 110, t: 250 },
+        { direction: "left", hostWidth: 600 },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an opposite-direction swipe", () => {
+    expect(
+      __pickSwipe(
+        { x: 10, y: 100, t: 0 },
+        { x: -50, y: 110, t: 200 },
+        { direction: "right", edge: "left", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a vertical-dominant swipe (vertical drift > 30px)", () => {
+    expect(
+      __pickSwipe(
+        { x: 10, y: 100, t: 0 },
+        { x: 70, y: 200, t: 250 },
+        { direction: "right", edge: "left", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a swipe that exceeds the 300ms time budget", () => {
+    expect(
+      __pickSwipe(
+        { x: 10, y: 100, t: 0 },
+        { x: 70, y: 110, t: 600 },
+        { direction: "right", edge: "left", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a swipe that is shorter than the 50px primary-axis threshold", () => {
+    expect(
+      __pickSwipe(
+        { x: 10, y: 100, t: 0 },
+        { x: 40, y: 110, t: 200 },
+        { direction: "right", edge: "left", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a right edge swipe (mirror of left edge)", () => {
+    expect(
+      __pickSwipe(
+        { x: 590, y: 100, t: 0 },
+        { x: 520, y: 110, t: 200 },
+        { direction: "left", edge: "right", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a right-edge start when host width places it outside the zone", () => {
+    expect(
+      __pickSwipe(
+        { x: 100, y: 100, t: 0 },
+        { x: 30, y: 110, t: 200 },
+        { direction: "left", edge: "right", edgeSize: 24, hostWidth: 600 },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("swipeGesture action", () => {
+  // Best-effort end-to-end test through the Svelte action contract. jsdom
+  // supports PointerEvent with clientX/Y via MouseEventInit since v22.
+  // If a future jsdom regression breaks this, the __pickSwipe tests above
+  // remain authoritative.
+
+  let host: HTMLDivElement;
+
+  afterEach(() => {
+    host?.remove();
+  });
+
+  function makeHost(width = 600) {
+    host = document.createElement("div");
+    Object.defineProperty(host, "getBoundingClientRect", {
+      value: () => ({
+        left: 0, right: width, top: 0, bottom: 800,
+        width, height: 800, x: 0, y: 0, toJSON: () => ({}),
+      }),
+    });
+    document.body.appendChild(host);
+    return host;
+  }
+
+  function pointer(type: string, x: number, y: number) {
+    return new PointerEvent(type, {
+      clientX: x,
+      clientY: y,
+      bubbles: true,
+      cancelable: true,
+      pointerType: "touch",
+      pointerId: 1,
+    });
+  }
+
+  it("fires onSwipe when a valid right-edge swipe completes", () => {
+    const onSwipe = vi.fn();
+    const node = makeHost();
+    const action = swipeGesture(node, { direction: "right", edge: "left", edgeSize: 24, onSwipe });
+    try {
+      node.dispatchEvent(pointer("pointerdown", 10, 100));
+      node.dispatchEvent(pointer("pointermove", 70, 110));
+      node.dispatchEvent(pointer("pointerup", 70, 110));
+      expect(onSwipe).toHaveBeenCalledTimes(1);
+    } finally {
+      action.destroy?.();
+    }
+  });
+
+  it("does not fire when the start is outside the edge zone", () => {
+    const onSwipe = vi.fn();
+    const node = makeHost();
+    const action = swipeGesture(node, { direction: "right", edge: "left", edgeSize: 24, onSwipe });
+    try {
+      node.dispatchEvent(pointer("pointerdown", 200, 100));
+      node.dispatchEvent(pointer("pointermove", 260, 110));
+      node.dispatchEvent(pointer("pointerup", 260, 110));
+      expect(onSwipe).not.toHaveBeenCalled();
+    } finally {
+      action.destroy?.();
+    }
+  });
+
+  it("destroy() removes listeners — subsequent pointerdown does nothing", () => {
+    const onSwipe = vi.fn();
+    const node = makeHost();
+    const action = swipeGesture(node, { direction: "right", edge: "left", edgeSize: 24, onSwipe });
+    action.destroy?.();
+    node.dispatchEvent(pointer("pointerdown", 10, 100));
+    node.dispatchEvent(pointer("pointermove", 70, 110));
+    node.dispatchEvent(pointer("pointerup", 70, 110));
+    expect(onSwipe).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/swipeGesture.ts
+++ b/src/lib/actions/swipeGesture.ts
@@ -1,0 +1,163 @@
+/**
+ * swipeGesture — Svelte action for single-pointer swipe recognition.
+ *
+ * Two callsites in the mobile shell:
+ *   - drawer element with `direction: "left"` to dismiss-on-swipe.
+ *   - layout root with `direction: "right", edge: "left"` to open the drawer
+ *     from a left-edge drag.
+ *
+ * Recognition rules (matched by the spec — see `__pickSwipe` tests):
+ *   - primary axis travel ≥ 50px
+ *   - secondary axis drift ≤ 30px
+ *   - elapsed time ≤ 300ms
+ *   - if `edge` is set, pointerdown must land within `edgeSize` of that edge
+ *     of the host (host width comes from getBoundingClientRect()).
+ *
+ * Pointer Events are used (not Touch) so the same code path covers stylus,
+ * touch, and mouse on Tauri's webview. `setPointerCapture` keeps tracking
+ * alive after the pointer leaves the host bounds.
+ *
+ * `__pickSwipe` is exported separately as a pure decision function so unit
+ * tests don't depend on jsdom's PointerEvent fidelity.
+ */
+export type SwipeDirection = "left" | "right";
+export type SwipeEdge = "left" | "right";
+
+export interface SwipeGestureOptions {
+  direction: SwipeDirection;
+  edge?: SwipeEdge;
+  edgeSize?: number;
+  onSwipe: () => void;
+}
+
+export interface SwipePoint {
+  x: number;
+  y: number;
+  t: number;
+}
+
+export interface PickSwipeOpts {
+  direction: SwipeDirection;
+  edge?: SwipeEdge;
+  edgeSize?: number;
+  hostWidth: number;
+}
+
+const PRIMARY_THRESHOLD = 50;
+const VERTICAL_LIMIT = 30;
+const TIME_BUDGET_MS = 300;
+
+export function __pickSwipe(start: SwipePoint, end: SwipePoint, opts: PickSwipeOpts): boolean {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const dt = end.t - start.t;
+
+  if (dt > TIME_BUDGET_MS) return false;
+  if (Math.abs(dy) > VERTICAL_LIMIT) return false;
+
+  if (opts.direction === "right") {
+    if (dx < PRIMARY_THRESHOLD) return false;
+  } else {
+    if (-dx < PRIMARY_THRESHOLD) return false;
+  }
+
+  if (opts.edge !== undefined) {
+    const edgeSize = opts.edgeSize ?? 24;
+    if (opts.edge === "left") {
+      if (start.x > edgeSize) return false;
+    } else {
+      if (start.x < opts.hostWidth - edgeSize) return false;
+    }
+  }
+
+  return true;
+}
+
+export interface SwipeActionReturn {
+  destroy(): void;
+  update?(opts: SwipeGestureOptions): void;
+}
+
+export function swipeGesture(node: HTMLElement, options: SwipeGestureOptions): SwipeActionReturn {
+  let opts = options;
+  let start: SwipePoint | null = null;
+  let activePointerId: number | null = null;
+
+  function onPointerDown(e: PointerEvent) {
+    start = { x: e.clientX, y: e.clientY, t: performance.now() };
+    activePointerId = e.pointerId;
+    if (typeof node.setPointerCapture === "function") {
+      try {
+        node.setPointerCapture(e.pointerId);
+      } catch {
+        // setPointerCapture can throw if the pointer was already released
+        // (rare; jsdom in particular doesn't always permit capture). The
+        // fallback is the bubble-phase pointermove/up handlers — they still
+        // fire on the host.
+      }
+    }
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (start === null || e.pointerId !== activePointerId) return;
+    const end: SwipePoint = { x: e.clientX, y: e.clientY, t: performance.now() };
+    const rect = node.getBoundingClientRect();
+    if (
+      __pickSwipe(start, end, {
+        direction: opts.direction,
+        edge: opts.edge,
+        edgeSize: opts.edgeSize,
+        hostWidth: rect.width,
+      })
+    ) {
+      opts.onSwipe();
+      reset();
+    }
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (start === null || e.pointerId !== activePointerId) {
+      reset();
+      return;
+    }
+    const end: SwipePoint = { x: e.clientX, y: e.clientY, t: performance.now() };
+    const rect = node.getBoundingClientRect();
+    if (
+      __pickSwipe(start, end, {
+        direction: opts.direction,
+        edge: opts.edge,
+        edgeSize: opts.edgeSize,
+        hostWidth: rect.width,
+      })
+    ) {
+      opts.onSwipe();
+    }
+    reset();
+  }
+
+  function onPointerCancel() {
+    reset();
+  }
+
+  function reset() {
+    start = null;
+    activePointerId = null;
+  }
+
+  node.addEventListener("pointerdown", onPointerDown);
+  node.addEventListener("pointermove", onPointerMove);
+  node.addEventListener("pointerup", onPointerUp);
+  node.addEventListener("pointercancel", onPointerCancel);
+
+  return {
+    destroy() {
+      node.removeEventListener("pointerdown", onPointerDown);
+      node.removeEventListener("pointermove", onPointerMove);
+      node.removeEventListener("pointerup", onPointerUp);
+      node.removeEventListener("pointercancel", onPointerCancel);
+    },
+    update(next: SwipeGestureOptions) {
+      opts = next;
+    },
+  };
+}

--- a/src/lib/actions/swipeGesture.ts
+++ b/src/lib/actions/swipeGesture.ts
@@ -14,8 +14,17 @@
  *     of the host (host width comes from getBoundingClientRect()).
  *
  * Pointer Events are used (not Touch) so the same code path covers stylus,
- * touch, and mouse on Tauri's webview. `setPointerCapture` keeps tracking
- * alive after the pointer leaves the host bounds.
+ * touch, and mouse on Tauri's webview.
+ *
+ * No `setPointerCapture`. The 50px-in-300ms gesture geometry stays well
+ * within both consumer host bounds (240px-wide drawer, full-viewport
+ * layout root), so capture isn't needed to keep tracking alive. More
+ * importantly, capture would steal events from nested swipeGesture
+ * instances — the layout-root listener would override the drawer's,
+ * breaking swipe-to-close — and would hold pointer capture across the
+ * editor for any touch lasting longer than the budget, corrupting
+ * CodeMirror's selection drag. Pointer Events bubble correctly without
+ * explicit capture.
  *
  * `__pickSwipe` is exported separately as a pure decision function so unit
  * tests don't depend on jsdom's PointerEvent fidelity.
@@ -86,16 +95,6 @@ export function swipeGesture(node: HTMLElement, options: SwipeGestureOptions): S
   function onPointerDown(e: PointerEvent) {
     start = { x: e.clientX, y: e.clientY, t: performance.now() };
     activePointerId = e.pointerId;
-    if (typeof node.setPointerCapture === "function") {
-      try {
-        node.setPointerCapture(e.pointerId);
-      } catch {
-        // setPointerCapture can throw if the pointer was already released
-        // (rare; jsdom in particular doesn't always permit capture). The
-        // fallback is the bubble-phase pointermove/up handlers — they still
-        // fire on the host.
-      }
-    }
   }
 
   function onPointerMove(e: PointerEvent) {

--- a/src/lib/actions/swipeGesture.ts
+++ b/src/lib/actions/swipeGesture.ts
@@ -105,8 +105,8 @@ export function swipeGesture(node: HTMLElement, options: SwipeGestureOptions): S
     if (
       __pickSwipe(start, end, {
         direction: opts.direction,
-        edge: opts.edge,
-        edgeSize: opts.edgeSize,
+        ...(opts.edge !== undefined ? { edge: opts.edge } : {}),
+        ...(opts.edgeSize !== undefined ? { edgeSize: opts.edgeSize } : {}),
         hostWidth: rect.width,
       })
     ) {
@@ -125,8 +125,8 @@ export function swipeGesture(node: HTMLElement, options: SwipeGestureOptions): S
     if (
       __pickSwipe(start, end, {
         direction: opts.direction,
-        edge: opts.edge,
-        edgeSize: opts.edgeSize,
+        ...(opts.edge !== undefined ? { edge: opts.edge } : {}),
+        ...(opts.edgeSize !== undefined ? { edgeSize: opts.edgeSize } : {}),
         hostWidth: rect.width,
       })
     ) {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -122,6 +122,14 @@ html, body, #app {
   background: var(--color-modal-scrim);
 }
 
+/* #386 — mobile drawer scrim. Stacks BELOW all real modals (≥199) so an
+   open OmniSearch / CommandPalette / Settings always covers the drawer.
+   Lives in the global sheet because component-scoped Svelte styles can't
+   reach this utility class. */
+.vc-mobile-scrim {
+  z-index: 49;
+}
+
 .vc-modal-surface {
   background: var(--color-modal-surface);
   backdrop-filter: blur(var(--modal-blur-radius)) saturate(140%);


### PR DESCRIPTION
## Summary

Implements the #386 mobile shell. Below 700px:
- VaultLayout collapses to a single editor pane.
- Left sidebar becomes a fixed-position drawer that slides in from the left edge (transform-driven, 240ms cubic-bezier per Vitruvius spec).
- Right sidebar + backlinks toggle drop out of the DOM entirely; their content routes through the burger sheet (#397).
- Hamburger trigger replaces the desktop collapse button in the topbar (32/44 hit-target, `aria-expanded` + `aria-controls` wired to the drawer).
- Drawer carries `role=dialog` + `aria-modal` when open; `aria-hidden` mirrors `!mobileDrawerOpen` on mobile and `sidebarCollapsed` off mobile (preserves desktop behaviour byte-for-byte).
- Swipe-to-open on layout root (24px left edge, right swipe) and swipe-to-close on the drawer (left swipe).
- Escape closes the drawer first, ahead of the existing modal-open guard, so a stacked Settings/CommandPalette can't swallow it.
- Mouse-handler `isMobile` early-returns added to every divider / drag handler (defence-in-depth even though `display:none` removes the dividers from the event flow).
- `backlinks-toggle` command no-ops on mobile via `get(viewportStore)`.
- Mobile scrim (z-index 49) lives in the global stylesheet so it stacks below every modal (≥199); Settings sits at 300, others at 200.

### New files
- `src/lib/actions/swipeGesture.ts` — Pointer Events Svelte action with `__pickSwipe` pure helper.
- `src/lib/actions/__tests__/swipeGesture.test.ts` — pure-helper + action-level coverage (already on branch).
- `src/components/Layout/__tests__/VaultLayout.responsiveCollapse.test.ts` — 7 test cases.
- `src/components/Layout/__tests__/testStubs/{EmptyComponent,SidebarStub}.svelte` — heavy children stubbed for mount budget.
- `e2e/specs/mobile-layout.spec.ts` — drawer open / scrim close / Escape / right-sidebar absence.

### Modified
- `src/components/Layout/VaultLayout.svelte` — drawer state + effects, topbar branching, `{#if !isMobile}` around right sidebar/divider/backlinks toggle, swipe wiring, Escape handler, @media block, mouse-handler guards, Boy Scout cleanup of duplicate mousemove/mouseup teardown.
- `src/styles/tailwind.css` — `.vc-mobile-scrim { z-index: 49 }`.

### Z-index audit (Socrates v2 #2)
Verified by grep across `src/components/{Search,CommandPalette,Settings,TemplatePicker,common}/`:

| Overlay | scrim | surface |
|---|---|---|
| OmniSearch / CommandPalette / TemplatePicker / Password / Encrypt / Url | 200 | 201 |
| ContextMenu / ColorPicker | 199 | 200 |
| SettingsModal | 300 | 301 (nested 310/311) |
| **Mobile drawer (new)** | **49** | **50** |

Drawer stacks BELOW every modal; no existing z-indexes need bumping.

### Plan-v3 caveats
1. `tailwind.css` test import: not needed — class-application assertion proved sufficient. CSS introspection assertion was dropped per the planning caveat.
2. Z-index audit — see table above.

### Sequencing
1. RED commit existed on branch (4f525f2 — `test(actions): add swipeGesture TDD spec`).
2. GREEN swipeGesture impl (07c8d91).
3. RED `VaultLayout.responsiveCollapse.test.ts` (fc9554c).
4. GREEN VaultLayout impl + CSS + scrim (2e6e8c1).
5. WDIO spec (a28f1e7).
6. Boy Scout: drop redundant mousemove/mouseup teardown (5ab9fb0).

## Test plan
- [x] `pnpm vitest run src/lib/actions/ src/components/Layout/ src/store/__tests__/viewportStore.test.ts` — 30/30 green
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [ ] Manual UAT: resize window below 700px → topbar shows hamburger, left sidebar collapses to drawer; click hamburger → drawer slides in; click scrim → closes; Escape → closes; resize back to desktop → drawer closes, layout restores.
- [ ] Manual UAT: swipe-to-open from left edge (24px) and swipe-to-close on the drawer (touch/coarse pointer).
- [ ] Manual UAT: open OmniSearch / CommandPalette / Settings while drawer is open → modal covers drawer.
- [ ] Manual UAT: desktop ≥700px is byte-identical (collapse/expand button, dividers, right sidebar, backlinks toggle).

Closes #386. Refs #74.