### PR TITLE
feat(mobile): bottom tab bar (Files / Search / More) (#389)

### DIFF
--- a/e2e/specs/bottom-tab-bar.spec.ts
+++ b/e2e/specs/bottom-tab-bar.spec.ts
@@ -102,17 +102,29 @@ describe("Mobile bottom tab bar (#389)", () => {
     });
   });
 
-  it("More tab shows the placeholder toast (until #397)", async () => {
+  it("More tab closes the drawer first if open AND shows the placeholder toast", async () => {
+    // Mirror of the Search-tab regression: the close-drawer-first guard in
+    // handleMobileMoreTab must work the same way as Search. Without this
+    // test, the More-tab close-first line could regress silently.
+    await clickFilesTab();
+    await browser.waitUntil(isDrawerOpen, { timeout: 3000 });
     await clickMoreTab();
     // toastStore renders into a host that stays in DOM; selector covers
     // the common conventions in this repo.
     const toast = await browser.$(".vc-toast, [role='status']");
     await toast.waitForDisplayed({ timeout: 3000 });
+    await browser.waitUntil(async () => !(await isDrawerOpen()), {
+      timeout: 3000,
+      timeoutMsg: "Drawer should close when More tab is tapped",
+    });
   });
 
   it("absent at desktop size", async () => {
     await browser.setWindowSize(1280, 900);
-    // Wait for the @media-driven re-render.
+    // Wait for the @media-driven re-render. Window-size restore is owned
+    // by the `after` hook — keeping the restore out of the test body means
+    // a `waitUntil` timeout produces the original assertion failure
+    // cleanly rather than hiding behind an unguarded restore line.
     await browser.waitUntil(async () => {
       const bars = await browser.$$(".vc-mobile-tab-bar");
       return bars.length === 0;
@@ -120,7 +132,5 @@ describe("Mobile bottom tab bar (#389)", () => {
       timeout: 3000,
       timeoutMsg: "Tab bar should be absent at desktop size",
     });
-    // Restore mobile size for the after-hook contract.
-    await browser.setWindowSize(600, 900);
   });
 });

--- a/e2e/specs/bottom-tab-bar.spec.ts
+++ b/e2e/specs/bottom-tab-bar.spec.ts
@@ -1,0 +1,126 @@
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+
+/**
+ * #389 — bottom-tab-bar e2e coverage.
+ *
+ * Resizes the WebKitWebDriver window to 600x900 (matches the #386 spec
+ * convention) so the responsive @media (max-width: 699px) branch fires
+ * and the tab bar mounts.
+ *
+ * Each test is self-contained — no test depends on the side effects of
+ * the one before it. afterEach closes the drawer if any test left it open.
+ */
+describe("Mobile bottom tab bar (#389)", () => {
+  let vault: TestVault;
+  let restoreSize: { width: number; height: number } | null = null;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+    restoreSize = await browser.getWindowSize();
+    await browser.setWindowSize(600, 900);
+  });
+
+  after(async () => {
+    if (restoreSize) {
+      await browser.setWindowSize(restoreSize.width, restoreSize.height);
+    }
+    vault.cleanup();
+  });
+
+  async function isDrawerOpen(): Promise<boolean> {
+    const drawer = await browser.$(".vc-layout-sidebar");
+    const cls = (await drawer.getAttribute("class")) ?? "";
+    return cls.includes("vc-layout-sidebar--mobile-open");
+  }
+
+  async function clickFilesTab(): Promise<void> {
+    await browser.execute(() => {
+      (document.getElementById("vc-mobile-tab-files") as HTMLElement | null)?.click();
+    });
+  }
+
+  async function clickSearchTab(): Promise<void> {
+    await browser.execute(() => {
+      (document.getElementById("vc-mobile-tab-search") as HTMLElement | null)?.click();
+    });
+  }
+
+  async function clickMoreTab(): Promise<void> {
+    await browser.execute(() => {
+      (document.getElementById("vc-mobile-tab-more") as HTMLElement | null)?.click();
+    });
+  }
+
+  afterEach(async () => {
+    if (await isDrawerOpen()) {
+      await browser.keys(["Escape"]);
+      await browser.waitUntil(async () => !(await isDrawerOpen()), { timeout: 3000 }).catch(() => {});
+    }
+    // Close OmniSearch / any modal that a test left open.
+    await browser.keys(["Escape"]);
+  });
+
+  it("renders the tab bar at mobile size", async () => {
+    const bar = await browser.$(".vc-mobile-tab-bar");
+    await bar.waitForDisplayed({ timeout: 3000 });
+    const tabs = await browser.$$('[role="tab"]');
+    expect(tabs.length).toBe(3);
+  });
+
+  it("Files tab opens the drawer", async () => {
+    expect(await isDrawerOpen()).toBe(false);
+    await clickFilesTab();
+    await browser.waitUntil(isDrawerOpen, {
+      timeout: 3000,
+      timeoutMsg: "Drawer never opened after Files tab click",
+    });
+  });
+
+  it("Files tab is open-only — second tap leaves the drawer open (no toggle)", async () => {
+    await clickFilesTab();
+    await browser.waitUntil(isDrawerOpen, { timeout: 3000 });
+    await clickFilesTab();
+    // Allow time for any unintended close to settle.
+    await browser.pause(150);
+    expect(await isDrawerOpen()).toBe(true);
+  });
+
+  it("Search tab opens OmniSearch (and closes the drawer first if open)", async () => {
+    // Regression for Socrates v1 #1 + #7 — drawer-open + Search-tap path.
+    // Without the close-drawer-first handler, the scrim's onclick consumes
+    // the tap and the modal never opens.
+    await clickFilesTab();
+    await browser.waitUntil(isDrawerOpen, { timeout: 3000 });
+    await clickSearchTab();
+    const omni = await browser.$(".vc-omnisearch, .vc-modal-surface");
+    await omni.waitForDisplayed({ timeout: 3000 });
+    await browser.waitUntil(async () => !(await isDrawerOpen()), {
+      timeout: 3000,
+      timeoutMsg: "Drawer should close when Search tab is tapped",
+    });
+  });
+
+  it("More tab shows the placeholder toast (until #397)", async () => {
+    await clickMoreTab();
+    // toastStore renders into a host that stays in DOM; selector covers
+    // the common conventions in this repo.
+    const toast = await browser.$(".vc-toast, [role='status']");
+    await toast.waitForDisplayed({ timeout: 3000 });
+  });
+
+  it("absent at desktop size", async () => {
+    await browser.setWindowSize(1280, 900);
+    // Wait for the @media-driven re-render.
+    await browser.waitUntil(async () => {
+      const bars = await browser.$$(".vc-mobile-tab-bar");
+      return bars.length === 0;
+    }, {
+      timeout: 3000,
+      timeoutMsg: "Tab bar should be absent at desktop size",
+    });
+    // Restore mobile size for the after-hook contract.
+    await browser.setWindowSize(600, 900);
+  });
+});

--- a/src/components/Layout/MobileTabBar.svelte
+++ b/src/components/Layout/MobileTabBar.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  /**
+   * MobileTabBar — fixed-bottom 3-tab nav for the mobile shell (#389).
+   *
+   * Parent-gated: VaultLayout decides via `{#if isMobile}` when to render
+   * this component; the component itself does NOT subscribe to viewportStore.
+   * State (drawer open, modal open, etc.) lives in the parent — this
+   * component only emits via callbacks.
+   *
+   * The "More" tab is a placeholder until #397's burger sheet lands; its
+   * onSelect is wired in VaultLayout to a toast for now.
+   */
+  import { Files, Search, Menu } from "lucide-svelte";
+
+  let {
+    drawerOpen,
+    onSelectFiles,
+    onSelectSearch,
+    onSelectMore,
+  }: {
+    drawerOpen: boolean;
+    onSelectFiles: () => void;
+    onSelectSearch: () => void;
+    onSelectMore: () => void;
+  } = $props();
+
+  type TabId = "files" | "search" | "more";
+  interface TabSpec {
+    id: TabId;
+    label: string;
+    icon: typeof Files;
+    controls?: string;
+    onSelect: () => void;
+  }
+
+  const tabs: TabSpec[] = $derived([
+    { id: "files",  label: "Dateien", icon: Files,  controls: "vc-mobile-drawer", onSelect: onSelectFiles  },
+    { id: "search", label: "Suche",   icon: Search,                                onSelect: onSelectSearch },
+    { id: "more",   label: "Mehr",    icon: Menu,                                  onSelect: onSelectMore   },
+  ]);
+
+  // Search/More never become "active" — Search is a transient modal that
+  // owns its own active state, More is a placeholder. Only Files has a
+  // persistent open state (the drawer).
+  const activeId = $derived<TabId | null>(drawerOpen ? "files" : null);
+
+  // Roving tabindex: the active tab is reachable via Tab; arrow keys move
+  // focus among the rest. When nothing is active, Files is the entry point
+  // so the bar is keyboard-reachable from a fresh tab-press.
+  function tabIndex(id: TabId, idx: number): 0 | -1 {
+    if (activeId === null) return idx === 0 ? 0 : -1;
+    return id === activeId ? 0 : -1;
+  }
+
+  function onTabKeydown(e: KeyboardEvent, idx: number) {
+    let next = idx;
+    if (e.key === "ArrowRight") next = (idx + 1) % tabs.length;
+    else if (e.key === "ArrowLeft") next = (idx - 1 + tabs.length) % tabs.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    const node = document.getElementById(`vc-mobile-tab-${tabs[next].id}`);
+    node?.focus();
+  }
+</script>
+
+<!-- div, not <nav> — Svelte's a11y_no_noninteractive_element_to_interactive_role
+     check rejects nav+role=tablist, and the W3C ARIA tabs pattern uses a div
+     anyway (the role is the landmark, not the element). -->
+<div class="vc-mobile-tab-bar" role="tablist" aria-label="Main navigation">
+  {#each tabs as tab, idx (tab.id)}
+    {@const Icon = tab.icon}
+    {@const isActive = activeId === tab.id}
+    <button
+      type="button"
+      role="tab"
+      id={`vc-mobile-tab-${tab.id}`}
+      aria-selected={isActive ? "true" : "false"}
+      aria-controls={tab.controls}
+      tabindex={tabIndex(tab.id, idx)}
+      onclick={tab.onSelect}
+      onkeydown={(e) => onTabKeydown(e, idx)}
+      class="vc-mobile-tab"
+      class:vc-mobile-tab--active={isActive}
+    >
+      <span class="vc-mobile-tab-pill" class:vc-mobile-tab-pill--active={isActive}>
+        <Icon size={20} strokeWidth={1.5} />
+        <span class="vc-mobile-tab-label">{tab.label}</span>
+      </span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .vc-mobile-tab-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    background: var(--color-surface);
+    border-top: 1px solid var(--color-border);
+    padding-bottom: env(safe-area-inset-bottom);
+    display: flex;
+    z-index: 40;
+  }
+
+  .vc-mobile-tab {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--vc-hit-target, 44px);
+    min-height: var(--vc-hit-target, 44px);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    font-family: var(--vc-font-body);
+    padding: 0;
+  }
+
+  .vc-mobile-tab--active {
+    color: var(--color-accent);
+  }
+
+  .vc-mobile-tab-pill {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 4px 10px;
+    border-radius: 8px;
+    transition: background 150ms, color 150ms;
+  }
+
+  .vc-mobile-tab-pill--active {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-mobile-tab-label {
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1;
+  }
+</style>

--- a/src/components/Layout/MobileTabBar.svelte
+++ b/src/components/Layout/MobileTabBar.svelte
@@ -30,14 +30,22 @@
     label: string;
     icon: typeof Files;
     controls?: string;
-    onSelect: () => void;
   }
 
-  const tabs: TabSpec[] = $derived([
-    { id: "files",  label: "Dateien", icon: Files,  controls: "vc-mobile-drawer", onSelect: onSelectFiles  },
-    { id: "search", label: "Suche",   icon: Search,                                onSelect: onSelectSearch },
-    { id: "more",   label: "Mehr",    icon: Menu,                                  onSelect: onSelectMore   },
-  ]);
+  // Static — labels, icons, ids, and aria-controls don't change at runtime.
+  // The per-tab onclick payload dispatches via the prop callbacks; recomputing
+  // this array every render would be wasted work.
+  const tabs: ReadonlyArray<TabSpec> = [
+    { id: "files",  label: "Dateien", icon: Files,  controls: "vc-mobile-drawer" },
+    { id: "search", label: "Suche",   icon: Search                               },
+    { id: "more",   label: "Mehr",    icon: Menu                                 },
+  ];
+
+  function onSelect(id: TabId) {
+    if (id === "files") onSelectFiles();
+    else if (id === "search") onSelectSearch();
+    else onSelectMore();
+  }
 
   // Search/More never become "active" — Search is a transient modal that
   // owns its own active state, More is a placeholder. Only Files has a
@@ -79,7 +87,7 @@
       aria-selected={isActive ? "true" : "false"}
       aria-controls={tab.controls}
       tabindex={tabIndex(tab.id, idx)}
-      onclick={tab.onSelect}
+      onclick={() => onSelect(tab.id)}
       onkeydown={(e) => onTabKeydown(e, idx)}
       class="vc-mobile-tab"
       class:vc-mobile-tab--active={isActive}

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -8,6 +8,7 @@
   import CommandPalette from "../CommandPalette/CommandPalette.svelte";
   import TemplatePicker from "../TemplatePicker/TemplatePicker.svelte";
   import RightSidebar from "./RightSidebar.svelte";
+  import MobileTabBar from "./MobileTabBar.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import EncryptionStatusbar from "../Statusbar/EncryptionStatusbar.svelte";
   import TopbarReadingToggle from "./TopbarReadingToggle.svelte";
@@ -138,6 +139,32 @@
       wasOpen = false;
     }
   });
+
+  // #389 — mobile bottom-tab-bar handlers. State (drawer + omni-search) is
+  // owned here in VaultLayout; MobileTabBar receives callbacks only. The
+  // close-drawer-first lines on Search/More are required because the drawer
+  // scrim sits at z-index 49 above the tab bar (40) — without this, a tap
+  // through the scrim region would hit the scrim's onclick (closes drawer)
+  // before the modal opens, requiring the user to tap twice.
+  function handleMobileFilesTab() {
+    // Open-only — native iOS/Android bottom-nav bars don't toggle. The drawer
+    // closes via scrim, swipe-left, or Escape.
+    if (mobileDrawerOpen) return;
+    mobileDrawerOpen = true;
+  }
+  function handleMobileSearchTab() {
+    mobileDrawerOpen = false;
+    omniSearchMode = "filename";
+    omniSearchPrefill = undefined;
+    omniSearchOpen = true;
+  }
+  function handleMobileMoreTab() {
+    mobileDrawerOpen = false;
+    // TODO #397: replace with the burger sheet open flag once the component
+    // lands. The placeholder toast tells the user the destination exists
+    // without misrepresenting it as broken.
+    toastStore.info("Mehr-Menü folgt");
+  }
 
   const unsubTab = tabStore.subscribe((state) => {
     rightPaneIds = state.splitState.right;
@@ -1016,6 +1043,17 @@
 <!-- #357: auto-encrypt-on-drop live progress pill. Self-hides while idle. -->
 <EncryptionStatusbar />
 
+<!-- #389 — mobile bottom-tab-bar. Parent gates on `isMobile`; the component
+     itself doesn't subscribe to viewportStore. -->
+{#if isMobile}
+  <MobileTabBar
+    drawerOpen={mobileDrawerOpen}
+    onSelectFiles={handleMobileFilesTab}
+    onSelectSearch={handleMobileSearchTab}
+    onSelectMore={handleMobileMoreTab}
+  />
+{/if}
+
 <!-- #345: global mount for the encryption modals. Encrypt modal stays
      open during the batch so the user sees progress; it closes on
      completion or on error. -->
@@ -1279,6 +1317,15 @@
     .vc-layout-divider-right-hidden,
     .vc-split-divider {
       display: none;
+    }
+
+    /* #389 — make room for the fixed-bottom mobile tab bar (56px + safe-area
+       inset). Padding on `.vc-vault-layout` is a no-op (display:grid +
+       height:100vh + overflow:hidden clips the padding), so the inset goes
+       on the editor flex column, where flex layout actually shrinks the
+       content to fit. */
+    .vc-layout-editor {
+      padding-bottom: calc(56px + env(safe-area-inset-bottom));
     }
   }
 </style>

--- a/src/components/Layout/__tests__/MobileTabBar.test.ts
+++ b/src/components/Layout/__tests__/MobileTabBar.test.ts
@@ -1,0 +1,152 @@
+/**
+ * MobileTabBar — bottom-nav for the mobile shell (#389).
+ *
+ * The component is parent-gated (VaultLayout decides via `{#if isMobile}`),
+ * so this spec doesn't mock viewportStore — it just renders the component
+ * directly and verifies the tablist contract: 3 tabs, ARIA tabs pattern,
+ * roving tabindex, click-callbacks, and arrow-key navigation.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+import MobileTabBar from "../MobileTabBar.svelte";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function renderBar(overrides: Partial<{
+  drawerOpen: boolean;
+  onSelectFiles: () => void;
+  onSelectSearch: () => void;
+  onSelectMore: () => void;
+}> = {}) {
+  return render(MobileTabBar, {
+    props: {
+      drawerOpen: false,
+      onSelectFiles: vi.fn(),
+      onSelectSearch: vi.fn(),
+      onSelectMore: vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
+describe("MobileTabBar (#389)", () => {
+  it("renders a tablist with 3 tabs and aria-label='Main navigation'", () => {
+    const { container } = renderBar();
+    const tablist = container.querySelector('[role="tablist"]');
+    expect(tablist).not.toBeNull();
+    expect(tablist!.getAttribute("aria-label")).toBe("Main navigation");
+    expect(container.querySelectorAll('[role="tab"]').length).toBe(3);
+  });
+
+  it("Files tab carries aria-controls='vc-mobile-drawer'; Search and More do not have aria-controls", () => {
+    const { container } = renderBar();
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    expect(tabs[0].getAttribute("aria-controls")).toBe("vc-mobile-drawer");
+    expect(tabs[1].hasAttribute("aria-controls")).toBe(false);
+    expect(tabs[2].hasAttribute("aria-controls")).toBe(false);
+  });
+
+  it("aria-selected is present on every tab — never omitted (ARIA tabs §3.23)", () => {
+    const { container } = renderBar();
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    for (const tab of Array.from(tabs)) {
+      expect(tab.hasAttribute("aria-selected")).toBe(true);
+    }
+  });
+
+  it("when drawerOpen=false, every aria-selected is 'false'", () => {
+    const { container } = renderBar({ drawerOpen: false });
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    for (const tab of Array.from(tabs)) {
+      expect(tab.getAttribute("aria-selected")).toBe("false");
+    }
+  });
+
+  it("when drawerOpen=true, Files tab is selected and others are not", () => {
+    const { container } = renderBar({ drawerOpen: true });
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+    expect(tabs[1].getAttribute("aria-selected")).toBe("false");
+    expect(tabs[2].getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("clicking each tab invokes the matching callback exactly once", async () => {
+    const onSelectFiles = vi.fn();
+    const onSelectSearch = vi.fn();
+    const onSelectMore = vi.fn();
+    const { container } = renderBar({ onSelectFiles, onSelectSearch, onSelectMore });
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    await fireEvent.click(tabs[0]);
+    await fireEvent.click(tabs[1]);
+    await fireEvent.click(tabs[2]);
+    expect(onSelectFiles).toHaveBeenCalledTimes(1);
+    expect(onSelectSearch).toHaveBeenCalledTimes(1);
+    expect(onSelectMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("roving tabindex follows the active tab — Files is reachable when drawerOpen, none when closed", async () => {
+    const { container, rerender } = renderBar({ drawerOpen: false });
+    let tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    // No active tab → first tab carries tabindex=0 (entry point) per the
+    // ARIA tabs pattern fallback.
+    expect(tabs[0].getAttribute("tabindex")).toBe("0");
+    expect(tabs[1].getAttribute("tabindex")).toBe("-1");
+    expect(tabs[2].getAttribute("tabindex")).toBe("-1");
+
+    await rerender({
+      drawerOpen: true,
+      onSelectFiles: vi.fn(),
+      onSelectSearch: vi.fn(),
+      onSelectMore: vi.fn(),
+    });
+    await tick();
+    tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    expect(tabs[0].getAttribute("tabindex")).toBe("0");
+    expect(tabs[1].getAttribute("tabindex")).toBe("-1");
+    expect(tabs[2].getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("ArrowRight cycles focus forward and wraps; ArrowLeft cycles backward and wraps", async () => {
+    const { container } = renderBar();
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    tabs[0].focus();
+    expect(document.activeElement).toBe(tabs[0]);
+
+    await fireEvent.keyDown(tabs[0], { key: "ArrowRight" });
+    expect(document.activeElement).toBe(tabs[1]);
+    await fireEvent.keyDown(tabs[1], { key: "ArrowRight" });
+    expect(document.activeElement).toBe(tabs[2]);
+    await fireEvent.keyDown(tabs[2], { key: "ArrowRight" });
+    expect(document.activeElement).toBe(tabs[0]);
+
+    await fireEvent.keyDown(tabs[0], { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(tabs[2]);
+  });
+
+  it("Home jumps to the first tab; End jumps to the last", async () => {
+    const { container } = renderBar();
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    tabs[1].focus();
+    await fireEvent.keyDown(tabs[1], { key: "Home" });
+    expect(document.activeElement).toBe(tabs[0]);
+    await fireEvent.keyDown(tabs[0], { key: "End" });
+    expect(document.activeElement).toBe(tabs[2]);
+  });
+
+  it("does not import viewportStore — parent-gated component is the architectural contract", async () => {
+    // Verifies the v2 #4 fix: MobileTabBar must not self-gate on viewport.
+    // Read the source instead of relying on a runtime probe (would still
+    // pass if a vi.mock blocked the import at runtime).
+    const fs = await import("node:fs/promises");
+    const url = await import("node:url");
+    const here = url.fileURLToPath(import.meta.url);
+    const path = await import("node:path");
+    const componentPath = path.resolve(path.dirname(here), "..", "MobileTabBar.svelte");
+    const src = await fs.readFile(componentPath, "utf8");
+    expect(src.includes("viewportStore")).toBe(false);
+  });
+});

--- a/src/components/Layout/__tests__/MobileTabBar.test.ts
+++ b/src/components/Layout/__tests__/MobileTabBar.test.ts
@@ -153,9 +153,10 @@ describe("MobileTabBar (#389)", () => {
     // the contract, and that's fine.
     const fs = await import("node:fs/promises");
     const url = await import("node:url");
-    const here = url.fileURLToPath(import.meta.url);
-    const path = await import("node:path");
-    const componentPath = path.resolve(path.dirname(here), "..", "MobileTabBar.svelte");
+    // import.meta.resolve goes through the runtime resolver — if the file
+    // moves or is renamed, this throws loud rather than silently resolving
+    // to a wrong path that happens to not contain the word.
+    const componentPath = url.fileURLToPath(import.meta.resolve("../MobileTabBar.svelte"));
     const src = await fs.readFile(componentPath, "utf8");
     expect(/from\s+["'][^"']*viewportStore["']/.test(src)).toBe(false);
   });

--- a/src/components/Layout/__tests__/MobileTabBar.test.ts
+++ b/src/components/Layout/__tests__/MobileTabBar.test.ts
@@ -33,6 +33,14 @@ function renderBar(overrides: Partial<{
   });
 }
 
+function tabsOf(container: HTMLElement): [HTMLButtonElement, HTMLButtonElement, HTMLButtonElement] {
+  const list = Array.from(
+    container.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+  );
+  if (list.length !== 3) throw new Error(`expected 3 tabs, got ${list.length}`);
+  return list as [HTMLButtonElement, HTMLButtonElement, HTMLButtonElement];
+}
+
 describe("MobileTabBar (#389)", () => {
   it("renders a tablist with 3 tabs and aria-label='Main navigation'", () => {
     const { container } = renderBar();
@@ -44,34 +52,32 @@ describe("MobileTabBar (#389)", () => {
 
   it("Files tab carries aria-controls='vc-mobile-drawer'; Search and More do not have aria-controls", () => {
     const { container } = renderBar();
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    expect(tabs[0].getAttribute("aria-controls")).toBe("vc-mobile-drawer");
-    expect(tabs[1].hasAttribute("aria-controls")).toBe(false);
-    expect(tabs[2].hasAttribute("aria-controls")).toBe(false);
+    const [files, search, more] = tabsOf(container);
+    expect(files.getAttribute("aria-controls")).toBe("vc-mobile-drawer");
+    expect(search.hasAttribute("aria-controls")).toBe(false);
+    expect(more.hasAttribute("aria-controls")).toBe(false);
   });
 
   it("aria-selected is present on every tab — never omitted (ARIA tabs §3.23)", () => {
     const { container } = renderBar();
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    for (const tab of Array.from(tabs)) {
+    for (const tab of tabsOf(container)) {
       expect(tab.hasAttribute("aria-selected")).toBe(true);
     }
   });
 
   it("when drawerOpen=false, every aria-selected is 'false'", () => {
     const { container } = renderBar({ drawerOpen: false });
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    for (const tab of Array.from(tabs)) {
+    for (const tab of tabsOf(container)) {
       expect(tab.getAttribute("aria-selected")).toBe("false");
     }
   });
 
   it("when drawerOpen=true, Files tab is selected and others are not", () => {
     const { container } = renderBar({ drawerOpen: true });
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    expect(tabs[0].getAttribute("aria-selected")).toBe("true");
-    expect(tabs[1].getAttribute("aria-selected")).toBe("false");
-    expect(tabs[2].getAttribute("aria-selected")).toBe("false");
+    const [files, search, more] = tabsOf(container);
+    expect(files.getAttribute("aria-selected")).toBe("true");
+    expect(search.getAttribute("aria-selected")).toBe("false");
+    expect(more.getAttribute("aria-selected")).toBe("false");
   });
 
   it("clicking each tab invokes the matching callback exactly once", async () => {
@@ -79,10 +85,10 @@ describe("MobileTabBar (#389)", () => {
     const onSelectSearch = vi.fn();
     const onSelectMore = vi.fn();
     const { container } = renderBar({ onSelectFiles, onSelectSearch, onSelectMore });
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    await fireEvent.click(tabs[0]);
-    await fireEvent.click(tabs[1]);
-    await fireEvent.click(tabs[2]);
+    const [files, search, more] = tabsOf(container);
+    await fireEvent.click(files);
+    await fireEvent.click(search);
+    await fireEvent.click(more);
     expect(onSelectFiles).toHaveBeenCalledTimes(1);
     expect(onSelectSearch).toHaveBeenCalledTimes(1);
     expect(onSelectMore).toHaveBeenCalledTimes(1);
@@ -90,12 +96,14 @@ describe("MobileTabBar (#389)", () => {
 
   it("roving tabindex follows the active tab — Files is reachable when drawerOpen, none when closed", async () => {
     const { container, rerender } = renderBar({ drawerOpen: false });
-    let tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    // No active tab → first tab carries tabindex=0 (entry point) per the
-    // ARIA tabs pattern fallback.
-    expect(tabs[0].getAttribute("tabindex")).toBe("0");
-    expect(tabs[1].getAttribute("tabindex")).toBe("-1");
-    expect(tabs[2].getAttribute("tabindex")).toBe("-1");
+    {
+      const [files, search, more] = tabsOf(container);
+      // No active tab → first tab carries tabindex=0 (entry point) per the
+      // ARIA tabs pattern fallback.
+      expect(files.getAttribute("tabindex")).toBe("0");
+      expect(search.getAttribute("tabindex")).toBe("-1");
+      expect(more.getAttribute("tabindex")).toBe("-1");
+    }
 
     await rerender({
       drawerOpen: true,
@@ -104,49 +112,51 @@ describe("MobileTabBar (#389)", () => {
       onSelectMore: vi.fn(),
     });
     await tick();
-    tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    expect(tabs[0].getAttribute("tabindex")).toBe("0");
-    expect(tabs[1].getAttribute("tabindex")).toBe("-1");
-    expect(tabs[2].getAttribute("tabindex")).toBe("-1");
+    const [files, search, more] = tabsOf(container);
+    expect(files.getAttribute("tabindex")).toBe("0");
+    expect(search.getAttribute("tabindex")).toBe("-1");
+    expect(more.getAttribute("tabindex")).toBe("-1");
   });
 
   it("ArrowRight cycles focus forward and wraps; ArrowLeft cycles backward and wraps", async () => {
     const { container } = renderBar();
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    tabs[0].focus();
-    expect(document.activeElement).toBe(tabs[0]);
+    const [files, search, more] = tabsOf(container);
+    files.focus();
+    expect(document.activeElement).toBe(files);
 
-    await fireEvent.keyDown(tabs[0], { key: "ArrowRight" });
-    expect(document.activeElement).toBe(tabs[1]);
-    await fireEvent.keyDown(tabs[1], { key: "ArrowRight" });
-    expect(document.activeElement).toBe(tabs[2]);
-    await fireEvent.keyDown(tabs[2], { key: "ArrowRight" });
-    expect(document.activeElement).toBe(tabs[0]);
+    await fireEvent.keyDown(files, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(search);
+    await fireEvent.keyDown(search, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(more);
+    await fireEvent.keyDown(more, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(files);
 
-    await fireEvent.keyDown(tabs[0], { key: "ArrowLeft" });
-    expect(document.activeElement).toBe(tabs[2]);
+    await fireEvent.keyDown(files, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(more);
   });
 
   it("Home jumps to the first tab; End jumps to the last", async () => {
     const { container } = renderBar();
-    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-    tabs[1].focus();
-    await fireEvent.keyDown(tabs[1], { key: "Home" });
-    expect(document.activeElement).toBe(tabs[0]);
-    await fireEvent.keyDown(tabs[0], { key: "End" });
-    expect(document.activeElement).toBe(tabs[2]);
+    const [files, search, more] = tabsOf(container);
+    search.focus();
+    await fireEvent.keyDown(search, { key: "Home" });
+    expect(document.activeElement).toBe(files);
+    await fireEvent.keyDown(files, { key: "End" });
+    expect(document.activeElement).toBe(more);
   });
 
   it("does not import viewportStore — parent-gated component is the architectural contract", async () => {
     // Verifies the v2 #4 fix: MobileTabBar must not self-gate on viewport.
     // Read the source instead of relying on a runtime probe (would still
-    // pass if a vi.mock blocked the import at runtime).
+    // pass if a vi.mock blocked the import at runtime). Match the import
+    // statement specifically — the word may appear in a comment explaining
+    // the contract, and that's fine.
     const fs = await import("node:fs/promises");
     const url = await import("node:url");
     const here = url.fileURLToPath(import.meta.url);
     const path = await import("node:path");
     const componentPath = path.resolve(path.dirname(here), "..", "MobileTabBar.svelte");
     const src = await fs.readFile(componentPath, "utf8");
-    expect(src.includes("viewportStore")).toBe(false);
+    expect(/from\s+["'][^"']*viewportStore["']/.test(src)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds the mobile bottom tab bar per #389 (Vitruvius brief in issue comments). Three tabs: Files / Search / More. Renders only on mobile (`viewportStore.mode === "mobile"`).

- **Files** → opens the existing drawer (open-only — native iOS/Android pattern; close stays owned by scrim, swipe-left, Escape).
- **Search** → closes the drawer first, then opens OmniSearch in filename mode. Close-first is required because the drawer scrim sits at z-index 49 above the tab bar (40); without it the scrim consumes the tap and costs the user a second click.
- **More** → closes the drawer and shows a `Mehr-Menü folgt` info toast (placeholder until #397 lands; TODO comment marks the wire-up site).

### Architecture
- `MobileTabBar.svelte` is parent-gated: VaultLayout decides via `{#if isMobile}`. Component does NOT subscribe to `viewportStore` — verified by a source-level test.
- All state (drawer + modals) stays in VaultLayout; tab bar only emits via callbacks.

### ARIA
- `<div role="tablist" aria-label="Main navigation">` (W3C ARIA tabs uses div; Svelte's `a11y_no_noninteractive_element_to_interactive_role` rejects `<nav role="tablist">`).
- `aria-selected` on EVERY tab — never omitted (ARIA tabs §3.23).
- `aria-controls="vc-mobile-drawer"` on Files tab; Search/More omit it (OmniSearch has no stable id; More wires later).
- Roving `tabindex` follows the active tab; Files acts as the entry point when nothing is active.
- Arrow-Left/Right cycle and wrap; Home/End jump to ends.

### Layout
- 56px tall, `position: fixed`, `background: var(--color-surface)`, `border-top: 1px solid var(--color-border)`, `z-index: 40` (below drawer 50, well below modals ≥199).
- `padding-bottom: env(safe-area-inset-bottom)` for notched devices.
- Active state: pill `var(--color-accent-bg)` + color `var(--color-accent)`; inactive `var(--color-text-muted)`. No border accent.
- Lucide icons (Files / Search / Menu) at 20px / strokeWidth 1.5.
- Editor padding-bottom of `calc(56px + env(safe-area-inset-bottom))` inside the existing `@media (max-width: 699px)` block — applied to `.vc-layout-editor` (flex column) because padding on `.vc-vault-layout` would be a no-op (display:grid + height:100vh + overflow:hidden clips it).

### Plan v2 caveats addressed (Socrates v1)
1. Scrim-swallows-tap → Search/More handlers explicitly close the drawer first.
2. `padding-bottom` on grid container is a no-op → moved to `.vc-layout-editor`.
3. Files = open-only → early-return when drawer already open.
4. Self-gating is a layering leak → component takes no viewportStore dep; parent owns the gate.
5. `aria-selected` on every tab → always present.
6. OmniSearch z-index → verified 200/201 (above drawer 50 and tab bar 40).
7. Drawer-open + Search-tap regression → covered by WDIO test "Search tab opens OmniSearch (and closes the drawer first if open)".
8. CSS placement → component `<style>` `@media` block, NOT global tailwind.css.

## Test plan
- [x] `pnpm vitest run src/components/Layout/` — 31/31 green (10 new MobileTabBar cases).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm build` — clean.
- [ ] Manual UAT: resize <700px, tab bar appears at the bottom; 3 tabs render with icons + German labels.
- [ ] Manual UAT: Files opens drawer; second tap leaves it open; Files cannot close it (close via scrim/swipe/Escape).
- [ ] Manual UAT: open drawer via Files, tap Search → drawer closes AND OmniSearch opens (single tap).
- [ ] Manual UAT: tap More → "Mehr-Menü folgt" toast.
- [ ] Manual UAT: arrow-key nav across the 3 tabs (focus the bar with Tab first).
- [ ] Manual UAT: resize to desktop → tab bar disappears, editor padding restores.

Closes #389. Refs #74.