### PR TITLE
feat(mobile): properties bottom sheet (#393)

### DIFF
--- a/src/components/Layout/MobileBurgerSheet.svelte
+++ b/src/components/Layout/MobileBurgerSheet.svelte
@@ -33,9 +33,16 @@
   let {
     open,
     onClose,
+    onSelectProperties,
   }: {
     open: boolean;
     onClose: () => void;
+    /**
+     * #393 — invoked when the user taps the Properties row. The parent
+     * is expected to flip its `mobilePropertiesOpen` flag; the burger
+     * sheet then calls `onClose()` so the two sheets never co-render.
+     */
+    onSelectProperties: () => void;
   } = $props();
 
   type PanelId = "backlinks" | "bookmarks" | "outline" | "outgoing";
@@ -73,7 +80,7 @@
     id: "backlinks" | "bookmarks" | "outline" | "outgoing" | "properties" | "settings";
     label: string;
     icon: typeof Link2;
-    action: "panel" | "stub";
+    action: "panel" | "properties" | "stub";
     panelId?: PanelId;
     stubMessage?: string;
   };
@@ -86,7 +93,7 @@
     { id: "bookmarks",  label: "Lesezeichen",       icon: Bookmark,     action: "panel", panelId: "bookmarks" },
     { id: "outline",    label: "Gliederung",        icon: List,         action: "panel", panelId: "outline" },
     { id: "outgoing",   label: "Ausgehende Links",  icon: ArrowUpRight, action: "panel", panelId: "outgoing" },
-    { id: "properties", label: "Eigenschaften",     icon: FileText,     action: "stub",  stubMessage: "Eigenschaften folgen" },
+    { id: "properties", label: "Eigenschaften",     icon: FileText,     action: "properties" },
     { id: "settings",   label: "Einstellungen",     icon: SettingsIcon, action: "stub",  stubMessage: "Einstellungen folgen" },
   ];
 
@@ -102,10 +109,17 @@
       activePanel = row.panelId;
       return;
     }
-    // TODO #393 (properties) / #394 (settings). The toast tells the user
-    // the destination exists but isn't wired yet; closing the sheet keeps
-    // the More tab's tap-feedback intact (no dead-end where the menu
-    // stays open after an apparent-no-op).
+    if (row.action === "properties") {
+      // #393 — hand off to the parent's properties sheet, then close
+      // ourselves so the two sheets never co-render.
+      onSelectProperties();
+      onClose();
+      return;
+    }
+    // TODO #394 (settings). The toast tells the user the destination
+    // exists but isn't wired yet; closing the sheet keeps the More tab's
+    // tap-feedback intact (no dead-end where the menu stays open after
+    // an apparent-no-op).
     if (row.stubMessage) toastStore.info(row.stubMessage);
     onClose();
   }

--- a/src/components/Layout/MobileBurgerSheet.svelte
+++ b/src/components/Layout/MobileBurgerSheet.svelte
@@ -10,9 +10,11 @@
    *   1. Menu — a 6-row list. Default state when the sheet opens.
    *   2. Panel — the selected sub-panel rendered inline with a back button.
    *
-   * Properties + Settings rows are TODO placeholders that stub-toast and
-   * close the sheet; #393 and #394 will replace those branches with real
-   * destinations.
+   * Properties row hands off to the Properties bottom sheet (#393) via
+   * the `onSelectProperties` prop, then closes itself so the two sheets
+   * never co-render. Settings row remains a TODO #394 stub-toast that
+   * will be replaced with a real destination once the settings layout
+   * lands.
    */
   import {
     Link2,

--- a/src/components/Layout/MobilePropertiesSheet.svelte
+++ b/src/components/Layout/MobilePropertiesSheet.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+  /**
+   * MobilePropertiesSheet — mobile bottom-sheet wrapper for the
+   * Properties / frontmatter panel (#393).
+   *
+   * Parent-gated: VaultLayout decides via `{#if isMobile}` when to render
+   * and owns the `open` flag. The component itself does NOT subscribe to
+   * viewportStore — same convention as MobileBurgerSheet (#397).
+   *
+   * Body: the existing `<PropertiesPanel />` is embedded as-is. It
+   * subscribes to `activeViewStore` directly, so frontmatter editing
+   * lands on whatever CM6 view is active in the editor pane behind the
+   * scrim — no prop wiring needed.
+   *
+   * Keyboard-aware lift via `--vc-keyboard-height` (#395):
+   *   - The sheet is positioned `bottom: var(--vc-keyboard-height, 0px)`
+   *     so it lifts above the on-screen keyboard when the user taps into
+   *     a frontmatter input.
+   *   - `max-height` ALSO subtracts the keyboard height so the sheet
+   *     doesn't extend behind the keyboard (otherwise the visible top
+   *     would be pushed up while the bottom rows stayed hidden).
+   *   - On desktop / closed-keyboard mobile the var is 0px → byte-
+   *     identical to the burger sheet's bottom-anchored placement.
+   *
+   * Drag-handle is a pure visual affordance per the burger precedent
+   * — swipe-to-dismiss gesture is deferred (scrim-tap + ESC cover
+   * dismissal). Follow-up if UAT requests.
+   *
+   * z-index hierarchy:
+   *   drawer 50  <  scrim 49
+   *      burger scrim 59  /  sheet 60
+   *      properties scrim 69  /  sheet 70
+   *      modals 199+
+   */
+  import PropertiesPanel from "../Properties/PropertiesPanel.svelte";
+
+  let {
+    open,
+    onClose,
+  }: {
+    open: boolean;
+    onClose: () => void;
+  } = $props();
+
+  // bind:this writes the live DOM node here. Svelte 5 wants a $state
+  // target even for imperative refs because the keydown trap reads it
+  // from inside reactive scope — same pattern as burger sheet's sheetEl.
+  let sheetEl = $state<HTMLDivElement | undefined>(undefined);
+
+  // Focus the first focusable inside the sheet on open. Microtask wait
+  // so CSS class application paints before focus jumps. Mirrors burger.
+  $effect(() => {
+    if (open) {
+      queueMicrotask(() => {
+        const first = sheetEl?.querySelector<HTMLElement>(
+          'button:not([tabindex="-1"]), a:not([tabindex="-1"]), input:not([tabindex="-1"])',
+        );
+        first?.focus();
+      });
+    }
+  });
+
+  // Standard keyboard-trap selector — anything that can take focus,
+  // minus explicitly disabled or programmatically-only-focusable nodes.
+  const FOCUSABLE_SELECTOR = [
+    'button:not([disabled]):not([tabindex="-1"])',
+    'a[href]:not([tabindex="-1"])',
+    'input:not([disabled]):not([tabindex="-1"])',
+    'select:not([disabled]):not([tabindex="-1"])',
+    'textarea:not([disabled]):not([tabindex="-1"])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(",");
+
+  function focusables(): HTMLElement[] {
+    if (!sheetEl) return [];
+    return Array.from(sheetEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (e.key === "Tab") {
+      // Focus trap: keep keyboard navigation inside the dialog. Without
+      // this, Shift+Tab from the first input (or Tab from the last)
+      // escapes into the editor behind the scrim.
+      const items = focusables();
+      if (items.length === 0) return;
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+</script>
+
+{#if open}
+  <!-- Scrim sits below the sheet (z-index 69 vs 70). Tapping closes. -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="vc-modal-scrim vc-mobile-properties-scrim"
+    aria-hidden="true"
+    tabindex="-1"
+    onclick={onClose}
+  ></div>
+
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="vc-mobile-properties-sheet"
+    bind:this={sheetEl}
+    role="dialog"
+    aria-modal="true"
+    aria-label="Eigenschaften"
+    tabindex="-1"
+    onkeydown={onKeydown}
+  >
+    <div class="vc-mobile-properties-handle" aria-hidden="true"></div>
+    <div class="vc-mobile-properties-body">
+      <PropertiesPanel />
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-mobile-properties-scrim {
+    z-index: 69;
+  }
+
+  .vc-mobile-properties-sheet {
+    position: fixed;
+    bottom: var(--vc-keyboard-height, 0px);
+    left: 0;
+    right: 0;
+    height: 70vh;
+    /* Subtract the keyboard height too so the sheet's TOP doesn't
+       overflow above the visual viewport — without this the visible
+       top edge gets pushed off-screen when the keyboard is open. */
+    max-height: calc(100vh - 80px - var(--vc-keyboard-height, 0px));
+    background: var(--color-surface);
+    border-radius: 16px 16px 0 0;
+    padding-bottom: env(safe-area-inset-bottom);
+    z-index: 70;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.12);
+    /* Match drawer + burger animation cadence. Animates the lift over
+       the keyboard so the transition feels coordinated with the
+       keyboard's own slide-in. */
+    transition: bottom 240ms cubic-bezier(0.4, 0, 0.2, 1),
+                max-height 240ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .vc-mobile-properties-handle {
+    width: 36px;
+    height: 4px;
+    margin: 8px auto 12px auto;
+    border-radius: 2px;
+    background: var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .vc-mobile-properties-body {
+    flex: 1;
+    overflow-y: auto;
+  }
+</style>

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -175,6 +175,24 @@
     }
   });
 
+  // #393 — Properties sheet focus-return latch. Same pattern as the burger
+  // sheet above: when the sheet closes, return focus to the More tab so
+  // the next Tab keypress doesn't drop the user somewhere arbitrary in
+  // the editor. The Properties sheet is always opened FROM the burger
+  // sheet's Properties row, and the burger calls onClose immediately
+  // before flipping this flag — so the user's mental "where I came from"
+  // is the More tab, same as for the burger itself.
+  let propertiesWasOpen = $state(false);
+  $effect(() => {
+    if (mobilePropertiesOpen) {
+      propertiesWasOpen = true;
+    } else if (propertiesWasOpen) {
+      const moreTab = document.getElementById("vc-mobile-tab-more");
+      moreTab?.focus();
+      propertiesWasOpen = false;
+    }
+  });
+
   // #389 — mobile bottom-tab-bar handlers. State (drawer + omni-search) is
   // owned here in VaultLayout; MobileTabBar receives callbacks only. The
   // close-drawer-first lines on Search/More are required because the drawer

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -10,6 +10,7 @@
   import RightSidebar from "./RightSidebar.svelte";
   import MobileTabBar from "./MobileTabBar.svelte";
   import MobileBurgerSheet from "./MobileBurgerSheet.svelte";
+  import MobilePropertiesSheet from "./MobilePropertiesSheet.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import EncryptionStatusbar from "../Statusbar/EncryptionStatusbar.svelte";
   import TopbarReadingToggle from "./TopbarReadingToggle.svelte";
@@ -115,16 +116,22 @@
   // #397 — burger sheet (More-tab destination). Mounted alongside the
   // drawer; both share the parent `isMobile` gate.
   let mobileBurgerOpen = $state(false);
+  // #393 — properties bottom sheet, opened from the burger sheet's
+  // Properties row. Mutually exclusive with `mobileBurgerOpen` at the
+  // user-flow level (burger calls onClose before flipping this), so the
+  // two never co-render in practice.
+  let mobilePropertiesOpen = $state(false);
   const isMobile = $derived($viewportStore.mode === "mobile");
 
   // Resize-to-desktop forces the drawer closed so re-entering mobile starts
-  // from a known state. Same applies to the burger sheet — without this,
-  // resizing while the burger is open would leave a stranded sheet that
-  // isn't reachable from any desktop affordance.
+  // from a known state. Same applies to the burger + properties sheets —
+  // without this, resizing while either is open would leave a stranded
+  // sheet that isn't reachable from any desktop affordance.
   $effect(() => {
     if (!isMobile) {
       mobileDrawerOpen = false;
       mobileBurgerOpen = false;
+      mobilePropertiesOpen = false;
     }
   });
 
@@ -1104,6 +1111,15 @@
   <MobileBurgerSheet
     open={mobileBurgerOpen}
     onClose={() => (mobileBurgerOpen = false)}
+    onSelectProperties={() => (mobilePropertiesOpen = true)}
+  />
+  <!-- #393 — properties bottom sheet, opened from the burger sheet's
+       Properties row. Reads frontmatter via PropertiesPanel's existing
+       activeViewStore subscription; lifts above the on-screen keyboard
+       via #395's `--vc-keyboard-height` CSS var. -->
+  <MobilePropertiesSheet
+    open={mobilePropertiesOpen}
+    onClose={() => (mobilePropertiesOpen = false)}
   />
 {/if}
 

--- a/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
@@ -48,11 +48,18 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function renderSheet(overrides: Partial<{ open: boolean; onClose: () => void }> = {}) {
+function renderSheet(
+  overrides: Partial<{
+    open: boolean;
+    onClose: () => void;
+    onSelectProperties: () => void;
+  }> = {},
+) {
   return render(MobileBurgerSheet, {
     props: {
       open: true,
       onClose: vi.fn(),
+      onSelectProperties: vi.fn(),
       ...overrides,
     },
   });
@@ -106,13 +113,19 @@ describe("MobileBurgerSheet (#397)", () => {
     expect(container.querySelector("[data-stub-panel]")).not.toBeNull();
   });
 
-  it("clicking the Properties row fires toastStore.info AND calls onClose (TODO #393)", async () => {
+  it("clicking the Properties row calls onSelectProperties AND onClose, NOT toastStore.info (#393)", async () => {
+    // #393 replaced the old toast stub with a real destination: the
+    // burger sheet emits onSelectProperties so the parent can flip
+    // its `mobilePropertiesOpen` flag, then closes itself so the two
+    // sheets never co-render.
     const onClose = vi.fn();
-    const { container } = renderSheet({ onClose });
+    const onSelectProperties = vi.fn();
+    const { container } = renderSheet({ onClose, onSelectProperties });
     const row = container.querySelector<HTMLButtonElement>('[data-row-id="properties"]');
     await fireEvent.click(row!);
-    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(onSelectProperties).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(toastInfo).not.toHaveBeenCalled();
   });
 
   it("clicking the Settings row fires toastStore.info AND calls onClose (TODO #394)", async () => {

--- a/src/components/Layout/__tests__/MobilePropertiesSheet.test.ts
+++ b/src/components/Layout/__tests__/MobilePropertiesSheet.test.ts
@@ -11,9 +11,8 @@
  * vars through layout) but we DO assert the property is referenced in
  * the rendered style block via class presence.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/svelte";
-import { tick } from "svelte";
 
 vi.mock("../../Properties/PropertiesPanel.svelte", async () => ({
   default: (await import("./testStubs/StubPanel.svelte")).default,
@@ -80,25 +79,46 @@ describe("MobilePropertiesSheet (#393)", () => {
   });
 
   it("focus trap: Tab from last focusable wraps to first; Shift+Tab from first wraps to last", async () => {
-    // The dialog itself is focusable (tabindex=-1 is non-tabbable but
-    // programmatically focusable). Real focusables here are whatever the
-    // stubbed PropertiesPanel exposes — for the stub, none. We add a real
-    // focusable to make the trap exercise meaningful: the close-on-scrim
-    // is purely an attribute on a div, but the dialog markup may grow
-    // its own buttons (drag-handle is currently aria-hidden div, no
-    // button). Without focusables the trap is a no-op AND the test
-    // expects no preventDefault.
-    //
-    // Strategy: assert the trap doesn't crash and the dialog stays
-    // focused. Real focusable coverage lives in the burger test which
-    // has 6 menuitem buttons.
+    // The PropertiesPanel stub has no focusable elements, so the real
+    // panel's inputs aren't reachable here. To exercise the trap's
+    // boundary semantics (not just the no-op early-return), inject two
+    // real `<button>` children into the sheet and drive Tab/Shift+Tab
+    // from the boundary elements. The trap's selector queries the live
+    // DOM via `sheetEl.querySelectorAll`, so injected buttons are
+    // observed identically to a real PropertiesPanel's inputs.
+    const { container } = renderSheet();
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    const first = document.createElement("button");
+    first.type = "button";
+    first.textContent = "first";
+    const last = document.createElement("button");
+    last.type = "button";
+    last.textContent = "last";
+    dialog.appendChild(first);
+    dialog.appendChild(last);
+
+    // Forward wrap: Tab from last → first.
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    await fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    // Backward wrap: Shift+Tab from first → last.
+    first.focus();
+    await fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("focus trap is a no-op when there are no focusables (early return)", () => {
+    // Boundary trap only. With zero focusables (the default stub state)
+    // the keydown handler must NOT preventDefault — letting the browser
+    // handle Tab natively, which is fine because there's nothing inside
+    // the sheet to trap to anyway.
     const { container } = renderSheet();
     const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
     dialog.focus();
     const ev = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
     dialog.dispatchEvent(ev);
-    // No focusables → no-op (no preventDefault). Same intent as burger
-    // test's "tab away from middle item" — boundary trap only.
     expect(ev.defaultPrevented).toBe(false);
   });
 

--- a/src/components/Layout/__tests__/MobilePropertiesSheet.test.ts
+++ b/src/components/Layout/__tests__/MobilePropertiesSheet.test.ts
@@ -1,0 +1,122 @@
+/**
+ * MobilePropertiesSheet — bottom-sheet wrapper for the Properties panel (#393).
+ *
+ * Mirrors the MobileBurgerSheet pattern: parent-gated, role=dialog, focus
+ * trap, ESC closes, scrim closes. Embeds the existing PropertiesPanel
+ * (stubbed here) as the body so frontmatter editing happens through the
+ * panel's own activeViewStore subscription — no prop wiring needed.
+ *
+ * Keyboard-aware lift via `--vc-keyboard-height` (#395) is a CSS-only
+ * concern; we don't assert pixel positions here (jsdom doesn't run CSS
+ * vars through layout) but we DO assert the property is referenced in
+ * the rendered style block via class presence.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+vi.mock("../../Properties/PropertiesPanel.svelte", async () => ({
+  default: (await import("./testStubs/StubPanel.svelte")).default,
+}));
+
+import MobilePropertiesSheet from "../MobilePropertiesSheet.svelte";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function renderSheet(overrides: Partial<{ open: boolean; onClose: () => void }> = {}) {
+  return render(MobilePropertiesSheet, {
+    props: {
+      open: true,
+      onClose: vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
+describe("MobilePropertiesSheet (#393)", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = renderSheet({ open: false });
+    expect(container.querySelector(".vc-mobile-properties-sheet")).toBeNull();
+    expect(container.querySelector(".vc-mobile-properties-scrim")).toBeNull();
+  });
+
+  it("renders scrim + sheet with role=dialog, aria-modal=true, aria-label='Eigenschaften' when open=true", () => {
+    const { container } = renderSheet();
+    const scrim = container.querySelector(".vc-mobile-properties-scrim");
+    expect(scrim).not.toBeNull();
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-modal")).toBe("true");
+    expect(dialog!.getAttribute("aria-label")).toBe("Eigenschaften");
+  });
+
+  it("renders the drag-handle as a visual affordance (per burger precedent)", () => {
+    const { container } = renderSheet();
+    expect(container.querySelector(".vc-mobile-properties-handle")).not.toBeNull();
+  });
+
+  it("embeds PropertiesPanel inside the sheet body", () => {
+    const { container } = renderSheet();
+    expect(container.querySelector("[data-stub-panel]")).not.toBeNull();
+  });
+
+  it("clicking the scrim calls onClose", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    const scrim = container.querySelector<HTMLElement>(".vc-mobile-properties-scrim");
+    expect(scrim).not.toBeNull();
+    await fireEvent.click(scrim!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape on the dialog calls onClose", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    await fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("focus trap: Tab from last focusable wraps to first; Shift+Tab from first wraps to last", async () => {
+    // The dialog itself is focusable (tabindex=-1 is non-tabbable but
+    // programmatically focusable). Real focusables here are whatever the
+    // stubbed PropertiesPanel exposes — for the stub, none. We add a real
+    // focusable to make the trap exercise meaningful: the close-on-scrim
+    // is purely an attribute on a div, but the dialog markup may grow
+    // its own buttons (drag-handle is currently aria-hidden div, no
+    // button). Without focusables the trap is a no-op AND the test
+    // expects no preventDefault.
+    //
+    // Strategy: assert the trap doesn't crash and the dialog stays
+    // focused. Real focusable coverage lives in the burger test which
+    // has 6 menuitem buttons.
+    const { container } = renderSheet();
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    dialog.focus();
+    const ev = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+    dialog.dispatchEvent(ev);
+    // No focusables → no-op (no preventDefault). Same intent as burger
+    // test's "tab away from middle item" — boundary trap only.
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("scrim has z-index below sheet (visual stacking sanity)", () => {
+    const { container } = renderSheet();
+    const scrim = container.querySelector<HTMLElement>(".vc-mobile-properties-scrim");
+    const sheet = container.querySelector<HTMLElement>(".vc-mobile-properties-sheet");
+    expect(scrim).not.toBeNull();
+    expect(sheet).not.toBeNull();
+    // z-index assertions: jsdom returns the inline style or computed value
+    // when explicit style is missing. The stylesheet in the component
+    // should set scrim z=69 / sheet z=70. Read via computed style; if
+    // jsdom returns "" because it doesn't apply <style> blocks, fall
+    // through (this is a smoke check, not a true layout test).
+    const scrimZ = window.getComputedStyle(scrim!).zIndex;
+    const sheetZ = window.getComputedStyle(sheet!).zIndex;
+    if (scrimZ && sheetZ && scrimZ !== "auto" && sheetZ !== "auto") {
+      expect(parseInt(scrimZ, 10)).toBeLessThan(parseInt(sheetZ, 10));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #393. Replaces the Properties stub-toast in the More-tab burger sheet (#397) with a real bottom sheet that hosts the existing `PropertiesPanel` for read + write of frontmatter on mobile. Only Phase E feature kept in mobile MVP scope.

- New `MobilePropertiesSheet.svelte` — parent-gated bottom sheet mirroring the `MobileBurgerSheet` pattern (scrim, drag-handle, role=dialog, aria-modal, ESC, focus trap). Embeds the existing `<PropertiesPanel />` as the body. PropertiesPanel subscribes to `activeViewStore` directly, so frontmatter editing lands on whatever CM6 view is active in the editor pane behind the scrim — no prop wiring needed.
- Keyboard-aware lift via #395's `--vc-keyboard-height` CSS var: `bottom: var(--vc-keyboard-height, 0px); max-height: calc(100vh - 80px - var(--vc-keyboard-height, 0px));` with a 240ms cubic-bezier transition matching drawer + burger animation cadence. Defaults to `0px` on desktop / closed-keyboard mobile → byte-identical to burger placement.
- `MobileBurgerSheet` Properties row swaps from `action: "stub"` (toast) to `action: "properties"` (call new `onSelectProperties` prop + `onClose`). Settings stub left intact for #394.
- `VaultLayout` adds `mobilePropertiesOpen` state alongside `mobileBurgerOpen`; resize-to-desktop force-closes it. The two sheets are mutually exclusive at the user-flow level — burger calls `onClose` before flipping the parent's properties flag.

## Decisions (per Socrates v1 plan-approval answers)

- **Swipe-to-dismiss deferred.** Drag-handle stays as pure visual affordance per the burger precedent. Scrim-tap + ESC cover dismissal in MVP. Follow-up if UAT requests.
- **z-index 70.** Clean step above burger 60. Hierarchy: drawer 50 < scrim 49 < burger 59/60 < properties 69/70 < modals 199+.
- **Sheet height 70vh.** Properties list can grow; 70vh leaves 30vh for scrim + visual context. `max-height: calc(...)` constrains under the keyboard.
- **`overflow-y: auto` on `.vc-mobile-properties-body`.** Matches burger pattern; the panel body scrolls independently of the sheet chrome.
- **Empty-state handled by PropertiesPanel.** Sheet still renders chrome (role=dialog, drag-handle, scrim). PropertiesPanel renders its own empty state when no active view.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — full suite **162 files / 1515 tests** green (+1 file / +8 tests vs prior).
- [x] `pnpm build` clean.
- [ ] Manual mobile-emulation: tap More tab → tap Eigenschaften → burger closes, properties sheet opens. Edit a frontmatter value → close sheet → re-open → value persisted. Tap into an input → keyboard appears → sheet lifts, content stays visible. Dismiss keyboard → sheet returns. Desktop: properties sheet does NOT mount (gated by `{#if isMobile}` in VaultLayout).
- [ ] UAT.

## Test coverage

- `MobilePropertiesSheet.test.ts` (new, 8 cases) — visibility matrix, scrim click, ESC, focus-trap boundary semantics, drag-handle present, PropertiesPanel embedded (stubbed), z-index sanity.
- `MobileBurgerSheet.test.ts` — Properties test updated for the new contract; default props extended with `onSelectProperties`. All other cases unchanged.