### PR TITLE
feat(mobile): keyboard-aware scrolling (#395)

### DIFF
--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -18,6 +18,7 @@
   import { readFile, writeFile, mergeExternalChange, getResolvedLinks, getResolvedAnchors, getResolvedAttachments, createFile, getFileHash } from "../../ipc/commands";
   import { openFileAsTab } from "../../lib/openFileAsTab";
   import { tabSupportsReading } from "../../lib/tabKind";
+  import { viewportStore } from "../../store/viewportStore";
   import { defaultViewModeForViewport } from "../../lib/viewport";
   import { isVaultError } from "../../types/errors";
   import { toastStore } from "../../store/toastStore";
@@ -252,6 +253,62 @@
   const paneActiveTabSupportsReading = $derived(
     paneActiveTab !== null && tabSupportsReading(paneActiveTab),
   );
+
+  // #395 — keyboard-aware caret centering. When the on-screen keyboard
+  // appears (`viewportStore.keyboardHeight` transitions 0 → >0) AND the
+  // active tab is a focused, edit-mode markdown view in THIS pane, dispatch
+  // `EditorView.scrollIntoView(selection.main.head, { y: "center" })` so
+  // the caret stays visible above the keyboard.
+  //
+  // Re-dispatch rules:
+  //   - Fires on 0→>0 transition (keyboard opens).
+  //   - Fires when `paneActiveTabId` changes while kb > 0 (so swiping to a
+  //     different tab while typing recenters its caret).
+  //   - Per-pixel jitter (250→245→260) does NOT re-dispatch — tracked via
+  //     `lastKbHeight === 0` gate.
+  //   - Closing the keyboard (>0 → 0) does NOT dispatch — the now-larger
+  //     viewport reveals the caret naturally.
+  //
+  // Why rAF: the padding-bottom on `.vc-editor-container` (driven by
+  // `--vc-keyboard-height`) shrinks CM6's host element. CM6 measures its
+  // visible rect against the host, but the layout pass that gives CM6 the
+  // new size happens before the next paint. Dispatching scrollIntoView in
+  // the same microtask risks measuring the stale rect.
+  let lastKbHeight = 0;
+  let lastDispatchTabId: string | null = null;
+  $effect(() => {
+    const kb = $viewportStore.keyboardHeight;
+    const tabId = paneActiveTabId;
+    const tab = paneActiveTab;
+    const isEditableActiveHere =
+      tab !== null &&
+      tabSupportsReading(tab) &&
+      (tab.viewMode ?? "edit") === "edit" &&
+      activePane === paneId;
+
+    if (
+      kb > 0 &&
+      isEditableActiveHere &&
+      tabId !== null &&
+      (lastKbHeight === 0 || lastDispatchTabId !== tabId)
+    ) {
+      const view = viewMap.get(tabId);
+      if (view && view.hasFocus) {
+        const v = view;
+        requestAnimationFrame(() => {
+          v.dispatch({
+            effects: EditorView.scrollIntoView(
+              v.state.selection.main.head,
+              { y: "center" },
+            ),
+          });
+        });
+        lastDispatchTabId = tabId;
+      }
+    }
+
+    lastKbHeight = kb;
+  });
 
   // #87: show ambient local-graph background in edit mode on markdown tabs.
   const showGraphBg = $derived(
@@ -1250,6 +1307,15 @@
     position: absolute;
     inset: 0;
     z-index: 1;
+    /* #395 — reserve room for the on-screen keyboard so CM6's host
+       element (which fills this container) actually shrinks. With
+       box-sizing: border-box the padding eats into the bottom of the
+       container, and CM6's `.cm-editor` (height: 100%) honors the new
+       content-box height. Default 0px → byte-identical desktop layout.
+       Applies to ReadingView and Canvas containers too — none of them
+       should render under the virtual keyboard. */
+    box-sizing: border-box;
+    padding-bottom: var(--vc-keyboard-height, 0px);
   }
 
   /* #87: semi-transparent editor backgrounds so the ambient graph shows through */

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -294,19 +294,35 @@
     ) {
       const view = viewMap.get(tabId);
       if (view && view.hasFocus) {
-        const v = view;
+        const scheduledTabId = tabId;
         requestAnimationFrame(() => {
-          v.dispatch({
+          // Re-check the tab and view still match: a rapid tab switch
+          // between schedule and frame would otherwise dispatch on a stale
+          // (or destroyed) view. Reading viewMap by id and comparing
+          // against the active tab keeps the rAF idempotent against
+          // mid-flight activation changes.
+          const liveView = viewMap.get(scheduledTabId);
+          if (!liveView) return;
+          if (tabStore.getActiveTab()?.id !== scheduledTabId) return;
+          liveView.dispatch({
             effects: EditorView.scrollIntoView(
-              v.state.selection.main.head,
+              liveView.state.selection.main.head,
               { y: "center" },
             ),
           });
+          // Commit `lastDispatchTabId` AFTER the dispatch lands. If we set
+          // it pre-rAF, a follow-up effect that enters the gate during the
+          // rAF window would see a stale "we already dispatched for A"
+          // record and skip the legitimate redispatch for B.
+          lastDispatchTabId = scheduledTabId;
         });
-        lastDispatchTabId = tabId;
       }
     }
 
+    // `lastKbHeight` MUST update synchronously (not inside rAF): it tracks
+    // the last seen value so the next $effect run can detect a 0→>0
+    // transition. Deferring it would lose intermediate transitions if the
+    // store fires twice before the frame.
     lastKbHeight = kb;
   });
 

--- a/src/components/Editor/__tests__/EditorPane.keyboardScroll.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.keyboardScroll.test.ts
@@ -325,4 +325,56 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
     const leftCalls = leftDispatch.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(leftCalls.length).toBe(0);
   });
+
+  it("rapid tab switch between rAF schedule and frame: tab-A's stale dispatch is suppressed", async () => {
+    // Aristotle iter-1 #1 regression guard. Sequence:
+    //   1. Tab A active, kb opens → $effect schedules rAF for A.
+    //   2. User switches to tab B BEFORE the frame fires.
+    //   3. The pending rAF callback re-checks the live tab id; since the
+    //      active tab is now B, it skips the dispatch (no stale-view crash,
+    //      no scroll on a tab the user moved away from).
+    //   4. The new $effect for tab B independently schedules its own rAF
+    //      and dispatches normally.
+    //
+    // Override the synchronous stubRaf with a queuing rAF so we can hold
+    // the callback while we mutate state in the test.
+    const queue: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      queue.push(cb);
+      return queue.length;
+    });
+
+    const { cm: cmA } = await mountPaneWithMarkdownTab();
+    const { EditorView: EV } = await import("@codemirror/view");
+    const viewA = EV.findFromDOM(cmA);
+    if (!viewA) throw new Error("no view A");
+    Object.defineProperty(viewA, "hasFocus", { configurable: true, get: () => true });
+    const dispatchA = vi.spyOn(viewA, "dispatch");
+
+    setKeyboardHeight(250);
+    await flushAsync();
+    // At least one rAF queued for tab A. Not flushed yet.
+    expect(queue.length).toBeGreaterThanOrEqual(1);
+    expect(dispatchA.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object)).length).toBe(0);
+
+    // User switches to tab B mid-flight (BEFORE any frame fires for A).
+    tabStore.openTab("/vault/other.md", "edit");
+    await flushAsync();
+
+    // Flush ALL queued rAFs. Each one captured `scheduledTabId` at the
+    // moment it was enqueued; the rAFs scheduled while tab A was active
+    // must skip their dispatch because the live active tab is now B.
+    while (queue.length > 0) {
+      const cb = queue.shift()!;
+      cb(0);
+    }
+
+    // Property under test: no dispatch lands on viewA (the stale view
+    // belonging to tab A — which is still active in this single-pane setup
+    // since openTab dedupes/activates new tabs in the same pane). With the
+    // pre-rAF guard removed, the rAF re-checks the active tab id at frame
+    // time and skips when it doesn't match the captured tab id.
+    const dispatchACalls = dispatchA.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
+    expect(dispatchACalls.length).toBe(0);
+  });
 });

--- a/src/components/Editor/__tests__/EditorPane.keyboardScroll.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.keyboardScroll.test.ts
@@ -1,0 +1,312 @@
+/**
+ * #395 — EditorPane reacts to viewportStore.keyboardHeight transitions by
+ * dispatching `EditorView.scrollIntoView(selection.main.head, { y: "center" })`
+ * on the active markdown tab. Padding-bottom on `.vc-editor-container` (driven
+ * by `--vc-keyboard-height`) shrinks CM6's host so the caret-relative
+ * scrollIntoView lands above the keyboard.
+ *
+ * Dispatch rules:
+ *   - Only on 0→>0 transition (keyboard opens) OR active-tab change while
+ *     kb > 0 (so swiping to a different tab while typing recenters its caret).
+ *     Per-pixel jitter does NOT re-dispatch.
+ *   - Tab must support reading (markdown / undefined viewer).
+ *   - Tab must be in edit mode.
+ *   - This pane must be the active pane (`activePane === paneId`).
+ *   - Active CM6 view must have DOM focus (`view.hasFocus`).
+ *
+ * Test setup mirrors `EditorPane.wikiLinkMobileMode.test.ts` for the IPC /
+ * Graph mock chain. `viewportStore` is mocked via a hoisted writable so each
+ * test can flip `keyboardHeight` deterministically without `vi.resetModules`
+ * (which is incompatible with Svelte 5 effect tracking — see the
+ * TopbarReadingToggle.test.ts header in #388 for the full story).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const { viewportWritable } = vi.hoisted(() => ({
+  viewportWritable: (() => {
+    const { writable } = require("svelte/store");
+    return writable({ mode: "mobile", isCoarsePointer: true, keyboardHeight: 0 });
+  })(),
+}));
+
+vi.mock("../../../store/viewportStore", () => ({
+  viewportStore: viewportWritable,
+  createViewportStore: () => viewportWritable,
+}));
+
+const { readFile, getResolvedLinks, getResolvedAnchors, getResolvedAttachments } = vi.hoisted(() => ({
+  readFile: vi.fn().mockResolvedValue(""),
+  getResolvedLinks: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAnchors: vi.fn().mockResolvedValue(new Map()),
+  getResolvedAttachments: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock("../../../ipc/commands", () => ({
+  readFile,
+  createFile: vi.fn().mockResolvedValue(""),
+  writeFile: vi.fn().mockResolvedValue("0".repeat(64)),
+  getFileHash: vi.fn().mockResolvedValue("0".repeat(64)),
+  mergeExternalChange: vi.fn().mockResolvedValue({ outcome: "clean", merged_content: "" }),
+  getResolvedLinks,
+  getResolvedAnchors,
+  getResolvedAttachments,
+  getLinkGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getLocalGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+  getBacklinks: vi.fn().mockResolvedValue([]),
+  getOutgoingLinks: vi.fn().mockResolvedValue([]),
+  getUnresolvedLinks: vi.fn().mockResolvedValue([]),
+  listTags: vi.fn().mockResolvedValue([]),
+  countWikiLinks: vi.fn().mockResolvedValue(0),
+  suggestLinks: vi.fn().mockResolvedValue([]),
+  searchFulltext: vi.fn().mockResolvedValue([]),
+  searchFilename: vi.fn().mockResolvedValue([]),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
+  normalizeError: (e: unknown) => e,
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenVaultStatus: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeStart: vi.fn().mockResolvedValue(() => {}),
+  listenBulkChangeEnd: vi.fn().mockResolvedValue(() => {}),
+  listenIndexProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("../../Graph/GraphView.svelte", async () => {
+  // @ts-ignore — *.svelte shim doesn't expose default in dynamic-import form
+  const { default: Empty } = await import("./emptyComponent.svelte");
+  return { default: Empty };
+});
+vi.mock("../../Graph/graphRender", () => ({
+  mountGraph: vi.fn(),
+  updateGraph: vi.fn(),
+  destroyGraph: vi.fn(),
+  DEFAULT_FORCE_SETTINGS: {},
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://${encodeURIComponent(p)}`,
+}));
+
+import { tabStore } from "../../../store/tabStore";
+import { vaultStore } from "../../../store/vaultStore";
+import EditorPane from "../EditorPane.svelte";
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    await Promise.resolve();
+    await tick();
+  }
+}
+
+function setKeyboardHeight(kb: number): void {
+  viewportWritable.set({ mode: "mobile", isCoarsePointer: true, keyboardHeight: kb });
+}
+
+function setViewportMode(mode: "desktop" | "tablet" | "mobile", kb: number = 0): void {
+  viewportWritable.set({
+    mode,
+    isCoarsePointer: mode === "mobile",
+    keyboardHeight: kb,
+  });
+}
+
+/**
+ * Stub `requestAnimationFrame` to run callbacks synchronously so the
+ * scrollIntoView dispatch happens within `flushAsync`'s reach without timing
+ * uncertainty. Restored in afterEach via `vi.restoreAllMocks`.
+ */
+function stubRaf(): void {
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+}
+
+interface MountedPane {
+  container: HTMLElement;
+  cm: HTMLElement;
+  tabId: string;
+}
+
+async function mountPaneWithMarkdownTab(paneId: "left" | "right" = "left"): Promise<MountedPane> {
+  const { container } = render(EditorPane, { props: { paneId } });
+  await flushAsync();
+  const tabId = tabStore.openTab("/vault/host.md", "edit");
+  await flushAsync();
+  const cm = container.querySelector(".cm-editor") as HTMLElement | null;
+  if (!cm) throw new Error("CM6 editor did not mount");
+  return { container, cm, tabId };
+}
+
+/**
+ * The CM6 view is held in EditorPane's module-private `viewMap` (Svelte 5
+ * doesn't expose component internals). Recover it through the DOM: CM6
+ * stores a back-reference at `.cmView` on its `.cm-editor` element under
+ * the `view` field of the EditorView instance. We rely on
+ * `EditorView.findFromDOM(cm)` instead — the official API.
+ */
+async function getActiveView(cm: HTMLElement): Promise<{ dispatch: ReturnType<typeof vi.spyOn> }> {
+  const { EditorView } = await import("@codemirror/view");
+  const view = EditorView.findFromDOM(cm);
+  if (!view) throw new Error("Could not recover EditorView from DOM");
+  // Force focus so the `view.hasFocus` gate passes for the dispatch tests.
+  view.focus();
+  // jsdom's focus() may not flip `view.hasFocus` (which reads
+  // `document.activeElement === this.contentDOM`). Override via spy.
+  Object.defineProperty(view, "hasFocus", { configurable: true, get: () => true });
+  return { dispatch: vi.spyOn(view, "dispatch") };
+}
+
+describe("EditorPane keyboard-aware scroll (#395)", () => {
+  beforeEach(() => {
+    tabStore._reset();
+    vaultStore.reset();
+    setViewportMode("mobile", 0);
+    stubRaf();
+    vaultStore.setReady({
+      currentPath: "/vault",
+      fileList: ["host.md", "other.md"],
+      fileCount: 2,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches scrollIntoView once when keyboard opens (0 → 250) on focused edit-mode markdown", async () => {
+    const { cm } = await mountPaneWithMarkdownTab();
+    const { dispatch } = await getActiveView(cm);
+
+    setKeyboardHeight(250);
+    await flushAsync();
+
+    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    expect(calls.length).toBe(1);
+  });
+
+  it("does NOT re-dispatch on per-pixel jitter (250 → 245 → 260)", async () => {
+    const { cm } = await mountPaneWithMarkdownTab();
+    const { dispatch } = await getActiveView(cm);
+
+    setKeyboardHeight(250);
+    await flushAsync();
+    setKeyboardHeight(245);
+    await flushAsync();
+    setKeyboardHeight(260);
+    await flushAsync();
+
+    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    expect(calls.length).toBe(1);
+  });
+
+  it("dispatches twice when keyboard reopens (0 → 250 → 0 → 250)", async () => {
+    const { cm } = await mountPaneWithMarkdownTab();
+    const { dispatch } = await getActiveView(cm);
+
+    setKeyboardHeight(250);
+    await flushAsync();
+    setKeyboardHeight(0);
+    await flushAsync();
+    setKeyboardHeight(250);
+    await flushAsync();
+
+    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    expect(calls.length).toBe(2);
+  });
+
+  it("dispatches an additional scrollIntoView when active tab changes while keyboard is open", async () => {
+    const { cm } = await mountPaneWithMarkdownTab();
+    const { dispatch: dispatchA } = await getActiveView(cm);
+
+    setKeyboardHeight(250);
+    await flushAsync();
+    expect(dispatchA.mock.calls.filter((c) => "effects" in (c[0] as object)).length).toBe(1);
+
+    // Open second tab — becomes active with kb still > 0.
+    tabStore.openTab("/vault/other.md", "edit");
+    await flushAsync();
+
+    // The DOM has two `.cm-editor` nodes now; the freshly-active one is
+    // the second container's CM6 host.
+    const cms = document.querySelectorAll(".cm-editor");
+    expect(cms.length).toBeGreaterThanOrEqual(2);
+    const activeCm = cms[cms.length - 1] as HTMLElement;
+    const { dispatch: dispatchB } = await getActiveView(activeCm);
+
+    // Re-trigger the effect by re-emitting the same kb height — the
+    // tab-id transition gate should fire even though kb didn't change.
+    // (In real flow the tab activation alone is enough because the
+    // $effect has paneActiveTabId in its dependency set; emit just to
+    // make the assertion timing robust under flushAsync.)
+    await flushAsync();
+
+    const dispatchBCalls = dispatchB.mock.calls.filter((c) => "effects" in (c[0] as object));
+    expect(dispatchBCalls.length).toBe(1);
+  });
+
+  it("does NOT dispatch when active tab is in read mode", async () => {
+    const { cm } = await mountPaneWithMarkdownTab();
+    const { dispatch } = await getActiveView(cm);
+
+    // Flip the existing tab to read mode (use the already-opened host.md).
+    const active = tabStore.getActiveTab();
+    if (active) tabStore.setViewMode(active.id, "read");
+    await flushAsync();
+
+    setKeyboardHeight(250);
+    await flushAsync();
+
+    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    expect(calls.length).toBe(0);
+  });
+
+  it("does NOT dispatch when the CM6 view does not have focus", async () => {
+    const { cm } = await mountPaneWithMarkdownTab();
+    const { EditorView } = await import("@codemirror/view");
+    const view = EditorView.findFromDOM(cm);
+    if (!view) throw new Error("no view");
+    // Override hasFocus to false; do NOT focus().
+    Object.defineProperty(view, "hasFocus", { configurable: true, get: () => false });
+    const dispatch = vi.spyOn(view, "dispatch");
+
+    setKeyboardHeight(250);
+    await flushAsync();
+
+    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    expect(calls.length).toBe(0);
+  });
+
+  it("does NOT dispatch on a non-active pane (left pane stays quiet when right pane is active)", async () => {
+    // Mount BOTH panes; the left pane mounts first and its tab becomes
+    // active. We then move that tab to the right pane via tabStore — both
+    // EditorPane instances subscribe to the same store, but only the
+    // active pane should react.
+    const { cm: leftCm } = await mountPaneWithMarkdownTab("left");
+    render(EditorPane, { props: { paneId: "right" } });
+    await flushAsync();
+
+    // Move the active tab to the right pane → activePane flips to "right".
+    tabStore.moveToPane("right");
+    await flushAsync();
+
+    // Spy on the left pane's CM6 view (which is now NOT in the active pane).
+    const { EditorView } = await import("@codemirror/view");
+    const leftView = EditorView.findFromDOM(leftCm);
+    if (!leftView) throw new Error("no left view");
+    Object.defineProperty(leftView, "hasFocus", { configurable: true, get: () => true });
+    const leftDispatch = vi.spyOn(leftView, "dispatch");
+
+    setKeyboardHeight(250);
+    await flushAsync();
+
+    const leftCalls = leftDispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    expect(leftCalls.length).toBe(0);
+  });
+});

--- a/src/components/Editor/__tests__/EditorPane.keyboardScroll.test.ts
+++ b/src/components/Editor/__tests__/EditorPane.keyboardScroll.test.ts
@@ -187,7 +187,7 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
     setKeyboardHeight(250);
     await flushAsync();
 
-    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    const calls = dispatch.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(calls.length).toBe(1);
   });
 
@@ -202,7 +202,7 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
     setKeyboardHeight(260);
     await flushAsync();
 
-    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    const calls = dispatch.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(calls.length).toBe(1);
   });
 
@@ -217,7 +217,7 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
     setKeyboardHeight(250);
     await flushAsync();
 
-    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    const calls = dispatch.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(calls.length).toBe(2);
   });
 
@@ -227,27 +227,35 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
 
     setKeyboardHeight(250);
     await flushAsync();
-    expect(dispatchA.mock.calls.filter((c) => "effects" in (c[0] as object)).length).toBe(1);
+    expect(dispatchA.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object)).length).toBe(1);
 
-    // Open second tab — becomes active with kb still > 0.
+    // Pre-spy on the second tab's CM6 view BEFORE making it active. We do
+    // this by opening the tab first (which mounts its view but leaves it
+    // inactive briefly — the new tab DOES become active immediately, so
+    // the dispatch may fire synchronously inside the activation effect).
+    // Strategy: open tab, immediately spy on the just-mounted view, THEN
+    // flush so any effect-driven dispatches are observable on dispatchB.
     tabStore.openTab("/vault/other.md", "edit");
+    // Settle one microtask so the new container exists and CM6 mounts.
     await flushAsync();
 
-    // The DOM has two `.cm-editor` nodes now; the freshly-active one is
-    // the second container's CM6 host.
     const cms = document.querySelectorAll(".cm-editor");
     expect(cms.length).toBeGreaterThanOrEqual(2);
     const activeCm = cms[cms.length - 1] as HTMLElement;
-    const { dispatch: dispatchB } = await getActiveView(activeCm);
+    const { EditorView: EV } = await import("@codemirror/view");
+    const viewB = EV.findFromDOM(activeCm);
+    if (!viewB) throw new Error("no view B");
+    Object.defineProperty(viewB, "hasFocus", { configurable: true, get: () => true });
+    const dispatchB = vi.spyOn(viewB, "dispatch");
 
-    // Re-trigger the effect by re-emitting the same kb height — the
-    // tab-id transition gate should fire even though kb didn't change.
-    // (In real flow the tab activation alone is enough because the
-    // $effect has paneActiveTabId in its dependency set; emit just to
-    // make the assertion timing robust under flushAsync.)
+    // Re-emit kb to force the $effect to re-run against the new active
+    // tab id — `lastDispatchTabId !== tabId` should fire dispatchB now.
+    // Per-pixel value is irrelevant; pick a different number to exercise
+    // the change path.
+    setKeyboardHeight(260);
     await flushAsync();
 
-    const dispatchBCalls = dispatchB.mock.calls.filter((c) => "effects" in (c[0] as object));
+    const dispatchBCalls = dispatchB.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(dispatchBCalls.length).toBe(1);
   });
 
@@ -263,7 +271,7 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
     setKeyboardHeight(250);
     await flushAsync();
 
-    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    const calls = dispatch.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(calls.length).toBe(0);
   });
 
@@ -279,26 +287,34 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
     setKeyboardHeight(250);
     await flushAsync();
 
-    const calls = dispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    const calls = dispatch.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(calls.length).toBe(0);
   });
 
   it("does NOT dispatch on a non-active pane (left pane stays quiet when right pane is active)", async () => {
-    // Mount BOTH panes; the left pane mounts first and its tab becomes
-    // active. We then move that tab to the right pane via tabStore — both
-    // EditorPane instances subscribe to the same store, but only the
-    // active pane should react.
+    // Setup:
+    //   1. Open tab A (host.md) in left pane.
+    //   2. Mount the right pane.
+    //   3. Open tab B (other.md) — lands in the active pane (left), then we
+    //      move it to the right pane via `moveToPane("right")`, which flips
+    //      `activePane` to "right".
+    //   4. With kb=0 still, attach the left-pane spy AFTER the move so any
+    //      mount-time dispatches don't pollute the count.
+    //   5. Emit kb=250 → only the RIGHT pane (active) should dispatch.
+    //      Left pane's spy stays at 0.
     const { cm: leftCm } = await mountPaneWithMarkdownTab("left");
     render(EditorPane, { props: { paneId: "right" } });
     await flushAsync();
 
-    // Move the active tab to the right pane → activePane flips to "right".
+    tabStore.openTab("/vault/other.md", "edit");
+    await flushAsync();
     tabStore.moveToPane("right");
     await flushAsync();
 
-    // Spy on the left pane's CM6 view (which is now NOT in the active pane).
-    const { EditorView } = await import("@codemirror/view");
-    const leftView = EditorView.findFromDOM(leftCm);
+    // The left pane still holds tab A (host.md). Spy on its CM6 view AFTER
+    // the moveToPane so we don't count any pre-move dispatches.
+    const { EditorView: EV } = await import("@codemirror/view");
+    const leftView = EV.findFromDOM(leftCm);
     if (!leftView) throw new Error("no left view");
     Object.defineProperty(leftView, "hasFocus", { configurable: true, get: () => true });
     const leftDispatch = vi.spyOn(leftView, "dispatch");
@@ -306,7 +322,7 @@ describe("EditorPane keyboard-aware scroll (#395)", () => {
     setKeyboardHeight(250);
     await flushAsync();
 
-    const leftCalls = leftDispatch.mock.calls.filter((c) => "effects" in (c[0] as object));
+    const leftCalls = leftDispatch.mock.calls.filter((c: unknown[]) => "effects" in (c[0] as object));
     expect(leftCalls.length).toBe(0);
   });
 });

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -247,10 +247,12 @@
   // panel into loading state and fires an IPC round-trip, causing the sidebar
   // to flicker as the user types. Only push through when the resolved rel
   // path actually changes.
-  let unsubBacklinksTab: (() => void) | null = null;
+  // #395 Boy Scout — return-from-onMount pattern matches the mousemove/mouseup
+  // block above (lines 235-242) and removes the cleanup-by-coordination dance
+  // where the onDestroy at the bottom had to know about every subscription.
   let lastDispatchedRelPath: string | null | undefined = undefined;
   onMount(() => {
-    unsubBacklinksTab = tabStore.subscribe((state) => {
+    const unsub = tabStore.subscribe((state) => {
       const activeTab = state.tabs.find((t) => t.id === state.activeTabId);
       // #259: snapshot vault path via get() — tabStore emits on every
       // per-keystroke mutation (setDirty, scroll, cursor) and a throwaway
@@ -272,6 +274,7 @@
       lastDispatchedRelPath = nextRelPath;
       backlinksStore.setActiveFile(nextRelPath);
     });
+    return unsub;
   });
 
   // Issue #50: reveal + select the active editor tab in the sidebar tree.
@@ -280,10 +283,9 @@
   // so a single subscription here covers every entry point. We guard by
   // the computed rel path so per-keystroke mutations (setDirty, scroll)
   // don't re-issue the same reveal on every tabStore emission.
-  let unsubActiveTabReveal: (() => void) | null = null;
   let lastRevealedRelPath: string | null | undefined = undefined;
   onMount(() => {
-    unsubActiveTabReveal = tabStore.subscribe((state) => {
+    const unsub = tabStore.subscribe((state) => {
       const activeTab = state.tabs.find((t) => t.id === state.activeTabId) ?? null;
       // #259: snapshot vault path via get() — see the backlinks-sync
       // subscription above for the per-keystroke hot-path rationale.
@@ -298,12 +300,15 @@
         treeRevealStore.requestReveal(relPath);
       }
     });
+    return unsub;
   });
 
   onDestroy(() => {
     unsubTab();
-    unsubBacklinksTab?.();
-    unsubActiveTabReveal?.();
+    // #395 Boy Scout — `unsubBacklinks` (line ~782) was previously module-level
+    // and never torn down, leaking a backlinksStore subscriber on every
+    // VaultLayout unmount (vault switch, HMR). Cleaned up here.
+    unsubBacklinks();
     // mousemove/mouseup are torn down by the onMount return above; calling
     // removeEventListener again here is a no-op (handler refs match) but
     // misleads readers into thinking the listeners are owned by both hooks.
@@ -765,6 +770,19 @@
   }
 
   const isSplit = $derived(rightPaneIds.length > 0);
+
+  // #395 — propagate the visualViewport-tracked keyboard height as the
+  // `--vc-keyboard-height` CSS variable. Cleanup removes the property so
+  // a re-mount (vault switch, HMR) starts from a clean slate. Desktop sees
+  // `0px` always (visualViewport.height === innerHeight) so the var is a
+  // no-op on non-mobile.
+  $effect(() => {
+    const kb = $viewportStore.keyboardHeight;
+    document.documentElement.style.setProperty("--vc-keyboard-height", `${kb}px`);
+    return () => {
+      document.documentElement.style.removeProperty("--vc-keyboard-height");
+    };
+  });
 
   // Reactive right sidebar CSS variables derived from store
   let backlinksOpen = $state(false);

--- a/src/components/Layout/__tests__/VaultLayout.keyboardCssVar.test.ts
+++ b/src/components/Layout/__tests__/VaultLayout.keyboardCssVar.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #395 — VaultLayout's `$effect` propagates `viewportStore.keyboardHeight`
+ * as the `--vc-keyboard-height` CSS custom property on `documentElement`.
+ * The effect's return cleanup MUST remove the property on unmount so a
+ * re-mount (vault switch / HMR) starts clean — otherwise stale padding
+ * could persist on `.vc-editor-container` for a brief window.
+ *
+ * Mock surface mirrors `VaultLayout.responsiveCollapse.test.ts`: heavy
+ * children stubbed, IPC mocked, viewportStore mocked via a hoisted writable
+ * so each test can flip `keyboardHeight` deterministically.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tick } from "svelte";
+
+const { viewportWritable } = await vi.hoisted(async () => {
+  const { writable } = await import("svelte/store");
+  return {
+    viewportWritable: writable<{
+      mode: "mobile" | "desktop" | "tablet";
+      isCoarsePointer: boolean;
+      keyboardHeight: number;
+    }>({
+      mode: "mobile",
+      isCoarsePointer: true,
+      keyboardHeight: 0,
+    }),
+  };
+});
+vi.mock("../../../store/viewportStore", () => ({
+  viewportStore: viewportWritable,
+  createViewportStore: () => viewportWritable,
+}));
+
+vi.mock("../../../ipc/commands", () => ({
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  exportNoteHtml: vi.fn(),
+  listDirectory: vi.fn().mockResolvedValue([]),
+  pickSavePath: vi.fn(),
+  readFile: vi.fn(),
+  renderNoteHtml: vi.fn(),
+  writeFile: vi.fn(),
+  encryptFolder: vi.fn(),
+  unlockFolder: vi.fn(),
+  lockAllFolders: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenFileChange: vi.fn().mockResolvedValue(() => {}),
+  listenEncryptDropProgress: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("../../../store/autoLockStore", () => ({
+  attachAutoLockListeners: vi.fn(),
+  armAutoLock: vi.fn(),
+  disarmAutoLock: vi.fn(),
+  resetAutoLockStore: vi.fn(),
+}));
+
+vi.mock("../../Editor/EditorPane.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Sidebar/Sidebar.svelte", async () => {
+  const Stub = (await import("./testStubs/SidebarStub.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Search/OmniSearch.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../CommandPalette/CommandPalette.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../TemplatePicker/TemplatePicker.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../RightSidebar.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Settings/SettingsModal.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+vi.mock("../../Statusbar/EncryptionStatusbar.svelte", async () => {
+  const Stub = (await import("./testStubs/EmptyComponent.svelte")).default;
+  return { default: Stub };
+});
+
+import { render } from "@testing-library/svelte";
+import VaultLayout from "../VaultLayout.svelte";
+
+beforeEach(() => {
+  viewportWritable.set({ mode: "mobile", isCoarsePointer: true, keyboardHeight: 0 });
+  // localStorage stub mirrors VaultLayout.responsiveCollapse.test.ts —
+  // VaultLayout's onMount reads sidebar width.
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => {
+      store.clear();
+    },
+    get length() {
+      return store.size;
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  });
+  // Always start each test from a clean :root.
+  document.documentElement.style.removeProperty("--vc-keyboard-height");
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+  document.documentElement.style.removeProperty("--vc-keyboard-height");
+});
+
+describe("VaultLayout — --vc-keyboard-height CSS var (#395)", () => {
+  it("sets --vc-keyboard-height on :root when keyboardHeight > 0", async () => {
+    const { unmount } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    viewportWritable.set({ mode: "mobile", isCoarsePointer: true, keyboardHeight: 250 });
+    await tick();
+
+    expect(
+      document.documentElement.style.getPropertyValue("--vc-keyboard-height"),
+    ).toBe("250px");
+    unmount();
+  });
+
+  it("updates --vc-keyboard-height when the store value changes", async () => {
+    const { unmount } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    viewportWritable.set({ mode: "mobile", isCoarsePointer: true, keyboardHeight: 250 });
+    await tick();
+    expect(
+      document.documentElement.style.getPropertyValue("--vc-keyboard-height"),
+    ).toBe("250px");
+
+    viewportWritable.set({ mode: "mobile", isCoarsePointer: true, keyboardHeight: 320 });
+    await tick();
+    expect(
+      document.documentElement.style.getPropertyValue("--vc-keyboard-height"),
+    ).toBe("320px");
+
+    unmount();
+  });
+
+  it("removes --vc-keyboard-height from :root on unmount", async () => {
+    const { unmount } = render(VaultLayout, { props: { onSwitchVault: () => {} } });
+    await tick();
+
+    viewportWritable.set({ mode: "mobile", isCoarsePointer: true, keyboardHeight: 250 });
+    await tick();
+    expect(
+      document.documentElement.style.getPropertyValue("--vc-keyboard-height"),
+    ).toBe("250px");
+
+    unmount();
+    await tick();
+
+    expect(
+      document.documentElement.style.getPropertyValue("--vc-keyboard-height"),
+    ).toBe("");
+  });
+});

--- a/src/store/__tests__/viewportStore.test.ts
+++ b/src/store/__tests__/viewportStore.test.ts
@@ -288,3 +288,194 @@ describe("viewportStore", () => {
     unsub2();
   });
 });
+
+// ── #395: visualViewport-driven keyboardHeight ──────────────────────────────
+//
+// On mobile, the on-screen keyboard shrinks the visual viewport without
+// resizing the layout viewport (iOS Safari behavior; Tauri Android with
+// adjustResize shrinks both, so the formula evaluates to 0 — correct).
+// `viewportStore` exposes the difference as `keyboardHeight` so consumers
+// (EditorPane padding, future bottom sheet) can react.
+//
+// Implementation extends `createViewportStore`'s `start` callback with one
+// `visualViewport.resize` listener (no `scroll` listener — that fires on user
+// pan, not keyboard appearance). Cleanup detaches it alongside matchMedia.
+
+interface FakeVv {
+  height: number;
+  listeners: Set<EventListener>;
+  addCount: number;
+  removeCount: number;
+  addEventListener: (type: string, l: EventListener) => void;
+  removeEventListener: (type: string, l: EventListener) => void;
+}
+
+function makeVv(initialHeight: number): FakeVv {
+  const vv: FakeVv = {
+    height: initialHeight,
+    listeners: new Set(),
+    addCount: 0,
+    removeCount: 0,
+    addEventListener: (type, l) => {
+      if (type !== "resize") return;
+      vv.addCount++;
+      vv.listeners.add(l);
+    },
+    removeEventListener: (type, l) => {
+      if (type !== "resize") return;
+      vv.removeCount++;
+      vv.listeners.delete(l);
+    },
+  };
+  return vv;
+}
+
+function installVv(height: number, innerHeight: number = 800): {
+  vv: FakeVv;
+  emit: () => void;
+} {
+  const vv = makeVv(height);
+  Object.defineProperty(window, "visualViewport", {
+    value: vv,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    value: innerHeight,
+    configurable: true,
+    writable: true,
+  });
+  return {
+    vv,
+    emit: () => {
+      for (const l of vv.listeners) l(new Event("resize"));
+    },
+  };
+}
+
+function uninstallVv(): void {
+  // `delete` requires the descriptor be configurable, which `installVv` set.
+  delete (window as unknown as { visualViewport?: unknown }).visualViewport;
+}
+
+describe("viewportStore — visualViewport / keyboardHeight (#395)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    uninstallVv();
+  });
+
+  it("defaults keyboardHeight to 0 when window.visualViewport is undefined", () => {
+    installHarness({ [Q_MOBILE]: false, [Q_TABLET]: false, [Q_COARSE]: false });
+    // No installVv() — visualViewport stays undefined.
+    const store = createViewportStore();
+    const unsub = store.subscribe(() => {});
+    expect(get(store).keyboardHeight).toBe(0);
+    unsub();
+  });
+
+  it("emits keyboardHeight: 0 on initial subscribe when keyboard is closed (vv.height === innerHeight)", () => {
+    installHarness({ [Q_MOBILE]: true, [Q_TABLET]: true, [Q_COARSE]: true });
+    installVv(800, 800);
+    const store = createViewportStore();
+    const unsub = store.subscribe(() => {});
+    expect(get(store).keyboardHeight).toBe(0);
+    unsub();
+  });
+
+  it("emits keyboardHeight on visualViewport resize (keyboard opens to 250px)", () => {
+    installHarness({ [Q_MOBILE]: true, [Q_TABLET]: true, [Q_COARSE]: true });
+    const { vv, emit } = installVv(800, 800);
+    const store = createViewportStore();
+    const unsub = store.subscribe(() => {});
+
+    expect(get(store).keyboardHeight).toBe(0);
+    vv.height = 550;
+    emit();
+    expect(get(store).keyboardHeight).toBe(250);
+    unsub();
+  });
+
+  it("does NOT re-emit when keyboard height is unchanged (rounded delta = 0)", () => {
+    installHarness({ [Q_MOBILE]: true, [Q_TABLET]: true, [Q_COARSE]: true });
+    const { vv, emit } = installVv(800, 800);
+    const store = createViewportStore();
+    const seen: number[] = [];
+    const unsub = store.subscribe((s) => seen.push(s.keyboardHeight));
+
+    // Initial subscribe → one emission with 0.
+    expect(seen).toEqual([0]);
+
+    vv.height = 550;
+    emit();
+    expect(seen).toEqual([0, 250]);
+
+    // Re-fire same value → no new emission.
+    emit();
+    expect(seen).toEqual([0, 250]);
+
+    unsub();
+  });
+
+  it("clamps to 0 when visualViewport.height exceeds innerHeight (overscroll edge case)", () => {
+    installHarness({ [Q_MOBILE]: false, [Q_TABLET]: false, [Q_COARSE]: false });
+    const { vv, emit } = installVv(800, 800);
+    const store = createViewportStore();
+    const unsub = store.subscribe(() => {});
+
+    vv.height = 805; // overscroll: visual viewport "taller" than layout
+    emit();
+    expect(get(store).keyboardHeight).toBe(0);
+    unsub();
+  });
+
+  it("emits keyboardHeight: 0 when keyboard closes (vv.height returns to innerHeight)", () => {
+    installHarness({ [Q_MOBILE]: true, [Q_TABLET]: true, [Q_COARSE]: true });
+    const { vv, emit } = installVv(800, 800);
+    const store = createViewportStore();
+    const seen: number[] = [];
+    const unsub = store.subscribe((s) => seen.push(s.keyboardHeight));
+
+    vv.height = 550;
+    emit();
+    expect(seen[seen.length - 1]).toBe(250);
+
+    vv.height = 800;
+    emit();
+    expect(seen[seen.length - 1]).toBe(0);
+    unsub();
+  });
+
+  it("detaches the visualViewport listener once the last subscriber unsubscribes", () => {
+    installHarness({ [Q_MOBILE]: true, [Q_TABLET]: true, [Q_COARSE]: true });
+    const { vv } = installVv(800, 800);
+    const store = createViewportStore();
+    const unsub = store.subscribe(() => {});
+    expect(vv.addCount).toBe(1);
+    expect(vv.removeCount).toBe(0);
+
+    unsub();
+    expect(vv.addCount).toBe(vv.removeCount);
+    expect(vv.listeners.size).toBe(0);
+  });
+
+  it("preserves keyboardHeight across matchMedia (mode/coarse) updates — does not zero on viewport-mode flip", () => {
+    // Regression guard: when the matchMedia listener fires (e.g. orientation
+    // change shifts width across the 700px boundary), the store must
+    // re-emit with the CURRENT keyboardHeight, not reset it to 0.
+    const harness = installHarness({ [Q_MOBILE]: false, [Q_TABLET]: false, [Q_COARSE]: false });
+    const { vv, emit } = installVv(800, 800);
+    const store = createViewportStore();
+    const unsub = store.subscribe(() => {});
+
+    vv.height = 550;
+    emit();
+    expect(get(store).keyboardHeight).toBe(250);
+    expect(get(store).mode).toBe("desktop");
+
+    harness.set(Q_MOBILE, true);
+    harness.set(Q_TABLET, true);
+    expect(get(store).mode).toBe("mobile");
+    expect(get(store).keyboardHeight).toBe(250);
+    unsub();
+  });
+});

--- a/src/store/viewportStore.ts
+++ b/src/store/viewportStore.ts
@@ -1,19 +1,25 @@
 /**
- * viewportStore — exposes the current viewport mode and pointer-coarseness so
- * mobile-aware components can branch without sprinkling matchMedia calls.
+ * viewportStore — exposes the current viewport mode, pointer-coarseness, and
+ * on-screen keyboard height so mobile-aware components can branch without
+ * sprinkling matchMedia / visualViewport calls.
  *
- * Driven by three matchMedia listeners — width queries gate layout collapse,
- * `(pointer: coarse)` gates hit-target bumps. The two are intentionally
- * independent: a desktop with a touchscreen reports coarse pointer at full
- * width, and that path must still apply 44px hit targets without collapsing
- * the layout.
+ * Driven by:
+ *   - 3 matchMedia listeners — width queries gate layout collapse,
+ *     `(pointer: coarse)` gates hit-target bumps. Independent of width: a
+ *     desktop with a touchscreen reports coarse pointer at full width and
+ *     must still apply 44px hit targets without collapsing the layout.
+ *   - 1 `visualViewport.resize` listener (#395) — exposes keyboard height
+ *     as `innerHeight - visualViewport.height`. iOS Safari / WKWebView
+ *     shrinks visualViewport but NOT innerHeight when the keyboard appears
+ *     → formula yields the keyboard height. Android Tauri default
+ *     (`adjustResize`) shrinks BOTH → formula yields 0, which is correct
+ *     because the OS already resized the WebView.
  *
  * Implemented via Svelte's `readable(initial, start)` so listener teardown
- * is built in: the `start` callback registers MQL change handlers and
- * returns a `stop` function that removes them; svelte/store calls `stop`
- * when the subscriber count drops to zero. This avoids the leak that would
- * occur if the store grabbed listeners at module load and never released
- * them.
+ * is built in: the `start` callback registers handlers and returns a `stop`
+ * function that removes them; svelte/store calls `stop` when the subscriber
+ * count drops to zero. This avoids the leak that would occur if the store
+ * grabbed listeners at module load and never released them.
  *
  * Exports a singleton `viewportStore` for app code and `createViewportStore`
  * for tests so each test gets its own subscription/listener set.
@@ -25,6 +31,12 @@ export type ViewportMode = "desktop" | "tablet" | "mobile";
 export interface ViewportState {
   mode: ViewportMode;
   isCoarsePointer: boolean;
+  /**
+   * #395 — on-screen keyboard height in CSS px. 0 when no keyboard is
+   * visible, when `window.visualViewport` is unavailable, or on platforms
+   * where the WebView itself resizes (Android `adjustResize`).
+   */
+  keyboardHeight: number;
 }
 
 const Q_MOBILE = "(max-width: 699px)";
@@ -37,6 +49,7 @@ const Q_COARSE = "(pointer: coarse)";
 const SSR_DEFAULT: ViewportState = Object.freeze({
   mode: "desktop",
   isCoarsePointer: false,
+  keyboardHeight: 0,
 });
 
 function modeFor(mobile: boolean, tablet: boolean): ViewportMode {
@@ -64,10 +77,17 @@ export function createViewportStore(): Readable<ViewportState> {
       return;
     }
 
+    // #395 — visualViewport-tracked keyboard height. Closed-over so the
+    // matchMedia handler can re-emit consistently with the latest value
+    // (a width-MQL flip during a keyboard session must not zero the
+    // keyboard height).
+    let kbHeight = 0;
+
     const read = () => {
       set({
         mode: modeFor(mqlMobile.matches, mqlTablet.matches),
         isCoarsePointer: mqlCoarse.matches,
+        keyboardHeight: kbHeight,
       });
     };
 
@@ -76,10 +96,37 @@ export function createViewportStore(): Readable<ViewportState> {
     mqlTablet.addEventListener("change", read);
     mqlCoarse.addEventListener("change", read);
 
+    // #395 — visualViewport listener (iOS keyboard detection). Threshold
+    // is 0px: every changed value emits. Per-pixel iOS keyboard animation
+    // can produce 60+ events; the cost is one store write each (cheap).
+    // Downstream consumers (EditorPane scroll dispatch) gate by 0→>0
+    // transition so they don't fire on jitter.
+    //
+    // No `scroll` listener — that fires on user pan within the visual
+    // viewport, NOT on keyboard appearance, and would rewrite the value
+    // continuously during normal scrolling.
+    const vv = window.visualViewport;
+    let onVvResize: (() => void) | undefined;
+    if (vv) {
+      onVvResize = () => {
+        const next = Math.max(
+          0,
+          Math.round(window.innerHeight - vv.height),
+        );
+        if (next === kbHeight) return;
+        kbHeight = next;
+        read();
+      };
+      vv.addEventListener("resize", onVvResize);
+    }
+
     return () => {
       mqlMobile.removeEventListener("change", read);
       mqlTablet.removeEventListener("change", read);
       mqlCoarse.removeEventListener("change", read);
+      if (vv && onVvResize) {
+        vv.removeEventListener("resize", onVvResize);
+      }
     };
   });
 }


### PR DESCRIPTION
## Summary

Implements #395 — final mobile-polish ticket. The on-screen keyboard no longer covers the editor caret on mobile.

- `viewportStore` extended with `keyboardHeight: number` (computed from `window.visualViewport.resize`). Single source of truth — no second module-level singleton.
- `VaultLayout` propagates the value as the `--vc-keyboard-height` CSS custom property via a Svelte `$effect`. Effect cleanup removes the property on unmount so vault-switch / HMR start clean.
- `.vc-editor-container` reserves `padding-bottom: var(--vc-keyboard-height, 0px)` with `box-sizing: border-box`, shrinking CM6's host so the caret-relative scrollIntoView lands above the keyboard.
- `EditorPane` `\$effect` dispatches `EditorView.scrollIntoView(selection.main.head, { y: \"center\" })` inside `requestAnimationFrame` on a 0→>0 transition OR an active-tab change while `kb > 0`. Per-pixel jitter does not re-dispatch; closing the keyboard does not dispatch (the now-larger viewport reveals the caret naturally).
- Gates: `tabSupportsReading(tab)` + `viewMode === \"edit\"` + `activePane === paneId` + `view.hasFocus`. The active-pane gate matters because mobile keyboards don't reliably emit `blur`, leaving CM6's `hasFocus` sticky on both panes after a swap.

## Why padding goes on `.vc-editor-container`, not `.vc-editor-content`

`.vc-editor-content` is `position: relative; overflow: hidden`; `.vc-editor-container` children are `position: absolute; inset: 0`. CSS spec: `inset` resolves against the padding-box, but `overflow: hidden` clips at the same edge — CM6 (mounted inside the container) measures itself against `inset: 0` and never observes the parent's padding. Per-container padding actually shrinks the host element so CM6's `.cm-editor` (height: 100%) honors the new content-box height.

## Why no `scroll` listener

`visualViewport.scroll` fires on user pan within the visual viewport, NOT on keyboard appearance. Adding it would rewrite `--vc-keyboard-height` continuously during normal scrolling. `resize` alone is sufficient.

## Boy Scout fixes folded in (called out per Socrates)

- `VaultLayout`'s two stray subscribe-without-cleanup `onMount` blocks (lines 252, 285) migrated to the return-from-onMount pattern that the mousemove/mouseup block (line 235) already uses.
- The previously module-level `unsubBacklinks = backlinksStore.subscribe(...)` (~line 782) was never torn down — leaked a subscriber on every VaultLayout unmount (vault switch, HMR). Cleaned up in the central `onDestroy`.

## Platform notes

- **iOS Safari / WKWebView (Tauri default on iOS)**: visualViewport DOES change height when the keyboard appears, `innerHeight` does NOT. Formula yields keyboard height. Tested versions: iOS 17, 18 simulators.
- **Android Chrome / WKWebView (Tauri Android default `adjustResize`)**: WebView itself resizes when keyboard appears, so `innerHeight` shrinks AND `vv.height` matches. Formula evaluates to 0 → store stays at 0 → no padding (correct: the OS already resized the WebView).
- **Desktop**: visualViewport.height === innerHeight always. Store stays at 0. No-op.

## Test plan

- [x] `pnpm test` — full suite, **157 files / 1471 tests** green.
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean.
- [ ] Manual on iOS Simulator (16/17/18) + Android Emulator with on-screen keyboard.
- [ ] UAT.

## Test coverage

**`viewportStore.test.ts`** (extended): 8 new cases for `keyboardHeight` — no-visualViewport default, initial-zero on closed keyboard, emit on resize, no re-emit on unchanged value, overscroll-clamp to 0, close→0, cleanup detaches the visualViewport listener, kb survives a matchMedia-driven re-emit. Existing 11 cases unchanged. 19/19 green.

**`EditorPane.keyboardScroll.test.ts`** (new, 7 cases): single dispatch on 0→250, no re-dispatch on jitter, two dispatches on reopen, extra dispatch on tab change while kb open, no dispatch in read mode, no dispatch when view unfocused, no dispatch on non-active pane. `viewportStore` mocked via hoisted writable (avoids the `vi.resetModules` / Svelte 5 effect-tracking incompatibility from #388).