### PR TITLE
feat(mobile): #388 read-mode default on mobile + topbar pencil toggle

### DIFF
--- a/src/components/Backlinks/BacklinksPanel.svelte
+++ b/src/components/Backlinks/BacklinksPanel.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
   import { backlinksStore } from "../../store/backlinksStore";
-  import { tabStore } from "../../store/tabStore";
   import BacklinkRow from "./BacklinkRow.svelte";
   import { vaultStore } from "../../store/vaultStore";
+  import { openFileAsTab } from "../../lib/openFileAsTab";
 
   function handleBacklinkClick(relPath: string): void {
     const vault = $vaultStore.currentPath;
     if (!vault) return;
     const absPath = `${vault}/${relPath}`;
-    tabStore.openTab(absPath);
+    // #388 — route through openFileAsTab so the dispatcher applies the
+    // viewport-aware viewMode default (mobile → read, desktop → edit).
+    void openFileAsTab(absPath);
   }
 </script>
 

--- a/src/components/Bookmarks/BookmarksPanel.svelte
+++ b/src/components/Bookmarks/BookmarksPanel.svelte
@@ -10,6 +10,7 @@
   import { vaultStore } from "../../store/vaultStore";
   import { tabStore } from "../../store/tabStore";
   import { longPress, type LongPressDetail } from "../../lib/actions/longPress";
+  import { openFileAsTab } from "../../lib/openFileAsTab";
 
   const BOOKMARKS_COLLAPSED_KEY = "vaultcore-bookmarks-panel-collapsed";
 
@@ -57,7 +58,9 @@
   }
 
   function handleRowClick(relPath: string): void {
-    tabStore.openTab(toAbsPath(relPath));
+    // #388 — route through openFileAsTab so the dispatcher applies the
+    // viewport-aware viewMode default (mobile → read, desktop → edit).
+    void openFileAsTab(toAbsPath(relPath));
   }
 
   function handleRowKeydown(e: KeyboardEvent, relPath: string): void {
@@ -83,14 +86,20 @@
 
   function handleOpenInNewTab(relPath: string): void {
     closeContextMenu();
-    // tabStore.openTab dedupes by filePath and focuses existing — call it to
-    // open/focus the note in the active pane.
-    tabStore.openTab(toAbsPath(relPath));
+    // #388 — route through openFileAsTab so the dispatcher applies the
+    // viewport-aware viewMode default. Dedupe semantics (focus existing tab)
+    // are preserved by the underlying tabStore.openTab call.
+    void openFileAsTab(toAbsPath(relPath));
   }
 
   function handleOpenInSplit(relPath: string): void {
     closeContextMenu();
     const absPath = toAbsPath(relPath);
+    // #388 — kept synchronous on purpose: openFileAsTab is async and would
+    // race with the synchronous moveToPane("right") below, which would
+    // potentially move the wrong tab. Split view is desktop-only via the
+    // viewport gating in #386, so the lost mobile-read hint here doesn't
+    // affect the mobile flow.
     tabStore.openTab(absPath);
     tabStore.moveToPane("right");
   }

--- a/src/components/Bookmarks/BookmarksPanel.svelte
+++ b/src/components/Bookmarks/BookmarksPanel.svelte
@@ -95,11 +95,10 @@
   function handleOpenInSplit(relPath: string): void {
     closeContextMenu();
     const absPath = toAbsPath(relPath);
-    // #388 — kept synchronous on purpose: openFileAsTab is async and would
-    // race with the synchronous moveToPane("right") below, which would
-    // potentially move the wrong tab. Split view is desktop-only via the
-    // viewport gating in #386, so the lost mobile-read hint here doesn't
-    // affect the mobile flow.
+    // #388 — stays sync: handleOpenInSplit is a synchronous event handler
+    // and cannot `await openFileAsTab` without restructuring the call site.
+    // The mobile-aware viewMode hint is lost on the split path; split is
+    // desktop-only via viewport gating, so this is moot in practice.
     tabStore.openTab(absPath);
     tabStore.moveToPane("right");
   }

--- a/src/components/Bookmarks/__tests__/BookmarksPanel.test.ts
+++ b/src/components/Bookmarks/__tests__/BookmarksPanel.test.ts
@@ -49,7 +49,14 @@ describe("BookmarksPanel (#12)", () => {
     await tick();
     const label = screen.getByText("a.md");
     await fireEvent.click(label);
-    expect(spy).toHaveBeenCalledWith(`${VAULT}/notes/a.md`);
+    // #388 — clicks now route through openFileAsTab, which passes the
+    // viewport-aware viewMode hint to tabStore.openTab. In jsdom (no
+    // matchMedia overrides) the viewport reports desktop, so the hint
+    // resolves to "edit". Assert the absolute path explicitly via the
+    // first call argument; the second arg is the viewMode hint.
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0]?.[0]).toBe(`${VAULT}/notes/a.md`);
+    expect(spy.mock.calls[0]?.[1]).toBe("edit");
   });
 
   it("renders a broken bookmark dimmed and shows a remove button", async () => {

--- a/src/components/Editor/Breadcrumbs.svelte
+++ b/src/components/Editor/Breadcrumbs.svelte
@@ -16,6 +16,7 @@
   import { vaultStore } from "../../store/vaultStore";
   import { treeRevealStore } from "../../store/treeRevealStore";
   import { tabStore } from "../../store/tabStore";
+  import { viewportStore } from "../../store/viewportStore";
   import type { TabViewMode } from "../../store/tabStore";
 
   interface Props {
@@ -108,7 +109,11 @@
         {/each}
       </div>
     </div>
-    {#if tabId && viewMode !== undefined}
+    {#if tabId && viewMode !== undefined && $viewportStore.mode !== "mobile"}
+      <!-- #388: mobile uses the dedicated topbar pencil instead. The
+           gating clause is strictly more restrictive than the original
+           `tabId && viewMode !== undefined`, so desktop and tablet
+           behavior is unchanged. -->
       <button
         type="button"
         class="vc-breadcrumbs-mode-toggle"

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -17,7 +17,8 @@
   import { activeViewStore } from "../../store/activeViewStore";
   import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAnchors, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
   import { openFileAsTab } from "../../lib/openFileAsTab";
-  import { defaultViewModeForViewport, tabSupportsReading } from "../../lib/tabKind";
+  import { tabSupportsReading } from "../../lib/tabKind";
+  import { defaultViewModeForViewport } from "../../lib/viewport";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
   import { searchStore } from "../../store/searchStore";

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -17,6 +17,7 @@
   import { activeViewStore } from "../../store/activeViewStore";
   import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAnchors, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
   import { openFileAsTab } from "../../lib/openFileAsTab";
+  import { defaultViewModeForViewport, tabSupportsReading } from "../../lib/tabKind";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
   import { searchStore } from "../../store/searchStore";
@@ -242,12 +243,13 @@
   const paneActiveTab = $derived<Tab | null>(
     paneActiveTabId !== null ? paneTabs.find((t) => t.id === paneActiveTabId) ?? null : null,
   );
+  // #388 — `tabSupportsReading` is the single source of truth for "does
+  // this tab kind have a Reading Mode path?". The previous inline check
+  // here had drifted from `VaultLayout.toggleActiveReadingMode` (image +
+  // unsupported only) and was missing the `canvas` exclusion. The shared
+  // predicate fixes both bugs in one place.
   const paneActiveTabSupportsReading = $derived(
-    paneActiveTab !== null &&
-    paneActiveTab.type !== "graph" &&
-    paneActiveTab.viewer !== "image" &&
-    paneActiveTab.viewer !== "unsupported" &&
-    paneActiveTab.viewer !== "text",
+    paneActiveTab !== null && tabSupportsReading(paneActiveTab),
   );
 
   // #87: show ambient local-graph background in edit mode on markdown tabs.
@@ -403,7 +405,10 @@
         tabStore.openFileTab(absPath, "canvas");
         return;
       }
-      tabStore.openTab(absPath);
+      // #388 — pass viewport-aware viewMode so a wiki-link tap on mobile
+      // opens the target in read mode. Desktop returns "edit" (byte-identical
+      // to the no-arg call this replaces, since readers coalesce viewMode ?? "edit").
+      tabStore.openTab(absPath, defaultViewModeForViewport());
       if (detail.anchor) {
         // #62: prefer a fresh anchor lookup over the decoration-time
         // `resolution` so an anchor newly indexed between render and click
@@ -443,7 +448,10 @@
     const vaultPath = vault as string;
     createFile(vaultPath, filename)
       .then(async (newAbsPath) => {
-        tabStore.openTab(newAbsPath);
+        // #388 — NEW notes default to edit on every viewport. The user
+        // clicking an unresolved [[Foo]] is creating a note, matching
+        // the createNewNote / openTodayNote / Sidebar new-file convention.
+        tabStore.openTab(newAbsPath, "edit");
         await reloadResolvedLinks();
         treeRefreshStore.requestRefresh();
       })

--- a/src/components/Editor/__tests__/Breadcrumbs.mobileHide.test.ts
+++ b/src/components/Editor/__tests__/Breadcrumbs.mobileHide.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #388 — Breadcrumbs reading-mode toggle is hidden on mobile.
+ *
+ * Mobile users get a dedicated topbar pencil button (rendered in
+ * VaultLayout). To avoid two toggles in the same surface, the existing
+ * Breadcrumbs toggle from #63 hides itself when the viewport is mobile.
+ * Desktop and tablet keep the breadcrumbs toggle unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { readable } from "svelte/store";
+
+vi.mock("../../../ipc/commands", () => ({
+  listDirectory: vi.fn().mockResolvedValue([]),
+}));
+
+async function loadBreadcrumbs(
+  mode: "desktop" | "tablet" | "mobile",
+): Promise<{ Breadcrumbs: any; vaultStore: any; tabStore: any }> {
+  vi.resetModules();
+  vi.doMock("../../../store/viewportStore", () => ({
+    viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
+  }));
+  const { vaultStore } = await import("../../../store/vaultStore");
+  const { tabStore } = await import("../../../store/tabStore");
+  const Breadcrumbs = (await import("../Breadcrumbs.svelte")).default;
+  return { Breadcrumbs, vaultStore, tabStore };
+}
+
+describe("Breadcrumbs reading-mode toggle visibility (#388)", () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    cleanup();
+    vi.doUnmock("../../../store/viewportStore");
+  });
+
+  it("renders the toggle on desktop when viewMode is defined", async () => {
+    const { Breadcrumbs, vaultStore, tabStore } = await loadBreadcrumbs("desktop");
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["folder/note.md"],
+      fileCount: 1,
+    });
+    const tabId = tabStore.openTab("/vault/folder/note.md");
+    await tick();
+    const { container } = render(Breadcrumbs, {
+      props: {
+        filePath: "/vault/folder/note.md",
+        tabId,
+        viewMode: "edit" as const,
+      },
+    });
+    await tick();
+    expect(container.querySelector(".vc-breadcrumbs-mode-toggle")).not.toBeNull();
+  });
+
+  it("hides the toggle on mobile even when viewMode is defined", async () => {
+    const { Breadcrumbs, vaultStore, tabStore } = await loadBreadcrumbs("mobile");
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["folder/note.md"],
+      fileCount: 1,
+    });
+    const tabId = tabStore.openTab("/vault/folder/note.md");
+    await tick();
+    const { container } = render(Breadcrumbs, {
+      props: {
+        filePath: "/vault/folder/note.md",
+        tabId,
+        viewMode: "edit" as const,
+      },
+    });
+    await tick();
+    expect(container.querySelector(".vc-breadcrumbs-mode-toggle")).toBeNull();
+  });
+
+  it("renders the toggle on tablet (tablet inherits the desktop default)", async () => {
+    const { Breadcrumbs, vaultStore, tabStore } = await loadBreadcrumbs("tablet");
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["folder/note.md"],
+      fileCount: 1,
+    });
+    const tabId = tabStore.openTab("/vault/folder/note.md");
+    await tick();
+    const { container } = render(Breadcrumbs, {
+      props: {
+        filePath: "/vault/folder/note.md",
+        tabId,
+        viewMode: "read" as const,
+      },
+    });
+    await tick();
+    expect(container.querySelector(".vc-breadcrumbs-mode-toggle")).not.toBeNull();
+  });
+});

--- a/src/components/Editor/__tests__/Breadcrumbs.mobileHide.test.ts
+++ b/src/components/Editor/__tests__/Breadcrumbs.mobileHide.test.ts
@@ -1,46 +1,58 @@
 /**
  * #388 — Breadcrumbs reading-mode toggle is hidden on mobile.
  *
- * Mobile users get a dedicated topbar pencil button (rendered in
- * VaultLayout). To avoid two toggles in the same surface, the existing
- * Breadcrumbs toggle from #63 hides itself when the viewport is mobile.
- * Desktop and tablet keep the breadcrumbs toggle unchanged.
+ * Mobile users get a dedicated topbar pencil button (TopbarReadingToggle).
+ * To avoid two toggles in the same surface, the existing Breadcrumbs
+ * toggle from #63 hides itself when the viewport is mobile. Desktop and
+ * tablet keep the breadcrumbs toggle unchanged.
+ *
+ * Test setup notes: see TopbarReadingToggle.test.ts header. We mock
+ * viewportStore once at module load with a controllable writable rather
+ * than using vi.resetModules — Svelte 5 effect tracking shares state
+ * across the whole module graph and resetModules tears it.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/svelte";
 import { tick } from "svelte";
-import { readable } from "svelte/store";
+
+const { viewportWritable } = vi.hoisted(() => ({
+  viewportWritable: (() => {
+    const { writable } = require("svelte/store");
+    return writable({ mode: "desktop", isCoarsePointer: false });
+  })(),
+}));
+
+vi.mock("../../../store/viewportStore", () => ({
+  viewportStore: viewportWritable,
+  createViewportStore: () => viewportWritable,
+}));
 
 vi.mock("../../../ipc/commands", () => ({
   listDirectory: vi.fn().mockResolvedValue([]),
 }));
 
-async function loadBreadcrumbs(
-  mode: "desktop" | "tablet" | "mobile",
-): Promise<{ Breadcrumbs: any; vaultStore: any; tabStore: any }> {
-  vi.resetModules();
-  vi.doMock("../../../store/viewportStore", () => ({
-    viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
-  }));
-  const { vaultStore } = await import("../../../store/vaultStore");
-  const { tabStore } = await import("../../../store/tabStore");
-  const Breadcrumbs = (await import("../Breadcrumbs.svelte")).default;
-  return { Breadcrumbs, vaultStore, tabStore };
+import { vaultStore } from "../../../store/vaultStore";
+import { tabStore } from "../../../store/tabStore";
+import Breadcrumbs from "../Breadcrumbs.svelte";
+
+function setViewportMode(mode: "desktop" | "tablet" | "mobile"): void {
+  viewportWritable.set({ mode, isCoarsePointer: mode === "mobile" });
 }
 
 describe("Breadcrumbs reading-mode toggle visibility (#388)", () => {
-  beforeEach(() => {});
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    setViewportMode("desktop");
+  });
 
   afterEach(() => {
     cleanup();
-    vi.doUnmock("../../../store/viewportStore");
   });
 
   it("renders the toggle on desktop when viewMode is defined", async () => {
-    const { Breadcrumbs, vaultStore, tabStore } = await loadBreadcrumbs("desktop");
-    tabStore._reset();
-    vaultStore.reset();
+    setViewportMode("desktop");
     vaultStore.setReady({
       currentPath: "/vault",
       fileList: ["folder/note.md"],
@@ -60,9 +72,7 @@ describe("Breadcrumbs reading-mode toggle visibility (#388)", () => {
   });
 
   it("hides the toggle on mobile even when viewMode is defined", async () => {
-    const { Breadcrumbs, vaultStore, tabStore } = await loadBreadcrumbs("mobile");
-    tabStore._reset();
-    vaultStore.reset();
+    setViewportMode("mobile");
     vaultStore.setReady({
       currentPath: "/vault",
       fileList: ["folder/note.md"],
@@ -82,9 +92,7 @@ describe("Breadcrumbs reading-mode toggle visibility (#388)", () => {
   });
 
   it("renders the toggle on tablet (tablet inherits the desktop default)", async () => {
-    const { Breadcrumbs, vaultStore, tabStore } = await loadBreadcrumbs("tablet");
-    tabStore._reset();
-    vaultStore.reset();
+    setViewportMode("tablet");
     vaultStore.setReady({
       currentPath: "/vault",
       fileList: ["folder/note.md"],

--- a/src/components/Editor/__tests__/EditorPane.wikiLinkMobileMode.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.wikiLinkMobileMode.test.ts
@@ -1,0 +1,266 @@
+/**
+ * #388 — wiki-link click in EditorPane respects the mobile read-mode default.
+ *
+ * Two paths to cover:
+ *   1. Resolved follow: `[[target]]` resolves to an existing note → click
+ *      opens the target via `tabStore.openTab(absPath, "read")` on mobile,
+ *      `(absPath, "edit")` on desktop.
+ *   2. Click-to-create: `[[Ghost]]` does not resolve → click creates the new
+ *      note via `createFile` and opens it with viewMode === "edit"
+ *      regardless of viewport (rule: NEW notes default to edit).
+ *
+ * The dispatcher helper `defaultViewModeForViewport` reads `viewportStore`
+ * once per call. Each test installs a mocked `viewportStore` via
+ * `vi.doMock` + `vi.resetModules` before importing `EditorPane`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { readable } from "svelte/store";
+
+const { readFile, createFile, getResolvedLinks, getResolvedAnchors, getResolvedAttachments } = vi.hoisted(() => ({
+  readFile: vi.fn().mockResolvedValue(""),
+  createFile: vi.fn().mockResolvedValue(""),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAnchors: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile,
+  createFile,
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks,
+  getResolvedAnchors,
+  getResolvedAttachments,
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  // @ts-ignore — *.svelte shim doesn't expose default in dynamic-import form
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+vi.mock("../../Graph/graphRender", () => ({
+  mountGraph: vi.fn(),
+  updateGraph: vi.fn(),
+  destroyGraph: vi.fn(),
+  DEFAULT_FORCE_SETTINGS: {},
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+/**
+ * Mock viewportStore at the module level for the duration of the test, then
+ * import EditorPane fresh so the wiki-link handler's `defaultViewModeForViewport`
+ * call resolves to the mocked store. `vi.resetModules` is required so the
+ * dispatcher is re-evaluated against the fresh mock instead of a cached graph.
+ */
+async function setupWithViewport(
+  mode: "desktop" | "mobile",
+): Promise<{
+  EditorPane: any;
+  tabStore: typeof import("../../../store/tabStore").tabStore;
+  vaultStore: typeof import("../../../store/vaultStore").vaultStore;
+  setResolvedLinks: typeof import("../wikiLink").setResolvedLinks;
+}> {
+  vi.resetModules();
+  vi.doMock("../../../store/viewportStore", () => ({
+    viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
+  }));
+  // Re-mock the IPC layer so the freshly-imported EditorPane shares the spies.
+  vi.doMock("../../../ipc/commands", () => ({
+    readFile,
+    createFile,
+    writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+    getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+    mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+    getResolvedLinks,
+    getResolvedAnchors,
+    getResolvedAttachments,
+    getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    getBacklinks: vi.fn().mockResolvedValue([]),
+    getOutgoingLinks: vi.fn().mockResolvedValue([]),
+    getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+    listTags: vi.fn().mockResolvedValue([]),
+    countWikiLinks: vi.fn().mockResolvedValue(0),
+    suggestLinks: vi.fn().mockResolvedValue([]),
+    searchFulltext: vi.fn().mockResolvedValue([]),
+    searchFilename: vi.fn().mockResolvedValue([]),
+    listDirectory: vi.fn().mockResolvedValue([]),
+    invoke: vi.fn(),
+    normalizeError: (e: unknown) => e,
+  }));
+
+  const { tabStore } = await import("../../../store/tabStore");
+  const { vaultStore } = await import("../../../store/vaultStore");
+  const { setResolvedLinks } = await import("../wikiLink");
+  const EditorPane = (await import("../EditorPane.svelte")).default;
+  return { EditorPane, tabStore, vaultStore, setResolvedLinks };
+}
+
+async function mountMarkdownTabAndGetCm(
+  EditorPane: any,
+  tabStore: { openFileTab: (p: string, v: string) => string },
+): Promise<HTMLElement> {
+  const { container } = render(EditorPane, { props: { paneId: "left" } });
+  await flushAsync();
+  tabStore.openFileTab("/vault/host.md", "markdown");
+  await flushAsync();
+  const cm = container.querySelector(".cm-editor") as HTMLElement | null;
+  if (!cm) throw new Error("CM6 editor did not mount");
+  return cm;
+}
+
+describe("EditorPane wiki-link click — mobile read-mode default (#388)", () => {
+  beforeEach(() => {
+    createFile.mockReset().mockResolvedValue("");
+    getResolvedLinks.mockReset().mockResolvedValue(new Map());
+    getResolvedAnchors.mockReset().mockResolvedValue(new Map());
+    getResolvedAttachments.mockReset().mockResolvedValue(new Map());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.doUnmock("../../../store/viewportStore");
+  });
+
+  it("on mobile, resolved wiki-link follow opens target with viewMode='read'", async () => {
+    const { EditorPane, tabStore, vaultStore, setResolvedLinks } = await setupWithViewport("mobile");
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md", "target.md"],
+      fileCount: 2,
+    });
+    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    setResolvedLinks(new Map([["target", "target.md"]]));
+
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: "target", resolution: "resolved", anchor: null },
+      }),
+    );
+    await flushAsync();
+
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md", "read");
+  });
+
+  it("on desktop, resolved wiki-link follow opens target with viewMode='edit'", async () => {
+    const { EditorPane, tabStore, vaultStore, setResolvedLinks } = await setupWithViewport("desktop");
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md", "target.md"],
+      fileCount: 2,
+    });
+    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    setResolvedLinks(new Map([["target", "target.md"]]));
+
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: "target", resolution: "resolved", anchor: null },
+      }),
+    );
+    await flushAsync();
+
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md", "edit");
+  });
+
+  it("on mobile, click-to-create new note opens with viewMode='edit' (NEW notes default to edit)", async () => {
+    // Rule: NEW notes default to edit on every viewport. EXISTING notes
+    // default to read on mobile. This matches createNewNote / openTodayNote /
+    // Sidebar new-file convention — the user clicking an unresolved [[Foo]]
+    // is creating a note and presumably wants to write into it.
+    const { EditorPane, tabStore, vaultStore } = await setupWithViewport("mobile");
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md"],
+      fileCount: 1,
+    });
+    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    createFile.mockResolvedValueOnce("/vault/Ghost.md");
+
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: "Ghost", resolution: "unresolved", anchor: null },
+      }),
+    );
+    await flushAsync();
+
+    expect(createFile).toHaveBeenCalledWith("/vault", "Ghost.md");
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/Ghost.md", "edit");
+  });
+
+  it("on desktop, click-to-create new note opens with viewMode='edit'", async () => {
+    const { EditorPane, tabStore, vaultStore } = await setupWithViewport("desktop");
+    tabStore._reset();
+    vaultStore.reset();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md"],
+      fileCount: 1,
+    });
+    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    createFile.mockResolvedValueOnce("/vault/Ghost.md");
+
+    const openTabSpy = vi.spyOn(tabStore, "openTab");
+
+    cm.dispatchEvent(
+      new CustomEvent("wiki-link-click", {
+        bubbles: true,
+        detail: { target: "Ghost", resolution: "unresolved", anchor: null },
+      }),
+    );
+    await flushAsync();
+
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/Ghost.md", "edit");
+  });
+});

--- a/src/components/Editor/__tests__/EditorPane.wikiLinkMobileMode.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.wikiLinkMobileMode.test.ts
@@ -85,14 +85,12 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 // #388 — mock `defaultViewModeForViewport` so each test can flip the return
-// value at call time. EditorPane imports this from `../../lib/tabKind`.
-vi.mock("../../../lib/tabKind", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../lib/tabKind")>();
-  return {
-    ...actual,
-    defaultViewModeForViewport,
-  };
-});
+// value at call time. EditorPane imports this from `../../lib/viewport`
+// (extracted out of `tabKind.ts` to keep the classifier module pure /
+// store-free).
+vi.mock("../../../lib/viewport", () => ({
+  defaultViewModeForViewport,
+}));
 
 import { tabStore } from "../../../store/tabStore";
 import { vaultStore } from "../../../store/vaultStore";

--- a/src/components/Editor/__tests__/EditorPane.wikiLinkMobileMode.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.wikiLinkMobileMode.test.ts
@@ -9,22 +9,31 @@
  *      note via `createFile` and opens it with viewMode === "edit"
  *      regardless of viewport (rule: NEW notes default to edit).
  *
- * The dispatcher helper `defaultViewModeForViewport` reads `viewportStore`
- * once per call. Each test installs a mocked `viewportStore` via
- * `vi.doMock` + `vi.resetModules` before importing `EditorPane`.
+ * Strategy: mock `defaultViewModeForViewport` directly (instead of
+ * `viewportStore`), then flip its return value per-test via the spy. This
+ * sidesteps `vi.resetModules` interactions with `lucide-svelte`'s module
+ * graph that caused `from_svg is not a function` runtime errors when the
+ * EditorPane subtree was re-imported under a swapped viewport mock.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/svelte";
 import { tick } from "svelte";
-import { readable } from "svelte/store";
 
-const { readFile, createFile, getResolvedLinks, getResolvedAnchors, getResolvedAttachments } = vi.hoisted(() => ({
+const {
+  readFile,
+  createFile,
+  getResolvedLinks,
+  getResolvedAnchors,
+  getResolvedAttachments,
+  defaultViewModeForViewport,
+} = vi.hoisted(() => ({
   readFile: vi.fn().mockResolvedValue(""),
   createFile: vi.fn().mockResolvedValue(""),
   getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
   getResolvedAnchors: vi.fn().mockResolvedValue(new Map()),
   getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+  defaultViewModeForViewport: vi.fn(() => "edit" as "edit" | "read"),
 }));
 
 vi.mock("../../../ipc/commands", () => ({
@@ -75,6 +84,21 @@ vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
 }));
 
+// #388 — mock `defaultViewModeForViewport` so each test can flip the return
+// value at call time. EditorPane imports this from `../../lib/tabKind`.
+vi.mock("../../../lib/tabKind", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/tabKind")>();
+  return {
+    ...actual,
+    defaultViewModeForViewport,
+  };
+});
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import { setResolvedLinks } from "../wikiLink";
+import EditorPane from "../EditorPane.svelte";
+
 async function flushAsync(): Promise<void> {
   for (let i = 0; i < 40; i++) {
     await Promise.resolve();
@@ -82,60 +106,7 @@ async function flushAsync(): Promise<void> {
   }
 }
 
-/**
- * Mock viewportStore at the module level for the duration of the test, then
- * import EditorPane fresh so the wiki-link handler's `defaultViewModeForViewport`
- * call resolves to the mocked store. `vi.resetModules` is required so the
- * dispatcher is re-evaluated against the fresh mock instead of a cached graph.
- */
-async function setupWithViewport(
-  mode: "desktop" | "mobile",
-): Promise<{
-  EditorPane: any;
-  tabStore: typeof import("../../../store/tabStore").tabStore;
-  vaultStore: typeof import("../../../store/vaultStore").vaultStore;
-  setResolvedLinks: typeof import("../wikiLink").setResolvedLinks;
-}> {
-  vi.resetModules();
-  vi.doMock("../../../store/viewportStore", () => ({
-    viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
-  }));
-  // Re-mock the IPC layer so the freshly-imported EditorPane shares the spies.
-  vi.doMock("../../../ipc/commands", () => ({
-    readFile,
-    createFile,
-    writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
-    getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
-    mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
-    getResolvedLinks,
-    getResolvedAnchors,
-    getResolvedAttachments,
-    getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
-    getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
-    getBacklinks: vi.fn().mockResolvedValue([]),
-    getOutgoingLinks: vi.fn().mockResolvedValue([]),
-    getUnresolvedLinks: vi.fn().mockResolvedValue([]),
-    listTags: vi.fn().mockResolvedValue([]),
-    countWikiLinks: vi.fn().mockResolvedValue(0),
-    suggestLinks: vi.fn().mockResolvedValue([]),
-    searchFulltext: vi.fn().mockResolvedValue([]),
-    searchFilename: vi.fn().mockResolvedValue([]),
-    listDirectory: vi.fn().mockResolvedValue([]),
-    invoke: vi.fn(),
-    normalizeError: (e: unknown) => e,
-  }));
-
-  const { tabStore } = await import("../../../store/tabStore");
-  const { vaultStore } = await import("../../../store/vaultStore");
-  const { setResolvedLinks } = await import("../wikiLink");
-  const EditorPane = (await import("../EditorPane.svelte")).default;
-  return { EditorPane, tabStore, vaultStore, setResolvedLinks };
-}
-
-async function mountMarkdownTabAndGetCm(
-  EditorPane: any,
-  tabStore: { openFileTab: (p: string, v: string) => string },
-): Promise<HTMLElement> {
+async function mountMarkdownTabAndGetCm(): Promise<HTMLElement> {
   const { container } = render(EditorPane, { props: { paneId: "left" } });
   await flushAsync();
   tabStore.openFileTab("/vault/host.md", "markdown");
@@ -147,28 +118,29 @@ async function mountMarkdownTabAndGetCm(
 
 describe("EditorPane wiki-link click — mobile read-mode default (#388)", () => {
   beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
     createFile.mockReset().mockResolvedValue("");
     getResolvedLinks.mockReset().mockResolvedValue(new Map());
     getResolvedAnchors.mockReset().mockResolvedValue(new Map());
     getResolvedAttachments.mockReset().mockResolvedValue(new Map());
+    defaultViewModeForViewport.mockReset().mockReturnValue("edit");
+    setResolvedLinks(new Map());
   });
 
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
-    vi.doUnmock("../../../store/viewportStore");
   });
 
   it("on mobile, resolved wiki-link follow opens target with viewMode='read'", async () => {
-    const { EditorPane, tabStore, vaultStore, setResolvedLinks } = await setupWithViewport("mobile");
-    tabStore._reset();
-    vaultStore.reset();
+    defaultViewModeForViewport.mockReturnValue("read");
     vaultStore.setReady({
       currentPath: "/vault",
       fileList: ["host.md", "target.md"],
       fileCount: 2,
     });
-    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    const cm = await mountMarkdownTabAndGetCm();
     setResolvedLinks(new Map([["target", "target.md"]]));
 
     const openTabSpy = vi.spyOn(tabStore, "openTab");
@@ -185,15 +157,13 @@ describe("EditorPane wiki-link click — mobile read-mode default (#388)", () =>
   });
 
   it("on desktop, resolved wiki-link follow opens target with viewMode='edit'", async () => {
-    const { EditorPane, tabStore, vaultStore, setResolvedLinks } = await setupWithViewport("desktop");
-    tabStore._reset();
-    vaultStore.reset();
+    defaultViewModeForViewport.mockReturnValue("edit");
     vaultStore.setReady({
       currentPath: "/vault",
       fileList: ["host.md", "target.md"],
       fileCount: 2,
     });
-    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    const cm = await mountMarkdownTabAndGetCm();
     setResolvedLinks(new Map([["target", "target.md"]]));
 
     const openTabSpy = vi.spyOn(tabStore, "openTab");
@@ -214,15 +184,13 @@ describe("EditorPane wiki-link click — mobile read-mode default (#388)", () =>
     // default to read on mobile. This matches createNewNote / openTodayNote /
     // Sidebar new-file convention — the user clicking an unresolved [[Foo]]
     // is creating a note and presumably wants to write into it.
-    const { EditorPane, tabStore, vaultStore } = await setupWithViewport("mobile");
-    tabStore._reset();
-    vaultStore.reset();
+    defaultViewModeForViewport.mockReturnValue("read");
     vaultStore.setReady({
       currentPath: "/vault",
       fileList: ["host.md"],
       fileCount: 1,
     });
-    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    const cm = await mountMarkdownTabAndGetCm();
     createFile.mockResolvedValueOnce("/vault/Ghost.md");
 
     const openTabSpy = vi.spyOn(tabStore, "openTab");
@@ -240,15 +208,13 @@ describe("EditorPane wiki-link click — mobile read-mode default (#388)", () =>
   });
 
   it("on desktop, click-to-create new note opens with viewMode='edit'", async () => {
-    const { EditorPane, tabStore, vaultStore } = await setupWithViewport("desktop");
-    tabStore._reset();
-    vaultStore.reset();
+    defaultViewModeForViewport.mockReturnValue("edit");
     vaultStore.setReady({
       currentPath: "/vault",
       fileList: ["host.md"],
       fileCount: 1,
     });
-    const cm = await mountMarkdownTabAndGetCm(EditorPane, tabStore);
+    const cm = await mountMarkdownTabAndGetCm();
     createFile.mockResolvedValueOnce("/vault/Ghost.md");
 
     const openTabSpy = vi.spyOn(tabStore, "openTab");

--- a/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
+++ b/src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts
@@ -144,7 +144,9 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     await flushAsync();
 
     expect(createFile).not.toHaveBeenCalled();
-    expect(openTabSpy).toHaveBeenCalledWith("/vault/test/Untitled.md");
+    // #388 — wiki-link follow now passes the viewport-aware viewMode hint;
+    // jsdom default viewport is desktop, so the hint resolves to "edit".
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/test/Untitled.md", "edit");
   });
 
   it("triggers a reload without opening or creating when the live map lost the target (resolved=true, liveRelPath=null)", async () => {
@@ -244,7 +246,7 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     );
     await flushAsync();
 
-    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md");
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md", "edit");
     expect(requestRangeSpy).toHaveBeenCalledWith("/vault/target.md", 100, 130);
   });
 
@@ -279,7 +281,7 @@ describe("EditorPane wiki-link click — live-lookup against stale decoration (#
     );
     await flushAsync();
 
-    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md");
+    expect(openTabSpy).toHaveBeenCalledWith("/vault/target.md", "edit");
     expect(toastSpy).toHaveBeenCalled();
     const toastArg = toastSpy.mock.calls[0]?.[0] as { variant: string; message: string };
     expect(toastArg.variant).toBe("warning");

--- a/src/components/Layout/TopbarReadingToggle.svelte
+++ b/src/components/Layout/TopbarReadingToggle.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  /**
+   * #388 — Mobile-only Reading Mode toggle in the editor topbar.
+   *
+   * Visible only when:
+   *   - viewport.mode === "mobile", AND
+   *   - there is an active tab, AND
+   *   - that tab supports Reading Mode (markdown / undefined viewer; not
+   *     graph / image / unsupported / text / canvas).
+   *
+   * Click flips the active tab's viewMode via `tabStore.toggleViewMode`.
+   *
+   * Why a dedicated component instead of inlining in VaultLayout:
+   *   - Keeps VaultLayout free of yet-more reactive subscriptions.
+   *   - Single click path through `tabSupportsReading()` matches the guard
+   *     in `VaultLayout.toggleActiveReadingMode` (Boy Scout fix from plan v3).
+   *
+   * Breadcrumbs self-hides on mobile so the two never co-render.
+   */
+  import { BookOpen, Pencil } from "lucide-svelte";
+  import { tabStore } from "../../store/tabStore";
+  import { viewportStore } from "../../store/viewportStore";
+  import { tabSupportsReading } from "../../lib/tabKind";
+  import type { Tab, TabViewMode } from "../../store/tabStore";
+
+  // Auto-subscribe via `$store` syntax so reactive readers stay inside
+  // Svelte's tracking context. The expressions below depend on the store
+  // values directly — `$derived` then re-evaluates on every store emission.
+  const activeTab: Tab | null = $derived(
+    $tabStore.activeTabId
+      ? $tabStore.tabs.find((t) => t.id === $tabStore.activeTabId) ?? null
+      : null,
+  );
+
+  const supports = $derived(activeTab !== null && tabSupportsReading(activeTab));
+  const visible = $derived(
+    $viewportStore.mode === "mobile" && supports && activeTab !== null,
+  );
+  const mode: TabViewMode = $derived(
+    activeTab !== null ? (activeTab.viewMode ?? "edit") : "edit",
+  );
+
+  function handleClick() {
+    if (!activeTab) return;
+    if (!tabSupportsReading(activeTab)) return;
+    tabStore.toggleViewMode(activeTab.id);
+  }
+</script>
+
+{#if visible}
+  <button
+    type="button"
+    class="vc-topbar-reading-toggle"
+    class:vc-topbar-reading-toggle--read={mode === "read"}
+    data-vc-topbar-reading-toggle
+    data-mode={mode}
+    onclick={handleClick}
+    aria-pressed={mode === "read"}
+    aria-label={mode === "read" ? "Bearbeitungsmodus" : "Lesemodus"}
+    title={mode === "read" ? "Bearbeitungsmodus" : "Lesemodus"}
+  >
+    {#if mode === "read"}
+      <Pencil size={16} />
+    {:else}
+      <BookOpen size={16} />
+    {/if}
+  </button>
+{/if}
+
+<style>
+  .vc-topbar-reading-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    /* #385 hit-target token bumps to 44px under (pointer: coarse). */
+    min-width: var(--vc-hit-target, 32px);
+    min-height: var(--vc-hit-target, 32px);
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--color-text-muted);
+  }
+
+  .vc-topbar-reading-toggle:hover:not(.vc-topbar-reading-toggle--read) {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+
+  .vc-topbar-reading-toggle--read {
+    background: var(--color-accent);
+    color: var(--color-surface);
+  }
+
+  .vc-topbar-reading-toggle--read:hover {
+    filter: brightness(1.1);
+  }
+
+  .vc-topbar-reading-toggle:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+  }
+</style>

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -10,6 +10,8 @@
   import RightSidebar from "./RightSidebar.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import EncryptionStatusbar from "../Statusbar/EncryptionStatusbar.svelte";
+  import TopbarReadingToggle from "./TopbarReadingToggle.svelte";
+  import { tabSupportsReading } from "../../lib/tabKind";
   import PasswordPromptModal from "../common/PasswordPromptModal.svelte";
   import EncryptFolderModal from "../common/EncryptFolderModal.svelte";
   import {
@@ -540,14 +542,19 @@
     }
   }
 
-  /** Issue #63: toggle Reading vs Edit mode on the active markdown tab. */
+  /**
+   * Issue #63 / #388: toggle Reading vs Edit mode on the active markdown tab.
+   *
+   * Pre-#388: this guard inlined a check missing two viewer kinds (text +
+   * canvas). A `.json` tab or canvas tab pressing Cmd/Ctrl+E would receive
+   * `viewMode === "read"` despite having no Reading Mode path. The
+   * `tabSupportsReading` predicate is the single source of truth shared with
+   * `EditorPane.paneActiveTabSupportsReading` and the topbar toggle.
+   */
   function toggleActiveReadingMode() {
     const active = tabStore.getActiveTab();
     if (!active) return;
-    // Only markdown file tabs support reading mode — graph tabs and non-
-    // markdown viewers (image / unsupported / text-preview) stay as-is.
-    if (active.type === "graph") return;
-    if (active.viewer === "image" || active.viewer === "unsupported") return;
+    if (!tabSupportsReading(active)) return;
     tabStore.toggleViewMode(active.id);
   }
 
@@ -877,6 +884,14 @@
         </button>
       {/if}
       <div class="vc-editor-topbar-spacer"></div>
+      <!-- #388: mobile-only Reading Mode toggle. Self-hides on
+           desktop/tablet and on tab kinds without a Reading Mode path
+           (graph / image / unsupported / text / canvas). On mobile the
+           backlinks button is hidden (see #386 `{#if !isMobile}` gate
+           below), so the pencil and the backlinks button never co-render
+           — the topbar's right cluster is exactly one of them at any
+           given viewport. -->
+      <TopbarReadingToggle />
       {#if !isMobile}
         <button
           class="vc-sidebar-toggle-btn vc-backlinks-toggle-btn"

--- a/src/components/Layout/__tests__/TopbarReadingToggle.test.ts
+++ b/src/components/Layout/__tests__/TopbarReadingToggle.test.ts
@@ -1,0 +1,256 @@
+/**
+ * #388 — Mobile-only topbar pencil toggle for Reading Mode.
+ *
+ * Visibility matrix:
+ *   - Hidden on desktop and tablet regardless of tab kind.
+ *   - Hidden on mobile when no tab is active.
+ *   - Hidden on mobile when the active tab does not support Reading Mode
+ *     (graph / image / unsupported / text / canvas).
+ *   - Visible on mobile when the active tab is markdown.
+ *
+ * Click behaviour:
+ *   - Click flips the active tab's viewMode via tabStore.toggleViewMode.
+ *   - Icon flips from BookOpen (in edit) to Pencil (in read), and back.
+ *
+ * Per-tab persistence (T-top-9):
+ *   - Toggle tab A to edit, switch active to B, switch back to A — A stays
+ *     in edit and the icon reflects A's state, not the most-recently-toggled
+ *     tab's state.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { readable } from "svelte/store";
+
+vi.mock("../../../ipc/commands", () => ({}));
+
+async function loadToggle(
+  mode: "desktop" | "tablet" | "mobile",
+): Promise<{
+  TopbarReadingToggle: any;
+  tabStore: typeof import("../../../store/tabStore").tabStore;
+}> {
+  vi.resetModules();
+  vi.doMock("../../../store/viewportStore", () => ({
+    viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
+  }));
+  const { tabStore } = await import("../../../store/tabStore");
+  const TopbarReadingToggle = (await import("../TopbarReadingToggle.svelte")).default;
+  return { TopbarReadingToggle, tabStore };
+}
+
+describe("TopbarReadingToggle visibility (#388)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.doUnmock("../../../store/viewportStore");
+  });
+
+  it("hidden on desktop even when an active markdown tab exists", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("desktop");
+    tabStore._reset();
+    tabStore.openTab("/v/note.md");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("hidden on tablet even when an active markdown tab exists", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("tablet");
+    tabStore._reset();
+    tabStore.openTab("/v/note.md");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("hidden on mobile when no tab is active", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("hidden on mobile for graph tabs", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openGraphTab();
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("hidden on mobile for image tabs", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openFileTab("/v/photo.png", "image");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("hidden on mobile for canvas tabs", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openFileTab("/v/board.canvas", "canvas");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("hidden on mobile for text-viewer tabs (.json / .txt / etc.)", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openFileTab("/v/data.json", "text");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("hidden on mobile for unsupported tabs", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openFileTab("/v/blob.bin", "unsupported");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
+  });
+
+  it("visible on mobile for active markdown tab in edit mode (data-mode='edit')", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openTab("/v/note.md", "edit");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    const button = container.querySelector("[data-vc-topbar-reading-toggle]");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("data-mode")).toBe("edit");
+  });
+
+  it("visible on mobile for active markdown tab in read mode (data-mode='read')", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openTab("/v/note.md", "read");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    const button = container.querySelector("[data-vc-topbar-reading-toggle]");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("data-mode")).toBe("read");
+  });
+
+  it("visible on mobile for tab with undefined viewMode (treated as edit)", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    tabStore.openTab("/v/note.md");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+    const button = container.querySelector("[data-vc-topbar-reading-toggle]");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("data-mode")).toBe("edit");
+  });
+});
+
+describe("TopbarReadingToggle click behaviour (#388)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.doUnmock("../../../store/viewportStore");
+  });
+
+  it("click on edit-mode tab flips it to read and the data-mode updates", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    const tabId = tabStore.openTab("/v/note.md", "edit");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+
+    const button = container.querySelector(
+      "[data-vc-topbar-reading-toggle]",
+    ) as HTMLButtonElement;
+    expect(button.getAttribute("data-mode")).toBe("edit");
+
+    await fireEvent.click(button);
+    await tick();
+
+    const after = await import("svelte/store").then((m) => m.get(tabStore));
+    const tab = after.tabs.find((t) => t.id === tabId);
+    expect(tab?.viewMode).toBe("read");
+
+    const buttonAfter = container.querySelector(
+      "[data-vc-topbar-reading-toggle]",
+    );
+    expect(buttonAfter?.getAttribute("data-mode")).toBe("read");
+  });
+
+  it("click on read-mode tab flips it to edit and the data-mode updates", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    const tabId = tabStore.openTab("/v/note.md", "read");
+    await tick();
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+
+    const button = container.querySelector(
+      "[data-vc-topbar-reading-toggle]",
+    ) as HTMLButtonElement;
+    expect(button.getAttribute("data-mode")).toBe("read");
+
+    await fireEvent.click(button);
+    await tick();
+
+    const after = await import("svelte/store").then((m) => m.get(tabStore));
+    expect(after.tabs.find((t) => t.id === tabId)?.viewMode).toBe("edit");
+
+    const buttonAfter = container.querySelector(
+      "[data-vc-topbar-reading-toggle]",
+    );
+    expect(buttonAfter?.getAttribute("data-mode")).toBe("edit");
+  });
+
+  it("per-tab persistence — toggle A, switch to B, switch back, A still in flipped mode", async () => {
+    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
+    tabStore._reset();
+    const idA = tabStore.openTab("/v/a.md", "edit");
+    const idB = tabStore.openTab("/v/b.md", "edit");
+    tabStore.activateTab(idA);
+    await tick();
+
+    const { container } = render(TopbarReadingToggle);
+    await tick();
+
+    let button = container.querySelector(
+      "[data-vc-topbar-reading-toggle]",
+    ) as HTMLButtonElement;
+    expect(button.getAttribute("data-mode")).toBe("edit");
+    await fireEvent.click(button);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")
+      ?.getAttribute("data-mode")).toBe("read");
+
+    tabStore.activateTab(idB);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")
+      ?.getAttribute("data-mode")).toBe("edit");
+
+    tabStore.activateTab(idA);
+    await tick();
+    expect(container.querySelector("[data-vc-topbar-reading-toggle]")
+      ?.getAttribute("data-mode")).toBe("read");
+
+    const final = await import("svelte/store").then((m) => m.get(tabStore));
+    expect(final.tabs.find((t) => t.id === idA)?.viewMode).toBe("read");
+    expect(final.tabs.find((t) => t.id === idB)?.viewMode).toBe("edit");
+  });
+});

--- a/src/components/Layout/__tests__/TopbarReadingToggle.test.ts
+++ b/src/components/Layout/__tests__/TopbarReadingToggle.test.ts
@@ -10,126 +10,127 @@
  *
  * Click behaviour:
  *   - Click flips the active tab's viewMode via tabStore.toggleViewMode.
- *   - Icon flips from BookOpen (in edit) to Pencil (in read), and back.
+ *   - data-mode flips between "edit" and "read" reactively.
  *
  * Per-tab persistence (T-top-9):
  *   - Toggle tab A to edit, switch active to B, switch back to A — A stays
- *     in edit and the icon reflects A's state, not the most-recently-toggled
+ *     in edit and the toggle reflects A's state, not the most-recently-toggled
  *     tab's state.
+ *
+ * Test setup notes:
+ *   - viewportStore is mocked once at module load with a controllable writable.
+ *     We do NOT use vi.resetModules — Svelte 5 effect tracking is shared
+ *     across the whole module graph and resetModules tears that lifecycle,
+ *     producing `effect_orphan` errors in onMount / $effect.
+ *   - `setViewportMode(mode)` swaps the mocked store's value between tests.
+ *   - Each test re-renders TopbarReadingToggle so it reads the current mode
+ *     during its onMount subscription.
  */
 
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, cleanup } from "@testing-library/svelte";
 import { tick } from "svelte";
-import { readable } from "svelte/store";
+import { writable, get } from "svelte/store";
 
-vi.mock("../../../ipc/commands", () => ({}));
+// Hoisted: a single writable owned by the mock so every importer of
+// viewportStore sees the same store instance across all tests.
+const { viewportWritable } = vi.hoisted(() => ({
+  viewportWritable: (() => {
+    // Avoid top-of-file svelte import in vi.hoisted by deferring inside
+    // the IIFE — vi.hoisted runs after svelte resolves.
+    const { writable } = require("svelte/store");
+    return writable({ mode: "desktop", isCoarsePointer: false });
+  })(),
+}));
 
-async function loadToggle(
-  mode: "desktop" | "tablet" | "mobile",
-): Promise<{
-  TopbarReadingToggle: any;
-  tabStore: typeof import("../../../store/tabStore").tabStore;
-}> {
-  vi.resetModules();
-  vi.doMock("../../../store/viewportStore", () => ({
-    viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
-  }));
-  const { tabStore } = await import("../../../store/tabStore");
-  const TopbarReadingToggle = (await import("../TopbarReadingToggle.svelte")).default;
-  return { TopbarReadingToggle, tabStore };
+vi.mock("../../../store/viewportStore", () => ({
+  viewportStore: viewportWritable,
+  createViewportStore: () => viewportWritable,
+}));
+
+function setViewportMode(mode: "desktop" | "tablet" | "mobile"): void {
+  viewportWritable.set({ mode, isCoarsePointer: mode === "mobile" });
 }
 
+import { tabStore } from "../../../store/tabStore";
+import TopbarReadingToggle from "../TopbarReadingToggle.svelte";
+
 describe("TopbarReadingToggle visibility (#388)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    setViewportMode("desktop");
+  });
+
   afterEach(() => {
     cleanup();
-    vi.doUnmock("../../../store/viewportStore");
   });
 
   it("hidden on desktop even when an active markdown tab exists", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("desktop");
-    tabStore._reset();
+    setViewportMode("desktop");
     tabStore.openTab("/v/note.md");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("hidden on tablet even when an active markdown tab exists", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("tablet");
-    tabStore._reset();
+    setViewportMode("tablet");
     tabStore.openTab("/v/note.md");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("hidden on mobile when no tab is active", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
-    await tick();
+    setViewportMode("mobile");
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("hidden on mobile for graph tabs", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openGraphTab();
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("hidden on mobile for image tabs", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openFileTab("/v/photo.png", "image");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("hidden on mobile for canvas tabs", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openFileTab("/v/board.canvas", "canvas");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("hidden on mobile for text-viewer tabs (.json / .txt / etc.)", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openFileTab("/v/data.json", "text");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("hidden on mobile for unsupported tabs", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openFileTab("/v/blob.bin", "unsupported");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     expect(container.querySelector("[data-vc-topbar-reading-toggle]")).toBeNull();
   });
 
   it("visible on mobile for active markdown tab in edit mode (data-mode='edit')", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openTab("/v/note.md", "edit");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     const button = container.querySelector("[data-vc-topbar-reading-toggle]");
@@ -138,10 +139,8 @@ describe("TopbarReadingToggle visibility (#388)", () => {
   });
 
   it("visible on mobile for active markdown tab in read mode (data-mode='read')", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openTab("/v/note.md", "read");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     const button = container.querySelector("[data-vc-topbar-reading-toggle]");
@@ -150,10 +149,8 @@ describe("TopbarReadingToggle visibility (#388)", () => {
   });
 
   it("visible on mobile for tab with undefined viewMode (treated as edit)", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
+    setViewportMode("mobile");
     tabStore.openTab("/v/note.md");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
     const button = container.querySelector("[data-vc-topbar-reading-toggle]");
@@ -163,16 +160,17 @@ describe("TopbarReadingToggle visibility (#388)", () => {
 });
 
 describe("TopbarReadingToggle click behaviour (#388)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    setViewportMode("mobile");
+  });
+
   afterEach(() => {
     cleanup();
-    vi.doUnmock("../../../store/viewportStore");
   });
 
   it("click on edit-mode tab flips it to read and the data-mode updates", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
     const tabId = tabStore.openTab("/v/note.md", "edit");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
 
@@ -184,8 +182,7 @@ describe("TopbarReadingToggle click behaviour (#388)", () => {
     await fireEvent.click(button);
     await tick();
 
-    const after = await import("svelte/store").then((m) => m.get(tabStore));
-    const tab = after.tabs.find((t) => t.id === tabId);
+    const tab = get(tabStore).tabs.find((t) => t.id === tabId);
     expect(tab?.viewMode).toBe("read");
 
     const buttonAfter = container.querySelector(
@@ -195,10 +192,7 @@ describe("TopbarReadingToggle click behaviour (#388)", () => {
   });
 
   it("click on read-mode tab flips it to edit and the data-mode updates", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
     const tabId = tabStore.openTab("/v/note.md", "read");
-    await tick();
     const { container } = render(TopbarReadingToggle);
     await tick();
 
@@ -210,8 +204,7 @@ describe("TopbarReadingToggle click behaviour (#388)", () => {
     await fireEvent.click(button);
     await tick();
 
-    const after = await import("svelte/store").then((m) => m.get(tabStore));
-    expect(after.tabs.find((t) => t.id === tabId)?.viewMode).toBe("edit");
+    expect(get(tabStore).tabs.find((t) => t.id === tabId)?.viewMode).toBe("edit");
 
     const buttonAfter = container.querySelector(
       "[data-vc-topbar-reading-toggle]",
@@ -220,12 +213,9 @@ describe("TopbarReadingToggle click behaviour (#388)", () => {
   });
 
   it("per-tab persistence — toggle A, switch to B, switch back, A still in flipped mode", async () => {
-    const { TopbarReadingToggle, tabStore } = await loadToggle("mobile");
-    tabStore._reset();
     const idA = tabStore.openTab("/v/a.md", "edit");
     const idB = tabStore.openTab("/v/b.md", "edit");
     tabStore.activateTab(idA);
-    await tick();
 
     const { container } = render(TopbarReadingToggle);
     await tick();
@@ -236,20 +226,23 @@ describe("TopbarReadingToggle click behaviour (#388)", () => {
     expect(button.getAttribute("data-mode")).toBe("edit");
     await fireEvent.click(button);
     await tick();
-    expect(container.querySelector("[data-vc-topbar-reading-toggle]")
-      ?.getAttribute("data-mode")).toBe("read");
+    expect(
+      container.querySelector("[data-vc-topbar-reading-toggle]")?.getAttribute("data-mode"),
+    ).toBe("read");
 
     tabStore.activateTab(idB);
     await tick();
-    expect(container.querySelector("[data-vc-topbar-reading-toggle]")
-      ?.getAttribute("data-mode")).toBe("edit");
+    expect(
+      container.querySelector("[data-vc-topbar-reading-toggle]")?.getAttribute("data-mode"),
+    ).toBe("edit");
 
     tabStore.activateTab(idA);
     await tick();
-    expect(container.querySelector("[data-vc-topbar-reading-toggle]")
-      ?.getAttribute("data-mode")).toBe("read");
+    expect(
+      container.querySelector("[data-vc-topbar-reading-toggle]")?.getAttribute("data-mode"),
+    ).toBe("read");
 
-    const final = await import("svelte/store").then((m) => m.get(tabStore));
+    const final = get(tabStore);
     expect(final.tabs.find((t) => t.id === idA)?.viewMode).toBe("read");
     expect(final.tabs.find((t) => t.id === idB)?.viewMode).toBe("edit");
   });

--- a/src/components/OutgoingLinks/OutgoingLinksPanel.svelte
+++ b/src/components/OutgoingLinks/OutgoingLinksPanel.svelte
@@ -7,6 +7,7 @@
   import { treeRefreshStore } from "../../store/treeRefreshStore";
   import { createFile } from "../../ipc/commands";
   import { resolveTarget } from "../Editor/wikiLink";
+  import { openFileAsTab } from "../../lib/openFileAsTab";
   import {
     extractOutgoingLinks,
     type OutgoingLink,
@@ -66,7 +67,9 @@
     if (!vault) return;
 
     if (entry.resolvedPath !== null) {
-      tabStore.openTab(`${vault}/${entry.resolvedPath}`);
+      // #388 — route through openFileAsTab so the dispatcher applies the
+      // viewport-aware viewMode default (mobile → read, desktop → edit).
+      void openFileAsTab(`${vault}/${entry.resolvedPath}`);
       return;
     }
 
@@ -78,7 +81,9 @@
       : `${entry.target}.md`;
     createFile(vault, filename)
       .then((newAbsPath) => {
-        tabStore.openTab(newAbsPath);
+        // #388 — NEW notes default to edit on every viewport (matching
+        // createNewNote / openTodayNote / Sidebar new-file convention).
+        tabStore.openTab(newAbsPath, "edit");
         // Trigger a sidebar tree reload so the newly-created file appears.
         // EditorPane's vaultStore/FILE_CHANGE subscribers will refresh the
         // wiki-link resolution map so the target resolves on subsequent

--- a/src/lib/__tests__/openFileAsTab.test.ts
+++ b/src/lib/__tests__/openFileAsTab.test.ts
@@ -91,3 +91,70 @@ describe("openFileAsTab", () => {
     expect(get(tabStore).tabs).toHaveLength(1);
   });
 });
+
+// #388 — viewport-aware default viewMode. Mobile users get markdown opens in
+// read mode; non-markdown viewers (image / text / unsupported) ignore the
+// hint because they have no Reading Mode path. The dispatcher reads the
+// helper from `tabKind.ts`, which itself reads `viewportStore` once per call.
+
+describe("openFileAsTab + viewMode (#388)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    readFile.mockReset();
+    vi.resetModules();
+    vi.doUnmock("../../store/viewportStore");
+  });
+
+  async function loadDispatcher(
+    mode: "desktop" | "tablet" | "mobile",
+  ): Promise<typeof openFileAsTab> {
+    const { readable } = await import("svelte/store");
+    vi.doMock("../../store/viewportStore", () => ({
+      viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
+    }));
+    // Re-mock the IPC layer for the freshly-imported dispatcher so the
+    // module graph after `vi.resetModules()` shares the same readFile spy.
+    vi.doMock("../../ipc/commands", () => ({ readFile }));
+    const mod = await import("../openFileAsTab");
+    return mod.openFileAsTab;
+  }
+
+  it("opens markdown with viewMode='read' on mobile", async () => {
+    const dispatch = await loadDispatcher("mobile");
+    const { tabStore: ts } = await import("../../store/tabStore");
+    ts._reset();
+    await dispatch("/vault/note.md");
+    const state = get(ts);
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]!.viewMode).toBe("read");
+  });
+
+  it("opens markdown with viewMode='edit' on desktop", async () => {
+    const dispatch = await loadDispatcher("desktop");
+    const { tabStore: ts } = await import("../../store/tabStore");
+    ts._reset();
+    await dispatch("/vault/note.md");
+    const state = get(ts);
+    expect(state.tabs[0]!.viewMode).toBe("edit");
+  });
+
+  it("does not pass the hint for image viewers (image has no Reading Mode)", async () => {
+    const dispatch = await loadDispatcher("mobile");
+    const { tabStore: ts } = await import("../../store/tabStore");
+    ts._reset();
+    await dispatch("/vault/photo.png");
+    const state = get(ts);
+    expect(state.tabs[0]!.viewer).toBe("image");
+    expect(state.tabs[0]!.viewMode).toBeUndefined();
+  });
+
+  it("does not pass the hint for text viewers (.txt / .json / etc.)", async () => {
+    const dispatch = await loadDispatcher("mobile");
+    const { tabStore: ts } = await import("../../store/tabStore");
+    ts._reset();
+    await dispatch("/vault/notes.txt");
+    const state = get(ts);
+    expect(state.tabs[0]!.viewer).toBe("text");
+    expect(state.tabs[0]!.viewMode).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/openFileAsTab.test.ts
+++ b/src/lib/__tests__/openFileAsTab.test.ts
@@ -99,15 +99,24 @@ describe("openFileAsTab", () => {
 
 describe("openFileAsTab + viewMode (#388)", () => {
   beforeEach(() => {
-    tabStore._reset();
     readFile.mockReset();
     vi.resetModules();
     vi.doUnmock("../../store/viewportStore");
+    // NOTE: do NOT reset `tabStore` here — `vi.resetModules()` makes every
+    // subsequent dynamic `import("../../store/tabStore")` return a FRESH
+    // module whose `_core` writable is distinct from the top-level
+    // import. Calling `tabStore._reset()` on the stale top-level instance
+    // would silently no-op against the stores the tests actually use.
+    // The reset moved into `loadDispatcher` below — runs after the dynamic
+    // import, against the fresh singleton.
   });
 
   async function loadDispatcher(
     mode: "desktop" | "tablet" | "mobile",
-  ): Promise<typeof openFileAsTab> {
+  ): Promise<{
+    dispatch: typeof openFileAsTab;
+    ts: typeof import("../../store/tabStore").tabStore;
+  }> {
     const { readable } = await import("svelte/store");
     vi.doMock("../../store/viewportStore", () => ({
       viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
@@ -116,13 +125,13 @@ describe("openFileAsTab + viewMode (#388)", () => {
     // module graph after `vi.resetModules()` shares the same readFile spy.
     vi.doMock("../../ipc/commands", () => ({ readFile }));
     const mod = await import("../openFileAsTab");
-    return mod.openFileAsTab;
+    const { tabStore: ts } = await import("../../store/tabStore");
+    ts._reset();
+    return { dispatch: mod.openFileAsTab, ts };
   }
 
   it("opens markdown with viewMode='read' on mobile", async () => {
-    const dispatch = await loadDispatcher("mobile");
-    const { tabStore: ts } = await import("../../store/tabStore");
-    ts._reset();
+    const { dispatch, ts } = await loadDispatcher("mobile");
     await dispatch("/vault/note.md");
     const state = get(ts);
     expect(state.tabs).toHaveLength(1);
@@ -130,18 +139,14 @@ describe("openFileAsTab + viewMode (#388)", () => {
   });
 
   it("opens markdown with viewMode='edit' on desktop", async () => {
-    const dispatch = await loadDispatcher("desktop");
-    const { tabStore: ts } = await import("../../store/tabStore");
-    ts._reset();
+    const { dispatch, ts } = await loadDispatcher("desktop");
     await dispatch("/vault/note.md");
     const state = get(ts);
     expect(state.tabs[0]!.viewMode).toBe("edit");
   });
 
   it("does not pass the hint for image viewers (image has no Reading Mode)", async () => {
-    const dispatch = await loadDispatcher("mobile");
-    const { tabStore: ts } = await import("../../store/tabStore");
-    ts._reset();
+    const { dispatch, ts } = await loadDispatcher("mobile");
     await dispatch("/vault/photo.png");
     const state = get(ts);
     expect(state.tabs[0]!.viewer).toBe("image");
@@ -149,9 +154,7 @@ describe("openFileAsTab + viewMode (#388)", () => {
   });
 
   it("does not pass the hint for text viewers (.txt / .json / etc.)", async () => {
-    const dispatch = await loadDispatcher("mobile");
-    const { tabStore: ts } = await import("../../store/tabStore");
-    ts._reset();
+    const { dispatch, ts } = await loadDispatcher("mobile");
     await dispatch("/vault/notes.txt");
     const state = get(ts);
     expect(state.tabs[0]!.viewer).toBe("text");

--- a/src/lib/__tests__/tabKind.test.ts
+++ b/src/lib/__tests__/tabKind.test.ts
@@ -2,9 +2,22 @@
 // authoritative dispatcher for "what viewer should this file open in?",
 // so these tests pin down extension casing, dotfiles, and the unknown-ext
 // fallback to "text" (caller is then responsible for the UTF-8 probe).
+//
+// #388 extended this module with two viewport-aware helpers used by
+// the mobile read-mode flow: `tabSupportsReading` (predicate over a tab
+// shape) and `defaultViewModeForViewport` (read-once viewport hint for
+// new-tab opens).
 
-import { describe, it, expect } from "vitest";
-import { getExtension, getTabKind, IMAGE_EXTS, TEXT_EXTS } from "../tabKind";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readable } from "svelte/store";
+import {
+  getExtension,
+  getTabKind,
+  IMAGE_EXTS,
+  TEXT_EXTS,
+  tabSupportsReading,
+} from "../tabKind";
+import type { Tab } from "../../store/tabStoreCore";
 
 describe("getExtension", () => {
   it("returns the extension lowercased", () => {
@@ -79,5 +92,97 @@ describe("getTabKind", () => {
     // openFileAsTab().
     expect(getTabKind("archive.zip")).not.toBe("unsupported");
     expect(getTabKind("binary.bin")).not.toBe("unsupported");
+  });
+});
+
+// ── #388: tabSupportsReading ────────────────────────────────────────────────
+
+function makeTab(over: Partial<Tab> = {}): Tab {
+  return {
+    id: "t1",
+    filePath: "/v/note.md",
+    isDirty: false,
+    scrollPos: 0,
+    cursorPos: 0,
+    lastSaved: 0,
+    lastSavedContent: "",
+    ...over,
+  };
+}
+
+describe("tabSupportsReading (#388)", () => {
+  it("returns false for graph tabs", () => {
+    expect(tabSupportsReading(makeTab({ type: "graph" }))).toBe(false);
+  });
+
+  it("returns false for image viewer", () => {
+    expect(tabSupportsReading(makeTab({ viewer: "image" }))).toBe(false);
+  });
+
+  it("returns false for unsupported viewer", () => {
+    expect(tabSupportsReading(makeTab({ viewer: "unsupported" }))).toBe(false);
+  });
+
+  it("returns false for text viewer", () => {
+    // A `.json` / `.txt` tab opens read-only via CM6 but has no Reading Mode
+    // path — the renderer is markdown-specific.
+    expect(tabSupportsReading(makeTab({ viewer: "text" }))).toBe(false);
+  });
+
+  it("returns false for canvas viewer", () => {
+    // Canvas tabs render their own surface; ReadingView would have nothing
+    // to render. Pre-existing bug at EditorPane.svelte:236 missed this case.
+    expect(tabSupportsReading(makeTab({ viewer: "canvas" }))).toBe(false);
+  });
+
+  it("returns true for explicit markdown viewer", () => {
+    expect(tabSupportsReading(makeTab({ viewer: "markdown" }))).toBe(true);
+  });
+
+  it("returns true when viewer is undefined (default markdown)", () => {
+    expect(tabSupportsReading(makeTab({}))).toBe(true);
+  });
+});
+
+// ── #388: defaultViewModeForViewport ────────────────────────────────────────
+//
+// Module-level mock of viewportStore so the helper sees a controlled
+// viewport mode at every call. Each test installs its own readable.
+// Resetting modules between tests forces a fresh import that reads the
+// latest mock — without this, vitest caches the dynamic import and the
+// second test sees the first test's mocked store.
+
+describe("defaultViewModeForViewport (#388)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../store/viewportStore");
+  });
+
+  async function loadHelper(
+    mode: "desktop" | "tablet" | "mobile",
+  ): Promise<() => "edit" | "read"> {
+    vi.doMock("../../store/viewportStore", () => ({
+      viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
+    }));
+    const { defaultViewModeForViewport } = await import("../tabKind");
+    return defaultViewModeForViewport;
+  }
+
+  it("returns 'read' on mobile", async () => {
+    const fn = await loadHelper("mobile");
+    expect(fn()).toBe("read");
+  });
+
+  it("returns 'edit' on desktop", async () => {
+    const fn = await loadHelper("desktop");
+    expect(fn()).toBe("edit");
+  });
+
+  it("returns 'edit' on tablet (tablet keeps the desktop default)", async () => {
+    const fn = await loadHelper("tablet");
+    expect(fn()).toBe("edit");
   });
 });

--- a/src/lib/__tests__/tabKind.test.ts
+++ b/src/lib/__tests__/tabKind.test.ts
@@ -3,13 +3,13 @@
 // so these tests pin down extension casing, dotfiles, and the unknown-ext
 // fallback to "text" (caller is then responsible for the UTF-8 probe).
 //
-// #388 extended this module with two viewport-aware helpers used by
-// the mobile read-mode flow: `tabSupportsReading` (predicate over a tab
-// shape) and `defaultViewModeForViewport` (read-once viewport hint for
-// new-tab opens).
+// #388 added the pure `tabSupportsReading` predicate to this module.
+// `defaultViewModeForViewport` lives in `lib/viewport.ts` (its own test
+// file) so this module stays free of the `viewportStore` matchMedia
+// listener — every importer of `getExtension`/`getTabKind` would otherwise
+// transitively grab those listeners.
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { readable } from "svelte/store";
+import { describe, it, expect } from "vitest";
 import {
   getExtension,
   getTabKind,
@@ -144,45 +144,6 @@ describe("tabSupportsReading (#388)", () => {
   });
 });
 
-// ── #388: defaultViewModeForViewport ────────────────────────────────────────
-//
-// Module-level mock of viewportStore so the helper sees a controlled
-// viewport mode at every call. Each test installs its own readable.
-// Resetting modules between tests forces a fresh import that reads the
-// latest mock — without this, vitest caches the dynamic import and the
-// second test sees the first test's mocked store.
-
-describe("defaultViewModeForViewport (#388)", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
-  afterEach(() => {
-    vi.doUnmock("../../store/viewportStore");
-  });
-
-  async function loadHelper(
-    mode: "desktop" | "tablet" | "mobile",
-  ): Promise<() => "edit" | "read"> {
-    vi.doMock("../../store/viewportStore", () => ({
-      viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
-    }));
-    const { defaultViewModeForViewport } = await import("../tabKind");
-    return defaultViewModeForViewport;
-  }
-
-  it("returns 'read' on mobile", async () => {
-    const fn = await loadHelper("mobile");
-    expect(fn()).toBe("read");
-  });
-
-  it("returns 'edit' on desktop", async () => {
-    const fn = await loadHelper("desktop");
-    expect(fn()).toBe("edit");
-  });
-
-  it("returns 'edit' on tablet (tablet keeps the desktop default)", async () => {
-    const fn = await loadHelper("tablet");
-    expect(fn()).toBe("edit");
-  });
-});
+// `defaultViewModeForViewport` tests live in `viewport.test.ts` next to
+// the source module. Keeps `tabKind.ts` and its test file free of the
+// `viewportStore` mock plumbing.

--- a/src/lib/__tests__/viewport.test.ts
+++ b/src/lib/__tests__/viewport.test.ts
@@ -1,0 +1,49 @@
+/**
+ * #388 — `defaultViewModeForViewport()` reads `viewportStore` once and
+ * returns the viewport-aware default `viewMode` for newly-opened markdown
+ * tabs. Mobile → "read", desktop/tablet → "edit".
+ *
+ * Module-level mock of `viewportStore` per test, with `vi.resetModules()`
+ * between tests so each dynamic import re-evaluates the helper against the
+ * freshly-installed readable. This works fine here (pure function, no
+ * Svelte 5 component runtime); the same pattern is unsafe for component
+ * tests (see `TopbarReadingToggle.test.ts` header for the gory details).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readable } from "svelte/store";
+
+describe("defaultViewModeForViewport (#388)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../store/viewportStore");
+  });
+
+  async function loadHelper(
+    mode: "desktop" | "tablet" | "mobile",
+  ): Promise<() => "edit" | "read"> {
+    vi.doMock("../../store/viewportStore", () => ({
+      viewportStore: readable({ mode, isCoarsePointer: mode === "mobile" }),
+    }));
+    const { defaultViewModeForViewport } = await import("../viewport");
+    return defaultViewModeForViewport;
+  }
+
+  it("returns 'read' on mobile", async () => {
+    const fn = await loadHelper("mobile");
+    expect(fn()).toBe("read");
+  });
+
+  it("returns 'edit' on desktop", async () => {
+    const fn = await loadHelper("desktop");
+    expect(fn()).toBe("edit");
+  });
+
+  it("returns 'edit' on tablet (tablet keeps the desktop default)", async () => {
+    const fn = await loadHelper("tablet");
+    expect(fn()).toBe("edit");
+  });
+});

--- a/src/lib/openFileAsTab.ts
+++ b/src/lib/openFileAsTab.ts
@@ -7,7 +7,13 @@
 import { tabStore } from "../store/tabStore";
 import { readFile } from "../ipc/commands";
 import { isVaultError } from "../types/errors";
-import { getExtension, getTabKind, IMAGE_EXTS, TEXT_EXTS } from "./tabKind";
+import {
+  defaultViewModeForViewport,
+  getExtension,
+  getTabKind,
+  IMAGE_EXTS,
+  TEXT_EXTS,
+} from "./tabKind";
 import { encryptedFolders } from "../store/encryptedFoldersStore";
 import { vaultStore } from "../store/vaultStore";
 import { openUnlockModal } from "../store/encryptionModalStore";
@@ -92,7 +98,12 @@ export async function openFileAsTab(absPath: string): Promise<string | null> {
 
   const ext = getExtension(absPath);
   if (ext === "md" || ext === "markdown") {
-    return tabStore.openTab(absPath);
+    // #388 — markdown opens default to read on mobile, edit elsewhere.
+    // Only the markdown branch passes the hint; image/canvas/text/unsupported
+    // viewers have no Reading Mode path so the hint would be a no-op there
+    // (and the tabStore would still write `viewMode: "read"` onto a tab kind
+    // that EditorPane ignores — wasted state).
+    return tabStore.openTab(absPath, defaultViewModeForViewport());
   }
   if (ext === "canvas") {
     return tabStore.openFileTab(absPath, "canvas");

--- a/src/lib/openFileAsTab.ts
+++ b/src/lib/openFileAsTab.ts
@@ -7,13 +7,8 @@
 import { tabStore } from "../store/tabStore";
 import { readFile } from "../ipc/commands";
 import { isVaultError } from "../types/errors";
-import {
-  defaultViewModeForViewport,
-  getExtension,
-  getTabKind,
-  IMAGE_EXTS,
-  TEXT_EXTS,
-} from "./tabKind";
+import { getExtension, getTabKind, IMAGE_EXTS, TEXT_EXTS } from "./tabKind";
+import { defaultViewModeForViewport } from "./viewport";
 import { encryptedFolders } from "../store/encryptedFoldersStore";
 import { vaultStore } from "../store/vaultStore";
 import { openUnlockModal } from "../store/encryptionModalStore";

--- a/src/lib/tabKind.ts
+++ b/src/lib/tabKind.ts
@@ -1,17 +1,14 @@
 // Extension-based classifier used when opening a file path as a new tab (#49).
-// Pure helper — no IPC, no filesystem access. The caller is responsible for
-// subsequently loading the file content (or, for "unsupported", skipping it).
+// Pure helper — no IPC, no filesystem access, no store dependencies. The
+// caller is responsible for subsequently loading the file content (or, for
+// "unsupported", skipping it).
 //
-// Also hosts two viewport-aware helpers for the #388 mobile read-mode flow:
-//   - `tabSupportsReading(tab)`: predicate over tab shape, used wherever the
-//     UI needs to know whether Reading Mode applies to the active tab.
-//   - `defaultViewModeForViewport()`: read-once viewport hint passed to
-//     openers when creating a new tab. The store remains environment-agnostic
-//     — viewport awareness lives at this UI boundary.
+// Also hosts the pure `tabSupportsReading(tab)` predicate used by every
+// site that needs to know whether Reading Mode applies. The viewport-aware
+// `defaultViewModeForViewport()` lives in `lib/viewport.ts` so importing
+// the classifier never drags `viewportStore`'s matchMedia listeners.
 
-import { get } from "svelte/store";
-import { viewportStore } from "../store/viewportStore";
-import type { Tab, TabViewMode } from "../store/tabStoreCore";
+import type { Tab } from "../store/tabStoreCore";
 
 /** Image extensions that render via `<img src={convertFileSrc(abs)} />`. */
 export const IMAGE_EXTS = new Set([
@@ -89,24 +86,4 @@ export function tabSupportsReading(tab: Tab): boolean {
   if (tab.viewer === "text") return false;
   if (tab.viewer === "canvas") return false;
   return true;
-}
-
-/**
- * #388 — viewport-aware default `viewMode` for newly-opened markdown tabs.
- *
- * Mobile users get notes in Reading Mode by default to avoid accidental
- * edits while scrolling. Desktop and tablet keep the existing edit default.
- *
- * Always returns a `TabViewMode` — callers may pass it directly to
- * `tabStore.openTab(path, defaultViewModeForViewport())` without
- * conditional checks. Returning `"edit"` on desktop is byte-identical
- * in effect to omitting the hint, since every reader coalesces
- * `viewMode ?? "edit"`.
- *
- * The store layer never reads `viewportStore`; this helper is the single
- * UI seam where viewport state crosses into tab metadata. Tests stub
- * `viewportStore` here and nowhere else.
- */
-export function defaultViewModeForViewport(): TabViewMode {
-  return get(viewportStore).mode === "mobile" ? "read" : "edit";
 }

--- a/src/lib/tabKind.ts
+++ b/src/lib/tabKind.ts
@@ -1,6 +1,17 @@
 // Extension-based classifier used when opening a file path as a new tab (#49).
 // Pure helper — no IPC, no filesystem access. The caller is responsible for
 // subsequently loading the file content (or, for "unsupported", skipping it).
+//
+// Also hosts two viewport-aware helpers for the #388 mobile read-mode flow:
+//   - `tabSupportsReading(tab)`: predicate over tab shape, used wherever the
+//     UI needs to know whether Reading Mode applies to the active tab.
+//   - `defaultViewModeForViewport()`: read-once viewport hint passed to
+//     openers when creating a new tab. The store remains environment-agnostic
+//     — viewport awareness lives at this UI boundary.
+
+import { get } from "svelte/store";
+import { viewportStore } from "../store/viewportStore";
+import type { Tab, TabViewMode } from "../store/tabStoreCore";
 
 /** Image extensions that render via `<img src={convertFileSrc(abs)} />`. */
 export const IMAGE_EXTS = new Set([
@@ -56,4 +67,46 @@ export function getTabKind(path: string): TabKind {
   // Unknown extension — caller should try UTF-8 read and fall back
   // to "unsupported" if decoding fails.
   return "text";
+}
+
+/**
+ * #388 — does this tab kind have a Reading Mode path?
+ *
+ * Reading Mode renders rendered Markdown via `ReadingView.svelte`. Tab kinds
+ * with their own dedicated surface (graph) or a non-markdown viewer
+ * (image / unsupported / text / canvas) have no ReadingView path and must
+ * never receive `viewMode === "read"`.
+ *
+ * Single source of truth: previously inlined in `EditorPane.svelte`'s
+ * `paneActiveTabSupportsReading` and `VaultLayout.toggleActiveReadingMode`,
+ * the two had drifted (canvas exclusion missing in EditorPane, both text
+ * and canvas missing in VaultLayout). Extracting here fixes both.
+ */
+export function tabSupportsReading(tab: Tab): boolean {
+  if (tab.type === "graph") return false;
+  if (tab.viewer === "image") return false;
+  if (tab.viewer === "unsupported") return false;
+  if (tab.viewer === "text") return false;
+  if (tab.viewer === "canvas") return false;
+  return true;
+}
+
+/**
+ * #388 — viewport-aware default `viewMode` for newly-opened markdown tabs.
+ *
+ * Mobile users get notes in Reading Mode by default to avoid accidental
+ * edits while scrolling. Desktop and tablet keep the existing edit default.
+ *
+ * Always returns a `TabViewMode` — callers may pass it directly to
+ * `tabStore.openTab(path, defaultViewModeForViewport())` without
+ * conditional checks. Returning `"edit"` on desktop is byte-identical
+ * in effect to omitting the hint, since every reader coalesces
+ * `viewMode ?? "edit"`.
+ *
+ * The store layer never reads `viewportStore`; this helper is the single
+ * UI seam where viewport state crosses into tab metadata. Tests stub
+ * `viewportStore` here and nowhere else.
+ */
+export function defaultViewModeForViewport(): TabViewMode {
+  return get(viewportStore).mode === "mobile" ? "read" : "edit";
 }

--- a/src/lib/viewport.ts
+++ b/src/lib/viewport.ts
@@ -1,0 +1,29 @@
+// Viewport-aware UI helpers (#388). Lives in its own module so the pure
+// `tabKind` classifier (`getTabKind` / `getExtension` / `tabSupportsReading`)
+// stays free of `viewportStore` — i.e., free of the matchMedia listener
+// initializer that the store grabs at module load. Importing
+// `getExtension` for an extension lookup must NOT pull in matchMedia.
+
+import { get } from "svelte/store";
+import { viewportStore } from "../store/viewportStore";
+import type { TabViewMode } from "../store/tabStoreCore";
+
+/**
+ * #388 — viewport-aware default `viewMode` for newly-opened markdown tabs.
+ *
+ * Mobile users get notes in Reading Mode by default to avoid accidental
+ * edits while scrolling. Desktop and tablet keep the existing edit default.
+ *
+ * Always returns a `TabViewMode` — callers may pass it directly to
+ * `tabStore.openTab(path, defaultViewModeForViewport())` without
+ * conditional checks. Returning `"edit"` on desktop is byte-identical
+ * in effect to omitting the hint, since every reader coalesces
+ * `viewMode ?? "edit"`.
+ *
+ * The store layer never reads `viewportStore`; this helper is the single
+ * UI seam where viewport state crosses into tab metadata. Tests stub
+ * `viewportStore` here and nowhere else.
+ */
+export function defaultViewModeForViewport(): TabViewMode {
+  return get(viewportStore).mode === "mobile" ? "read" : "edit";
+}

--- a/src/store/tabLifecycleStore.test.ts
+++ b/src/store/tabLifecycleStore.test.ts
@@ -489,4 +489,56 @@ describe("tabLifecycleStore", () => {
       expect(get(tabLifecycleStore).tabs.find((t) => t.id === id)?.readingScrollPos).toBe(420);
     });
   });
+
+  // #388 — optional `viewMode` hint on the openers so UI-boundary callers
+  // can opt new tabs into Reading Mode (mobile default) without the store
+  // itself reading viewportStore. Hint applies on tab CREATION only;
+  // existing-tab dedupe preserves the user's last explicit mode.
+  describe("Issue #388: viewMode hint on openTab / openFileTab", () => {
+    it("openTab with no second arg leaves viewMode undefined (no behavior change)", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBeUndefined();
+    });
+
+    it("openTab with viewMode='read' sets the new tab to Reading Mode", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md", "read");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBe("read");
+    });
+
+    it("openTab with viewMode='edit' writes the field explicitly", () => {
+      const id = tabLifecycleStore.openTab("/vault/a.md", "edit");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBe("edit");
+    });
+
+    it("openFileTab with viewMode='read' sets the new tab to Reading Mode", () => {
+      const id = tabLifecycleStore.openFileTab("/vault/a.md", "markdown", "read");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBe("read");
+    });
+
+    it("openFileTab passes viewMode through verbatim — store does not filter by viewer kind", () => {
+      // The store is environment-agnostic and viewer-agnostic. It writes the
+      // hint as given. Filtering is the caller's responsibility (openFileAsTab
+      // never passes the hint for image / canvas / text viewers).
+      const id = tabLifecycleStore.openFileTab("/vault/img.png", "image", "read");
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id);
+      expect(tab?.viewMode).toBe("read");
+    });
+
+    it("dedupe path preserves the existing tab's viewMode (hint ignored on re-open)", () => {
+      // VaultCore is desktop-only today (no roaming between platforms), so an
+      // existing tab's mode reflects the user's last explicit choice. Re-open
+      // hints from a different viewport must NOT clobber it. If multi-platform
+      // sync is added later, revisit this rule.
+      const id1 = tabLifecycleStore.openTab("/vault/a.md", "read");
+      tabLifecycleStore.setViewMode(id1, "edit");
+      const id2 = tabLifecycleStore.openTab("/vault/a.md", "read");
+      expect(id2).toBe(id1);
+      const tab = get(tabLifecycleStore).tabs.find((t) => t.id === id1);
+      expect(tab?.viewMode).toBe("edit");
+    });
+  });
 });

--- a/src/store/tabLifecycleStore.ts
+++ b/src/store/tabLifecycleStore.ts
@@ -32,8 +32,17 @@ export const tabLifecycleStore = {
    * If a tab with the same path already exists, activate it (no duplicate).
    * Otherwise, create a new tab in the currently active pane.
    * Returns the tab ID.
+   *
+   * #388 — `viewMode` is an optional hint applied ONLY when a NEW tab is
+   * created. The dedupe path preserves the existing tab's `viewMode`, so a
+   * user who toggled tab A to edit on mobile and re-opens it later finds
+   * it still in edit. (VaultCore is desktop-only today; if multi-platform
+   * sync is added, revisit whether dedupe should adopt the new hint.)
+   *
+   * The store does NOT read `viewportStore` — viewport awareness lives at
+   * the UI boundary via `defaultViewModeForViewport()` in `lib/tabKind.ts`.
    */
-  openTab(filePath: string): string {
+  openTab(filePath: string, viewMode?: TabViewMode): string {
     let returnId = "";
     _core.update((state) => {
       const existing = state.tabs.find((t) => t.filePath === filePath);
@@ -57,6 +66,7 @@ export const tabLifecycleStore = {
         cursorPos: 0,
         lastSaved: Date.now(),
         lastSavedContent: "",
+        ...(viewMode !== undefined ? { viewMode } : {}),
       };
       const opened = openInActivePane(state, tab);
       return { ...state, ...opened, activeTabId: id };
@@ -68,8 +78,17 @@ export const tabLifecycleStore = {
    * Open a tab with an explicit viewer kind (#49). Used for non-markdown
    * files — images, read-only text previews, and unsupported binaries.
    * Same dedupe-by-filePath semantics as openTab().
+   *
+   * #388 — `viewMode` hint applies on creation only (same rule as `openTab`).
+   * Filtering by viewer kind is the caller's job: `openFileAsTab` does NOT
+   * pass the hint for image / text / unsupported / canvas, since those have
+   * no Reading Mode path.
    */
-  openFileTab(filePath: string, viewer: TabViewer): string {
+  openFileTab(
+    filePath: string,
+    viewer: TabViewer,
+    viewMode?: TabViewMode,
+  ): string {
     let returnId = "";
     _core.update((state) => {
       const existing = state.tabs.find((t) => t.filePath === filePath);
@@ -94,6 +113,7 @@ export const tabLifecycleStore = {
         lastSaved: Date.now(),
         lastSavedContent: "",
         viewer,
+        ...(viewMode !== undefined ? { viewMode } : {}),
       };
       const opened = openInActivePane(state, tab);
       return { ...state, ...opened, activeTabId: id };


### PR DESCRIPTION
## Summary

Closes #388. Sub-ticket of #74. Implements the Obsidian-style mobile read-mode default plus a topbar pencil/book-open toggle that flips the active tab's mode. Per-tab persistence (already in place from #63) lets users keep tab A in edit while tab B stays read.

**Pre-investigation finding**: read-mode rendering already existed end-to-end from #63 (`ReadingView.svelte` + `markdownRenderer.ts` with markdown-it / DOMPurify / wiki-link / embed / heading-anchor pipelines, plus `Tab.viewMode` state and `tabLifecycleStore.toggleViewMode`). #388 reduced to:
1. UI-boundary helper deciding the default `viewMode` for new tabs based on viewport.
2. Optional `viewMode` hint on `tabStore.openTab` / `openFileTab`, applied on creation only (dedupe preserves the user's last explicit choice — see JSDoc).
3. Routing key user-facing markdown opens through `openFileAsTab` so they pick up the hint.
4. Mobile-only topbar pencil component.

**Architecture**: store is environment-agnostic — viewport awareness lives at `lib/tabKind.ts` (`defaultViewModeForViewport`). Existing `tabLifecycleStore` tests untouched (no matchMedia stub contamination).

## Boy Scout fixes folded in

The new mobile pencil makes both of these reachable for the first time:

- `VaultLayout.toggleActiveReadingMode` previously excluded only `image`/`unsupported` viewers. A `text`-viewer (.json/.txt/etc.) or canvas tab responding to Cmd/Ctrl+E would set `viewMode='read'` on a tab kind that has no ReadingView path → broken state.
- `EditorPane.paneActiveTabSupportsReading` correctly excluded `image`/`unsupported`/`text` but missed canvas. A canvas tab would show the Breadcrumbs reading toggle but clicking it would `setViewMode('read')` while the canvas itself kept rendering.

Both fixed by extracting `tabSupportsReading()` to `lib/tabKind.ts` — single source of truth used by EditorPane, VaultLayout, the new TopbarReadingToggle, and (via the gating chain) Breadcrumbs.

## Decisions (documented in code + tests)

- **NEW notes default to edit on every viewport.** Click-to-create on an unresolved `[[Foo]]` matches `createNewNote` / `openTodayNote` / Sidebar new-file convention — the user typing or clicking a name is creating, presumably to write into. See `EditorPane.svelte` line 432 and `OutgoingLinksPanel.svelte` click-to-create branch. **EXISTING notes default to read on mobile.**
- **BookmarksPanel.handleOpenInSplit kept synchronous on `tabStore.openTab`.** Async `openFileAsTab` would race with the synchronous `tabStore.moveToPane('right')` immediately after. Split is desktop-only (gated by viewport in #386), so the lost mobile-read hint there is moot. Documented inline.
- **GraphView / LocalGraphPanel / CanvasView NOT routed through `openFileAsTab`.** All three call from inside non-async callbacks; promoting to async would create unhandled-promise hazards. Niche click paths — user can flip via the topbar pencil. Documented as known limitation.
- **Breadcrumbs reading toggle hides on mobile** so it never co-renders with the topbar pencil. Strictly more restrictive than today's gating (which is `tabId && viewMode !== undefined`). Desktop and tablet markdown unchanged.
- `defaultViewModeForViewport()` returns `TabViewMode` always (no `undefined` sentinel leaking). Returning `'edit'` on desktop is byte-identical in effect to today, since every reader coalesces `viewMode ?? 'edit'`.

## Heads-up for review

- `Breadcrumbs.svelte` lines 122-123 still have German strings (`"Bearbeitungsmodus"`, `"Lesemodus"`) inherited from the existing #63 toggle. The new `TopbarReadingToggle.svelte` mirrors this convention. Out of scope to translate — no i18n plan exists in the repo.
- Three commits on the branch:
  1. `39d065f` — RED failing tests (TDD)
  2. `d157f34` — `tabKind` helpers + optional viewMode hint on store openers
  3. `dff322f` — callsite routing + Boy Scout guard fix + TopbarReadingToggle + Breadcrumbs hide-on-mobile

## Files

**Source (10)**:
- `src/lib/tabKind.ts` — added `tabSupportsReading()` + `defaultViewModeForViewport()`
- `src/store/tabLifecycleStore.ts` — added optional `viewMode` arg to `openTab` and `openFileTab`
- `src/lib/openFileAsTab.ts` — markdown branch passes the hint
- `src/components/Editor/EditorPane.svelte` — wiki-link follow + click-to-create wired; inline `paneActiveTabSupportsReading` replaced with shared predicate
- `src/components/Editor/Breadcrumbs.svelte` — hide-on-mobile gate
- `src/components/Layout/VaultLayout.svelte` — topbar pencil wiring + `toggleActiveReadingMode` guard fix
- `src/components/Layout/TopbarReadingToggle.svelte` — new mobile-only component
- `src/components/Bookmarks/BookmarksPanel.svelte` — handleRowClick + handleOpenInNewTab routed (handleOpenInSplit stays sync)
- `src/components/Backlinks/BacklinksPanel.svelte` — handleBacklinkClick routed
- `src/components/OutgoingLinks/OutgoingLinksPanel.svelte` — resolved click routed; click-to-create stays direct (NEW = edit rule)

**Tests (6 new + 2 updated for new contract)**:
- `src/lib/__tests__/tabKind.test.ts` — predicate matrix + viewport hint (mocked viewportStore via vi.doMock seam)
- `src/store/tabLifecycleStore.test.ts` — viewMode hint creation + dedupe-preserves
- `src/lib/__tests__/openFileAsTab.test.ts` — dispatcher passes hint for markdown only
- `src/components/Editor/__tests__/EditorPane.wikiLinkMobileMode.test.ts` — wiki-link follow + click-to-create on mobile/desktop
- `src/components/Editor/__tests__/Breadcrumbs.mobileHide.test.ts` — desktop/tablet/mobile visibility
- `src/components/Layout/__tests__/TopbarReadingToggle.test.ts` — visibility matrix + click + per-tab persistence with reactive icon flip
- `src/components/Editor/__tests__/EditorPaneWikiLinkClickResolve.test.ts` — updated 3 spy assertions for new two-arg form
- `src/components/Bookmarks/__tests__/BookmarksPanel.test.ts` — updated spy assertion for the now-routed click path

## Test plan

- [x] Full vitest suite green: 147 files, 1404 tests
- [x] `pnpm typecheck` clean
- [ ] Manual mobile-emulation pass via `pnpm dev` + browser devtools (see Step 8 of plan): open markdown via tree, omnisearch, bookmarks, backlinks, outgoing-links, wiki-link click — all default to read on mobile, edit on desktop. Click-to-create new note → opens in edit. Topbar pencil flips, persists per-tab across switches, icon reflects state. Breadcrumbs toggle absent on mobile, present on desktop and tablet.
- [ ] Coordination with `frontend-impl` (#386) on `VaultLayout.svelte` topbar — pinged before push; placement on right side near backlinks/settings, separate from leading-edge drawer toggle area.