### PR TITLE
feat(mobile): burger sheet — More-tab destination (#397)

### DIFF
--- a/e2e/specs/mobile-burger.spec.ts
+++ b/e2e/specs/mobile-burger.spec.ts
@@ -1,0 +1,142 @@
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+
+/**
+ * #397 — mobile burger sheet e2e coverage.
+ *
+ * Resizes to 600x900 (matches #386 / #389 spec convention) so the
+ * responsive @media branch fires and the burger sheet's parent gate
+ * (`{#if isMobile}` in VaultLayout) is satisfied.
+ *
+ * Each test is self-contained — the afterEach drains burger + drawer
+ * state with Escape so a failure produces a clean message rather than
+ * a side-effect chain.
+ */
+describe("Mobile burger sheet (#397)", () => {
+  let vault: TestVault;
+  let restoreSize: { width: number; height: number } | null = null;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+    restoreSize = await browser.getWindowSize();
+    await browser.setWindowSize(600, 900);
+  });
+
+  after(async () => {
+    if (restoreSize) {
+      await browser.setWindowSize(restoreSize.width, restoreSize.height);
+    }
+    vault.cleanup();
+  });
+
+  async function isBurgerOpen(): Promise<boolean> {
+    const sheets = await browser.$$(".vc-mobile-burger-sheet");
+    return sheets.length > 0;
+  }
+
+  async function clickMoreTab(): Promise<void> {
+    await browser.execute(() => {
+      (document.getElementById("vc-mobile-tab-more") as HTMLElement | null)?.click();
+    });
+  }
+
+  async function clickBurgerRow(rowId: string): Promise<void> {
+    await browser.execute((id: string) => {
+      const sel = `[data-row-id="${id}"]`;
+      (document.querySelector(sel) as HTMLElement | null)?.click();
+    }, rowId);
+  }
+
+  afterEach(async () => {
+    // Drain any open sheet/menu/modal so each test starts clean.
+    if (await isBurgerOpen()) {
+      await browser.keys(["Escape"]); // panel view → menu, or menu → close
+      await browser.keys(["Escape"]); // safety: close menu if still open
+      await browser.waitUntil(async () => !(await isBurgerOpen()), { timeout: 3000 }).catch(() => {});
+    }
+  });
+
+  it("More tab opens the burger sheet (menu view)", async () => {
+    expect(await isBurgerOpen()).toBe(false);
+    await clickMoreTab();
+    await browser.waitUntil(isBurgerOpen, {
+      timeout: 3000,
+      timeoutMsg: "Burger sheet never opened after More tap",
+    });
+    const dialog = await browser.$('[role="dialog"][aria-label="More options"]');
+    await dialog.waitForDisplayed({ timeout: 3000 });
+    const rows = await browser.$$('[role="menuitem"]');
+    expect(rows.length).toBe(6);
+  });
+
+  it("tapping the Backlinks row swaps the menu for the panel view", async () => {
+    await clickMoreTab();
+    await browser.waitUntil(isBurgerOpen, { timeout: 3000 });
+    await clickBurgerRow("backlinks");
+    const panelDialog = await browser.$('[role="dialog"][aria-label="Backlinks"]');
+    await panelDialog.waitForDisplayed({ timeout: 3000 });
+    // Menu role should be gone in the panel view.
+    const menus = await browser.$$('[role="menu"]');
+    expect(menus.length).toBe(0);
+  });
+
+  it("the back button returns to the menu view (does NOT close the sheet)", async () => {
+    await clickMoreTab();
+    await browser.waitUntil(isBurgerOpen, { timeout: 3000 });
+    await clickBurgerRow("outline");
+    await browser.$('[role="dialog"][aria-label="Gliederung"]').waitForDisplayed({ timeout: 3000 });
+    await browser.execute(() => {
+      (document.querySelector(".vc-mobile-burger-back") as HTMLElement | null)?.click();
+    });
+    await browser.$('[role="dialog"][aria-label="More options"]').waitForDisplayed({ timeout: 3000 });
+    expect(await isBurgerOpen()).toBe(true);
+  });
+
+  it("scrim click closes the sheet", async () => {
+    await clickMoreTab();
+    await browser.waitUntil(isBurgerOpen, { timeout: 3000 });
+    await browser.execute(() => {
+      (document.querySelector(".vc-mobile-burger-scrim") as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(async () => !(await isBurgerOpen()), {
+      timeout: 3000,
+      timeoutMsg: "Burger sheet never closed after scrim click",
+    });
+  });
+
+  it("Escape from the menu view closes; Escape from the panel view returns to menu", async () => {
+    // Menu view → Escape → close.
+    await clickMoreTab();
+    await browser.waitUntil(isBurgerOpen, { timeout: 3000 });
+    await browser.keys(["Escape"]);
+    await browser.waitUntil(async () => !(await isBurgerOpen()), { timeout: 3000 });
+
+    // Panel view → Escape → menu (does not close).
+    await clickMoreTab();
+    await browser.waitUntil(isBurgerOpen, { timeout: 3000 });
+    await clickBurgerRow("bookmarks");
+    await browser.$('[role="dialog"][aria-label="Lesezeichen"]').waitForDisplayed({ timeout: 3000 });
+    await browser.keys(["Escape"]);
+    await browser.$('[role="dialog"][aria-label="More options"]').waitForDisplayed({ timeout: 3000 });
+    expect(await isBurgerOpen()).toBe(true);
+  });
+
+  it("More tab closes the drawer if it was open before opening the burger", async () => {
+    // Open the drawer via the Files tab, then tap More — the drawer
+    // should close and the burger should open.
+    await browser.execute(() => {
+      (document.getElementById("vc-mobile-tab-files") as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(async () => {
+      const drawer = await browser.$(".vc-layout-sidebar");
+      const cls = (await drawer.getAttribute("class")) ?? "";
+      return cls.includes("vc-layout-sidebar--mobile-open");
+    }, { timeout: 3000 });
+    await clickMoreTab();
+    await browser.waitUntil(isBurgerOpen, { timeout: 3000 });
+    const drawer = await browser.$(".vc-layout-sidebar");
+    const cls = (await drawer.getAttribute("class")) ?? "";
+    expect(cls.includes("vc-layout-sidebar--mobile-open")).toBe(false);
+  });
+});

--- a/src/components/Layout/MobileBurgerSheet.svelte
+++ b/src/components/Layout/MobileBurgerSheet.svelte
@@ -41,7 +41,12 @@
   type PanelId = "backlinks" | "bookmarks" | "outline" | "outgoing";
 
   let activePanel = $state<PanelId | null>(null);
-  let sheetEl: HTMLDivElement | undefined = $state(undefined);
+  // bind:this writes the live DOM node here. Svelte 5 wants a $state target
+  // even for imperative refs because the keydown trap (focusables() below)
+  // reads it from inside reactive scope — plain `let` triggers a
+  // non_reactive_update warning. Same pattern as the drawer's drawerEl in
+  // VaultLayout.svelte.
+  let sheetEl = $state<HTMLDivElement | undefined>(undefined);
 
   // Reset to the menu view whenever the sheet closes. Each open thus
   // starts on the menu — no implicit deep-link to the last-viewed panel,
@@ -105,17 +110,53 @@
     onClose();
   }
 
+  // Standard keyboard-trap selector: anything that can take focus, minus
+  // explicitly disabled or programmatically-only-focusable nodes.
+  const FOCUSABLE_SELECTOR = [
+    'button:not([disabled]):not([tabindex="-1"])',
+    'a[href]:not([tabindex="-1"])',
+    'input:not([disabled]):not([tabindex="-1"])',
+    'select:not([disabled]):not([tabindex="-1"])',
+    'textarea:not([disabled]):not([tabindex="-1"])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(",");
+
+  function focusables(): HTMLElement[] {
+    if (!sheetEl) return [];
+    return Array.from(sheetEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  }
+
   function onKeydown(e: KeyboardEvent) {
-    if (e.key !== "Escape") return;
-    e.preventDefault();
-    if (activePanel !== null) {
-      // Two-step Escape: panel view → menu view first; another Escape
-      // would then close. Matches the drawer pattern from #386 where a
-      // stacked nav element gives users an "undo last navigation"
-      // affordance instead of dumping them back to the editor.
-      activePanel = null;
-    } else {
-      onClose();
+    if (e.key === "Escape") {
+      e.preventDefault();
+      if (activePanel !== null) {
+        // Two-step Escape: panel view → menu view first; another Escape
+        // would then close. Matches the drawer pattern from #386 where a
+        // stacked nav element gives users an "undo last navigation"
+        // affordance instead of dumping them back to the editor.
+        activePanel = null;
+      } else {
+        onClose();
+      }
+      return;
+    }
+    if (e.key === "Tab") {
+      // Focus trap: keep keyboard navigation inside the dialog. Without
+      // this, Shift+Tab from the back button (or Tab from the last row)
+      // escapes into the editor behind the scrim — confusing for any
+      // assistive-tech user.
+      const items = focusables();
+      if (items.length === 0) return;
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     }
   }
 </script>

--- a/src/components/Layout/MobileBurgerSheet.svelte
+++ b/src/components/Layout/MobileBurgerSheet.svelte
@@ -1,0 +1,302 @@
+<script lang="ts">
+  /**
+   * MobileBurgerSheet — bottom-sheet router for the mobile More tab (#397).
+   *
+   * Parent-gated: VaultLayout decides via `{#if isMobile}` when to render;
+   * the component itself does NOT subscribe to viewportStore. State (open
+   * flag, close callback) lives in the parent.
+   *
+   * Two views:
+   *   1. Menu — a 6-row list. Default state when the sheet opens.
+   *   2. Panel — the selected sub-panel rendered inline with a back button.
+   *
+   * Properties + Settings rows are TODO placeholders that stub-toast and
+   * close the sheet; #393 and #394 will replace those branches with real
+   * destinations.
+   */
+  import {
+    Link2,
+    Bookmark,
+    List,
+    ArrowUpRight,
+    FileText,
+    Settings as SettingsIcon,
+    ChevronRight,
+    ChevronLeft,
+  } from "lucide-svelte";
+  import BacklinksPanel from "../Backlinks/BacklinksPanel.svelte";
+  import BookmarksPanel from "../Bookmarks/BookmarksPanel.svelte";
+  import OutlinePanel from "../Outline/OutlinePanel.svelte";
+  import OutgoingLinksPanel from "../OutgoingLinks/OutgoingLinksPanel.svelte";
+  import { toastStore } from "../../store/toastStore";
+
+  let {
+    open,
+    onClose,
+  }: {
+    open: boolean;
+    onClose: () => void;
+  } = $props();
+
+  type PanelId = "backlinks" | "bookmarks" | "outline" | "outgoing";
+
+  let activePanel = $state<PanelId | null>(null);
+  let sheetEl: HTMLDivElement | undefined = $state(undefined);
+
+  // Reset to the menu view whenever the sheet closes. Each open thus
+  // starts on the menu — no implicit deep-link to the last-viewed panel,
+  // which would surprise users coming back to the More tab for something
+  // unrelated.
+  $effect(() => {
+    if (!open) activePanel = null;
+  });
+
+  // Focus the first focusable inside the sheet on open. Microtask wait so
+  // CSS class application paints before focus jumps.
+  $effect(() => {
+    if (open) {
+      queueMicrotask(() => {
+        const first = sheetEl?.querySelector<HTMLElement>(
+          'button:not([tabindex="-1"]), a:not([tabindex="-1"]), input:not([tabindex="-1"])',
+        );
+        first?.focus();
+      });
+    }
+  });
+
+  type RowSpec = {
+    id: "backlinks" | "bookmarks" | "outline" | "outgoing" | "properties" | "settings";
+    label: string;
+    icon: typeof Link2;
+    action: "panel" | "stub";
+    panelId?: PanelId;
+    stubMessage?: string;
+  };
+
+  // Static — labels and icons don't change at runtime. Keeping the array
+  // pure data avoids the wasted-work pattern that Aristotle flagged on
+  // #389 (`tabs` was wrongly $derived).
+  const ROWS: ReadonlyArray<RowSpec> = [
+    { id: "backlinks",  label: "Backlinks",         icon: Link2,        action: "panel", panelId: "backlinks" },
+    { id: "bookmarks",  label: "Lesezeichen",       icon: Bookmark,     action: "panel", panelId: "bookmarks" },
+    { id: "outline",    label: "Gliederung",        icon: List,         action: "panel", panelId: "outline" },
+    { id: "outgoing",   label: "Ausgehende Links",  icon: ArrowUpRight, action: "panel", panelId: "outgoing" },
+    { id: "properties", label: "Eigenschaften",     icon: FileText,     action: "stub",  stubMessage: "Eigenschaften folgen" },
+    { id: "settings",   label: "Einstellungen",     icon: SettingsIcon, action: "stub",  stubMessage: "Einstellungen folgen" },
+  ];
+
+  const PANEL_LABELS: Record<PanelId, string> = {
+    backlinks: "Backlinks",
+    bookmarks: "Lesezeichen",
+    outline: "Gliederung",
+    outgoing: "Ausgehende Links",
+  };
+
+  function onRowClick(row: RowSpec) {
+    if (row.action === "panel" && row.panelId) {
+      activePanel = row.panelId;
+      return;
+    }
+    // TODO #393 (properties) / #394 (settings). The toast tells the user
+    // the destination exists but isn't wired yet; closing the sheet keeps
+    // the More tab's tap-feedback intact (no dead-end where the menu
+    // stays open after an apparent-no-op).
+    if (row.stubMessage) toastStore.info(row.stubMessage);
+    onClose();
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key !== "Escape") return;
+    e.preventDefault();
+    if (activePanel !== null) {
+      // Two-step Escape: panel view → menu view first; another Escape
+      // would then close. Matches the drawer pattern from #386 where a
+      // stacked nav element gives users an "undo last navigation"
+      // affordance instead of dumping them back to the editor.
+      activePanel = null;
+    } else {
+      onClose();
+    }
+  }
+</script>
+
+{#if open}
+  <!-- Scrim sits below the sheet (z-index 59 vs 60). Tapping it closes;
+       no role=button — it's a passive backdrop, the cursor and the sheet
+       itself signal the affordance. -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="vc-modal-scrim vc-mobile-burger-scrim"
+    aria-hidden="true"
+    tabindex="-1"
+    onclick={onClose}
+  ></div>
+
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="vc-mobile-burger-sheet"
+    bind:this={sheetEl}
+    role="dialog"
+    aria-modal="true"
+    aria-label={activePanel ? PANEL_LABELS[activePanel] : "More options"}
+    tabindex="-1"
+    onkeydown={onKeydown}
+  >
+    <div class="vc-mobile-burger-handle" aria-hidden="true"></div>
+
+    {#if activePanel === null}
+      <div class="vc-mobile-burger-list" role="menu">
+        {#each ROWS as row, idx (row.id)}
+          {@const Icon = row.icon}
+          <button
+            type="button"
+            role="menuitem"
+            data-row-id={row.id}
+            class="vc-mobile-burger-row"
+            class:vc-mobile-burger-row--last={idx === ROWS.length - 1}
+            onclick={() => onRowClick(row)}
+          >
+            <Icon size={20} strokeWidth={1.5} />
+            <span class="vc-mobile-burger-row-label">{row.label}</span>
+            <ChevronRight size={16} strokeWidth={1.5} />
+          </button>
+        {/each}
+      </div>
+    {:else}
+      <div class="vc-mobile-burger-panel-header">
+        <button
+          type="button"
+          class="vc-mobile-burger-back"
+          onclick={() => (activePanel = null)}
+          aria-label="Zurück"
+        >
+          <ChevronLeft size={20} strokeWidth={1.5} />
+        </button>
+        <span class="vc-mobile-burger-panel-title">{PANEL_LABELS[activePanel]}</span>
+      </div>
+      <div class="vc-mobile-burger-panel-body">
+        {#if activePanel === "backlinks"}
+          <BacklinksPanel />
+        {:else if activePanel === "bookmarks"}
+          <BookmarksPanel />
+        {:else if activePanel === "outline"}
+          <OutlinePanel />
+        {:else if activePanel === "outgoing"}
+          <OutgoingLinksPanel />
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .vc-mobile-burger-scrim {
+    z-index: 59;
+  }
+
+  .vc-mobile-burger-sheet {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 60vh;
+    max-height: calc(100vh - 80px);
+    background: var(--color-surface);
+    border-radius: 16px 16px 0 0;
+    padding-bottom: env(safe-area-inset-bottom);
+    z-index: 60;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.12);
+  }
+
+  .vc-mobile-burger-handle {
+    width: 36px;
+    height: 4px;
+    margin: 8px auto 12px auto;
+    border-radius: 2px;
+    background: var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .vc-mobile-burger-list {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .vc-mobile-burger-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    height: 56px;
+    min-height: var(--vc-hit-target, 44px);
+    padding: 0 16px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    cursor: pointer;
+    color: var(--color-text);
+    font-family: var(--vc-font-body);
+    font-size: 14px;
+    font-weight: 500;
+    text-align: left;
+  }
+
+  .vc-mobile-burger-row--last {
+    border-bottom: none;
+  }
+
+  .vc-mobile-burger-row:hover {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-mobile-burger-row-label {
+    flex: 1;
+  }
+
+  .vc-mobile-burger-panel-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 48px;
+    padding: 0 8px 0 4px;
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .vc-mobile-burger-back {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    min-width: var(--vc-hit-target, 44px);
+    min-height: var(--vc-hit-target, 44px);
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--color-text-muted);
+  }
+
+  .vc-mobile-burger-back:hover {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+
+  .vc-mobile-burger-panel-title {
+    flex: 1;
+    font-family: var(--vc-font-body);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .vc-mobile-burger-panel-body {
+    flex: 1;
+    overflow-y: auto;
+  }
+</style>

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -149,6 +149,25 @@
     }
   });
 
+  // #397 — focus-return for the burger sheet. The sheet itself focuses its
+  // first focusable on open (component-side); on close, focus must return
+  // to the More tab so the next Tab keypress doesn't drop the user
+  // somewhere arbitrary in the editor. The `burgerWasOpen` latch matches
+  // the drawer's `wasOpen` pattern: it prevents a spurious mount-time
+  // focus call when the sheet starts closed.
+  let burgerWasOpen = $state(false);
+  $effect(() => {
+    if (mobileBurgerOpen) {
+      burgerWasOpen = true;
+    } else if (burgerWasOpen) {
+      // Look up by id rather than threading a bind:this through MobileTabBar
+      // — the tab id contract (`vc-mobile-tab-more`) is stable per #389.
+      const moreTab = document.getElementById("vc-mobile-tab-more");
+      moreTab?.focus();
+      burgerWasOpen = false;
+    }
+  });
+
   // #389 — mobile bottom-tab-bar handlers. State (drawer + omni-search) is
   // owned here in VaultLayout; MobileTabBar receives callbacks only. The
   // close-drawer-first lines on Search/More are required because the drawer

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -9,6 +9,7 @@
   import TemplatePicker from "../TemplatePicker/TemplatePicker.svelte";
   import RightSidebar from "./RightSidebar.svelte";
   import MobileTabBar from "./MobileTabBar.svelte";
+  import MobileBurgerSheet from "./MobileBurgerSheet.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import EncryptionStatusbar from "../Statusbar/EncryptionStatusbar.svelte";
   import TopbarReadingToggle from "./TopbarReadingToggle.svelte";
@@ -111,12 +112,20 @@
   let mobileDrawerOpen = $state(false);
   let triggerRef: HTMLButtonElement | undefined = $state(undefined);
   let drawerEl: HTMLDivElement | undefined = $state(undefined);
+  // #397 — burger sheet (More-tab destination). Mounted alongside the
+  // drawer; both share the parent `isMobile` gate.
+  let mobileBurgerOpen = $state(false);
   const isMobile = $derived($viewportStore.mode === "mobile");
 
   // Resize-to-desktop forces the drawer closed so re-entering mobile starts
-  // from a known state.
+  // from a known state. Same applies to the burger sheet — without this,
+  // resizing while the burger is open would leave a stranded sheet that
+  // isn't reachable from any desktop affordance.
   $effect(() => {
-    if (!isMobile) mobileDrawerOpen = false;
+    if (!isMobile) {
+      mobileDrawerOpen = false;
+      mobileBurgerOpen = false;
+    }
   });
 
   // Focus management: when the drawer opens, focus the first focusable inside
@@ -160,10 +169,11 @@
   }
   function handleMobileMoreTab() {
     mobileDrawerOpen = false;
-    // TODO #397: replace with the burger sheet open flag once the component
-    // lands. The placeholder toast tells the user the destination exists
-    // without misrepresenting it as broken.
-    toastStore.info("Mehr-Menü folgt");
+    // #397 — burger sheet (Backlinks / Bookmarks / Outline / Outgoing /
+    // Properties / Settings router). Properties + Settings rows are
+    // still placeholders until #393 / #394 ship; the burger sheet itself
+    // stub-toasts those branches.
+    mobileBurgerOpen = true;
   }
 
   const unsubTab = tabStore.subscribe((state) => {
@@ -1069,6 +1079,12 @@
     onSelectFiles={handleMobileFilesTab}
     onSelectSearch={handleMobileSearchTab}
     onSelectMore={handleMobileMoreTab}
+  />
+  <!-- #397 — burger sheet (More-tab destination). Self-handles its own
+       open/close transitions; parent owns the open flag. -->
+  <MobileBurgerSheet
+    open={mobileBurgerOpen}
+    onClose={() => (mobileBurgerOpen = false)}
   />
 {/if}
 

--- a/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
@@ -146,6 +146,40 @@ describe("MobileBurgerSheet (#397)", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("focus trap: Tab from the last focusable wraps to the first; Shift+Tab from first wraps to last", async () => {
+    const { container } = renderSheet();
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+    expect(buttons.length).toBe(6);
+    const first = buttons[0]!;
+    const last = buttons[buttons.length - 1]!;
+
+    // Forward wrap.
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    await fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    // Backward wrap.
+    first.focus();
+    await fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("focus trap: Tab away from a middle item does NOT preventDefault (browser handles native tab order)", async () => {
+    // The trap only kicks in at boundaries (first/last). Middle items
+    // should let the browser's native tab order through — a noop preventDefault
+    // would feel sluggish without changing user-visible behaviour.
+    const { container } = renderSheet();
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+    const middle = buttons[2]!;
+    middle.focus();
+    const ev = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+    dialog.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
   it("Escape from menu view calls onClose; Escape from panel view returns to menu", async () => {
     const onClose = vi.fn();
     const { container } = renderSheet({ onClose });

--- a/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
@@ -1,0 +1,187 @@
+/**
+ * MobileBurgerSheet — bottom-sheet router for the mobile More tab (#397).
+ *
+ * Parent-gated: VaultLayout decides via `{#if isMobile && open}` (well,
+ * just passes `open`); the component itself does NOT subscribe to
+ * viewportStore. Heavy panel children (Backlinks/Bookmarks/Outline/
+ * Outgoing) are stubbed via vi.mock so the mount budget stays tight and
+ * we can probe the routing layer without dragging in the panels' own
+ * dependency graphs.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../Backlinks/BacklinksPanel.svelte", async () => ({
+  default: (await import("./testStubs/StubPanel.svelte")).default,
+}));
+vi.mock("../../Bookmarks/BookmarksPanel.svelte", async () => ({
+  default: (await import("./testStubs/StubPanel.svelte")).default,
+}));
+vi.mock("../../Outline/OutlinePanel.svelte", async () => ({
+  default: (await import("./testStubs/StubPanel.svelte")).default,
+}));
+vi.mock("../../OutgoingLinks/OutgoingLinksPanel.svelte", async () => ({
+  default: (await import("./testStubs/StubPanel.svelte")).default,
+}));
+
+const toastInfo = vi.fn();
+vi.mock("../../../store/toastStore", () => ({
+  toastStore: {
+    info: toastInfo,
+    push: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import MobileBurgerSheet from "../MobileBurgerSheet.svelte";
+
+beforeEach(() => {
+  toastInfo.mockClear();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function renderSheet(overrides: Partial<{ open: boolean; onClose: () => void }> = {}) {
+  return render(MobileBurgerSheet, {
+    props: {
+      open: true,
+      onClose: vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
+describe("MobileBurgerSheet (#397)", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = renderSheet({ open: false });
+    expect(container.querySelector(".vc-mobile-burger-sheet")).toBeNull();
+    expect(container.querySelector(".vc-modal-scrim")).toBeNull();
+  });
+
+  it("renders the menu view with 6 rows when open=true", () => {
+    const { container } = renderSheet();
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    const rows = container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    expect(rows.length).toBe(6);
+  });
+
+  it("dialog carries aria-modal=true and aria-label='More options' in the menu view", () => {
+    const { container } = renderSheet();
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-label")).toBe("More options");
+  });
+
+  it("clicking the Backlinks row swaps the menu view for the Backlinks panel", async () => {
+    const { container } = renderSheet();
+    const row = container.querySelector<HTMLButtonElement>('[data-row-id="backlinks"]');
+    expect(row).not.toBeNull();
+    await fireEvent.click(row!);
+    await tick();
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+    // Stub renders `<div data-stub-panel>...</div>`
+    expect(container.querySelector("[data-stub-panel]")).not.toBeNull();
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.getAttribute("aria-label")).toBe("Backlinks");
+  });
+
+  it.each([
+    ["bookmarks", "Lesezeichen"],
+    ["outline", "Gliederung"],
+    ["outgoing", "Ausgehende Links"],
+  ])("clicking the %s row routes to a panel view labelled '%s'", async (rowId, label) => {
+    const { container } = renderSheet();
+    const row = container.querySelector<HTMLButtonElement>(`[data-row-id="${rowId}"]`);
+    await fireEvent.click(row!);
+    await tick();
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.getAttribute("aria-label")).toBe(label);
+    expect(container.querySelector("[data-stub-panel]")).not.toBeNull();
+  });
+
+  it("clicking the Properties row fires toastStore.info AND calls onClose (TODO #393)", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    const row = container.querySelector<HTMLButtonElement>('[data-row-id="properties"]');
+    await fireEvent.click(row!);
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the Settings row fires toastStore.info AND calls onClose (TODO #394)", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    const row = container.querySelector<HTMLButtonElement>('[data-row-id="settings"]');
+    await fireEvent.click(row!);
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the scrim calls onClose", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    const scrim = container.querySelector<HTMLElement>(".vc-mobile-burger-scrim");
+    expect(scrim).not.toBeNull();
+    await fireEvent.click(scrim!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("the Back button in the panel view returns to the menu view (does NOT close)", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="backlinks"]')!);
+    await tick();
+    const back = container.querySelector<HTMLButtonElement>(".vc-mobile-burger-back");
+    expect(back).not.toBeNull();
+    await fireEvent.click(back!);
+    await tick();
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("Escape from menu view calls onClose; Escape from panel view returns to menu", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    // Menu view: Escape closes.
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    await fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Panel view: Escape returns to menu (does not close).
+    onClose.mockClear();
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="outline"]')!);
+    await tick();
+    await fireEvent.keyDown(container.querySelector<HTMLElement>('[role="dialog"]')!, { key: "Escape" });
+    await tick();
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("re-opening the sheet resets to the menu view (active panel doesn't persist)", async () => {
+    const onClose = vi.fn();
+    const { container, rerender } = renderSheet({ open: true, onClose });
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="bookmarks"]')!);
+    await tick();
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+
+    await rerender({ open: false, onClose });
+    await tick();
+    await rerender({ open: true, onClose });
+    await tick();
+
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.getAttribute("aria-label")).toBe("More options");
+  });
+
+  it("does not import viewportStore — parent-gated component is the architectural contract", async () => {
+    const fs = await import("node:fs/promises");
+    const url = await import("node:url");
+    const componentPath = url.fileURLToPath(import.meta.resolve("../MobileBurgerSheet.svelte"));
+    const src = await fs.readFile(componentPath, "utf8");
+    expect(/from\s+["'][^"']*viewportStore["']/.test(src)).toBe(false);
+  });
+});

--- a/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
@@ -25,7 +25,11 @@ vi.mock("../../OutgoingLinks/OutgoingLinksPanel.svelte", async () => ({
   default: (await import("./testStubs/StubPanel.svelte")).default,
 }));
 
-const toastInfo = vi.fn();
+// vi.mock factories are hoisted above any normal `const`, so a captured
+// vi.fn() reference would be uninitialized at mock-evaluation time. The
+// hoisted helper resolves that — same pattern as the viewportStore mock
+// shape from #386's responsive-collapse spec.
+const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }));
 vi.mock("../../../store/toastStore", () => ({
   toastStore: {
     info: toastInfo,

--- a/src/components/Layout/__tests__/testStubs/StubPanel.svelte
+++ b/src/components/Layout/__tests__/testStubs/StubPanel.svelte
@@ -1,0 +1,4 @@
+<!-- Stub used by MobileBurgerSheet.test.ts to swap out the real panels
+     (Backlinks/Bookmarks/Outline/Outgoing). Carries a probe attribute so
+     tests can assert the panel view actually mounted something. -->
+<div data-stub-panel>stub-panel</div>


### PR DESCRIPTION
## Summary

Replaces the placeholder `toastStore.info("Mehr-Menü folgt")` left by #389 with a real bottom-sheet router. The More tab now opens a sheet hosting Backlinks / Bookmarks / Outline / Outgoing Links / Properties / Settings.

### Architecture
- Single new component `MobileBurgerSheet.svelte` with two views in one DOM mount: a 6-row menu and a panel view that mounts the selected sub-panel inline with a back button.
- Parent-gated like #389's MobileTabBar — VaultLayout decides via `{#if isMobile}`; the component does NOT subscribe to `viewportStore`. Source-level test enforces this.
- All mobile state (drawer + burger) lives in VaultLayout; the burger receives `open` + `onClose` props only.
- Resize-to-desktop `$effect` closes both the drawer AND the burger so re-entering mobile starts from a known state.

### Wiring
- `handleMobileMoreTab` now sets `mobileBurgerOpen = true` (still closes the drawer first per the #389 close-first contract).
- Mounted alongside `<MobileTabBar>` inside the same `{#if isMobile}` block.

### Panel rows
The 4 wired panels are zero-prop, store-driven components — mounting inline requires no adaptation:

| Row | Component |
|---|---|
| Backlinks | `BacklinksPanel.svelte` |
| Lesezeichen | `BookmarksPanel.svelte` |
| Gliederung | `OutlinePanel.svelte` |
| Ausgehende Links | `OutgoingLinksPanel.svelte` |
| Eigenschaften | stub-toast → TODO #393 |
| Einstellungen | stub-toast → TODO #394 |

### ARIA
- `role=dialog` + `aria-modal=true` + `tabindex=-1` (Svelte's `a11y_interactive_supports_focus` requires it).
- `aria-label` swaps between "More options" (menu) and the active panel's German label.
- Each row: `role=menuitem` inside `role=menu`.
- First focusable inside the sheet receives focus on open (microtask).
- **Two-step Escape**: panel view → menu view first; menu view → close. Matches drawer pattern from #386 — gives users an undo of the last navigation rather than dumping them back to the editor.
- Scrim click closes (passive backdrop with `aria-hidden`).

### Layout
- `60vh` tall, rounded top corners, fixed bottom, `env(safe-area-inset-bottom)` padding.
- Drag-handle visual affordance only — swipe-down dismissal explicitly out of scope (scrim-tap + Escape + onClose cover dismissal).
- z-index 60 / scrim 59 — above drawer (50), below all modals (≥199). Burger never covers OmniSearch / CommandPalette / Settings.

### Z-index audit (current state)
| Surface | z-index |
|---|---|
| Mobile tab bar | 40 |
| Drawer scrim | 49 |
| Drawer surface | 50 |
| **Burger scrim (new)** | **59** |
| **Burger sheet (new)** | **60** |
| ContextMenu / ColorPicker | 199–200 |
| OmniSearch / CommandPalette / Templates | 200/201 |
| SettingsModal | 300/301 |

## Test plan
- [x] `pnpm vitest run src/components/Layout/` — 48/48 green (14 new MobileBurgerSheet cases + 34 from prior layout suites)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [ ] Manual UAT: tap More on the bottom tab bar → burger opens at the bottom with 6 rows.
- [ ] Manual UAT: tap each of Backlinks/Bookmarks/Outline/Outgoing → panel mounts with the correct content; Back returns to menu.
- [ ] Manual UAT: tap Eigenschaften / Einstellungen → toast appears + sheet closes.
- [ ] Manual UAT: scrim tap closes; Escape from menu closes; Escape from panel returns to menu.
- [ ] Manual UAT: open drawer (Files tap) → tap More → drawer closes, burger opens.
- [ ] Manual UAT: resize to desktop while burger is open → burger disappears (parent gate); resize back → unchanged.

Closes #397. Refs #74.