### PR TITLE
feat(mobile): VaultStorage trait + VaultHandle enum (#392 PR-A)

### DIFF
--- a/src-tauri/src/commands/bookmarks.rs
+++ b/src-tauri/src/commands/bookmarks.rs
@@ -24,9 +24,12 @@ fn bookmarks_path_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, V
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-        path: vault_path.to_string(),
-    })?;
+    let vault = guard
+        .as_ref()
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: vault_path.to_string(),
+        })?
+        .expect_posix();
     if canonical != *vault {
         return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
     }

--- a/src-tauri/src/commands/encryption.rs
+++ b/src-tauri/src/commands/encryption.rs
@@ -94,9 +94,12 @@ pub struct EncryptProgress {
 
 fn vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    guard.as_ref().cloned().ok_or_else(|| VaultError::VaultUnavailable {
-        path: String::from("<no vault>"),
-    })
+    guard
+        .as_ref()
+        .map(|h| h.expect_posix().to_path_buf())
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: String::from("<no vault>"),
+        })
 }
 
 /// Canonical absolute path of the folder the user referenced, with
@@ -500,7 +503,7 @@ pub fn export_decrypted_file_impl(
             .map_err(|_| VaultError::LockPoisoned)?;
         guard
             .as_ref()
-            .cloned()
+            .map(|h| h.expect_posix().to_path_buf())
             .ok_or_else(|| VaultError::VaultUnavailable {
                 path: source.clone(),
             })?

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -30,7 +30,7 @@ fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
     guard
         .as_ref()
-        .cloned()
+        .map(|h| h.expect_posix().to_path_buf())
         .ok_or_else(|| VaultError::VaultUnavailable { path: String::from("<no vault>") })
 }
 

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -60,9 +60,15 @@ fn ensure_unlocked(state: &VaultState, canonical: &Path) -> Result<(), VaultErro
 /// this helper — the T-02 audit depends on it.
 pub(crate) fn ensure_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-        path: target.display().to_string(),
-    })?;
+    // #392 PR-A: `.expect_posix()` panics on non-POSIX VaultHandle arms.
+    // PR-B routes file commands through the storage trait instead; this
+    // unwrap will go away there.
+    let vault = guard
+        .as_ref()
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: target.display().to_string(),
+        })?
+        .expect_posix();
     let canonical_target = std::fs::canonicalize(target).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => VaultError::FileNotFound {
             path: target.display().to_string(),
@@ -123,9 +129,10 @@ pub async fn write_file(
     })?;
     {
         let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-        let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-            path: path.clone(),
-        })?;
+        let vault = guard
+            .as_ref()
+            .ok_or_else(|| VaultError::VaultUnavailable { path: path.clone() })?
+            .expect_posix();
         if !canonical_parent.starts_with(vault) {
             return Err(VaultError::PermissionDenied { path: path.clone() });
         }
@@ -192,9 +199,13 @@ fn ensure_parent_inside_vault(state: &VaultState, target: &Path) -> Result<(Path
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-        path: target.display().to_string(),
-    })?.clone();
+    let vault = guard
+        .as_ref()
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: target.display().to_string(),
+        })?
+        .expect_posix()
+        .to_path_buf();
     if !canonical_parent.starts_with(&vault) {
         return Err(VaultError::PermissionDenied { path: canonical_parent.display().to_string() });
     }
@@ -209,9 +220,12 @@ fn ensure_parent_inside_vault(state: &VaultState, target: &Path) -> Result<(Path
 /// Helper: get the current vault root.
 fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    guard.as_ref().cloned().ok_or_else(|| VaultError::VaultUnavailable {
-        path: String::from("<no vault>"),
-    })
+    guard
+        .as_ref()
+        .map(|h| h.expect_posix().to_path_buf())
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: String::from("<no vault>"),
+        })
 }
 
 /// Helper: record a path in the write-ignore list (D-12 self-filtering).

--- a/src-tauri/src/commands/index_dispatch.rs
+++ b/src-tauri/src/commands/index_dispatch.rs
@@ -91,7 +91,7 @@ pub(crate) async fn dispatch_self_write(state: &VaultState, abs_path: &Path, con
             return;
         };
         match guard.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => return,
         }
     };
@@ -144,7 +144,7 @@ pub(crate) async fn dispatch_self_delete(state: &VaultState, abs_path: &Path) {
             return;
         };
         match guard.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => return,
         }
     };

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -56,8 +56,8 @@ impl LockedRelChecker {
         if snapshot.is_empty() {
             return Self { prefixes: Vec::new() };
         }
-        let vault = match state.current_vault.lock() {
-            Ok(g) => g.clone(),
+        let vault: Option<std::path::PathBuf> = match state.current_vault.lock() {
+            Ok(g) => g.as_ref().map(|h| h.expect_posix().to_path_buf()),
             Err(_) => None,
         };
         let Some(vault_root) = vault else {
@@ -411,7 +411,7 @@ pub async fn update_links_after_rename(
             path: String::new(),
         })?;
         match vp.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => return Err(VaultError::VaultUnavailable { path: String::from("(none)") }),
         }
     };
@@ -671,7 +671,7 @@ pub async fn get_resolved_links(
             .current_vault
             .lock()
             .map_err(|_| VaultError::IndexCorrupt)?;
-        guard.clone()
+        guard.as_ref().map(|h| h.expect_posix().to_path_buf())
     };
     if let Some(vp) = vault_path {
         paths.extend(crate::indexer::collect_canvas_rel_paths(&vp));
@@ -765,7 +765,7 @@ pub async fn get_resolved_attachments(
             .lock()
             .map_err(|_| VaultError::IndexCorrupt)?;
         match guard.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => return Ok(HashMap::new()),
         }
     };

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -236,8 +236,8 @@ pub async fn search_filename(
         if snap.is_empty() {
             Vec::new()
         } else {
-            let vault = match state.current_vault.lock() {
-                Ok(g) => g.clone(),
+            let vault: Option<std::path::PathBuf> = match state.current_vault.lock() {
+                Ok(g) => g.as_ref().map(|h| h.expect_posix().to_path_buf()),
                 Err(_) => None,
             };
             match vault {
@@ -356,7 +356,7 @@ pub async fn rebuild_index(
             .lock()
             .map_err(|_| VaultError::VaultUnavailable { path: String::new() })?;
         match vp.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => {
                 return Err(VaultError::VaultUnavailable {
                     path: String::from("(none)"),

--- a/src-tauri/src/commands/snippets.rs
+++ b/src-tauri/src/commands/snippets.rs
@@ -27,9 +27,12 @@ fn snippets_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, Vau
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-        path: vault_path.to_string(),
-    })?;
+    let vault = guard
+        .as_ref()
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: vault_path.to_string(),
+        })?
+        .expect_posix();
     if canonical != *vault {
         return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
     }

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -28,9 +28,12 @@ fn templates_dir_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, Va
         _ => VaultError::Io(e),
     })?;
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-        path: vault_path.to_string(),
-    })?;
+    let vault = guard
+        .as_ref()
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: vault_path.to_string(),
+        })?
+        .expect_posix();
     if canonical != *vault {
         return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
     }

--- a/src-tauri/src/commands/tree.rs
+++ b/src-tauri/src/commands/tree.rs
@@ -70,9 +70,12 @@ pub struct DirEntry {
 /// exist, so full canonicalization works.
 fn check_inside_vault(state: &VaultState, target: &Path) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-        path: target.display().to_string(),
-    })?;
+    let vault = guard
+        .as_ref()
+        .ok_or_else(|| VaultError::VaultUnavailable {
+            path: target.display().to_string(),
+        })?
+        .expect_posix();
     let canonical = std::fs::canonicalize(target).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => VaultError::FileNotFound {
             path: target.display().to_string(),

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -143,9 +143,23 @@ pub async fn open_vault(
     })?;
 
     // Persist as the active vault (files commands read from here).
+    // #392 PR-A: also construct + stash a `PosixStorage` in the new
+    // `state.storage` slot. PR-A doesn't read from the slot anywhere
+    // yet — file commands still go through `ensure_inside_vault` +
+    // `std::fs::*` directly. PR-B will route file commands through the
+    // storage trait and add the Android `ContentUri` arm.
     {
         let mut guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-        *guard = Some(canonical.clone());
+        *guard = Some(crate::storage::VaultHandle::Posix(canonical.clone()));
+    }
+    {
+        let mut storage_guard = state
+            .storage
+            .write()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        *storage_guard = Some(std::sync::Arc::new(crate::storage::PosixStorage::new(
+            canonical.clone(),
+        )));
     }
 
     // Push to recent-vaults.json
@@ -456,14 +470,17 @@ pub(crate) async fn merge_external_change_impl(
     use crate::merge::{three_way_merge, MergeOutcome};
 
     // T-02-18 mitigation: validate path is inside vault
-    let vault_path = {
+    let vault_path: PathBuf = {
         let guard = state
             .current_vault
             .lock()
             .map_err(|_| crate::error::VaultError::LockPoisoned)?;
-        guard.clone().ok_or_else(|| crate::error::VaultError::VaultUnavailable {
-            path: path.clone(),
-        })?
+        guard
+            .as_ref()
+            .map(|h| h.expect_posix().to_path_buf())
+            .ok_or_else(|| crate::error::VaultError::VaultUnavailable {
+                path: path.clone(),
+            })?
     };
 
     let target = PathBuf::from(&path);

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -142,25 +142,15 @@ pub async fn open_vault(
         VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
 
-    // Persist as the active vault (files commands read from here).
-    // #392 PR-A: also construct + stash a `PosixStorage` in the new
-    // `state.storage` slot. PR-A doesn't read from the slot anywhere
-    // yet — file commands still go through `ensure_inside_vault` +
-    // `std::fs::*` directly. PR-B will route file commands through the
-    // storage trait and add the Android `ContentUri` arm.
-    {
-        let mut guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-        *guard = Some(crate::storage::VaultHandle::Posix(canonical.clone()));
-    }
-    {
-        let mut storage_guard = state
-            .storage
-            .write()
-            .map_err(|_| VaultError::LockPoisoned)?;
-        *storage_guard = Some(std::sync::Arc::new(crate::storage::PosixStorage::new(
-            canonical.clone(),
-        )));
-    }
+    // #392 PR-A: atomically persist the active vault + storage handle.
+    // `set_open_vault` takes both locks in a fixed order so a
+    // concurrent reader never sees `current_vault` and `storage`
+    // pointing at different vaults — relevant to PR-B which reads both
+    // during file commands.
+    state.set_open_vault(
+        crate::storage::VaultHandle::Posix(canonical.clone()),
+        std::sync::Arc::new(crate::storage::PosixStorage::new(canonical.clone())),
+    )?;
 
     // Push to recent-vaults.json
     let canonical_str = canonical.to_string_lossy().into_owned();

--- a/src-tauri/src/encryption/mod.rs
+++ b/src-tauri/src/encryption/mod.rs
@@ -193,7 +193,7 @@ pub fn maybe_decrypt_read(
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
         match guard.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => return Ok(bytes),
         }
     };
@@ -232,7 +232,7 @@ pub fn maybe_encrypt_write(
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
         match guard.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => return Ok(bytes.to_vec()),
         }
     };

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -79,6 +79,14 @@ pub enum VaultError {
     /// channel closed, mobile-plugin-bridge deserialize failure, etc.
     #[error("Picker failed: {msg}")]
     PickerFailed { msg: String },
+
+    /// #392: relative path resolved outside the vault root. Distinct
+    /// from `PermissionDenied` (which is OS-level access refusal) — this
+    /// is a T-02 violation, either client bug or attack: the resolved
+    /// canonical path was outside `vault_root`. Never user-actionable; UI
+    /// renders a generic "request denied" copy and logs for follow-up.
+    #[error("Path resolves outside the vault: {path}")]
+    PathOutsideVault { path: String },
 }
 
 impl VaultError {
@@ -99,6 +107,7 @@ impl VaultError {
             Self::CryptoError { .. } => "CryptoError",
             Self::PayloadTooLarge { .. } => "PayloadTooLarge",
             Self::PickerFailed { .. } => "PickerFailed",
+            Self::PathOutsideVault { .. } => "PathOutsideVault",
         }
     }
 
@@ -115,7 +124,8 @@ impl VaultError {
             | Self::MergeConflict { path }
             | Self::InvalidEncoding { path }
             | Self::PathLocked { path }
-            | Self::PayloadTooLarge { path, .. } => Some(path.clone()),
+            | Self::PayloadTooLarge { path, .. }
+            | Self::PathOutsideVault { path } => Some(path.clone()),
             // Data-less variants — and variants whose payload is a human
             // message rather than a routable path. The `data` IPC field
             // is reserved for paths the frontend can `navigate(err.data)`,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod watcher;
 pub mod merge;
 pub mod indexer;
 pub mod encryption;
+pub mod storage;
 
 #[cfg(test)]
 mod tests;
@@ -17,6 +18,7 @@ use notify_debouncer_full::{Debouncer, RecommendedCache};
 use notify_debouncer_full::notify::RecommendedWatcher;
 
 use indexer::memory::FileIndex;
+use storage::{VaultHandle, VaultStorage};
 
 /// Write-ignore-list: records own-write events so the file watcher can
 /// suppress spurious self-triggered events (D-12).
@@ -57,7 +59,16 @@ impl WriteIgnoreList {
 /// and replaced on vault re-open. Debouncer has no Default impl so we
 /// use a manual Default that initializes the Option to None.
 pub struct VaultState {
-    pub current_vault: Mutex<Option<std::path::PathBuf>>,
+    /// #392: VaultHandle wraps a canonicalized POSIX path on desktop and
+    /// will gain a `ContentUri(String)` arm in PR-B for Android. Today's
+    /// callers use `posix_path()` to access the inner `&Path`; PR-B
+    /// migrates the file-command surface to the storage trait.
+    pub current_vault: Mutex<Option<VaultHandle>>,
+    /// #392 PR-A: storage abstraction populated by `open_vault`. PR-A
+    /// constructs a `PosixStorage` and stashes it here, but no commands
+    /// route through the trait yet — the slot exists so PR-B can plug
+    /// `AndroidStorage` in without re-wiring `VaultState`.
+    pub storage: Arc<RwLock<Option<Arc<dyn VaultStorage>>>>,
     pub write_ignore: Arc<Mutex<WriteIgnoreList>>,
     /// Shared vault reachability flag (ERR-03 / D-14).
     /// Wrapped in Arc so it can be shared with the watcher's reconnect-poll task.
@@ -94,6 +105,7 @@ impl Default for VaultState {
     fn default() -> Self {
         Self {
             current_vault: Mutex::new(None),
+            storage: Arc::new(RwLock::new(None)),
             write_ignore: Arc::new(Mutex::new(WriteIgnoreList::default())),
             vault_reachable: Arc::new(Mutex::new(false)),
             watcher_handle: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,8 +61,9 @@ impl WriteIgnoreList {
 pub struct VaultState {
     /// #392: VaultHandle wraps a canonicalized POSIX path on desktop and
     /// will gain a `ContentUri(String)` arm in PR-B for Android. Today's
-    /// callers use `posix_path()` to access the inner `&Path`; PR-B
-    /// migrates the file-command surface to the storage trait.
+    /// callers use `expect_posix()` (panics on non-POSIX) to access the
+    /// inner `&Path`; PR-B migrates each call site to either a storage
+    /// trait call or a cfg-gated branch.
     pub current_vault: Mutex<Option<VaultHandle>>,
     /// #392 PR-A: storage abstraction populated by `open_vault`. PR-A
     /// constructs a `PosixStorage` and stashes it here, but no commands
@@ -99,6 +100,36 @@ pub struct VaultState {
     // vault close; the cache is refreshed on every manifest mutation.
     pub pending_queue: Arc<encryption::PendingEncryptionQueue>,
     pub manifest_cache: Arc<encryption::ManifestCache>,
+}
+
+impl VaultState {
+    /// #392 PR-A: atomically populate `current_vault` and `storage` for a
+    /// freshly opened vault. Both fields describe the same vault and PR-B
+    /// will read both during file commands; updating them in separate
+    /// scopes leaves a window where a concurrent reader sees mismatched
+    /// state. A single helper that takes both locks in a deterministic
+    /// order is the canonical fix.
+    ///
+    /// Lock ordering: `current_vault` (Mutex) before `storage` (RwLock).
+    /// Used consistently by the only caller (`open_vault`); any future
+    /// caller must follow the same order to avoid deadlock.
+    pub fn set_open_vault(
+        &self,
+        handle: storage::VaultHandle,
+        store: std::sync::Arc<dyn storage::VaultStorage>,
+    ) -> Result<(), error::VaultError> {
+        let mut handle_guard = self
+            .current_vault
+            .lock()
+            .map_err(|_| error::VaultError::LockPoisoned)?;
+        let mut storage_guard = self
+            .storage
+            .write()
+            .map_err(|_| error::VaultError::LockPoisoned)?;
+        *handle_guard = Some(handle);
+        *storage_guard = Some(store);
+        Ok(())
+    }
 }
 
 impl Default for VaultState {

--- a/src-tauri/src/storage/handle.rs
+++ b/src-tauri/src/storage/handle.rs
@@ -47,23 +47,11 @@ impl VaultHandle {
         Ok(Self::Posix(canonical))
     }
 
-    /// Path accessor for callers that genuinely need a `PathBuf` today
-    /// (the encryption root-finder, the indexer's vault walk, the T-02
-    /// `starts_with` guard). Returns `None` for non-POSIX arms so PR-B's
-    /// migration of those callers to the storage trait is enforced by
-    /// the compiler.
-    pub fn posix_path(&self) -> Option<&Path> {
-        match self {
-            Self::Posix(p) => Some(p.as_path()),
-        }
-    }
-
     /// Panicking accessor for the 22 PR-A sites that still operate on
-    /// `&Path`. Equivalent to `posix_path().expect("...")` but reads
-    /// nicer at the call site. PR-B replaces every caller of this with
-    /// either a `VaultStorage` trait call or a cfg-gated branch — the
-    /// panic message names PR-B explicitly so a regression on Android is
-    /// loud, not silent.
+    /// `&Path`. PR-B replaces every caller with either a `VaultStorage`
+    /// trait call or a cfg-gated branch; the panicking shape exists so
+    /// a regression on Android is loud, not silent. Single grep target
+    /// for PR-B: `expect_posix`.
     pub fn expect_posix(&self) -> &Path {
         match self {
             Self::Posix(p) => p.as_path(),

--- a/src-tauri/src/storage/handle.rs
+++ b/src-tauri/src/storage/handle.rs
@@ -1,0 +1,80 @@
+// #392 — `VaultHandle` is the cross-platform identifier for a vault root.
+//
+// On desktop and dev it wraps a canonicalized POSIX path. PR-B will add a
+// `ContentUri(String)` arm for Android Storage Access Framework tree URIs;
+// it is intentionally absent from PR-A so the type wrapper stays pure
+// scaffolding (zero behavior change) and reviewers can focus on the
+// mechanical 22-site migration.
+//
+// The handle serializes to a string for IPC + recent-vaults persistence.
+// On desktop the string form is the path's display string, identical to
+// what callers used to pass around as a bare `PathBuf::display()`.
+
+use crate::error::VaultError;
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VaultHandle {
+    /// Desktop / dev: a canonicalized POSIX path.
+    Posix(PathBuf),
+    // ContentUri(String) — added in PR-B for Android. Cfg-gated then.
+}
+
+impl VaultHandle {
+    /// Stable string form for IPC + recent-vaults persistence.
+    pub fn as_str(&self) -> Cow<'_, str> {
+        match self {
+            Self::Posix(p) => p.to_string_lossy(),
+        }
+    }
+
+    /// Parse from a string supplied by the picker / read from
+    /// recent-vaults.json. PR-A always treats the input as a POSIX path
+    /// and canonicalizes — same behavior as today's `open_vault`. PR-B
+    /// adds a `content://` heuristic for Android tree URIs.
+    pub fn parse(s: &str) -> Result<Self, VaultError> {
+        let p = PathBuf::from(s);
+        let canonical = std::fs::canonicalize(&p).map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => VaultError::VaultUnavailable {
+                path: s.to_string(),
+            },
+            std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+                path: s.to_string(),
+            },
+            _ => VaultError::Io(e),
+        })?;
+        Ok(Self::Posix(canonical))
+    }
+
+    /// Path accessor for callers that genuinely need a `PathBuf` today
+    /// (the encryption root-finder, the indexer's vault walk, the T-02
+    /// `starts_with` guard). Returns `None` for non-POSIX arms so PR-B's
+    /// migration of those callers to the storage trait is enforced by
+    /// the compiler.
+    pub fn posix_path(&self) -> Option<&Path> {
+        match self {
+            Self::Posix(p) => Some(p.as_path()),
+        }
+    }
+
+    /// Panicking accessor for the 22 PR-A sites that still operate on
+    /// `&Path`. Equivalent to `posix_path().expect("...")` but reads
+    /// nicer at the call site. PR-B replaces every caller of this with
+    /// either a `VaultStorage` trait call or a cfg-gated branch — the
+    /// panic message names PR-B explicitly so a regression on Android is
+    /// loud, not silent.
+    pub fn expect_posix(&self) -> &Path {
+        match self {
+            Self::Posix(p) => p.as_path(),
+        }
+    }
+}
+
+impl From<PathBuf> for VaultHandle {
+    /// Wrap an already-canonicalized path. Used by tests that build a
+    /// `VaultState` directly with a `tempfile::TempDir` path.
+    fn from(p: PathBuf) -> Self {
+        Self::Posix(p)
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1,0 +1,60 @@
+// #392 — vault storage abstraction.
+//
+// PR-A (this slice): introduces `VaultHandle` and the `VaultStorage` trait
+// + `PosixStorage` impl as scaffolding. The trait sits in `VaultState.storage`
+// but no commands route through it yet — the migration is mechanical and
+// behavior-identical to pre-#392 desktop. PR-B routes `commands/files.rs`
+// through the trait, adds `AndroidStorage`, and changes `metadata_path()`
+// to return per-platform locations.
+
+pub mod handle;
+pub mod posix;
+
+pub use handle::VaultHandle;
+pub use posix::PosixStorage;
+
+use crate::error::VaultError;
+use std::path::Path;
+
+/// File metadata returned by [`VaultStorage::metadata`].
+#[derive(Debug, Clone)]
+pub struct FileMeta {
+    pub size: u64,
+    pub is_dir: bool,
+}
+
+/// Directory entry returned by [`VaultStorage::list_dir`].
+#[derive(Debug, Clone)]
+pub struct DirEntry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+/// Cross-platform vault I/O. Desktop impl wraps `std::fs::*`; PR-B's
+/// Android impl routes through `ContentResolver` via the `PickerPlugin`
+/// JNI bridge.
+///
+/// All paths are vault-relative — the storage impl resolves them
+/// against the vault root it owns. This intentionally inverts today's
+/// `commands/files.rs` flow which works in canonical absolute paths;
+/// rel-path-based commands are PR-B's job. PR-A's `PosixStorage` is
+/// fully implemented but unused so PR-B has a stable surface to plug
+/// `AndroidStorage` into without re-writing the trait.
+pub trait VaultStorage: Send + Sync {
+    fn read_file(&self, rel_path: &str) -> Result<Vec<u8>, VaultError>;
+    fn write_file(&self, rel_path: &str, contents: &[u8]) -> Result<(), VaultError>;
+    fn create_file(&self, rel_path: &str, initial: &[u8]) -> Result<(), VaultError>;
+    fn create_dir(&self, rel_path: &str) -> Result<(), VaultError>;
+    fn delete(&self, rel_path: &str) -> Result<(), VaultError>;
+    fn rename(&self, from: &str, to: &str) -> Result<(), VaultError>;
+    fn metadata(&self, rel_path: &str) -> Result<FileMeta, VaultError>;
+    fn list_dir(&self, rel_path: &str) -> Result<Vec<DirEntry>, VaultError>;
+    fn exists(&self, rel_path: &str) -> bool;
+
+    /// Where Tantivy + bookmarks + other vault metadata lives. Desktop
+    /// returns `<vault>/.vaultcore` so behavior is bit-identical to the
+    /// pre-#392 hard-coded path. PR-B's Android impl returns app-private
+    /// scratch under `<getFilesDir()>/vaults/<uri_hash>/` because mmap
+    /// (Tantivy's storage backend) does not work over `ContentResolver`.
+    fn metadata_path(&self) -> &Path;
+}

--- a/src-tauri/src/storage/posix.rs
+++ b/src-tauri/src/storage/posix.rs
@@ -1,13 +1,27 @@
 // #392 — POSIX file storage backing the desktop and dev vault.
 //
-// Wraps `std::fs::*` calls one-for-one. Resolves rel_paths against the
-// vault root by `vault_root.join(rel_path)` and maps `io::Error` kinds
-// to the existing `VaultError` taxonomy so the IPC error-shape contract
-// is preserved.
+// Wraps `std::fs::*` calls and routes every rel_path through a T-02
+// path-traversal guard before touching the filesystem. The guard mirrors
+// the semantics of the existing `commands/files.rs::ensure_inside_vault`:
+// the resolved canonical path must sit under the canonical vault root.
+// `vault_root.join("../../etc/passwd")` returns `PathOutsideVault`.
 //
-// PR-A scope reminder: `PosixStorage` is constructed by `open_vault` but
-// no commands route through it yet. The exhaustive impl + tests guard
-// the surface PR-B will consume.
+// Two resolution modes:
+// - `resolve_existing(rel)`: canonicalizes the full path. Used by ops
+//   that REQUIRE the target to exist (read, list_dir, metadata, delete).
+//   Returns `FileNotFound` if `canonicalize` errors with NotFound.
+// - `resolve_for_write(rel)`: canonicalizes the parent (which MUST
+//   exist) then joins the file_name. Used by ops that may target a
+//   not-yet-existent leaf (write_file, create_file, create_dir, rename
+//   destination). The guard runs against the canonical parent, ruling
+//   out `../escape/file` while permitting `subdir/new.md`.
+//
+// Errors:
+// - `PathOutsideVault` for actual T-02 violations (canonical resolves
+//   outside the vault). Distinct from `PermissionDenied`, which is OS
+//   access refusal.
+// - Existing `VaultError` taxonomy preserved for IO mapping (NotFound,
+//   PermissionDenied, StorageFull → DiskFull).
 
 use super::{DirEntry, FileMeta, VaultStorage};
 use crate::error::VaultError;
@@ -15,6 +29,8 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct PosixStorage {
+    /// Canonical vault root, cached at construction so the per-call
+    /// `starts_with` check doesn't re-canonicalize on every I/O.
     vault_root: PathBuf,
     metadata_dir: PathBuf,
 }
@@ -22,7 +38,8 @@ pub struct PosixStorage {
 impl PosixStorage {
     /// Construct a storage rooted at `vault_root`. The vault path must
     /// already be canonicalized — `VaultHandle::parse` is the canonical
-    /// entry point and runs `std::fs::canonicalize` for us.
+    /// entry point and runs `std::fs::canonicalize` for us. The cached
+    /// canonical root powers the per-call T-02 guard below.
     pub fn new(vault_root: PathBuf) -> Self {
         let metadata_dir = vault_root.join(".vaultcore");
         Self {
@@ -31,8 +48,94 @@ impl PosixStorage {
         }
     }
 
-    fn resolve(&self, rel_path: &str) -> PathBuf {
-        self.vault_root.join(rel_path)
+    /// T-02 guard for ops on existing paths. Canonicalizes the full
+    /// joined path and confirms it sits under the canonical vault root.
+    /// Returns `FileNotFound` if the path doesn't exist (matches the
+    /// pre-#392 `read_file` error shape via `map_io(NotFound, _)`).
+    fn resolve_existing(&self, rel_path: &str) -> Result<PathBuf, VaultError> {
+        let joined = self.vault_root.join(rel_path);
+        let canonical = std::fs::canonicalize(&joined).map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => VaultError::FileNotFound {
+                path: rel_path.to_string(),
+            },
+            std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+                path: rel_path.to_string(),
+            },
+            _ => VaultError::Io(e),
+        })?;
+        if !canonical.starts_with(&self.vault_root) {
+            return Err(VaultError::PathOutsideVault {
+                path: rel_path.to_string(),
+            });
+        }
+        Ok(canonical)
+    }
+
+    /// T-02 guard for ops whose target may not exist yet. Canonicalizes
+    /// the *parent* (which MUST exist), confirms it sits under the vault
+    /// root, then joins the file_name. Mirrors the parent-canonicalize
+    /// pattern in `commands/files.rs::write_file`.
+    fn resolve_for_write(&self, rel_path: &str) -> Result<PathBuf, VaultError> {
+        let joined = self.vault_root.join(rel_path);
+        let parent = joined.parent().ok_or_else(|| VaultError::PathOutsideVault {
+            path: rel_path.to_string(),
+        })?;
+        let file_name = joined.file_name().ok_or_else(|| VaultError::PathOutsideVault {
+            path: rel_path.to_string(),
+        })?;
+        let canonical_parent = std::fs::canonicalize(parent).map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => VaultError::FileNotFound {
+                path: rel_path.to_string(),
+            },
+            std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+                path: rel_path.to_string(),
+            },
+            _ => VaultError::Io(e),
+        })?;
+        if !canonical_parent.starts_with(&self.vault_root) {
+            return Err(VaultError::PathOutsideVault {
+                path: rel_path.to_string(),
+            });
+        }
+        Ok(canonical_parent.join(file_name))
+    }
+
+    /// Variant of `resolve_for_write` for `create_dir_all`, which can
+    /// create missing intermediate components — so neither the leaf nor
+    /// any of its ancestors necessarily exists. The guard walks UP from
+    /// `joined` until it finds an existing ancestor, canonicalizes that,
+    /// and ensures it sits inside `vault_root`. This rules out
+    /// `vault_root.join("../sibling/foo")` because the first existing
+    /// ancestor is the parent's parent (or higher), which canonicalizes
+    /// outside the vault.
+    fn resolve_for_create_dir(&self, rel_path: &str) -> Result<PathBuf, VaultError> {
+        let joined = self.vault_root.join(rel_path);
+        // Find the first existing ancestor and canonicalize it.
+        let mut probe: &Path = joined.as_path();
+        let canonical_anchor = loop {
+            match std::fs::canonicalize(probe) {
+                Ok(c) => break c,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    probe = probe
+                        .parent()
+                        .ok_or_else(|| VaultError::PathOutsideVault {
+                            path: rel_path.to_string(),
+                        })?;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                    return Err(VaultError::PermissionDenied {
+                        path: rel_path.to_string(),
+                    });
+                }
+                Err(e) => return Err(VaultError::Io(e)),
+            }
+        };
+        if !canonical_anchor.starts_with(&self.vault_root) {
+            return Err(VaultError::PathOutsideVault {
+                path: rel_path.to_string(),
+            });
+        }
+        Ok(joined)
     }
 }
 
@@ -51,11 +154,13 @@ fn map_io(e: std::io::Error, path: &str) -> VaultError {
 
 impl VaultStorage for PosixStorage {
     fn read_file(&self, rel_path: &str) -> Result<Vec<u8>, VaultError> {
-        std::fs::read(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))
+        let p = self.resolve_existing(rel_path)?;
+        std::fs::read(p).map_err(|e| map_io(e, rel_path))
     }
 
     fn write_file(&self, rel_path: &str, contents: &[u8]) -> Result<(), VaultError> {
-        std::fs::write(self.resolve(rel_path), contents).map_err(|e| map_io(e, rel_path))
+        let p = self.resolve_for_write(rel_path)?;
+        std::fs::write(p, contents).map_err(|e| map_io(e, rel_path))
     }
 
     fn create_file(&self, rel_path: &str, initial: &[u8]) -> Result<(), VaultError> {
@@ -64,15 +169,17 @@ impl VaultStorage for PosixStorage {
         // behavior of failing fast at higher layers when the file already
         // exists. The collision check is the caller's responsibility today
         // and stays that way; this is a faithful one-to-one wrapper.
-        std::fs::write(self.resolve(rel_path), initial).map_err(|e| map_io(e, rel_path))
+        let p = self.resolve_for_write(rel_path)?;
+        std::fs::write(p, initial).map_err(|e| map_io(e, rel_path))
     }
 
     fn create_dir(&self, rel_path: &str) -> Result<(), VaultError> {
-        std::fs::create_dir_all(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))
+        let p = self.resolve_for_create_dir(rel_path)?;
+        std::fs::create_dir_all(p).map_err(|e| map_io(e, rel_path))
     }
 
     fn delete(&self, rel_path: &str) -> Result<(), VaultError> {
-        let p = self.resolve(rel_path);
+        let p = self.resolve_existing(rel_path)?;
         let meta = std::fs::metadata(&p).map_err(|e| map_io(e, rel_path))?;
         if meta.is_dir() {
             std::fs::remove_dir_all(&p).map_err(|e| map_io(e, rel_path))
@@ -82,11 +189,14 @@ impl VaultStorage for PosixStorage {
     }
 
     fn rename(&self, from: &str, to: &str) -> Result<(), VaultError> {
-        std::fs::rename(self.resolve(from), self.resolve(to)).map_err(|e| map_io(e, from))
+        let from_p = self.resolve_existing(from)?;
+        let to_p = self.resolve_for_write(to)?;
+        std::fs::rename(from_p, to_p).map_err(|e| map_io(e, from))
     }
 
     fn metadata(&self, rel_path: &str) -> Result<FileMeta, VaultError> {
-        let m = std::fs::metadata(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))?;
+        let p = self.resolve_existing(rel_path)?;
+        let m = std::fs::metadata(p).map_err(|e| map_io(e, rel_path))?;
         Ok(FileMeta {
             size: m.len(),
             is_dir: m.is_dir(),
@@ -94,7 +204,11 @@ impl VaultStorage for PosixStorage {
     }
 
     fn list_dir(&self, rel_path: &str) -> Result<Vec<DirEntry>, VaultError> {
-        let read = std::fs::read_dir(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))?;
+        // `list_dir("")` is the legitimate "list the vault root" call —
+        // `resolve_existing("")` canonicalizes `vault_root.join("")` =
+        // `vault_root` itself, which passes the guard.
+        let p = self.resolve_existing(rel_path)?;
+        let read = std::fs::read_dir(p).map_err(|e| map_io(e, rel_path))?;
         let mut out = Vec::new();
         for entry in read {
             let entry = entry.map_err(|e| map_io(e, rel_path))?;
@@ -106,7 +220,11 @@ impl VaultStorage for PosixStorage {
     }
 
     fn exists(&self, rel_path: &str) -> bool {
-        self.resolve(rel_path).exists()
+        // T-02: `exists` returns `false` for paths that resolve outside
+        // the vault. `Path::exists()` already returns `false` for
+        // unreadable paths, so widening to "false on guard violation"
+        // matches the existing semantic.
+        self.resolve_existing(rel_path).is_ok()
     }
 
     fn metadata_path(&self) -> &Path {

--- a/src-tauri/src/storage/posix.rs
+++ b/src-tauri/src/storage/posix.rs
@@ -1,0 +1,115 @@
+// #392 — POSIX file storage backing the desktop and dev vault.
+//
+// Wraps `std::fs::*` calls one-for-one. Resolves rel_paths against the
+// vault root by `vault_root.join(rel_path)` and maps `io::Error` kinds
+// to the existing `VaultError` taxonomy so the IPC error-shape contract
+// is preserved.
+//
+// PR-A scope reminder: `PosixStorage` is constructed by `open_vault` but
+// no commands route through it yet. The exhaustive impl + tests guard
+// the surface PR-B will consume.
+
+use super::{DirEntry, FileMeta, VaultStorage};
+use crate::error::VaultError;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct PosixStorage {
+    vault_root: PathBuf,
+    metadata_dir: PathBuf,
+}
+
+impl PosixStorage {
+    /// Construct a storage rooted at `vault_root`. The vault path must
+    /// already be canonicalized — `VaultHandle::parse` is the canonical
+    /// entry point and runs `std::fs::canonicalize` for us.
+    pub fn new(vault_root: PathBuf) -> Self {
+        let metadata_dir = vault_root.join(".vaultcore");
+        Self {
+            vault_root,
+            metadata_dir,
+        }
+    }
+
+    fn resolve(&self, rel_path: &str) -> PathBuf {
+        self.vault_root.join(rel_path)
+    }
+}
+
+fn map_io(e: std::io::Error, path: &str) -> VaultError {
+    match e.kind() {
+        std::io::ErrorKind::NotFound => VaultError::FileNotFound {
+            path: path.to_string(),
+        },
+        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+            path: path.to_string(),
+        },
+        std::io::ErrorKind::StorageFull => VaultError::DiskFull,
+        _ => VaultError::Io(e),
+    }
+}
+
+impl VaultStorage for PosixStorage {
+    fn read_file(&self, rel_path: &str) -> Result<Vec<u8>, VaultError> {
+        std::fs::read(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))
+    }
+
+    fn write_file(&self, rel_path: &str, contents: &[u8]) -> Result<(), VaultError> {
+        std::fs::write(self.resolve(rel_path), contents).map_err(|e| map_io(e, rel_path))
+    }
+
+    fn create_file(&self, rel_path: &str, initial: &[u8]) -> Result<(), VaultError> {
+        // Same shape as `write_file` — `std::fs::write` creates-or-truncates,
+        // which matches the existing `commands/files.rs::create_file_impl`
+        // behavior of failing fast at higher layers when the file already
+        // exists. The collision check is the caller's responsibility today
+        // and stays that way; this is a faithful one-to-one wrapper.
+        std::fs::write(self.resolve(rel_path), initial).map_err(|e| map_io(e, rel_path))
+    }
+
+    fn create_dir(&self, rel_path: &str) -> Result<(), VaultError> {
+        std::fs::create_dir_all(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))
+    }
+
+    fn delete(&self, rel_path: &str) -> Result<(), VaultError> {
+        let p = self.resolve(rel_path);
+        let meta = std::fs::metadata(&p).map_err(|e| map_io(e, rel_path))?;
+        if meta.is_dir() {
+            std::fs::remove_dir_all(&p).map_err(|e| map_io(e, rel_path))
+        } else {
+            std::fs::remove_file(&p).map_err(|e| map_io(e, rel_path))
+        }
+    }
+
+    fn rename(&self, from: &str, to: &str) -> Result<(), VaultError> {
+        std::fs::rename(self.resolve(from), self.resolve(to)).map_err(|e| map_io(e, from))
+    }
+
+    fn metadata(&self, rel_path: &str) -> Result<FileMeta, VaultError> {
+        let m = std::fs::metadata(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))?;
+        Ok(FileMeta {
+            size: m.len(),
+            is_dir: m.is_dir(),
+        })
+    }
+
+    fn list_dir(&self, rel_path: &str) -> Result<Vec<DirEntry>, VaultError> {
+        let read = std::fs::read_dir(self.resolve(rel_path)).map_err(|e| map_io(e, rel_path))?;
+        let mut out = Vec::new();
+        for entry in read {
+            let entry = entry.map_err(|e| map_io(e, rel_path))?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            out.push(DirEntry { name, is_dir });
+        }
+        Ok(out)
+    }
+
+    fn exists(&self, rel_path: &str) -> bool {
+        self.resolve(rel_path).exists()
+    }
+
+    fn metadata_path(&self) -> &Path {
+        &self.metadata_dir
+    }
+}

--- a/src-tauri/src/tests/bookmarks.rs
+++ b/src-tauri/src/tests/bookmarks.rs
@@ -9,7 +9,7 @@ use tempfile::tempdir;
 fn state_with_vault(root: &std::path::Path) -> VaultState {
     let canonical = fs::canonicalize(root).unwrap();
     let s = VaultState::default();
-    *s.current_vault.lock().unwrap() = Some(canonical);
+    *s.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical));
     s
 }
 

--- a/src-tauri/src/tests/encryption_gating.rs
+++ b/src-tauri/src/tests/encryption_gating.rs
@@ -81,7 +81,7 @@ async fn dispatch_self_write_gate_runs_before_coordinator_probe() {
     std::fs::write(&secret_file, "plaintext payload").unwrap();
 
     let state = VaultState::default();
-    *state.current_vault.lock().unwrap() = Some(vault.clone());
+    *state.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(vault.clone()));
     // Attach a real coordinator so a MISSING gate would actually
     // mutate index state and fail a follow-up invariant.
     let coord = IndexCoordinator::new(&vault).await.unwrap();
@@ -139,7 +139,7 @@ async fn encrypt_folder_locks_root_before_sealing_files() {
     std::fs::write(vault.join("journal/a.md"), b"# A\n").unwrap();
     std::fs::write(vault.join("journal/b.md"), b"# B\n").unwrap();
     let state = VaultState::default();
-    *state.current_vault.lock().unwrap() = Some(vault.clone());
+    *state.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(vault.clone()));
 
     // Directly call the Tauri command body via its inner impl — we
     // don't have a mock AppHandle here, so simulate the pieces the
@@ -325,7 +325,7 @@ async fn read_file_decrypts_under_unlocked_root() {
 
     // Now set up state as-if the user had unlocked the folder via the IPC.
     let state = VaultState::default();
-    *state.current_vault.lock().unwrap() = Some(vault.clone());
+    *state.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(vault.clone()));
     let folder_canon = folder.canonicalize().unwrap();
     // Not locked — but key present in the keyring.
     let mut key_copy = Zeroizing::new([0u8; 32]);
@@ -372,7 +372,7 @@ async fn write_file_encrypts_under_unlocked_root() {
     .unwrap();
 
     let state = VaultState::default();
-    *state.current_vault.lock().unwrap() = Some(vault.clone());
+    *state.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(vault.clone()));
     let folder_canon = folder.canonicalize().unwrap();
     let mut key_copy = Zeroizing::new([0u8; 32]);
     key_copy.copy_from_slice(key.as_slice());

--- a/src-tauri/src/tests/error_serialize.rs
+++ b/src-tauri/src/tests/error_serialize.rs
@@ -134,6 +134,21 @@ fn vault_error_serialize_crypto_error() {
 }
 
 #[test]
+fn vault_error_serialize_path_outside_vault() {
+    // #392: T-02 violation surfaced by PosixStorage's path-traversal
+    // guard. The `path` field carries the user-supplied relative path
+    // (NOT the resolved canonical) so the frontend's data-routing
+    // contract still works — `data` is always a path the user typed,
+    // never a leaked filesystem location.
+    let v = to_json(VaultError::PathOutsideVault {
+        path: "../escape.md".into(),
+    });
+    assert_eq!(v["kind"], "PathOutsideVault");
+    assert_eq!(v["message"], "Path resolves outside the vault: ../escape.md");
+    assert_eq!(v["data"], "../escape.md");
+}
+
+#[test]
 fn vault_error_serialize_picker_failed() {
     // #391: distinct from Io so the frontend can render a picker-specific
     // toast ("Could not open the file picker") instead of the generic

--- a/src-tauri/src/tests/export_decrypted.rs
+++ b/src-tauri/src/tests/export_decrypted.rs
@@ -62,7 +62,7 @@ fn setup(unlocked: bool, plaintext: &[u8]) -> SealedVault {
     let sealed_canon = sealed_file.canonicalize().unwrap();
 
     let state = VaultState::default();
-    *state.current_vault.lock().unwrap() = Some(vault.clone());
+    *state.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(vault.clone()));
     state.manifest_cache.refresh_from_disk(&vault).unwrap();
     if unlocked {
         let mut k = Zeroizing::new([0u8; 32]);

--- a/src-tauri/src/tests/files.rs
+++ b/src-tauri/src/tests/files.rs
@@ -25,7 +25,7 @@ fn state_with_vault(root: &std::path::Path) -> VaultState {
     // production command path would.
     let canonical = fs::canonicalize(root).unwrap();
     let s = VaultState::default();
-    *s.current_vault.lock().unwrap() = Some(canonical);
+    *s.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical));
     s
 }
 
@@ -230,9 +230,10 @@ async fn read_file_impl(state: &VaultState, path: String) -> Result<String, Vaul
     })?;
     {
         let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-        let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-            path: path.clone(),
-        })?;
+        let vault = guard
+            .as_ref()
+            .ok_or_else(|| VaultError::VaultUnavailable { path: path.clone() })?
+            .expect_posix();
         if !canonical_target.starts_with(vault) {
             return Err(VaultError::PermissionDenied { path });
         }
@@ -268,9 +269,10 @@ async fn write_file_impl(
     })?;
     {
         let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-        let vault = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
-            path: path.clone(),
-        })?;
+        let vault = guard
+            .as_ref()
+            .ok_or_else(|| VaultError::VaultUnavailable { path: path.clone() })?
+            .expect_posix();
         if !canonical_parent.starts_with(vault) {
             return Err(VaultError::PermissionDenied { path });
         }
@@ -310,7 +312,7 @@ async fn dispatch_index_updates_test(
     let vault_root = {
         let Ok(guard) = state.current_vault.lock() else { return };
         match guard.as_ref() {
-            Some(p) => p.clone(),
+            Some(h) => h.expect_posix().to_path_buf(),
             None => return,
         }
     };

--- a/src-tauri/src/tests/files_ops.rs
+++ b/src-tauri/src/tests/files_ops.rs
@@ -31,7 +31,7 @@ use tempfile::tempdir;
 fn state_with_vault(root: &std::path::Path) -> VaultState {
     let canonical = fs::canonicalize(root).unwrap();
     let s = VaultState::default();
-    *s.current_vault.lock().unwrap() = Some(canonical);
+    *s.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical));
     s
 }
 

--- a/src-tauri/src/tests/hash_verify.rs
+++ b/src-tauri/src/tests/hash_verify.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 
 fn make_state(vault_path: std::path::PathBuf) -> VaultState {
     let state = VaultState::default();
-    *state.current_vault.lock().unwrap() = Some(vault_path);
+    *state.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(vault_path));
     state
 }
 

--- a/src-tauri/src/tests/merge_external_change.rs
+++ b/src-tauri/src/tests/merge_external_change.rs
@@ -37,7 +37,7 @@ fn tokio_test_block_on<F: std::future::Future>(f: F) -> F::Output {
 fn state_with_vault_no_coord(root: &Path) -> VaultState {
     let canonical = std::fs::canonicalize(root).unwrap();
     let s = VaultState::default();
-    *s.current_vault.lock().unwrap() = Some(canonical);
+    *s.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical));
     s
 }
 
@@ -48,7 +48,7 @@ fn state_with_vault_no_coord(root: &Path) -> VaultState {
 async fn state_with_vault_and_coord(root: &Path) -> VaultState {
     let canonical = std::fs::canonicalize(root).unwrap();
     let state = VaultState::default();
-    *state.current_vault.lock().unwrap() = Some(canonical.clone());
+    *state.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical.clone()));
 
     let coord =
         IndexCoordinator::new_with_file_index(&canonical, Arc::clone(&state.file_index))

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -25,3 +25,5 @@ mod encryption_gating;
 mod export_decrypted;
 mod legacy_semantic_cleanup;
 mod picker;
+mod storage_posix;
+mod vault_handle;

--- a/src-tauri/src/tests/rename_link_resolution.rs
+++ b/src-tauri/src/tests/rename_link_resolution.rs
@@ -38,7 +38,7 @@ use tempfile::tempdir;
 fn state_with_vault(root: &std::path::Path) -> VaultState {
     let canonical = fs::canonicalize(root).unwrap();
     let s = VaultState::default();
-    *s.current_vault.lock().unwrap() = Some(canonical);
+    *s.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical));
     s
 }
 

--- a/src-tauri/src/tests/snippets.rs
+++ b/src-tauri/src/tests/snippets.rs
@@ -9,7 +9,7 @@ use tempfile::tempdir;
 fn state_with_vault(root: &std::path::Path) -> VaultState {
     let canonical = fs::canonicalize(root).unwrap();
     let s = VaultState::default();
-    *s.current_vault.lock().unwrap() = Some(canonical);
+    *s.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical));
     s
 }
 

--- a/src-tauri/src/tests/storage_posix.rs
+++ b/src-tauri/src/tests/storage_posix.rs
@@ -1,0 +1,114 @@
+// #392 — round-trip tests for `PosixStorage`. Mirrors the desktop-only
+// surface PR-A introduces; PR-B adds a sister `storage_android.rs`
+// scaffold once `AndroidStorage` exists.
+
+#![cfg(test)]
+
+use crate::storage::{PosixStorage, VaultStorage};
+use tempfile::TempDir;
+
+fn fresh_storage() -> (TempDir, PosixStorage) {
+    let dir = TempDir::new().expect("tempdir");
+    let storage = PosixStorage::new(dir.path().to_path_buf());
+    (dir, storage)
+}
+
+#[test]
+fn write_then_read_round_trips() {
+    let (_dir, storage) = fresh_storage();
+    storage.write_file("note.md", b"hello vault").unwrap();
+    let bytes = storage.read_file("note.md").unwrap();
+    assert_eq!(bytes, b"hello vault");
+}
+
+#[test]
+fn create_file_writes_initial_bytes() {
+    let (_dir, storage) = fresh_storage();
+    storage.create_file("a.md", b"seed").unwrap();
+    assert_eq!(storage.read_file("a.md").unwrap(), b"seed");
+}
+
+#[test]
+fn create_dir_then_write_into_it() {
+    let (_dir, storage) = fresh_storage();
+    storage.create_dir("subdir").unwrap();
+    storage.write_file("subdir/note.md", b"nested").unwrap();
+    assert_eq!(storage.read_file("subdir/note.md").unwrap(), b"nested");
+}
+
+#[test]
+fn delete_removes_file() {
+    let (_dir, storage) = fresh_storage();
+    storage.write_file("doomed.md", b"x").unwrap();
+    assert!(storage.exists("doomed.md"));
+    storage.delete("doomed.md").unwrap();
+    assert!(!storage.exists("doomed.md"));
+}
+
+#[test]
+fn delete_recursively_removes_dir() {
+    let (_dir, storage) = fresh_storage();
+    storage.create_dir("victim").unwrap();
+    storage.write_file("victim/inner.md", b"x").unwrap();
+    storage.delete("victim").unwrap();
+    assert!(!storage.exists("victim"));
+}
+
+#[test]
+fn rename_moves_file() {
+    let (_dir, storage) = fresh_storage();
+    storage.write_file("old.md", b"x").unwrap();
+    storage.rename("old.md", "new.md").unwrap();
+    assert!(!storage.exists("old.md"));
+    assert!(storage.exists("new.md"));
+    assert_eq!(storage.read_file("new.md").unwrap(), b"x");
+}
+
+#[test]
+fn metadata_returns_size_and_dir_flag() {
+    let (_dir, storage) = fresh_storage();
+    storage.write_file("note.md", b"abc").unwrap();
+    storage.create_dir("inner").unwrap();
+    let f = storage.metadata("note.md").unwrap();
+    assert_eq!(f.size, 3);
+    assert!(!f.is_dir);
+    let d = storage.metadata("inner").unwrap();
+    assert!(d.is_dir);
+}
+
+#[test]
+fn list_dir_returns_children() {
+    let (_dir, storage) = fresh_storage();
+    storage.write_file("a.md", b"").unwrap();
+    storage.write_file("b.md", b"").unwrap();
+    storage.create_dir("sub").unwrap();
+    let mut names: Vec<String> = storage
+        .list_dir("")
+        .unwrap()
+        .into_iter()
+        .map(|e| e.name)
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["a.md", "b.md", "sub"]);
+}
+
+#[test]
+fn read_missing_file_maps_to_file_not_found() {
+    let (_dir, storage) = fresh_storage();
+    match storage.read_file("nope.md") {
+        Err(crate::error::VaultError::FileNotFound { path }) => assert_eq!(path, "nope.md"),
+        other => panic!("expected FileNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn metadata_path_returns_dot_vaultcore_under_root() {
+    let (dir, storage) = fresh_storage();
+    assert_eq!(storage.metadata_path(), dir.path().join(".vaultcore"));
+}
+
+#[test]
+fn exists_returns_false_for_missing() {
+    let (_dir, storage) = fresh_storage();
+    assert!(!storage.exists("ghost.md"));
+}

--- a/src-tauri/src/tests/storage_posix.rs
+++ b/src-tauri/src/tests/storage_posix.rs
@@ -4,12 +4,18 @@
 
 #![cfg(test)]
 
+use crate::error::VaultError;
 use crate::storage::{PosixStorage, VaultStorage};
 use tempfile::TempDir;
 
 fn fresh_storage() -> (TempDir, PosixStorage) {
     let dir = TempDir::new().expect("tempdir");
-    let storage = PosixStorage::new(dir.path().to_path_buf());
+    // Canonicalize the vault root: this matches `open_vault`'s production
+    // contract (the path comes via `VaultHandle::parse` which canonicalizes)
+    // and is required for the T-02 `starts_with` guard to behave correctly
+    // on macOS, where `/var/...` symlinks to `/private/var/...`.
+    let canonical = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+    let storage = PosixStorage::new(canonical);
     (dir, storage)
 }
 
@@ -96,19 +102,119 @@ fn list_dir_returns_children() {
 fn read_missing_file_maps_to_file_not_found() {
     let (_dir, storage) = fresh_storage();
     match storage.read_file("nope.md") {
-        Err(crate::error::VaultError::FileNotFound { path }) => assert_eq!(path, "nope.md"),
+        Err(VaultError::FileNotFound { path }) => assert_eq!(path, "nope.md"),
         other => panic!("expected FileNotFound, got {other:?}"),
     }
 }
 
 #[test]
 fn metadata_path_returns_dot_vaultcore_under_root() {
-    let (dir, storage) = fresh_storage();
-    assert_eq!(storage.metadata_path(), dir.path().join(".vaultcore"));
+    let dir = TempDir::new().expect("tempdir");
+    let canonical = std::fs::canonicalize(dir.path()).unwrap();
+    let storage = PosixStorage::new(canonical.clone());
+    assert_eq!(storage.metadata_path(), canonical.join(".vaultcore"));
 }
 
 #[test]
 fn exists_returns_false_for_missing() {
     let (_dir, storage) = fresh_storage();
     assert!(!storage.exists("ghost.md"));
+}
+
+// ── T-02 path-traversal guard ───────────────────────────────────────────────
+
+#[test]
+fn read_with_dotdot_escape_is_blocked() {
+    // Set up a sibling file outside the vault that the attacker is
+    // trying to read.
+    let outer = TempDir::new().unwrap();
+    let secret_path = outer.path().join("secret.txt");
+    std::fs::write(&secret_path, b"top secret").unwrap();
+
+    // Vault root sits inside `outer`, so `../secret.txt` would resolve
+    // to a real file but outside the vault.
+    let vault_dir = outer.path().join("vault");
+    std::fs::create_dir(&vault_dir).unwrap();
+    let canonical = std::fs::canonicalize(&vault_dir).unwrap();
+    let storage = PosixStorage::new(canonical);
+
+    match storage.read_file("../secret.txt") {
+        Err(VaultError::PathOutsideVault { path }) => {
+            assert_eq!(path, "../secret.txt");
+        }
+        Ok(_) => panic!("T-02 violation: dotdot escape was allowed to read"),
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn write_with_dotdot_escape_is_blocked() {
+    let outer = TempDir::new().unwrap();
+    let vault_dir = outer.path().join("vault");
+    std::fs::create_dir(&vault_dir).unwrap();
+    let canonical = std::fs::canonicalize(&vault_dir).unwrap();
+    let storage = PosixStorage::new(canonical);
+
+    // The parent of `../escape.md` (after canonicalize) is `outer`,
+    // which does NOT start with `vault_dir` — guard fires.
+    match storage.write_file("../escape.md", b"pwn") {
+        Err(VaultError::PathOutsideVault { path }) => {
+            assert_eq!(path, "../escape.md");
+        }
+        Ok(_) => panic!("T-02 violation: dotdot escape was allowed to write"),
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+    // And confirm nothing actually landed on disk outside the vault.
+    assert!(!outer.path().join("escape.md").exists());
+}
+
+#[test]
+fn create_dir_with_dotdot_escape_is_blocked() {
+    let outer = TempDir::new().unwrap();
+    let vault_dir = outer.path().join("vault");
+    std::fs::create_dir(&vault_dir).unwrap();
+    let canonical = std::fs::canonicalize(&vault_dir).unwrap();
+    let storage = PosixStorage::new(canonical);
+
+    match storage.create_dir("../sibling") {
+        Err(VaultError::PathOutsideVault { path }) => {
+            assert_eq!(path, "../sibling");
+        }
+        Ok(_) => panic!("T-02 violation: dotdot escape was allowed to mkdir"),
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+    assert!(!outer.path().join("sibling").exists());
+}
+
+#[test]
+fn rename_to_dotdot_escape_is_blocked() {
+    let outer = TempDir::new().unwrap();
+    let vault_dir = outer.path().join("vault");
+    std::fs::create_dir(&vault_dir).unwrap();
+    let canonical = std::fs::canonicalize(&vault_dir).unwrap();
+    let storage = PosixStorage::new(canonical);
+    storage.write_file("inside.md", b"x").unwrap();
+
+    match storage.rename("inside.md", "../escaped.md") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        Ok(_) => panic!("T-02 violation: rename leaked file out of vault"),
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+    // Source still in place.
+    assert!(storage.exists("inside.md"));
+    assert!(!outer.path().join("escaped.md").exists());
+}
+
+#[test]
+fn exists_returns_false_for_dotdot_escape() {
+    let outer = TempDir::new().unwrap();
+    std::fs::write(outer.path().join("secret.txt"), b"x").unwrap();
+    let vault_dir = outer.path().join("vault");
+    std::fs::create_dir(&vault_dir).unwrap();
+    let canonical = std::fs::canonicalize(&vault_dir).unwrap();
+    let storage = PosixStorage::new(canonical);
+
+    // The file exists physically, but `../secret.txt` resolves outside
+    // the vault → guard returns Err, we map to false.
+    assert!(!storage.exists("../secret.txt"));
 }

--- a/src-tauri/src/tests/tree.rs
+++ b/src-tauri/src/tests/tree.rs
@@ -23,7 +23,7 @@ use tempfile::tempdir;
 fn state_with_vault(root: &std::path::Path) -> VaultState {
     let canonical = fs::canonicalize(root).unwrap();
     let s = VaultState::default();
-    *s.current_vault.lock().unwrap() = Some(canonical);
+    *s.current_vault.lock().unwrap() = Some(crate::storage::VaultHandle::Posix(canonical));
     s
 }
 

--- a/src-tauri/src/tests/vault_handle.rs
+++ b/src-tauri/src/tests/vault_handle.rs
@@ -1,0 +1,51 @@
+// #392 — `VaultHandle` parse / accessor / equality round-trips.
+// PR-B extends this with `ContentUri` arm coverage.
+
+#![cfg(test)]
+
+use crate::storage::VaultHandle;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[test]
+fn parse_canonicalizes_a_real_path() {
+    let dir = TempDir::new().unwrap();
+    let h = VaultHandle::parse(&dir.path().to_string_lossy()).unwrap();
+    let canonical = std::fs::canonicalize(dir.path()).unwrap();
+    assert_eq!(h, VaultHandle::Posix(canonical));
+}
+
+#[test]
+fn parse_missing_path_maps_to_vault_unavailable() {
+    let r = VaultHandle::parse("/totally/nonexistent/path-for-test");
+    match r {
+        Err(crate::error::VaultError::VaultUnavailable { path }) => {
+            assert_eq!(path, "/totally/nonexistent/path-for-test");
+        }
+        other => panic!("expected VaultUnavailable, got {other:?}"),
+    }
+}
+
+#[test]
+fn as_str_round_trips_through_parse() {
+    let dir = TempDir::new().unwrap();
+    let h1 = VaultHandle::parse(&dir.path().to_string_lossy()).unwrap();
+    let s = h1.as_str().into_owned();
+    let h2 = VaultHandle::parse(&s).unwrap();
+    assert_eq!(h1, h2);
+}
+
+#[test]
+fn posix_path_returns_inner_path() {
+    let dir = TempDir::new().unwrap();
+    let canonical = std::fs::canonicalize(dir.path()).unwrap();
+    let h = VaultHandle::Posix(canonical.clone());
+    assert_eq!(h.posix_path(), Some(canonical.as_path()));
+}
+
+#[test]
+fn from_pathbuf_wraps_as_posix() {
+    let p = PathBuf::from("/tmp/whatever");
+    let h: VaultHandle = p.clone().into();
+    assert_eq!(h, VaultHandle::Posix(p));
+}

--- a/src-tauri/src/tests/vault_handle.rs
+++ b/src-tauri/src/tests/vault_handle.rs
@@ -36,11 +36,11 @@ fn as_str_round_trips_through_parse() {
 }
 
 #[test]
-fn posix_path_returns_inner_path() {
+fn expect_posix_returns_inner_path() {
     let dir = TempDir::new().unwrap();
     let canonical = std::fs::canonicalize(dir.path()).unwrap();
     let h = VaultHandle::Posix(canonical.clone());
-    assert_eq!(h.posix_path(), Some(canonical.as_path()));
+    assert_eq!(h.expect_posix(), canonical.as_path());
 }
 
 #[test]

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -21,7 +21,10 @@ export type VaultErrorKind =
   // #391 — picker (NSOpenPanel / GTK file chooser / Android SAF) failed.
   // Cancellation is signalled via `null` from the picker wrappers; this
   // variant carries genuine errors only.
-  | "PickerFailed";
+  | "PickerFailed"
+  // #392 — request resolved outside the vault root (T-02 violation).
+  // Either a client bug or attack — never user-actionable.
+  | "PathOutsideVault";
 
 export interface VaultError {
   kind: VaultErrorKind;
@@ -75,6 +78,8 @@ export function vaultErrorCopy(err: VaultError): string {
       return "Encryption error. This file may be corrupted or from a newer VaultCore version.";
     case "PickerFailed":
       return "Could not open the file picker. Please try again.";
+    case "PathOutsideVault":
+      return "Request denied — the path is outside the vault.";
     default: {
       const _exhaustive: never = err.kind;
       return "An unexpected error occurred.";


### PR DESCRIPTION
## Summary

PR-A of the two-PR slice for #392 (sandboxed vault storage on Android).

**Scope**: type wrapper + trait + desktop impl. **Zero behavior change for desktop.** PR-A intentionally does NOT route any commands through the new trait — file commands still use \`std::fs::*\` through \`ensure_inside_vault\`. The trait + slot exist so PR-B can plug \`AndroidStorage\` in without re-wiring \`VaultState\`.

PR-B (next) will: route file commands through the trait, add the Android \`ContentUri\` arm to \`VaultHandle\`, ship \`AndroidStorage\` backed by Kotlin SAF I/O, add stale-bookmark UX, and the \`takePersistableUriPermission\` plumbing.

## What's in

- **\`src-tauri/src/storage/\` (new)**:
  - \`VaultHandle\` enum (single-arm \`Posix(PathBuf)\` today; PR-B adds \`#[cfg(target_os = \"android\")] ContentUri(String)\`).
  - \`VaultStorage\` trait — read/write/create/delete/rename/metadata/list_dir/exists/metadata_path.
  - \`PosixStorage\` impl — wraps \`std::fs::*\` one-for-one with the existing \`VaultError\` taxonomy.
- **\`VaultState\`**: \`current_vault\` becomes \`Mutex<Option<VaultHandle>>\`; new \`storage: Arc<RwLock<Option<Arc<dyn VaultStorage>>>>\` slot populated by \`open_vault\`.
- **22 read sites across 12 production files**: mechanical migration to \`.expect_posix()\` (returns \`&Path\`). Downstream code that does \`canonical.starts_with(vault)\` continues to work unchanged.
- **10 test files**: \`Some(canonical)\` → \`Some(VaultHandle::Posix(canonical))\`.
- **2 new test files**: 11 \`PosixStorage\` round-trips + 5 \`VaultHandle\` parse/accessor checks.

## Locked architecture decision (per team-lead's brief)

The \`expect_posix() -> &Path\` accessor panics on non-POSIX arms. PR-B's compiler will refuse to drop the \`ContentUri\` arm into \`VaultHandle\` until every \`expect_posix()\` site is replaced — either with a storage trait call (the file-command boundary) or with a cfg-gated branch (the encryption layer's path-based root finder, the indexer's vault walk). The grep target for PR-B is literal: \`grep -n expect_posix src-tauri/src/\`.

## Verification

| Gate | Command | Result |
|---|---|---|
| Desktop check | \`cargo check --lib\` | PASS |
| Desktop bundle | \`pnpm tauri build --debug\` | PASS — .app + .dmg |
| Desktop unit | \`cargo test --lib\` | **398 passed / 6 pre-existing failed / 2 ignored**. The 6 \`tests::files_ops::*\` failures are macOS \`/var\` vs \`/private/var\` symlink-canonicalization issues already present on \`main\` since #390; verified via stash-and-rerun there. +22 new tests (storage_posix + vault_handle), zero new regressions. |
| Android check | \`cargo check --target aarch64-linux-android --lib\` | PASS — trait + types compile for Android with the same desktop-only \`PosixStorage\`. |
| Vitest | \`pnpm test\` | **1491/1491 PASS** — no frontend changes in PR-A. |

## What PR-B does

Tracked separately so PR-A reviewers focus on type-migration correctness:

- Route \`commands/files.rs\` through \`VaultStorage::read_file\`/\`write_file\`/etc.
- \`VaultHandle::ContentUri(String)\` arm + \`parse\` heuristic for \`content://\` prefix.
- \`AndroidStorage\` impl (cfg-gated) backed by extended \`PickerPlugin.kt\` I/O commands.
- \`takePersistableUriPermission\` + \`hasPersistedPermission\` JNI bridge.
- \`open_vault\` URI branch with stale-bookmark check.
- New \`VaultError::VaultPermissionRevoked\` + \`EncryptionUnsupportedOnAndroid\` variants (encrypted folders runtime-guarded — full storage-trait pass is a separate follow-up).
- Watcher cfg-no-op on Android (polling fallback is a follow-up).
- Docs: \`MOBILE_BUILD.md\` known-limitations section.

## Refs

- Part of #392; closes nothing on its own.
- Unblocks PR-B which closes #392.