### PR TITLE
fix(mobile): move PickerPlugin to package matching plugin identifier

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/app/vaultcore/picker/PickerPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/app/vaultcore/picker/PickerPlugin.kt
@@ -31,7 +31,7 @@
 // (Samsung/MIUI vendor extensions), and any future vendor-specific
 // codes — cancellation is a UX state, not an error.
 
-package com.vaultcore.app
+package app.vaultcore.picker
 
 import android.app.Activity
 import android.content.Intent


### PR DESCRIPTION
## Hot fix — production crash on Android app launch

**Symptom**: app crashes immediately on launch, before WebView loads. Logcat shows:
\`\`\`
PluginInitialization(\"vaultcore-picker\", \"jni error: Java exception was thrown\")
ClassNotFoundException: app.vaultcore.picker.PickerPlugin
\`\`\`

**Cause**: Tauri's \`register_android_plugin(\"app.vaultcore.picker\", \"PickerPlugin\")\` looks for the class at the FQN \`<identifier>.<class_name>\` — i.e. \`app.vaultcore.picker.PickerPlugin\`. But the Kotlin file from #391 was at \`package com.vaultcore.app\` (matching the app's package, not the plugin identifier namespace). Mismatch → \`ClassNotFoundException\` → JNI exception → unrecoverable crash.

This wasn't caught in #391 because \`pnpm tauri android build --debug\` succeeds — the .kt compiles and lands in the APK. The mismatch only manifests at runtime when Tauri tries to instantiate the plugin class via JNI \`Class.forName()\`.

**Fix**: move the file to the correct package path:
- \`gen/android/app/src/main/java/com/vaultcore/app/PickerPlugin.kt\` → \`gen/android/app/src/main/java/app/vaultcore/picker/PickerPlugin.kt\`
- Update package statement: \`package com.vaultcore.app\` → \`package app.vaultcore.picker\`

Tauri 2's bundled plugins follow this same convention (e.g. \`tauri-plugin-dialog\` ships \`app.tauri.dialog.DialogPlugin\` matching its identifier).

## Verification
- \`pnpm tauri android build --debug\` succeeds
- \`adb install -r ...apk\` succeeds
- \`adb shell am start -n com.vaultcore.app/.MainActivity\` boots cleanly — Tauri plugin loads, WebView mounts, no JNI exception in logcat
- \`adb logcat | grep -i fatal\` empty after launch

## Affected
Anyone trying to launch the Android debug build on a real device hits this crash. CI's \`pnpm tauri android build --debug\` smoke test passes (build succeeds), so this slipped through.

## Follow-up
- Should add a runtime smoke test (boot the APK in CI emulator + verify no fatal log lines) to catch this class of issue. Tracked separately.

Refs #391.