### PR TITLE
feat(mobile): settings full-screen sheet (#394)

### DIFF
--- a/e2e/specs/mobile-settings.spec.ts
+++ b/e2e/specs/mobile-settings.spec.ts
@@ -53,7 +53,10 @@ describe("Mobile settings sheet (#394)", () => {
     if (await isSheetOpen()) {
       await browser.keys(["Escape"]); // detail → master, or master → close
       await browser.keys(["Escape"]); // safety: ensure close
-      await browser.waitUntil(async () => !(await isSheetOpen()), { timeout: 3000 }).catch(() => {});
+      // No .catch() — let cleanup failures propagate. If a test leaves
+      // the sheet stuck open, that's a real bug worth seeing rather
+      // than silently swallowing.
+      await browser.waitUntil(async () => !(await isSheetOpen()), { timeout: 3000 });
     }
   });
 

--- a/e2e/specs/mobile-settings.spec.ts
+++ b/e2e/specs/mobile-settings.spec.ts
@@ -1,0 +1,155 @@
+import { createTestVault, type TestVault } from "../helpers/vault.js";
+import { openVaultInApp } from "../helpers/open-vault.js";
+
+/**
+ * #394 — mobile settings sheet e2e coverage.
+ *
+ * Resizes to 600x900 (matches #386 / #389 / #397 spec convention) so the
+ * VaultLayout `{#if isMobile}` branch fires and renders MobileSettingsSheet
+ * instead of the desktop SettingsModal.
+ *
+ * Each test is self-contained — afterEach drains sheet state with Escape
+ * presses so a failure produces a clean message rather than a side-effect
+ * chain.
+ */
+describe("Mobile settings sheet (#394)", () => {
+  let vault: TestVault;
+  let restoreSize: { width: number; height: number } | null = null;
+
+  before(async () => {
+    vault = createTestVault();
+    await openVaultInApp(vault.path);
+    restoreSize = await browser.getWindowSize();
+    await browser.setWindowSize(600, 900);
+  });
+
+  after(async () => {
+    if (restoreSize) {
+      await browser.setWindowSize(restoreSize.width, restoreSize.height);
+    }
+    vault.cleanup();
+  });
+
+  async function isSheetOpen(): Promise<boolean> {
+    const sheets = await browser.$$(".vc-mobile-settings-sheet");
+    return sheets.length > 0;
+  }
+
+  async function clickGearIcon(): Promise<void> {
+    await browser.execute(() => {
+      // The gear icon's only stable selector is its aria-label.
+      const btn = document.querySelector('button[aria-label="Einstellungen"]') as HTMLElement | null;
+      btn?.click();
+    });
+  }
+
+  async function clickRow(rowId: string): Promise<void> {
+    await browser.execute((id: string) => {
+      (document.querySelector(`[data-row-id="${id}"]`) as HTMLElement | null)?.click();
+    }, rowId);
+  }
+
+  afterEach(async () => {
+    if (await isSheetOpen()) {
+      await browser.keys(["Escape"]); // detail → master, or master → close
+      await browser.keys(["Escape"]); // safety: ensure close
+      await browser.waitUntil(async () => !(await isSheetOpen()), { timeout: 3000 }).catch(() => {});
+    }
+  });
+
+  it("topbar gear renders the mobile sheet (NOT the desktop modal)", async () => {
+    expect(await isSheetOpen()).toBe(false);
+    await clickGearIcon();
+    await browser.waitUntil(isSheetOpen, {
+      timeout: 3000,
+      timeoutMsg: "Mobile settings sheet never opened after gear click",
+    });
+    // Verify the desktop modal is NOT in the DOM.
+    const desktopModal = await browser.$$('[data-testid="settings-modal"]');
+    expect(desktopModal.length).toBe(0);
+  });
+
+  it("master view renders 5 category rows", async () => {
+    await clickGearIcon();
+    await browser.waitUntil(isSheetOpen, { timeout: 3000 });
+    const rows = await browser.$$('[role="menuitem"]');
+    expect(rows.length).toBe(5);
+  });
+
+  it("Erscheinungsbild detail → theme change → back persists store state", async () => {
+    await clickGearIcon();
+    await browser.waitUntil(isSheetOpen, { timeout: 3000 });
+    await clickRow("appearance");
+    // Pick the dark radio and check the document attribute.
+    await browser.execute(() => {
+      const r = document.querySelector('input[type="radio"][value="dark"]') as HTMLInputElement | null;
+      if (r) {
+        r.checked = true;
+        r.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    });
+    await browser.waitUntil(async () => {
+      return await browser.execute(() => document.documentElement.dataset.theme === "dark");
+    }, { timeout: 3000, timeoutMsg: "Theme attribute never reflected dark choice" });
+
+    // Back → master view.
+    await browser.execute(() => {
+      (document.querySelector(".vc-mobile-settings-back") as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(async () => (await browser.$$('[role="menu"]')).length > 0, {
+      timeout: 3000,
+      timeoutMsg: "Back never returned to master view",
+    });
+  });
+
+  it("X close button closes the sheet from master view", async () => {
+    await clickGearIcon();
+    await browser.waitUntil(isSheetOpen, { timeout: 3000 });
+    await browser.execute(() => {
+      (document.querySelector(".vc-mobile-settings-close") as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(async () => !(await isSheetOpen()), {
+      timeout: 3000,
+      timeoutMsg: "Sheet never closed after X click",
+    });
+  });
+
+  it("Escape closes from master view; Escape from detail view returns to master", async () => {
+    await clickGearIcon();
+    await browser.waitUntil(isSheetOpen, { timeout: 3000 });
+    await browser.keys(["Escape"]);
+    await browser.waitUntil(async () => !(await isSheetOpen()), { timeout: 3000 });
+
+    await clickGearIcon();
+    await browser.waitUntil(isSheetOpen, { timeout: 3000 });
+    await clickRow("fonts");
+    await browser.waitUntil(async () => (await browser.$$('[role="menu"]')).length === 0, { timeout: 3000 });
+    await browser.keys(["Escape"]);
+    await browser.waitUntil(async () => (await browser.$$('[role="menu"]')).length > 0, {
+      timeout: 3000,
+      timeoutMsg: "Escape from detail view never returned to master",
+    });
+    expect(await isSheetOpen()).toBe(true);
+  });
+
+  it("burger sheet → Einstellungen row opens the same mobile settings sheet", async () => {
+    // Open burger via More tab.
+    await browser.execute(() => {
+      (document.getElementById("vc-mobile-tab-more") as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(async () => (await browser.$$(".vc-mobile-burger-sheet")).length > 0, {
+      timeout: 3000,
+    });
+    // Click Einstellungen row.
+    await browser.execute(() => {
+      (document.querySelector('[data-row-id="settings"]') as HTMLElement | null)?.click();
+    });
+    await browser.waitUntil(isSheetOpen, {
+      timeout: 3000,
+      timeoutMsg: "Mobile settings sheet never opened from burger row",
+    });
+    // The burger sheet itself should have closed.
+    const burgers = await browser.$$(".vc-mobile-burger-sheet");
+    expect(burgers.length).toBe(0);
+  });
+});

--- a/src/components/Layout/MobileBurgerSheet.svelte
+++ b/src/components/Layout/MobileBurgerSheet.svelte
@@ -36,6 +36,7 @@
     open,
     onClose,
     onSelectProperties,
+    onOpenSettings,
   }: {
     open: boolean;
     onClose: () => void;
@@ -45,6 +46,14 @@
      * sheet then calls `onClose()` so the two sheets never co-render.
      */
     onSelectProperties: () => void;
+    /**
+     * #394 — invoked when the user taps the Einstellungen row. Same
+     * close-then-open contract as Properties: the burger calls
+     * `onClose()` first so its `wasOpen` latch can move focus to the
+     * More tab synchronously, THEN this fires so the settings sheet's
+     * own focus microtask resolves on a stable element.
+     */
+    onOpenSettings: () => void;
   } = $props();
 
   type PanelId = "backlinks" | "bookmarks" | "outline" | "outgoing";
@@ -82,7 +91,15 @@
     id: "backlinks" | "bookmarks" | "outline" | "outgoing" | "properties" | "settings";
     label: string;
     icon: typeof Link2;
-    action: "panel" | "properties" | "stub";
+    // Action discriminant names the destination directly so onRowClick is
+    // a pure switch — no id checks. Each non-"panel" arm dispatches to a
+    // dedicated callback prop. Future external rows add a new arm to the
+    // union AND a new prop; no string-id matching.
+    //   - "panel":      routes to an in-sheet panel view (uses panelId).
+    //   - "stub":       toasts a placeholder + closes (until the wiring ticket lands).
+    //   - "properties": hands off to onSelectProperties (#393).
+    //   - "settings":   hands off to onOpenSettings (#394).
+    action: "panel" | "stub" | "properties" | "settings";
     panelId?: PanelId;
     stubMessage?: string;
   };
@@ -91,12 +108,12 @@
   // pure data avoids the wasted-work pattern that Aristotle flagged on
   // #389 (`tabs` was wrongly $derived).
   const ROWS: ReadonlyArray<RowSpec> = [
-    { id: "backlinks",  label: "Backlinks",         icon: Link2,        action: "panel", panelId: "backlinks" },
-    { id: "bookmarks",  label: "Lesezeichen",       icon: Bookmark,     action: "panel", panelId: "bookmarks" },
-    { id: "outline",    label: "Gliederung",        icon: List,         action: "panel", panelId: "outline" },
-    { id: "outgoing",   label: "Ausgehende Links",  icon: ArrowUpRight, action: "panel", panelId: "outgoing" },
+    { id: "backlinks",  label: "Backlinks",         icon: Link2,        action: "panel",      panelId: "backlinks" },
+    { id: "bookmarks",  label: "Lesezeichen",       icon: Bookmark,     action: "panel",      panelId: "bookmarks" },
+    { id: "outline",    label: "Gliederung",        icon: List,         action: "panel",      panelId: "outline" },
+    { id: "outgoing",   label: "Ausgehende Links",  icon: ArrowUpRight, action: "panel",      panelId: "outgoing" },
     { id: "properties", label: "Eigenschaften",     icon: FileText,     action: "properties" },
-    { id: "settings",   label: "Einstellungen",     icon: SettingsIcon, action: "stub",  stubMessage: "Einstellungen folgen" },
+    { id: "settings",   label: "Einstellungen",     icon: SettingsIcon, action: "settings" },
   ];
 
   const PANEL_LABELS: Record<PanelId, string> = {
@@ -107,23 +124,34 @@
   };
 
   function onRowClick(row: RowSpec) {
-    if (row.action === "panel" && row.panelId) {
-      activePanel = row.panelId;
-      return;
+    switch (row.action) {
+      case "panel":
+        if (row.panelId) activePanel = row.panelId;
+        return;
+      case "properties":
+        // Close-then-open ORDER MATTERS. Closing the burger first lets
+        // the burgerWasOpen $effect in VaultLayout move focus to the
+        // More tab synchronously; THEN opening the target sheet
+        // schedules its own focus-to-first-focusable via microtask,
+        // which now wins cleanly. Reversing this order produces a
+        // race: target schedules focus, burger close yanks focus back
+        // to More tab, microtask resolves on a stale element.
+        onClose();
+        onSelectProperties();
+        return;
+      case "settings":
+        onClose();
+        onOpenSettings();
+        return;
+      case "stub":
+        // Still a placeholder. The toast tells the user the destination
+        // exists but isn't wired yet; closing the sheet keeps the More
+        // tab's tap-feedback intact (no dead-end where the menu stays
+        // open after an apparent-no-op).
+        if (row.stubMessage) toastStore.info(row.stubMessage);
+        onClose();
+        return;
     }
-    if (row.action === "properties") {
-      // #393 — hand off to the parent's properties sheet, then close
-      // ourselves so the two sheets never co-render.
-      onSelectProperties();
-      onClose();
-      return;
-    }
-    // TODO #394 (settings). The toast tells the user the destination
-    // exists but isn't wired yet; closing the sheet keeps the More tab's
-    // tap-feedback intact (no dead-end where the menu stays open after
-    // an apparent-no-op).
-    if (row.stubMessage) toastStore.info(row.stubMessage);
-    onClose();
   }
 
   // Standard keyboard-trap selector: anything that can take focus, minus

--- a/src/components/Layout/MobileSettingsSheet.svelte
+++ b/src/components/Layout/MobileSettingsSheet.svelte
@@ -1,0 +1,516 @@
+<script lang="ts">
+  /**
+   * MobileSettingsSheet — full-screen settings sheet for mobile (#394).
+   *
+   * Parent-gated: VaultLayout decides via `{#if isMobile}` when to render
+   * this OR the desktop SettingsModal; component does NOT subscribe to
+   * viewportStore. State lives in the parent.
+   *
+   * Per team-lead direction this is an opaque full-screen sheet — no
+   * scrim. The X close button + Escape are the dismissal paths.
+   *
+   * Master/detail navigation (same shape as the burger sheet from #397):
+   *   - master = 5-row category list.
+   *   - detail = the chosen category's controls, with a back button.
+   *
+   * Categories rebuild the relevant SettingsModal sections against the
+   * SAME stores (themeStore, settingsStore, vaultStore). Stores are the
+   * single source of truth — mobile and desktop see identical state.
+   *
+   * Excluded sections (per ticket): keyboard shortcut customization,
+   * plugin settings, snippets management, build version, security.
+   * Auto-lock is included — it's a pure setting on settingsStore with no
+   * encrypted-folders UI dependency.
+   */
+  import { X, ChevronLeft, ChevronRight, Palette, Type, Calendar, ShieldCheck, FolderOpen } from "lucide-svelte";
+  import { themeStore, type Theme } from "../../store/themeStore";
+  import {
+    settingsStore,
+    FONT_SIZE_MIN,
+    FONT_SIZE_MAX,
+    AUTO_LOCK_MINUTES_MIN,
+    AUTO_LOCK_MINUTES_MAX,
+    type BodyFont,
+    type MonoFont,
+  } from "../../store/settingsStore";
+  import { vaultStore } from "../../store/vaultStore";
+  import { onDestroy } from "svelte";
+
+  let {
+    open,
+    onClose,
+    onSwitchVault,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onSwitchVault: () => void;
+  } = $props();
+
+  type CategoryId = "appearance" | "fonts" | "daily" | "security" | "vault";
+  let activeCategory = $state<CategoryId | null>(null);
+  // bind:this writes a live DOM node here — $state matches the drawer /
+  // burger pattern so Svelte's reactive scope sees the binding writes
+  // and the keydown trap can read sheetEl without warnings.
+  let sheetEl = $state<HTMLDivElement | undefined>(undefined);
+
+  // Subscribe to the stores once. Per-control reactive bindings would
+  // also work, but explicit subscriptions match SettingsModal's pattern
+  // and make the test mock surface obvious.
+  let currentTheme = $state<Theme>("auto");
+  let currentBody = $state<BodyFont>("system");
+  let currentMono = $state<MonoFont>("system");
+  let currentSize = $state<number>(14);
+  let dailyFolder = $state<string>("");
+  let dailyFormat = $state<string>("");
+  let dailyTemplate = $state<string>("");
+  let autoLockMinutes = $state<number>(15);
+  let currentVaultPath = $state<string | null>(null);
+
+  const unsubTheme = themeStore.subscribe((t) => { currentTheme = t; });
+  const unsubSettings = settingsStore.subscribe((s) => {
+    currentBody = s.fontBody;
+    currentMono = s.fontMono;
+    currentSize = s.fontSize;
+    dailyFolder = s.dailyNotesFolder;
+    dailyFormat = s.dailyNotesDateFormat;
+    dailyTemplate = s.dailyNotesTemplate;
+    autoLockMinutes = s.autoLockMinutes;
+  });
+  const unsubVault = vaultStore.subscribe((s) => { currentVaultPath = s.currentPath; });
+
+  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); });
+
+  $effect(() => {
+    if (!open) activeCategory = null;
+  });
+
+  $effect(() => {
+    if (open) {
+      queueMicrotask(() => {
+        const first = sheetEl?.querySelector<HTMLElement>(
+          'button:not([disabled]):not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])',
+        );
+        first?.focus();
+      });
+    }
+  });
+
+  const CATEGORIES: ReadonlyArray<{
+    id: CategoryId;
+    label: string;
+    icon: typeof Palette;
+  }> = [
+    { id: "appearance", label: "Erscheinungsbild", icon: Palette },
+    { id: "fonts",      label: "Schrift",          icon: Type },
+    { id: "daily",      label: "Tagesnotizen",     icon: Calendar },
+    { id: "security",   label: "Sicherheit",       icon: ShieldCheck },
+    { id: "vault",      label: "Vault",            icon: FolderOpen },
+  ];
+
+  function onThemeChange(e: Event) {
+    themeStore.set((e.target as HTMLInputElement).value as Theme);
+  }
+  function onBodyChange(e: Event) {
+    settingsStore.setFontBody((e.target as HTMLSelectElement).value as BodyFont);
+  }
+  function onMonoChange(e: Event) {
+    settingsStore.setFontMono((e.target as HTMLSelectElement).value as MonoFont);
+  }
+  function onSizeInput(e: Event) {
+    settingsStore.setFontSize(Number((e.target as HTMLInputElement).value));
+  }
+  function onDailyFolderInput(e: Event) {
+    settingsStore.setDailyNotesFolder((e.target as HTMLInputElement).value);
+  }
+  function onDailyFormatInput(e: Event) {
+    settingsStore.setDailyNotesDateFormat((e.target as HTMLInputElement).value);
+  }
+  function onDailyTemplateInput(e: Event) {
+    settingsStore.setDailyNotesTemplate((e.target as HTMLInputElement).value);
+  }
+  function onAutoLockInput(e: Event) {
+    settingsStore.setAutoLockMinutes(Number((e.target as HTMLInputElement).value));
+  }
+
+  // Boundary-only focus trap (matches burger sheet from #397).
+  const FOCUSABLE_SELECTOR = [
+    'button:not([disabled]):not([tabindex="-1"])',
+    'a[href]:not([tabindex="-1"])',
+    'input:not([disabled]):not([tabindex="-1"])',
+    'select:not([disabled]):not([tabindex="-1"])',
+    'textarea:not([disabled]):not([tabindex="-1"])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(",");
+
+  function focusables(): HTMLElement[] {
+    if (!sheetEl) return [];
+    return Array.from(sheetEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      if (activeCategory !== null) activeCategory = null;
+      else onClose();
+      return;
+    }
+    if (e.key === "Tab") {
+      const items = focusables();
+      if (items.length === 0) return;
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  const CATEGORY_LABELS: Record<CategoryId, string> = {
+    appearance: "Erscheinungsbild",
+    fonts: "Schrift",
+    daily: "Tagesnotizen",
+    security: "Sicherheit",
+    vault: "Vault",
+  };
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="vc-mobile-settings-sheet"
+    bind:this={sheetEl}
+    role="dialog"
+    aria-modal="true"
+    aria-label="Einstellungen"
+    tabindex="-1"
+    onkeydown={onKeydown}
+  >
+    <header class="vc-mobile-settings-header">
+      {#if activeCategory === null}
+        <h2 class="vc-mobile-settings-title">Einstellungen</h2>
+        <button
+          type="button"
+          class="vc-mobile-settings-close"
+          onclick={onClose}
+          aria-label="Einstellungen schließen"
+        >
+          <X size={20} strokeWidth={1.5} />
+        </button>
+      {:else}
+        <button
+          type="button"
+          class="vc-mobile-settings-back"
+          onclick={() => (activeCategory = null)}
+          aria-label="Zurück"
+        >
+          <ChevronLeft size={20} strokeWidth={1.5} />
+        </button>
+        <h2 class="vc-mobile-settings-title">{CATEGORY_LABELS[activeCategory]}</h2>
+      {/if}
+    </header>
+
+    <div class="vc-mobile-settings-body">
+      {#if activeCategory === null}
+        <div class="vc-mobile-settings-list" role="menu">
+          {#each CATEGORIES as cat (cat.id)}
+            {@const Icon = cat.icon}
+            <button
+              type="button"
+              role="menuitem"
+              data-row-id={cat.id}
+              class="vc-mobile-settings-row"
+              onclick={() => (activeCategory = cat.id)}
+            >
+              <Icon size={20} strokeWidth={1.5} />
+              <span class="vc-mobile-settings-row-label">{cat.label}</span>
+              <ChevronRight size={16} strokeWidth={1.5} />
+            </button>
+          {/each}
+        </div>
+      {:else if activeCategory === "appearance"}
+        <section class="vc-mobile-settings-section">
+          <div class="vc-theme-radio-group" role="radiogroup" aria-label="Erscheinungsbild">
+            {#each [{ id: "auto", label: "Automatisch" }, { id: "light", label: "Hell" }, { id: "dark", label: "Dunkel" }] as opt (opt.id)}
+              <label class="vc-mobile-settings-radio">
+                <input
+                  type="radio"
+                  name="theme"
+                  value={opt.id}
+                  checked={currentTheme === opt.id}
+                  onchange={onThemeChange}
+                />
+                <span>{opt.label}</span>
+              </label>
+            {/each}
+          </div>
+        </section>
+      {:else if activeCategory === "fonts"}
+        <section class="vc-mobile-settings-section">
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Textschrift</span>
+            <select value={currentBody} onchange={onBodyChange}>
+              <option value="system">Systemschrift</option>
+              <option value="inter">Inter</option>
+              <option value="lora">Lora</option>
+            </select>
+          </label>
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Monospace</span>
+            <select value={currentMono} onchange={onMonoChange}>
+              <option value="system">Systemschrift</option>
+              <option value="jetbrains-mono">JetBrains Mono</option>
+              <option value="fira-code">Fira Code</option>
+            </select>
+          </label>
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Schriftgröße ({currentSize} px)</span>
+            <input
+              type="range"
+              min={FONT_SIZE_MIN}
+              max={FONT_SIZE_MAX}
+              step="1"
+              value={currentSize}
+              oninput={onSizeInput}
+              aria-label="Schriftgröße"
+            />
+          </label>
+        </section>
+      {:else if activeCategory === "daily"}
+        <section class="vc-mobile-settings-section">
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Ordner</span>
+            <input type="text" value={dailyFolder} oninput={onDailyFolderInput} />
+          </label>
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Datumsformat</span>
+            <input type="text" value={dailyFormat} oninput={onDailyFormatInput} />
+          </label>
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Vorlage</span>
+            <input type="text" value={dailyTemplate} oninput={onDailyTemplateInput} />
+          </label>
+        </section>
+      {:else if activeCategory === "security"}
+        <section class="vc-mobile-settings-section">
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Auto-Sperre nach (Minuten)</span>
+            <input
+              type="number"
+              min={AUTO_LOCK_MINUTES_MIN}
+              max={AUTO_LOCK_MINUTES_MAX}
+              value={autoLockMinutes}
+              oninput={onAutoLockInput}
+            />
+          </label>
+        </section>
+      {:else if activeCategory === "vault"}
+        <section class="vc-mobile-settings-section">
+          <div class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Aktueller Vault</span>
+            <div class="vc-mobile-settings-vault-path">{currentVaultPath ?? "—"}</div>
+          </div>
+          <button
+            type="button"
+            class="vc-mobile-settings-action"
+            data-testid="settings-switch-vault"
+            onclick={onSwitchVault}
+          >
+            Vault wechseln…
+          </button>
+        </section>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .vc-mobile-settings-sheet {
+    position: fixed;
+    inset: 0;
+    background: var(--color-surface);
+    z-index: 80;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    /* No scrim — opaque full-screen per #394 plan. */
+  }
+
+  .vc-mobile-settings-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 48px;
+    padding: 0 8px;
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .vc-mobile-settings-title {
+    flex: 1;
+    margin: 0;
+    font-family: var(--vc-font-body);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .vc-mobile-settings-close,
+  .vc-mobile-settings-back {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    min-width: var(--vc-hit-target, 44px);
+    min-height: var(--vc-hit-target, 44px);
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--color-text-muted);
+  }
+
+  .vc-mobile-settings-close:hover,
+  .vc-mobile-settings-back:hover {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+  }
+
+  .vc-mobile-settings-body {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .vc-mobile-settings-list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .vc-mobile-settings-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    height: 56px;
+    min-height: var(--vc-hit-target, 44px);
+    padding: 0 16px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    cursor: pointer;
+    color: var(--color-text);
+    font-family: var(--vc-font-body);
+    font-size: 14px;
+    font-weight: 500;
+    text-align: left;
+  }
+
+  .vc-mobile-settings-row:hover {
+    background: var(--color-accent-bg);
+  }
+
+  .vc-mobile-settings-row-label {
+    flex: 1;
+  }
+
+  .vc-mobile-settings-section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px;
+  }
+
+  .vc-mobile-settings-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .vc-mobile-settings-field-label {
+    font-family: var(--vc-font-body);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .vc-mobile-settings-field input[type="text"],
+  .vc-mobile-settings-field input[type="number"],
+  .vc-mobile-settings-field select {
+    width: 100%;
+    min-height: var(--vc-hit-target, 44px);
+    padding: 0 12px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--vc-font-body);
+    font-size: 14px;
+  }
+
+  .vc-mobile-settings-field input[type="range"] {
+    width: 100%;
+  }
+
+  .vc-mobile-settings-radio {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    min-height: var(--vc-hit-target, 44px);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    cursor: pointer;
+    font-family: var(--vc-font-body);
+    font-size: 14px;
+  }
+
+  .vc-mobile-settings-radio input[type="radio"] {
+    accent-color: var(--color-accent);
+  }
+
+  .vc-theme-radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .vc-mobile-settings-action {
+    height: 44px;
+    min-height: var(--vc-hit-target, 44px);
+    padding: 0 16px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--vc-font-body);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .vc-mobile-settings-action:hover {
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  .vc-mobile-settings-vault-path {
+    padding: 12px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-family: var(--vc-font-mono);
+    font-size: 13px;
+    color: var(--color-text);
+    word-break: break-all;
+  }
+</style>

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -11,6 +11,7 @@
   import MobileTabBar from "./MobileTabBar.svelte";
   import MobileBurgerSheet from "./MobileBurgerSheet.svelte";
   import MobilePropertiesSheet from "./MobilePropertiesSheet.svelte";
+  import MobileSettingsSheet from "./MobileSettingsSheet.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import EncryptionStatusbar from "../Statusbar/EncryptionStatusbar.svelte";
   import TopbarReadingToggle from "./TopbarReadingToggle.svelte";
@@ -123,15 +124,20 @@
   let mobilePropertiesOpen = $state(false);
   const isMobile = $derived($viewportStore.mode === "mobile");
 
-  // Resize-to-desktop forces the drawer closed so re-entering mobile starts
-  // from a known state. Same applies to the burger + properties sheets —
-  // without this, resizing while either is open would leave a stranded
-  // sheet that isn't reachable from any desktop affordance.
+  // Resize-to-desktop forces all mobile-only sheets closed so re-entering
+  // mobile starts from a known state. The drawer, burger, and properties
+  // sheets are mobile-exclusive surfaces. settingsOpen is shared with the
+  // desktop modal — without forcing it false here, a resize while the
+  // mobile settings sheet is open would silently swap the mobile sheet for
+  // the desktop modal mid-flow. The sheet was opened via a mobile
+  // affordance (gear icon at mobile width, or burger row); reopening on
+  // desktop is a fresh user action.
   $effect(() => {
     if (!isMobile) {
       mobileDrawerOpen = false;
       mobileBurgerOpen = false;
       mobilePropertiesOpen = false;
+      settingsOpen = false;
     }
   });
 
@@ -1106,11 +1112,24 @@
   onClose={() => { templatePickerOpen = false; }}
 />
 
-<SettingsModal
-  open={settingsOpen}
-  onClose={() => { settingsOpen = false; }}
-  {onSwitchVault}
-/>
+<!-- #394 — render-time switch between desktop modal and mobile full-screen
+     sheet. Single shared `settingsOpen` flag — both viewports use the same
+     trigger paths (topbar gear + burger Einstellungen row), so unifying the
+     state avoids duplication. The sheet's content reads the same stores as
+     the modal. -->
+{#if isMobile}
+  <MobileSettingsSheet
+    open={settingsOpen}
+    onClose={() => { settingsOpen = false; }}
+    {onSwitchVault}
+  />
+{:else}
+  <SettingsModal
+    open={settingsOpen}
+    onClose={() => { settingsOpen = false; }}
+    {onSwitchVault}
+  />
+{/if}
 
 <!-- #357: auto-encrypt-on-drop live progress pill. Self-hides while idle. -->
 <EncryptionStatusbar />
@@ -1130,6 +1149,7 @@
     open={mobileBurgerOpen}
     onClose={() => (mobileBurgerOpen = false)}
     onSelectProperties={() => (mobilePropertiesOpen = true)}
+    onOpenSettings={() => (settingsOpen = true)}
   />
   <!-- #393 — properties bottom sheet, opened from the burger sheet's
        Properties row. Reads frontmatter via PropertiesPanel's existing

--- a/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
@@ -144,6 +144,20 @@ describe("MobileBurgerSheet (#397)", () => {
     expect(toastInfo).not.toHaveBeenCalled();
   });
 
+  it("Settings row calls onClose BEFORE onOpenSettings (focus-race regression)", async () => {
+    // Aristotle iter 1 #394 finding #2: opening the target sheet first
+    // schedules its focus-to-first-focusable microtask, but the burger's
+    // synchronous wasOpen latch then yanks focus to the More tab when
+    // the close fires after — race lost. Closing first lets the latch
+    // resolve synchronously, then the target sheet's microtask wins.
+    const order: string[] = [];
+    const onClose = vi.fn(() => { order.push("close"); });
+    const onOpenSettings = vi.fn(() => { order.push("open"); });
+    const { container } = renderSheet({ onClose, onOpenSettings });
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="settings"]')!);
+    expect(order).toEqual(["close", "open"]);
+  });
+
   it("clicking the scrim calls onClose", async () => {
     const onClose = vi.fn();
     const { container } = renderSheet({ onClose });

--- a/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileBurgerSheet.test.ts
@@ -53,6 +53,7 @@ function renderSheet(
     open: boolean;
     onClose: () => void;
     onSelectProperties: () => void;
+    onOpenSettings: () => void;
   }> = {},
 ) {
   return render(MobileBurgerSheet, {
@@ -60,6 +61,7 @@ function renderSheet(
       open: true,
       onClose: vi.fn(),
       onSelectProperties: vi.fn(),
+      onOpenSettings: vi.fn(),
       ...overrides,
     },
   });
@@ -128,13 +130,18 @@ describe("MobileBurgerSheet (#397)", () => {
     expect(toastInfo).not.toHaveBeenCalled();
   });
 
-  it("clicking the Settings row fires toastStore.info AND calls onClose (TODO #394)", async () => {
+  it("clicking the Settings row calls onOpenSettings AND onClose (#394 wired)", async () => {
+    // #394 replaces the old stub-toast with a real callback. The row no
+    // longer fires toastStore.info — the parent (VaultLayout) now opens
+    // the mobile settings sheet via the onOpenSettings callback.
     const onClose = vi.fn();
-    const { container } = renderSheet({ onClose });
+    const onOpenSettings = vi.fn();
+    const { container } = renderSheet({ onClose, onOpenSettings });
     const row = container.querySelector<HTMLButtonElement>('[data-row-id="settings"]');
     await fireEvent.click(row!);
-    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(toastInfo).not.toHaveBeenCalled();
   });
 
   it("clicking the scrim calls onClose", async () => {

--- a/src/components/Layout/__tests__/MobileSettingsSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileSettingsSheet.test.ts
@@ -74,11 +74,12 @@ vi.mock("../../../store/settingsStore", () => {
 });
 
 vi.mock("../../../store/vaultStore", () => {
-  const subscribers = new Set<(s: { currentPath: string | null }) => void>();
-  const state = { currentPath: "/test/vault" };
+  type VaultLike = { currentPath: string | null };
+  const state: VaultLike = { currentPath: "/test/vault" };
+  const subscribers = new Set<(s: VaultLike) => void>();
   return {
     vaultStore: {
-      subscribe: (cb: (s: typeof state) => void) => {
+      subscribe: (cb: (s: VaultLike) => void) => {
         cb(state);
         subscribers.add(cb);
         return () => subscribers.delete(cb);

--- a/src/components/Layout/__tests__/MobileSettingsSheet.test.ts
+++ b/src/components/Layout/__tests__/MobileSettingsSheet.test.ts
@@ -1,0 +1,254 @@
+/**
+ * MobileSettingsSheet — full-screen settings sheet for mobile (#394).
+ *
+ * Parent-gated: VaultLayout decides via `{#if isMobile}`; the component
+ * doesn't subscribe to viewportStore. Per team-lead direction this is a
+ * full-screen, opaque sheet — no scrim, just an X close button + Escape.
+ *
+ * Master/detail navigation: a category list (master view) drills into a
+ * single-category detail view. Two-step Escape (detail → master → close)
+ * matches the burger-sheet pattern from #397.
+ *
+ * Stores are mocked so we can assert call shape without exercising
+ * theme/font side-effects on the test DOM.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const { themeSet, settingsCalls, fakeSettingsState } = vi.hoisted(() => ({
+  themeSet: vi.fn(),
+  settingsCalls: {
+    setFontBody: vi.fn(),
+    setFontMono: vi.fn(),
+    setFontSize: vi.fn(),
+    setDailyNotesFolder: vi.fn(),
+    setDailyNotesDateFormat: vi.fn(),
+    setDailyNotesTemplate: vi.fn(),
+    setAutoLockMinutes: vi.fn(),
+  },
+  fakeSettingsState: {
+    fontBody: "system" as const,
+    fontMono: "system" as const,
+    fontSize: 14,
+    dailyNotesFolder: "Daily",
+    dailyNotesDateFormat: "YYYY-MM-DD",
+    dailyNotesTemplate: "",
+    autoLockMinutes: 15,
+  },
+}));
+
+vi.mock("../../../store/themeStore", () => {
+  const subscribers = new Set<(t: string) => void>();
+  return {
+    themeStore: {
+      subscribe: (cb: (t: string) => void) => {
+        cb("auto");
+        subscribers.add(cb);
+        return () => subscribers.delete(cb);
+      },
+      set: (t: string) => {
+        themeSet(t);
+        subscribers.forEach((s) => s(t));
+      },
+    },
+  };
+});
+
+vi.mock("../../../store/settingsStore", () => {
+  const subscribers = new Set<(s: typeof fakeSettingsState) => void>();
+  return {
+    settingsStore: {
+      subscribe: (cb: (s: typeof fakeSettingsState) => void) => {
+        cb(fakeSettingsState);
+        subscribers.add(cb);
+        return () => subscribers.delete(cb);
+      },
+      ...settingsCalls,
+    },
+    FONT_SIZE_MIN: 12,
+    FONT_SIZE_MAX: 20,
+    AUTO_LOCK_MINUTES_MIN: 0,
+    AUTO_LOCK_MINUTES_MAX: 120,
+  };
+});
+
+vi.mock("../../../store/vaultStore", () => {
+  const subscribers = new Set<(s: { currentPath: string | null }) => void>();
+  const state = { currentPath: "/test/vault" };
+  return {
+    vaultStore: {
+      subscribe: (cb: (s: typeof state) => void) => {
+        cb(state);
+        subscribers.add(cb);
+        return () => subscribers.delete(cb);
+      },
+    },
+  };
+});
+
+import MobileSettingsSheet from "../MobileSettingsSheet.svelte";
+
+beforeEach(() => {
+  themeSet.mockClear();
+  Object.values(settingsCalls).forEach((fn) => fn.mockClear());
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function renderSheet(overrides: Partial<{
+  open: boolean;
+  onClose: () => void;
+  onSwitchVault: () => void;
+}> = {}) {
+  return render(MobileSettingsSheet, {
+    props: {
+      open: true,
+      onClose: vi.fn(),
+      onSwitchVault: vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
+describe("MobileSettingsSheet (#394)", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = renderSheet({ open: false });
+    expect(container.querySelector(".vc-mobile-settings-sheet")).toBeNull();
+  });
+
+  it("renders the master view with 5 category rows when open=true", () => {
+    const { container } = renderSheet();
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    const rows = container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    expect(rows.length).toBe(5);
+  });
+
+  it("dialog is full-screen — no scrim element exists (per team-lead direction)", () => {
+    const { container } = renderSheet();
+    expect(container.querySelector(".vc-modal-scrim")).toBeNull();
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-label")).toBe("Einstellungen");
+  });
+
+  it("clicking the Erscheinungsbild row swaps the master view for the appearance detail view", async () => {
+    const { container } = renderSheet();
+    const row = container.querySelector<HTMLButtonElement>('[data-row-id="appearance"]')!;
+    await fireEvent.click(row);
+    await tick();
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+    const radios = container.querySelectorAll<HTMLInputElement>('input[type="radio"][name="theme"]');
+    expect(radios.length).toBe(3);
+  });
+
+  it("changing the theme radio dispatches themeStore.set", async () => {
+    const { container } = renderSheet();
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="appearance"]')!);
+    await tick();
+    const dark = container.querySelector<HTMLInputElement>('input[type="radio"][value="dark"]')!;
+    await fireEvent.click(dark);
+    expect(themeSet).toHaveBeenCalledWith("dark");
+  });
+
+  it("changing the font-size slider dispatches settingsStore.setFontSize with a numeric value", async () => {
+    const { container } = renderSheet();
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="fonts"]')!);
+    await tick();
+    const slider = container.querySelector<HTMLInputElement>('input[type="range"]')!;
+    expect(slider).not.toBeNull();
+    await fireEvent.input(slider, { target: { value: "18" } });
+    expect(settingsCalls.setFontSize).toHaveBeenCalledWith(18);
+  });
+
+  it("Vault → Switch vault button calls onSwitchVault", async () => {
+    const onSwitchVault = vi.fn();
+    const { container } = renderSheet({ onSwitchVault });
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="vault"]')!);
+    await tick();
+    const btn = container.querySelector<HTMLButtonElement>('[data-testid="settings-switch-vault"]')!;
+    await fireEvent.click(btn);
+    expect(onSwitchVault).toHaveBeenCalledTimes(1);
+  });
+
+  it("the Back button in detail view returns to the master view (does NOT close)", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="appearance"]')!);
+    await tick();
+    const back = container.querySelector<HTMLButtonElement>(".vc-mobile-settings-back")!;
+    await fireEvent.click(back);
+    await tick();
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("the X close button in master view calls onClose", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    const close = container.querySelector<HTMLButtonElement>(".vc-mobile-settings-close")!;
+    await fireEvent.click(close);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape from master view calls onClose; Escape from detail view returns to master", async () => {
+    const onClose = vi.fn();
+    const { container } = renderSheet({ onClose });
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+
+    await fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    onClose.mockClear();
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="fonts"]')!);
+    await tick();
+    await fireEvent.keyDown(container.querySelector<HTMLElement>('[role="dialog"]')!, { key: "Escape" });
+    await tick();
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("focus trap: Tab from the last focusable wraps to the first; Shift+Tab from first wraps to last", async () => {
+    const { container } = renderSheet();
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    // Master view focusables: close button + 5 menuitem rows = 6 items.
+    const focusables = Array.from(
+      dialog.querySelectorAll<HTMLElement>('button:not([disabled]):not([tabindex="-1"])'),
+    );
+    expect(focusables.length).toBeGreaterThanOrEqual(2);
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+
+    last.focus();
+    await fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    await fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("re-opening resets to the master view (active category doesn't persist)", async () => {
+    const onClose = vi.fn();
+    const { container, rerender } = renderSheet({ open: true, onClose });
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-row-id="security"]')!);
+    await tick();
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+
+    await rerender({ open: false, onClose, onSwitchVault: vi.fn() });
+    await tick();
+    await rerender({ open: true, onClose, onSwitchVault: vi.fn() });
+    await tick();
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+  });
+
+  it("does not import viewportStore — parent-gated component is the architectural contract", async () => {
+    const fs = await import("node:fs/promises");
+    const url = await import("node:url");
+    const componentPath = url.fileURLToPath(import.meta.resolve("../MobileSettingsSheet.svelte"));
+    const src = await fs.readFile(componentPath, "utf8");
+    expect(/from\s+["'][^"']*viewportStore["']/.test(src)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the cramped desktop SettingsModal on mobile with a new opaque full-screen sheet using master/detail navigation. Triggered from BOTH existing entry points: the topbar gear icon AND the burger sheet's Einstellungen row (#397's stub-toast is gone).

### Architecture
- New `MobileSettingsSheet.svelte` — full-screen, NO scrim per team-lead direction. X close button + Escape are the dismissal paths.
- VaultLayout render-time switch: `{#if isMobile} <MobileSettingsSheet> {:else} <SettingsModal> {/if}`. Single shared `settingsOpen` flag — both viewports use the same trigger paths, so unifying state avoids duplication.
- Parent-gated like #389 / #397: VaultLayout decides via `{#if isMobile}`; component does NOT subscribe to `viewportStore`. Source-level test enforces this.

### Burger sheet API change
- `MobileBurgerSheet` gains an `onOpenSettings` callback prop. Settings RowSpec switches from `action: "stub"` (toast + close) to `action: "external"` (callback + close).
- Naming matches `onSelectFiles` etc. from MobileTabBar — explicit over a generic `onAction(id)` (anti-pattern).
- Properties row stays on `action: "stub"` until #393 lands `onOpenProperties`.

### 5 categories (master/detail)

| Category | Detail content |
|---|---|
| Erscheinungsbild | 3 theme radios (`themeStore.set`) |
| Schrift | Body/mono font selects + size slider 12–20 (`settingsStore.setFont*`) |
| Tagesnotizen | Folder / format / template text inputs |
| Sicherheit | Auto-lock minutes (0–120) |
| Vault | Current path + "Vault wechseln…" button |

Each detail re-implements its section's markup against the SAME stores SettingsModal uses. Stores remain the single source of truth — mobile + desktop see identical state. The 1084-line modal isn't cheaply sub-component-extractable, so this is the pragmatic path.

### Excluded (per ticket)
- Custom keyboard shortcut editor on mobile.
- Plugin settings.
- Snippets management UI.
- Build version display.
- Encrypted-folders list (Sicherheit shows just the auto-lock minutes).

### ARIA + keyboard
- `role=dialog` + `aria-modal=true` + `aria-label="Einstellungen"`, `tabindex=-1`.
- First focusable inside the sheet receives focus on open (microtask).
- **Two-step Escape**: detail view → master view; master view → close. Matches the burger sheet from #397.
- Boundary-only Tab focus trap: Tab from last → first; Shift+Tab from first → last. Middle items pass through to native order.

### Layout
- `position: fixed; inset: 0` — opaque full-screen.
- `padding-top` + `padding-bottom: env(safe-area-inset-*)` for notches.
- 56px row hit targets via `--vc-hit-target` (#385 token).
- z-index 80 — above burger 60, well below modals ≥199.

### Z-index audit (current state)
| Surface | z-index |
|---|---|
| Mobile tab bar | 40 |
| Drawer surface | 50 |
| Burger sheet | 60 |
| **Mobile settings sheet (new)** | **80** |
| OmniSearch / CommandPalette | 200/201 |
| SettingsModal (desktop) | 300/301 |

## Test plan
- [x] `pnpm vitest run src/components/Layout/` — 63/63 green (13 new MobileSettingsSheet cases + updated burger Settings-row test + 49 prior)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [ ] Manual UAT: tap topbar gear at mobile size → mobile sheet opens (NOT desktop modal). Each category drills in; back returns; X closes.
- [ ] Manual UAT: change theme to Dunkel → app theme reflects immediately. Reopen → choice persisted.
- [ ] Manual UAT: change font-size slider → editor font scales. Reopen → choice persisted.
- [ ] Manual UAT: tap More tab → burger → Einstellungen → mobile settings sheet opens (burger closes).
- [ ] Manual UAT: Escape from detail returns to master; Escape from master closes.
- [ ] Manual UAT: Vault → Vault wechseln… invokes the onSwitchVault flow.
- [ ] Manual UAT: resize back to desktop with sheet open → desktop modal appears (or sheet closes — depends on resize-effect; verify what happens).

### Coordination note
mode-impl-2's #393 will add `onOpenProperties` to MobileBurgerSheet for the same architectural reason (`action: "external"` for that row). Both PRs touch the burger's RowSpec union; mechanical conflict at merge.

Closes #394. Refs #74.