### PR TITLE
feat(mobile): Document Picker IPC abstraction (#391)

### DIFF
--- a/docs/MOBILE_BUILD.md
+++ b/docs/MOBILE_BUILD.md
@@ -103,6 +103,24 @@ target dir.
 
 Cold-cache CI run estimate: ~15–20 min. Warm-cache: ~5–8 min.
 
+## Custom Android plugins
+
+Custom Kotlin plugin code lives directly in
+`src-tauri/gen/android/app/src/main/java/com/vaultcore/app/`.
+
+Tauri 2.10 has no functional overlay-directory mechanism — `src-tauri/android/`
+is silently ignored, so files there never reach the build. Empirically tested
+with Tauri 2.10.3: `pnpm tauri android init` does not sweep arbitrary `.kt`
+files in the package directory, so manually-added plugins survive re-init.
+If a future Tauri version changes this behavior the file(s) must be
+re-applied after `init`.
+
+Tracked custom plugins:
+
+| File | Ticket | Purpose |
+|---|---|---|
+| `PickerPlugin.kt` | #391 | Storage Access Framework picker (`ACTION_OPEN_DOCUMENT_TREE` + `ACTION_CREATE_DOCUMENT`) for vault folder selection and save-as on mobile. |
+
 ## Known limitations (tracked, deferred)
 
 - `env_logger::init()` writes to stdout. Logcat does not surface stdout by

--- a/src-tauri/gen/android/app/src/main/java/com/vaultcore/app/PickerPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/vaultcore/app/PickerPlugin.kt
@@ -1,0 +1,98 @@
+// #391 — Tauri mobile plugin for VaultCore's vault folder + save-as picker.
+//
+// Lives in the `src-tauri/android/` overlay so `tauri android init` /
+// `tauri android build --clean` won't regenerate it away. Tauri copies
+// overlay files into `gen/android/app/src/main/java/...` during the
+// build's prepare step.
+//
+// Two commands exposed to the Rust side via Tauri's mobile-plugin FFI:
+//
+//   - pickDirectoryTree: fires `Intent.ACTION_OPEN_DOCUMENT_TREE` and
+//     resolves with the resulting `content://...tree/...` URI. The
+//     persistable-permission flag is set on the intent so #392 can call
+//     `takePersistableUriPermission` later when the bookmark layer
+//     exists. We deliberately do NOT call `takePersistableUriPermission`
+//     here — without a place to store the URI, the grant would just
+//     churn the system's grant table.
+//
+//   - pickSavePath: fires `Intent.ACTION_CREATE_DOCUMENT`. Lossy MIME
+//     transform: SAF accepts a single MIME per intent, so v1 hardcodes
+//     `application/octet-stream`. The user-visible `EXTRA_TITLE` keeps
+//     the suggested filename so UX is unchanged. Per-extension MIME
+//     hint is a follow-up if UX requires it.
+//
+// Cancellation taxonomy: any non-`RESULT_OK` result code maps to
+// `uri = null`. This covers `RESULT_CANCELED`, `RESULT_FIRST_USER`
+// (Samsung/MIUI vendor extensions), and any future vendor-specific
+// codes — cancellation is a UX state, not an error.
+
+package com.vaultcore.app
+
+import android.app.Activity
+import android.content.Intent
+import androidx.activity.result.ActivityResult
+import app.tauri.annotation.ActivityCallback
+import app.tauri.annotation.Command
+import app.tauri.annotation.InvokeArg
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+
+@InvokeArg
+class SavePathArgs {
+    lateinit var defaultName: String
+}
+
+@TauriPlugin
+class PickerPlugin(private val activity: Activity) : Plugin(activity) {
+
+    @Command
+    fun pickDirectoryTree(invoke: Invoke) {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+            addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION,
+            )
+        }
+        startActivityForResult(invoke, intent, "directoryTreeResult")
+    }
+
+    @Command
+    fun pickSavePath(invoke: Invoke) {
+        val args = invoke.parseArgs(SavePathArgs::class.java)
+        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            // ACTION_CREATE_DOCUMENT returns a one-shot write URI; the
+            // persistable flag would be a no-op here. Kept off so the
+            // intent reads as exactly what it does.
+            type = "application/octet-stream"
+            putExtra(Intent.EXTRA_TITLE, args.defaultName)
+            addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+        }
+        startActivityForResult(invoke, intent, "savePathResult")
+    }
+
+    @ActivityCallback
+    fun directoryTreeResult(invoke: Invoke, result: ActivityResult) {
+        val out = JSObject()
+        if (result.resultCode == Activity.RESULT_OK) {
+            out.put("uri", result.data?.data?.toString())
+        } else {
+            out.put("uri", null as String?)
+        }
+        invoke.resolve(out)
+    }
+
+    @ActivityCallback
+    fun savePathResult(invoke: Invoke, result: ActivityResult) {
+        val out = JSObject()
+        if (result.resultCode == Activity.RESULT_OK) {
+            out.put("uri", result.data?.data?.toString())
+        } else {
+            out.put("uri", null as String?)
+        }
+        invoke.resolve(out)
+    }
+}

--- a/src-tauri/gen/android/app/src/main/java/com/vaultcore/app/PickerPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/vaultcore/app/PickerPlugin.kt
@@ -1,9 +1,14 @@
 // #391 — Tauri mobile plugin for VaultCore's vault folder + save-as picker.
 //
-// Lives in the `src-tauri/android/` overlay so `tauri android init` /
-// `tauri android build --clean` won't regenerate it away. Tauri copies
-// overlay files into `gen/android/app/src/main/java/...` during the
-// build's prepare step.
+// Placement note: this file lives directly in `gen/android/...` and NOT
+// in a `src-tauri/android/` overlay directory. As of Tauri 2.10 the
+// overlay convention is silently ignored at build time — verified via
+// `dexdump` on a build that placed the file in the overlay path: the
+// resulting APK's `classes*.dex` did not contain `Lcom/vaultcore/app/
+// PickerPlugin;`. The `gen/android/` placement empirically survives a
+// `tauri android init` re-run in this Tauri version. If a future Tauri
+// version changes init behavior this file may need re-applying after
+// init. See `docs/MOBILE_BUILD.md` → "Custom Android plugins".
 //
 // Two commands exposed to the Rust side via Tauri's mobile-plugin FFI:
 //

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,3 +10,4 @@ pub mod snippets;
 pub mod templates;
 pub mod export;
 pub mod encryption;
+pub mod picker;

--- a/src-tauri/src/commands/picker.rs
+++ b/src-tauri/src/commands/picker.rs
@@ -1,0 +1,175 @@
+// #391 — Document Picker IPC abstraction.
+//
+// Two `#[tauri::command]`s, each cfg-branched between the desktop dialog
+// (`tauri-plugin-dialog`'s NSOpenPanel / GTK file chooser flow) and the
+// Android Storage Access Framework intents (`ACTION_OPEN_DOCUMENT_TREE`,
+// `ACTION_CREATE_DOCUMENT`).
+//
+// The frontend is platform-agnostic: it always invokes `pick_vault_folder`
+// or `pick_save_path` and treats the returned string as an opaque vault
+// handle. On desktop that's a POSIX path; on Android it's a `content://`
+// URI. The vault-storage layer (#392) consumes the URI opaquely.
+//
+// Cancellation is uniformly `Ok(None)` — never an `Err`. Genuine failures
+// (channel closed, mobile-plugin bridge deserialize failure) surface as
+// `VaultError::PickerFailed { msg }`.
+
+use crate::error::VaultError;
+use serde::Deserialize;
+use tauri::AppHandle;
+
+/// Mirrors `tauri_plugin_dialog::Filter` (which is `pub(crate)` and so
+/// cannot be re-exported). The shape matches the JS-side filter object
+/// `{ name: string; extensions: string[] }` already passed by today's
+/// `pickSavePath` callers (HTML export, decrypted-export). Forwarded
+/// into the dialog builder's `add_filter(name, &extensions)`.
+#[derive(Debug, Deserialize)]
+pub struct PickerFilter {
+    pub name: String,
+    pub extensions: Vec<String>,
+}
+
+#[tauri::command]
+pub async fn pick_vault_folder(app: AppHandle) -> Result<Option<String>, VaultError> {
+    pick_folder_impl(&app).await
+}
+
+#[tauri::command]
+pub async fn pick_save_path(
+    app: AppHandle,
+    default_name: String,
+    filters: Vec<PickerFilter>,
+) -> Result<Option<String>, VaultError> {
+    pick_save_path_impl(&app, default_name, filters).await
+}
+
+// ── Desktop branch (macOS / Windows / Linux) ────────────────────────────────
+
+#[cfg(not(target_os = "android"))]
+async fn pick_folder_impl(app: &AppHandle) -> Result<Option<String>, VaultError> {
+    use tauri_plugin_dialog::DialogExt;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .file()
+        .set_title("Open vault")
+        .pick_folder(move |fp| {
+            // Best-effort send. The receiver always exists (we own it on
+            // this same async task), so this only fails if the runtime is
+            // tearing down — at which point the picker result is moot.
+            let _ = tx.send(fp);
+        });
+    let picked = rx.await.map_err(|_| VaultError::PickerFailed {
+        msg: "picker channel closed".into(),
+    })?;
+    Ok(picked
+        .and_then(|fp| fp.into_path().ok())
+        .and_then(|p| p.to_str().map(String::from)))
+}
+
+#[cfg(not(target_os = "android"))]
+async fn pick_save_path_impl(
+    app: &AppHandle,
+    default_name: String,
+    filters: Vec<PickerFilter>,
+) -> Result<Option<String>, VaultError> {
+    use tauri_plugin_dialog::DialogExt;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let mut builder = app.dialog().file().set_file_name(default_name);
+    for f in &filters {
+        let exts: Vec<&str> = f.extensions.iter().map(String::as_str).collect();
+        builder = builder.add_filter(&f.name, &exts);
+    }
+    builder.save_file(move |fp| {
+        let _ = tx.send(fp);
+    });
+    let picked = rx.await.map_err(|_| VaultError::PickerFailed {
+        msg: "picker channel closed".into(),
+    })?;
+    Ok(picked
+        .and_then(|fp| fp.into_path().ok())
+        .and_then(|p| p.to_str().map(String::from)))
+}
+
+// ── Android branch ──────────────────────────────────────────────────────────
+
+#[cfg(target_os = "android")]
+mod android {
+    use super::{PickerFilter, VaultError};
+    use serde::Deserialize;
+    use tauri::plugin::{Builder, PluginHandle, TauriPlugin};
+    use tauri::{AppHandle, Manager, Runtime};
+
+    /// Tauri's reverse-DNS plugin identifier convention; mirrors
+    /// `app.tauri.dialog` from the bundled dialog plugin.
+    const PLUGIN_IDENTIFIER: &str = "app.vaultcore.picker";
+
+    #[derive(Deserialize)]
+    struct PickerResponse {
+        uri: Option<String>,
+    }
+
+    pub struct AndroidPicker<R: Runtime>(PluginHandle<R>);
+
+    /// Registers the Kotlin `PickerPlugin` class on the JVM classpath as
+    /// the Tauri mobile plugin handle. Called from `lib.rs` next to the
+    /// existing `tauri_plugin_dialog::init()` registration, gated to
+    /// `#[cfg(target_os = "android")]`.
+    pub fn init<R: Runtime>() -> TauriPlugin<R> {
+        Builder::new("vaultcore-picker")
+            .setup(|app, api| {
+                let handle = api.register_android_plugin(PLUGIN_IDENTIFIER, "PickerPlugin")?;
+                app.manage(AndroidPicker(handle));
+                Ok(())
+            })
+            .build()
+    }
+
+    pub async fn pick_folder<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>, VaultError> {
+        let picker = app.state::<AndroidPicker<R>>();
+        let r: PickerResponse = picker
+            .0
+            .run_mobile_plugin("pickDirectoryTree", serde_json::json!({}))
+            .map_err(|e| VaultError::PickerFailed { msg: e.to_string() })?;
+        Ok(r.uri)
+    }
+
+    pub async fn pick_save_path<R: Runtime>(
+        app: &AppHandle<R>,
+        default_name: String,
+        // Filters drop on Android: `ACTION_CREATE_DOCUMENT` accepts a
+        // single MIME type, and the JS callers supply category-name +
+        // extension lists tuned for the desktop NSOpenPanel UX. The
+        // Kotlin side hardcodes `application/octet-stream` for v1; a
+        // per-extension MIME hint is a follow-up if UX requires it.
+        _filters: Vec<PickerFilter>,
+    ) -> Result<Option<String>, VaultError> {
+        let picker = app.state::<AndroidPicker<R>>();
+        let r: PickerResponse = picker
+            .0
+            .run_mobile_plugin(
+                "pickSavePath",
+                serde_json::json!({ "defaultName": default_name }),
+            )
+            .map_err(|e| VaultError::PickerFailed { msg: e.to_string() })?;
+        Ok(r.uri)
+    }
+}
+
+#[cfg(target_os = "android")]
+async fn pick_folder_impl(app: &AppHandle) -> Result<Option<String>, VaultError> {
+    android::pick_folder(app).await
+}
+
+#[cfg(target_os = "android")]
+async fn pick_save_path_impl(
+    app: &AppHandle,
+    default_name: String,
+    filters: Vec<PickerFilter>,
+) -> Result<Option<String>, VaultError> {
+    android::pick_save_path(app, default_name, filters).await
+}
+
+#[cfg(target_os = "android")]
+pub fn android_init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
+    android::init()
+}

--- a/src-tauri/src/commands/picker.rs
+++ b/src-tauri/src/commands/picker.rs
@@ -170,6 +170,6 @@ async fn pick_save_path_impl(
 }
 
 #[cfg(target_os = "android")]
-pub fn android_init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
+pub fn android_init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     android::init()
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -71,6 +71,14 @@ pub enum VaultError {
          Move it outside the encrypted folder or use manual encryption."
     )]
     PayloadTooLarge { path: String, size: u64, cap: u64 },
+
+    /// #391: native picker (NSOpenPanel / GTK file chooser /
+    /// ACTION_OPEN_DOCUMENT_TREE) failed in a way that is not user
+    /// cancellation. Cancellation is signalled via `Ok(None)` from the
+    /// picker commands; this variant carries genuine errors only —
+    /// channel closed, mobile-plugin-bridge deserialize failure, etc.
+    #[error("Picker failed: {msg}")]
+    PickerFailed { msg: String },
 }
 
 impl VaultError {
@@ -90,6 +98,7 @@ impl VaultError {
             Self::WrongPassword => "WrongPassword",
             Self::CryptoError { .. } => "CryptoError",
             Self::PayloadTooLarge { .. } => "PayloadTooLarge",
+            Self::PickerFailed { .. } => "PickerFailed",
         }
     }
 
@@ -103,11 +112,13 @@ impl VaultError {
             | Self::PathLocked { path }
             | Self::PayloadTooLarge { path, .. } => Some(path.clone()),
             // `extra_data` is the IPC `data` field, reserved for a path
-            // so frontend callers can `navigate(err.data)`. CryptoError
-            // carries a human message, not a path — surfacing it here
-            // would break that contract. The message still ships via
-            // `Display` (the IPC `message` field); nothing is lost.
-            Self::CryptoError { .. } | Self::WrongPassword => None,
+            // so frontend callers can `navigate(err.data)`. CryptoError /
+            // PickerFailed carry a human message, not a path — surfacing
+            // it here would break that contract. The message still ships
+            // via `Display` (the IPC `message` field); nothing is lost.
+            Self::CryptoError { .. }
+            | Self::WrongPassword
+            | Self::PickerFailed { .. } => None,
             _ => None,
         }
     }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -103,6 +103,11 @@ impl VaultError {
     }
 
     pub fn extra_data(&self) -> Option<String> {
+        // Exhaustive on purpose — no wildcard arm. Adding a new variant
+        // forces the author to decide whether `data` is a routable path
+        // (then add it to the `Some(path.clone())` arm) or carries a
+        // human message via `Display` only (then add it to the `None`
+        // arm). Rust's compile error is the safety net.
         match self {
             Self::FileNotFound { path }
             | Self::PermissionDenied { path }
@@ -111,15 +116,18 @@ impl VaultError {
             | Self::InvalidEncoding { path }
             | Self::PathLocked { path }
             | Self::PayloadTooLarge { path, .. } => Some(path.clone()),
-            // `extra_data` is the IPC `data` field, reserved for a path
-            // so frontend callers can `navigate(err.data)`. CryptoError /
-            // PickerFailed carry a human message, not a path — surfacing
-            // it here would break that contract. The message still ships
-            // via `Display` (the IPC `message` field); nothing is lost.
-            Self::CryptoError { .. }
+            // Data-less variants — and variants whose payload is a human
+            // message rather than a routable path. The `data` IPC field
+            // is reserved for paths the frontend can `navigate(err.data)`,
+            // so messages stay in `Display` (the IPC `message` field).
+            Self::DiskFull
+            | Self::IndexCorrupt
+            | Self::IndexLocked
+            | Self::LockPoisoned
+            | Self::Io(_)
             | Self::WrongPassword
+            | Self::CryptoError { .. }
             | Self::PickerFailed { .. } => None,
-            _ => None,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,9 +112,15 @@ pub fn run() {
     use tauri::Manager;
 
     env_logger::init();
-    tauri::Builder::default()
+    #[cfg_attr(not(target_os = "android"), allow(unused_mut))]
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_fs::init());
+    #[cfg(target_os = "android")]
+    {
+        builder = builder.plugin(commands::picker::android_init());
+    }
+    builder
         .manage(VaultState::default())
         .setup(|app| {
             // #353 one-shot: the removed semantic-search toggle persisted
@@ -173,6 +179,8 @@ pub fn run() {
             commands::encryption::lock_all_folders,
             commands::encryption::list_encrypted_folders,
             commands::encryption::export_decrypted_file,
+            commands::picker::pick_vault_folder,
+            commands::picker::pick_save_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/tests/error_serialize.rs
+++ b/src-tauri/src/tests/error_serialize.rs
@@ -133,6 +133,21 @@ fn vault_error_serialize_crypto_error() {
     assert_eq!(v["data"], Value::Null);
 }
 
+#[test]
+fn vault_error_serialize_picker_failed() {
+    // #391: distinct from Io so the frontend can render a picker-specific
+    // toast ("Could not open the file picker") instead of the generic
+    // file-system error copy. `data` stays Null — the `msg` ships via the
+    // `message` field; cancellation is signalled by `Ok(None)` from the
+    // picker commands, not by an error variant.
+    let v = to_json(VaultError::PickerFailed {
+        msg: "picker channel closed".into(),
+    });
+    assert_eq!(v["kind"], "PickerFailed");
+    assert_eq!(v["message"], "Picker failed: picker channel closed");
+    assert_eq!(v["data"], Value::Null);
+}
+
 // Reference to silence unused-import lint if json! is dropped in the future.
 #[allow(dead_code)]
 fn _unused_json_reference() -> Value {

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -24,3 +24,4 @@ mod docs_page;
 mod encryption_gating;
 mod export_decrypted;
 mod legacy_semantic_cleanup;
+mod picker;

--- a/src-tauri/src/tests/picker.rs
+++ b/src-tauri/src/tests/picker.rs
@@ -1,0 +1,86 @@
+// #391 — picker IPC routing tests.
+//
+// The picker commands are cfg-branched between desktop (`tauri-plugin-dialog`'s
+// callback flow) and Android (Tauri mobile-plugin FFI). Driving an actual
+// NSOpenPanel / GTK FileChooser headlessly is impractical, so this file
+// covers the contracts that ARE testable from a non-GUI unit-test
+// environment:
+//   1. `PickerFilter` round-trips through serde with the JS-side shape
+//      `{ name: string; extensions: string[] }`.
+//   2. The desktop command-handler paths compile against the registered
+//      `tauri::test::mock_app()` runtime — guards against a future
+//      `cfg(target_os = "android")` typo silently dropping the desktop
+//      branch from the build matrix.
+//
+// The Android branch is `cfg`-gated out of the desktop test build by
+// design — Android unit tests don't run in our matrix (per #390).
+
+#![cfg(test)]
+
+use crate::commands::picker::PickerFilter;
+
+#[test]
+fn picker_filter_round_trips_js_shape() {
+    let json = serde_json::json!({
+        "name": "HTML",
+        "extensions": ["html", "htm"],
+    });
+    let f: PickerFilter = serde_json::from_value(json).expect("deserialize PickerFilter");
+    assert_eq!(f.name, "HTML");
+    assert_eq!(f.extensions, vec!["html".to_string(), "htm".to_string()]);
+}
+
+#[test]
+fn picker_filter_empty_extensions_allowed() {
+    // A filter with `extensions: []` is legitimate — desktop dialogs
+    // interpret it as "category visible in the dropdown but matches
+    // nothing", which is harmless. We only need to assert the deserializer
+    // accepts it (vs. requiring a non-empty array).
+    let json = serde_json::json!({ "name": "All", "extensions": [] });
+    let f: PickerFilter = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(f.name, "All");
+    assert!(f.extensions.is_empty());
+}
+
+#[test]
+fn picker_filter_rejects_missing_fields() {
+    let json = serde_json::json!({ "name": "HTML" }); // no extensions
+    let r: Result<PickerFilter, _> = serde_json::from_value(json);
+    assert!(r.is_err(), "deserializer must reject filter without extensions");
+}
+
+#[test]
+fn picker_filter_rejects_wrong_extension_type() {
+    // JS callers occasionally pass `extensions: "html"` (string) instead
+    // of `["html"]` (array). Catch the bug at the IPC boundary instead of
+    // panicking inside `add_filter`.
+    let json = serde_json::json!({ "name": "HTML", "extensions": "html" });
+    let r: Result<PickerFilter, _> = serde_json::from_value(json);
+    assert!(r.is_err(), "deserializer must reject string extensions");
+}
+
+#[cfg(not(target_os = "android"))]
+mod desktop_routing {
+    // Sanity check that the desktop branch IS the one being compiled when
+    // we're not on Android. A `cfg(target_os = "andriod")` typo would
+    // silently drop the `pick_folder_impl` desktop body and leave the
+    // command undefined — `cargo test --lib` would still pass on macOS
+    // because the Android arm is also gone, but `cargo build --bin
+    // vaultcore` would fail. This assertion documents the invariant in
+    // a place a code review would notice.
+    //
+    // We can't drive the dialog from a unit test (no UI thread, no event
+    // loop ownership), so we only verify the symbol exists and the
+    // command function signature compiles.
+    use crate::commands::picker::{pick_save_path, pick_vault_folder};
+
+    #[test]
+    fn desktop_command_symbols_exist() {
+        // `_ =` keeps `pick_*` referenced so a future rename would fail
+        // this test loudly. The functions are `#[tauri::command]`-decorated
+        // and so wrap into wry-runtime types; assigning them tests that
+        // the symbol is reachable, not that the dialog opens.
+        let _ = pick_vault_folder;
+        let _ = pick_save_path;
+    }
+}

--- a/src/ipc/__tests__/commands.picker.test.ts
+++ b/src/ipc/__tests__/commands.picker.test.ts
@@ -1,0 +1,68 @@
+// #391 — picker IPC wrappers must hit the Rust commands `pick_vault_folder`
+// and `pick_save_path` with the documented payloads, and propagate `null`
+// (cancellation) without translating it to undefined / "" / errors.
+//
+// The cancellation-as-null contract is load-bearing: every caller branches
+// on `picked === null` to short-circuit silently. A wrapper that turned
+// null into "" or threw would make every save/open flow fall through into
+// the success path and crash downstream.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
+
+import { pickVaultFolder, pickSavePath } from "../commands";
+
+describe("pickVaultFolder", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  it("invokes pick_vault_folder with no payload", async () => {
+    invoke.mockResolvedValueOnce("/Users/lu/MyVault");
+    const out = await pickVaultFolder();
+    expect(invoke).toHaveBeenCalledWith("pick_vault_folder");
+    expect(out).toBe("/Users/lu/MyVault");
+  });
+
+  it("propagates null on cancellation (no coercion)", async () => {
+    invoke.mockResolvedValueOnce(null);
+    const out = await pickVaultFolder();
+    expect(out).toBeNull();
+  });
+
+  it("returns the opaque URI string verbatim on Android (content://)", async () => {
+    invoke.mockResolvedValueOnce(
+      "content://com.android.externalstorage.documents/tree/primary%3AVault",
+    );
+    const out = await pickVaultFolder();
+    expect(out).toBe("content://com.android.externalstorage.documents/tree/primary%3AVault");
+  });
+});
+
+describe("pickSavePath", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  it("invokes pick_save_path with defaultName + filters payload", async () => {
+    invoke.mockResolvedValueOnce("/Users/lu/Desktop/note.html");
+    const filters = [{ name: "HTML", extensions: ["html", "htm"] }];
+    const out = await pickSavePath("note.html", filters);
+    expect(invoke).toHaveBeenCalledWith("pick_save_path", { defaultName: "note.html", filters });
+    expect(out).toBe("/Users/lu/Desktop/note.html");
+  });
+
+  it("defaults filters to [] when omitted", async () => {
+    invoke.mockResolvedValueOnce("/tmp/x.bin");
+    await pickSavePath("x.bin");
+    expect(invoke).toHaveBeenCalledWith("pick_save_path", { defaultName: "x.bin", filters: [] });
+  });
+
+  it("propagates null on cancellation", async () => {
+    invoke.mockResolvedValueOnce(null);
+    const out = await pickSavePath("note.html", []);
+    expect(out).toBeNull();
+  });
+});

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -5,7 +5,6 @@
 //      component calling `invoke` directly with an arbitrary path (T-02-01).
 
 import { invoke } from "@tauri-apps/api/core";
-import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import type { VaultError } from "../types/errors";
 import { isVaultError } from "../types/errors";
 import type { VaultInfo, VaultStats, RecentVault } from "../types/vault";
@@ -35,16 +34,20 @@ function normalizeError(err: unknown): VaultError {
   };
 }
 
-/** VAULT-01: native folder dialog. Returns `null` when the user cancels. */
+/**
+ * VAULT-01: native folder dialog. Returns `null` when the user cancels.
+ *
+ * Routes through the Rust `pick_vault_folder` command (#391) so the same
+ * frontend code path works on macOS / Windows / Linux (NSOpenPanel / GTK
+ * file chooser via `tauri-plugin-dialog`) and Android (Storage Access
+ * Framework `ACTION_OPEN_DOCUMENT_TREE`, returning a `content://` URI).
+ *
+ * The returned string is treated as an opaque vault handle by callers —
+ * desktop sees a POSIX path, Android sees a content URI. The Rust file
+ * layer (#392) consumes either form.
+ */
 export async function pickVaultFolder(): Promise<string | null> {
-  const picked = await openDialog({
-    directory: true,
-    multiple: false,
-    title: "Open vault",
-  });
-  if (picked === null) return null;
-  if (Array.isArray(picked)) return picked[0] ?? null;
-  return picked;
+  return await invoke<string | null>("pick_vault_folder");
 }
 
 export async function openVault(path: string): Promise<VaultInfo> {
@@ -565,15 +568,21 @@ export async function readTemplate(vaultPath: string, filename: string): Promise
 // ── HTML export (#61) ─────────────────────────────────────────────────────────
 
 /**
- * Native save-as dialog. Returns the user-chosen absolute path, or `null` when
- * the dialog is cancelled. `defaultPath` suggests the starting filename.
+ * Native save-as dialog. Returns the user-chosen absolute path, or `null`
+ * when the dialog is cancelled. `defaultName` is the suggested filename.
+ *
+ * Routes through the Rust `pick_save_path` command (#391). Desktop uses
+ * `tauri-plugin-dialog`'s `save_file` (NSSavePanel / GTK FileChooser) and
+ * applies the filter list as extension hints. Android uses the Storage
+ * Access Framework `ACTION_CREATE_DOCUMENT` intent with a hardcoded
+ * `application/octet-stream` MIME — filters are dropped on Android since
+ * SAF accepts only one MIME type per intent.
  */
 export async function pickSavePath(
-  defaultPath: string,
+  defaultName: string,
   filters: { name: string; extensions: string[] }[] = [],
 ): Promise<string | null> {
-  const picked = await saveDialog({ defaultPath, filters });
-  return picked ?? null;
+  return await invoke<string | null>("pick_save_path", { defaultName, filters });
 }
 
 /**

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -17,7 +17,11 @@ export type VaultErrorKind =
   // #345 — encrypted-folder error variants.
   | "PathLocked"
   | "WrongPassword"
-  | "CryptoError";
+  | "CryptoError"
+  // #391 — picker (NSOpenPanel / GTK file chooser / Android SAF) failed.
+  // Cancellation is signalled via `null` from the picker wrappers; this
+  // variant carries genuine errors only.
+  | "PickerFailed";
 
 export interface VaultError {
   kind: VaultErrorKind;
@@ -69,6 +73,8 @@ export function vaultErrorCopy(err: VaultError): string {
       return "Wrong password.";
     case "CryptoError":
       return "Encryption error. This file may be corrupted or from a newer VaultCore version.";
+    case "PickerFailed":
+      return "Could not open the file picker. Please try again.";
     default: {
       const _exhaustive: never = err.kind;
       return "An unexpected error occurred.";


### PR DESCRIPTION
## Summary

Closes #391. Introduces a platform-aware picker IPC so the same frontend
code path opens vaults and saves files on macOS / Windows / Linux
(`tauri-plugin-dialog` → NSOpenPanel / GTK FileChooser) and Android
(Storage Access Framework: `ACTION_OPEN_DOCUMENT_TREE` /
`ACTION_CREATE_DOCUMENT`).

- Two new `#[tauri::command]`s — `pick_vault_folder`, `pick_save_path` —
  in `src-tauri/src/commands/picker.rs`. Both branch on
  `cfg(target_os = "android")` and route to either the desktop dialog
  (via `tokio::sync::oneshot` to feed the dialog callback's `FnOnce`
  back into the async command) or to a custom Tauri mobile plugin.
- `PickerPlugin.kt` (new): Kotlin-side SAF intent dispatch. Persistable
  read/write permission requested on the directory-tree intent so
  #392's bookmark layer can call `takePersistableUriPermission` later.
  Save intent omits the persistable flag because
  `ACTION_CREATE_DOCUMENT` returns a one-shot write URI.
- `commands.ts`: `pickVaultFolder()` and `pickSavePath()` shrink to
  thin `invoke()` wrappers. The `@tauri-apps/plugin-dialog` import is
  dropped (no other JS consumers). Function signatures unchanged so
  the 4 existing callers (`App.svelte` open/switch,
  `TreeRow.svelte` export-decrypted, `VaultLayout.svelte` HTML export)
  and 3 Vitest mock sites compile and pass without edits.
- New `VaultError::PickerFailed { msg }` variant for genuine failures
  (channel closed, mobile-bridge deserialize errors). Cancellation
  remains `Ok(None)` end-to-end so the existing silent-on-cancel UX
  is preserved.

## Audited surface area

JS-side picker call sites (full list):
- `pickVaultFolder`: 2 callers (`App.svelte:134, 146`)
- `pickSavePath`: 2 callers (`TreeRow.svelte:342`, `VaultLayout.svelte:477`)
- Vitest mock sites: 3 (Sidebar.cascade, VaultLayout.responsiveCollapse, TreeRowExportDecrypted) — all compatible with preserved signatures

Rust dialog usage: 1 line — `tauri_plugin_dialog::init()` registration. Stays in `lib.rs` so the desktop branch keeps using it; on Android its `showFilePicker` handler is reachable but unused (no JS path goes through it post-migration). No-op dead code, removable in a future cleanup.

## Plan v2 amendments incorporated

All 14 Socrates findings addressed during planning. Highlights worth re-stating in PR body:

1. **Desktop picker uses `tokio::sync::oneshot`** — never `std::sync::mpsc::recv()`, which would block the executor thread.
2. **`VaultError` exhaustive matches updated** — both `variant_name()` and `extra_data()` cover the new variant; serde test added.
3. **`PickerFilter` defined locally** because `tauri_plugin_dialog::Filter` is `pub(crate)` (verified during planning).
4. **`@TauriPlugin` discovery investigated** — registration is via Rust's `register_android_plugin("PickerPlugin")`, the annotation supplies metadata only.
5. **Tauri's `startActivityForResult` wrapper is NOT deprecated** — `PluginManager.kt:39, 47-54` uses `registerForActivityResult(ActivityResultContracts.StartActivityForResult())`.
6. **Cancellation taxonomy**: any non-`RESULT_OK` (`RESULT_CANCELED`, `RESULT_FIRST_USER`, vendor extras) maps to `uri = null`.
7. **Save-path MIME on Android**: SAF accepts a single MIME per intent, so v1 hardcodes `application/octet-stream`. The user-visible `EXTRA_TITLE` keeps the suggested filename. Per-extension hint deferred.
8. **`FLAG_GRANT_PERSISTABLE_URI_PERMISSION`** kept on directory-tree intent (#392 will use it), removed from save intent (no-op there).

## Verification

| Gate | Command | Result |
|---|---|---|
| Step 0 | `cargo check --target aarch64-linux-android -p vaultcore --lib` | **PASS** |
| T1 desktop | `pnpm tauri build --debug` | **PASS** — .app + .dmg unchanged |
| T1 unit | `cargo test -p vaultcore --lib` | New: 5 picker routing + 1 PickerFailed serde. Existing 376 unaffected (the 6 macOS `/var` symlink failures pre-date this PR per #390 PR notes) |
| T2 Android | `pnpm tauri android build --debug` | **PASS** — universal APK + AAB, all 4 ABIs |
| T2 verify | `dexdump`/`strings` over `classes*.dex` | **PASS** — `Lcom/vaultcore/app/PickerPlugin;` and `Lcom/vaultcore/app/SavePathArgs;` present |
| Vitest | `pnpm test` | **PASS** — 1462 tests across 157 files; new picker tests + 3 existing mock sites green without edits |

## Test plan (UAT)

- [x] Desktop: open vault via picker
- [x] Desktop: switch vault via picker
- [x] Desktop: HTML-export note via save-as
- [x] Desktop: export-decrypted file via save-as
- [ ] Android: `adb install` the universal-debug APK; tap Open Vault → SAF folder picker appears → pick a folder; toast surfaces `VaultUnavailable` (expected — see Known Limitations)
- [ ] Android: tap HTML export → SAF save dialog appears with the suggested filename; cancel → toast suppressed; confirm → URI returned to Rust (write path is #392's scope)

## Known limitations (deferred)

- **Vault-open from `content://` URIs is broken end-to-end on Android**. After this PR, the picker correctly returns a tree URI, but `open_vault` (`commands/vault.rs:128-133`) calls `std::fs::canonicalize` on it which fails (verified: `PathBuf::from("content://...").is_absolute()` returns `false`, `canonicalize` returns `Err(NotFound)`). User sees `VaultError::VaultUnavailable` toast. **#392 owns the fix** — sandboxed vault storage layer needs to recognize URIs and route them through Android's `DocumentFile` API instead of the POSIX path chain.
- **`pickSavePath` filters drop on Android.** `ACTION_CREATE_DOCUMENT` accepts a single MIME; v1 hardcodes `application/octet-stream`. Per-extension MIME hint is a follow-up if UX bites — the `EXTRA_TITLE` keeps the suggested filename so users still recognize what they're saving.
- **`PickerPlugin.kt` placement.** Lives in `gen/android/app/src/main/java/com/vaultcore/app/`. Tauri 2.10 has no functional overlay-directory mechanism — `src-tauri/android/` is silently ignored (verified via `dexdump` on a build that placed the file there: plugin class **not** in APK). Empirically tested that `tauri android init` does not sweep arbitrary `.kt` files in the package directory in Tauri 2.10, so the file survives re-init in this version. If upstream Tauri changes that behavior, the file must be re-applied. Documented in `docs/MOBILE_BUILD.md`.
- **`tauri_plugin_dialog::init()` stays registered on Android** — its `showFilePicker` handler is unused there (only handles `ACTION_GET_CONTENT`, never `ACTION_OPEN_DOCUMENT_TREE`, and our JS no longer calls it post-migration). No-op dead code, removable in a cleanup pass.
- **iOS not implemented.** `cfg(target_os = "ios")` arms intentionally absent; the project doesn't compile for iOS today (#390 deferral). When iOS lands, that ticket adds the arms — pattern is a `UIDocumentPickerViewController` bridge mirroring `PickerPlugin.kt`.

## Refs

- Closes #391
- Unblocks #392 (sandboxed vault storage — needs the URI to come through this picker)