### PR TITLE
feat(mobile): AndroidStorage + ContentUri routing (#392 PR-B)

### DIFF
--- a/docs/MOBILE_BUILD.md
+++ b/docs/MOBILE_BUILD.md
@@ -119,7 +119,30 @@ Tracked custom plugins:
 
 | File | Ticket | Purpose |
 |---|---|---|
-| `PickerPlugin.kt` | #391 | Storage Access Framework picker (`ACTION_OPEN_DOCUMENT_TREE` + `ACTION_CREATE_DOCUMENT`) for vault folder selection and save-as on mobile. |
+| `PickerPlugin.kt` | #391, #392 | SAF picker + I/O. #391 added `ACTION_OPEN_DOCUMENT_TREE` / `ACTION_CREATE_DOCUMENT`. #392 PR-B added `takePersistableUriPermission`, `hasPersistedPermission`, and the read/write/create/delete/rename/metadata/listDir/exists I/O commands backed by `DocumentFile.fromTreeUri`. |
+
+## Android — feature surface (PR-B v1)
+
+What works:
+
+- Picker → open vault → vault re-opens across app restart (the SAF tree URI is persisted via `takePersistableUriPermission` and restored from `recent-vaults.json`).
+- Read / edit / save markdown files. Bytes round-trip through `ContentResolver` per file (see Performance below).
+- Create / delete / rename / move files. Same-parent rename via `DocumentFile.renameTo`; cross-parent rename uses `DocumentsContract.moveDocument` (requires the SAF provider to advertise `FLAG_SUPPORTS_MOVE` — most stock providers do).
+- Create / delete folders. Recursive folder delete via `DocumentFile.delete`; Android 11+ moves the deleted document to the OS Files-app Trash, so user-level recovery is preserved without an in-vault `.trash` subfolder.
+- File tree (`list_directory`) populates lazily as the user navigates.
+- Bookmarks persist across sessions in app-private scratch (`<getFilesDir()>/vaults/<sha256(uri)[..16]>/bookmarks.json`).
+- Stale-bookmark UX: revoking the SAF grant via system Settings (or reinstalling the app) surfaces a `VaultPermissionRevoked` error; the frontend automatically re-fires `pickVaultFolder` so the user can re-grant access without retyping.
+
+Known limitations (tracked follow-ups):
+
+- **No live file watching.** The `notify` crate uses inotify which doesn't reach `content://` URIs. Vault refreshes happen on close + reopen for now. Tracked: `feat(watcher): Android polling fallback for content-URI vaults`.
+- **Fulltext search starts empty on each session.** Tantivy's cold-start indexer walks the vault with `walkdir` + `std::fs::read`, which is impractical over `ContentResolver`. Per-file index updates via `dispatch_self_write` populate the index as the user opens/edits files (so search hits show up incrementally). Tracked: `feat(indexer): cold-start lazy index for ContentResolver vaults`.
+- **Backlinks and link graph are empty on Android.** Same root cause as the indexer — they require a full vault walk. The frontend's "Outgoing links" panel and graph view show empty states. Tracked under the same lazy-index follow-up.
+- **No encrypted folders on Android (#345).** The encryption manifest is canonical-path-keyed (`encryption/mod.rs:185`); a URI-aware variant requires manifest format changes. `encrypt_folder` / `unlock_folder` / `lock_folder` / `lock_all_folders` / `list_encrypted_folders` / `export_decrypted_file` all return `EncryptionUnsupportedOnAndroid`. Plain (unencrypted) vaults work in full. Tracked: `feat(crypto): VaultStorage-aware encryption layer for Android`.
+- **HTML export deferred on Android.** Asset-inlining requires walkdir + raw `std::fs::read`. Returns `PermissionDenied` with a clear message. The frontend's "Export to HTML" menu entry should be hidden on Android in a UI-only follow-up.
+- **Templates / snippets / canvas / tags / wiki-link counter** all return empty/no-op on Android. Each is a power-user feature whose POSIX-only walkdir hot path didn't earn a port in PR-B.
+- **Per-file ContentResolver round-trip cost.** Each `walkRel` step is one Binder call (1-5ms). 5-deep paths cost 5-25ms. Acceptable for v1; batch-API optimization is a UAT-driven follow-up.
+- **No in-vault `.trash` subfolder on Android.** SAF doesn't expose a portable trash semantic; relying on the OS-level Files-app Trash on Android 11+ is the v1 strategy.
 
 ## Known limitations (tracked, deferred)
 

--- a/src-tauri/gen/android/app/src/main/java/app/vaultcore/picker/PickerPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/app/vaultcore/picker/PickerPlugin.kt
@@ -1,56 +1,107 @@
-// #391 — Tauri mobile plugin for VaultCore's vault folder + save-as picker.
+// #391 / #392 — Tauri mobile plugin for VaultCore's vault folder picker
+// (#391) and Storage Access Framework I/O (#392 PR-B).
 //
 // Placement note: this file lives directly in `gen/android/...` and NOT
 // in a `src-tauri/android/` overlay directory. As of Tauri 2.10 the
 // overlay convention is silently ignored at build time — verified via
-// `dexdump` on a build that placed the file in the overlay path: the
-// resulting APK's `classes*.dex` did not contain `Lcom/vaultcore/app/
-// PickerPlugin;`. The `gen/android/` placement empirically survives a
-// `tauri android init` re-run in this Tauri version. If a future Tauri
-// version changes init behavior this file may need re-applying after
-// init. See `docs/MOBILE_BUILD.md` → "Custom Android plugins".
+// `dexdump`. The `gen/android/` placement empirically survives a
+// `tauri android init` re-run in this Tauri version. See
+// `docs/MOBILE_BUILD.md` → "Custom Android plugins".
 //
-// Two commands exposed to the Rust side via Tauri's mobile-plugin FFI:
+// Commands exposed to the Rust side via Tauri's mobile-plugin FFI:
 //
-//   - pickDirectoryTree: fires `Intent.ACTION_OPEN_DOCUMENT_TREE` and
-//     resolves with the resulting `content://...tree/...` URI. The
-//     persistable-permission flag is set on the intent so #392 can call
-//     `takePersistableUriPermission` later when the bookmark layer
-//     exists. We deliberately do NOT call `takePersistableUriPermission`
-//     here — without a place to store the URI, the grant would just
-//     churn the system's grant table.
+//   #391 (already shipped):
+//   - pickDirectoryTree:  ACTION_OPEN_DOCUMENT_TREE  → content:// tree URI.
+//   - pickSavePath:       ACTION_CREATE_DOCUMENT     → content:// save URI.
 //
-//   - pickSavePath: fires `Intent.ACTION_CREATE_DOCUMENT`. Lossy MIME
-//     transform: SAF accepts a single MIME per intent, so v1 hardcodes
-//     `application/octet-stream`. The user-visible `EXTRA_TITLE` keeps
-//     the suggested filename so UX is unchanged. Per-extension MIME
-//     hint is a follow-up if UX requires it.
+//   #392 PR-B:
+//   - takePersistableUriPermission(uri): persists the read+write grant
+//     so the URI survives app restart. MUST be called inside the
+//     directoryTreeResult callback flow before the activity completes.
+//   - hasPersistedPermission(uri):       boolean check on
+//     contentResolver.getPersistedUriPermissions(). Used by `open_vault`
+//     before opening a recents URI to surface VaultPermissionRevoked.
+//   - readFile(treeUri, relPath):       returns base64 content.
+//   - writeFile(treeUri, relPath, contentB64): creates parents as needed.
+//   - createFile(treeUri, relPath, contentB64): same as writeFile today;
+//     kept distinct so a future "fail if exists" semantic can diverge.
+//   - createDir(treeUri, relPath):       walk + DocumentFile.createDirectory.
+//   - delete(treeUri, relPath):           DocumentFile.delete (recursive).
+//   - rename(treeUri, fromRel, toRel):    rename within the tree.
+//   - metadata(treeUri, relPath):         returns { exists, isDir, size }.
+//   - listDir(treeUri, relPath):          returns { entries: [{name, isDir}] }.
+//   - exists(treeUri, relPath):           boolean.
 //
-// Cancellation taxonomy: any non-`RESULT_OK` result code maps to
-// `uri = null`. This covers `RESULT_CANCELED`, `RESULT_FIRST_USER`
-// (Samsung/MIUI vendor extensions), and any future vendor-specific
-// codes — cancellation is a UX state, not an error.
+// Cancellation: not applicable for I/O commands. They either succeed or
+// reject with a stable error string. The Rust side maps rejections to
+// `VaultError::Io { msg }` (the IPC's free-form Io variant).
+//
+// Performance: each `walkRel` step is one Binder round-trip (1-5ms).
+// Deep paths cost more; documented in MOBILE_BUILD.md. Batch-API
+// optimization deferred until UAT calls it out.
 
 package app.vaultcore.picker
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
+import android.provider.DocumentsContract
+import android.util.Base64
 import androidx.activity.result.ActivityResult
+import androidx.documentfile.provider.DocumentFile
 import app.tauri.annotation.ActivityCallback
 import app.tauri.annotation.Command
 import app.tauri.annotation.InvokeArg
 import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.JSArray
 import app.tauri.plugin.Invoke
 import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
+
+// ── #391 picker args ────────────────────────────────────────────────────────
 
 @InvokeArg
 class SavePathArgs {
     lateinit var defaultName: String
 }
 
+// ── #392 PR-B I/O args ──────────────────────────────────────────────────────
+
+@InvokeArg
+class UriArg {
+    lateinit var uri: String
+}
+
+@InvokeArg
+class ReadArgs {
+    lateinit var treeUri: String
+    lateinit var relPath: String
+}
+
+@InvokeArg
+class WriteArgs {
+    lateinit var treeUri: String
+    lateinit var relPath: String
+    lateinit var contentB64: String
+}
+
+@InvokeArg
+class DirArgs {
+    lateinit var treeUri: String
+    lateinit var relPath: String
+}
+
+@InvokeArg
+class RenameArgs {
+    lateinit var treeUri: String
+    lateinit var fromRel: String
+    lateinit var toRel: String
+}
+
 @TauriPlugin
 class PickerPlugin(private val activity: Activity) : Plugin(activity) {
+
+    // ── #391 commands (unchanged) ───────────────────────────────────────────
 
     @Command
     fun pickDirectoryTree(invoke: Invoke) {
@@ -69,9 +120,6 @@ class PickerPlugin(private val activity: Activity) : Plugin(activity) {
         val args = invoke.parseArgs(SavePathArgs::class.java)
         val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
-            // ACTION_CREATE_DOCUMENT returns a one-shot write URI; the
-            // persistable flag would be a no-op here. Kept off so the
-            // intent reads as exactly what it does.
             type = "application/octet-stream"
             putExtra(Intent.EXTRA_TITLE, args.defaultName)
             addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
@@ -99,5 +147,277 @@ class PickerPlugin(private val activity: Activity) : Plugin(activity) {
             out.put("uri", null as String?)
         }
         invoke.resolve(out)
+    }
+
+    // ── #392 PR-B: persistable permission ──────────────────────────────────
+
+    @Command
+    fun takePersistableUriPermission(invoke: Invoke) {
+        val args = invoke.parseArgs(UriArg::class.java)
+        val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+            Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        try {
+            activity.contentResolver
+                .takePersistableUriPermission(Uri.parse(args.uri), flags)
+            invoke.resolve(JSObject())
+        } catch (ex: SecurityException) {
+            // Tree URI was not surfaced via SAF in this app session
+            // (e.g. trying to take perms on a stale URI from recents
+            // when the picker hasn't been invoked since reinstall).
+            invoke.reject("takePersistableUriPermission denied: ${ex.message}")
+        }
+    }
+
+    @Command
+    fun hasPersistedPermission(invoke: Invoke) {
+        val args = invoke.parseArgs(UriArg::class.java)
+        val target = Uri.parse(args.uri)
+        val granted = activity.contentResolver.persistedUriPermissions.any {
+            it.uri == target && (it.isReadPermission || it.isWritePermission)
+        }
+        invoke.resolve(JSObject().apply { put("granted", granted) })
+    }
+
+    // ── #392 PR-B: I/O against SAF tree ────────────────────────────────────
+
+    @Command
+    fun readFile(invoke: Invoke) {
+        val args = invoke.parseArgs(ReadArgs::class.java)
+        try {
+            val node = walkRel(args.treeUri, args.relPath, createParents = false)
+                ?: return invoke.reject("not found: ${args.relPath}")
+            val bytes = activity.contentResolver
+                .openInputStream(node.uri)
+                ?.use { it.readBytes() }
+                ?: return invoke.reject("openInputStream returned null: ${args.relPath}")
+            val b64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+            invoke.resolve(JSObject().apply { put("contentB64", b64) })
+        } catch (ex: Exception) {
+            invoke.reject("readFile ${args.relPath}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    @Command
+    fun writeFile(invoke: Invoke) {
+        val args = invoke.parseArgs(WriteArgs::class.java)
+        try {
+            val bytes = Base64.decode(args.contentB64, Base64.NO_WRAP)
+            val parent = walkRel(
+                args.treeUri,
+                parentOf(args.relPath),
+                createParents = true,
+            ) ?: return invoke.reject("could not resolve parent: ${args.relPath}")
+            val name = lastSegment(args.relPath)
+                ?: return invoke.reject("invalid relPath: ${args.relPath}")
+            val target = parent.findFile(name) ?: parent.createFile(
+                /* mimeType */ "application/octet-stream",
+                name,
+            ) ?: return invoke.reject("createFile failed: ${args.relPath}")
+            activity.contentResolver
+                .openOutputStream(target.uri, "wt")
+                ?.use { it.write(bytes) }
+                ?: return invoke.reject("openOutputStream returned null: ${args.relPath}")
+            invoke.resolve(JSObject())
+        } catch (ex: Exception) {
+            invoke.reject("writeFile ${args.relPath}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    @Command
+    fun createFile(invoke: Invoke) {
+        // PR-B v1: same behavior as writeFile (creates-or-truncates).
+        // The "fail if exists" semantic the Rust caller expects is
+        // enforced one layer up by `commands/files.rs::create_file_impl`
+        // which checks for collision before invoking us.
+        writeFile(invoke)
+    }
+
+    @Command
+    fun createDir(invoke: Invoke) {
+        val args = invoke.parseArgs(DirArgs::class.java)
+        try {
+            walkRel(args.treeUri, args.relPath, createParents = true)
+                ?: return invoke.reject("createDir failed: ${args.relPath}")
+            invoke.resolve(JSObject())
+        } catch (ex: Exception) {
+            invoke.reject("createDir ${args.relPath}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    @Command
+    fun deletePath(invoke: Invoke) {
+        val args = invoke.parseArgs(DirArgs::class.java)
+        try {
+            val node = walkRel(args.treeUri, args.relPath, createParents = false)
+                ?: return invoke.reject("not found: ${args.relPath}")
+            // DocumentFile.delete is recursive on directories per platform docs.
+            if (!node.delete()) {
+                return invoke.reject("delete returned false: ${args.relPath}")
+            }
+            invoke.resolve(JSObject())
+        } catch (ex: Exception) {
+            invoke.reject("delete ${args.relPath}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    @Command
+    fun renamePath(invoke: Invoke) {
+        val args = invoke.parseArgs(RenameArgs::class.java)
+        try {
+            val from = walkRel(args.treeUri, args.fromRel, createParents = false)
+                ?: return invoke.reject("not found: ${args.fromRel}")
+            val fromParent = parentOf(args.fromRel)
+            val toParent = parentOf(args.toRel)
+            if (fromParent == toParent) {
+                // Same-parent rename — DocumentFile.renameTo handles it.
+                val newName = lastSegment(args.toRel)
+                    ?: return invoke.reject("invalid toRel: ${args.toRel}")
+                if (!from.renameTo(newName)) {
+                    return invoke.reject("renameTo returned false: ${args.toRel}")
+                }
+                invoke.resolve(JSObject())
+            } else {
+                // Cross-parent rename — SAF doesn't support this directly.
+                // Use DocumentsContract.moveDocument if both parents are
+                // queryable (provider must support FLAG_SUPPORTS_MOVE).
+                val to = lastSegment(args.toRel)
+                    ?: return invoke.reject("invalid toRel: ${args.toRel}")
+                val newParent = walkRel(args.treeUri, toParent, createParents = true)
+                    ?: return invoke.reject("could not resolve dest parent: ${args.toRel}")
+                val moved = DocumentsContract.moveDocument(
+                    activity.contentResolver,
+                    from.uri,
+                    from.parentFile?.uri ?: return invoke.reject("source has no parent"),
+                    newParent.uri,
+                ) ?: return invoke.reject(
+                    "moveDocument failed (provider may not support cross-parent move)",
+                )
+                // After move, rename the leaf if the basename changed.
+                val movedDoc = DocumentFile.fromTreeUri(activity, moved)
+                if (movedDoc?.name != to) {
+                    movedDoc?.renameTo(to)
+                }
+                invoke.resolve(JSObject())
+            }
+        } catch (ex: Exception) {
+            invoke.reject("rename ${args.fromRel} → ${args.toRel}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    @Command
+    fun metadata(invoke: Invoke) {
+        val args = invoke.parseArgs(DirArgs::class.java)
+        try {
+            val node = walkRel(args.treeUri, args.relPath, createParents = false)
+            val out = JSObject()
+            if (node == null) {
+                out.put("exists", false)
+                out.put("isDir", false)
+                out.put("size", 0)
+            } else {
+                out.put("exists", true)
+                out.put("isDir", node.isDirectory)
+                out.put("size", node.length())
+            }
+            invoke.resolve(out)
+        } catch (ex: Exception) {
+            invoke.reject("metadata ${args.relPath}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    @Command
+    fun listDir(invoke: Invoke) {
+        val args = invoke.parseArgs(DirArgs::class.java)
+        try {
+            val dir = walkRel(args.treeUri, args.relPath, createParents = false)
+                ?: return invoke.reject("not found: ${args.relPath}")
+            if (!dir.isDirectory) {
+                return invoke.reject("not a directory: ${args.relPath}")
+            }
+            val entries = JSArray()
+            for (child in dir.listFiles()) {
+                val e = JSObject()
+                e.put("name", child.name ?: continue)
+                e.put("isDir", child.isDirectory)
+                entries.put(e)
+            }
+            invoke.resolve(JSObject().apply { put("entries", entries) })
+        } catch (ex: Exception) {
+            invoke.reject("listDir ${args.relPath}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    @Command
+    fun pathExists(invoke: Invoke) {
+        val args = invoke.parseArgs(DirArgs::class.java)
+        try {
+            val node = walkRel(args.treeUri, args.relPath, createParents = false)
+            invoke.resolve(JSObject().apply { put("exists", node != null) })
+        } catch (ex: Exception) {
+            invoke.reject("exists ${args.relPath}: ${ex.message ?: ex.javaClass.simpleName}")
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * Walk a forward-slash-separated rel path under the SAF tree URI,
+     * returning the leaf DocumentFile (file or directory). Returns
+     * `null` if any intermediate component is missing AND
+     * [createParents] is `false`.
+     *
+     * If [createParents] is `true`, missing intermediate directories
+     * are created via DocumentFile.createDirectory. The leaf component
+     * is always treated as the target — this function never creates a
+     * leaf file (writeFile/createFile own that).
+     *
+     * `relPath = ""` returns the tree root.
+     *
+     * Rel-path validation is the Rust caller's job (storage::validate_rel)
+     * — this function trusts its input is normalized.
+     */
+    private fun walkRel(
+        treeUri: String,
+        relPath: String,
+        createParents: Boolean,
+    ): DocumentFile? {
+        val root = DocumentFile.fromTreeUri(activity, Uri.parse(treeUri)) ?: return null
+        if (relPath.isEmpty()) return root
+        val parts = relPath.split('/').filter { it.isNotEmpty() }
+        var cur: DocumentFile = root
+        for ((i, name) in parts.withIndex()) {
+            val isLeaf = i == parts.size - 1
+            val existing = cur.findFile(name)
+            cur = if (existing != null) {
+                existing
+            } else if (createParents && !isLeaf) {
+                cur.createDirectory(name) ?: return null
+            } else if (createParents && isLeaf) {
+                // Caller wants the leaf itself — treat as a dir (we
+                // don't know the target type for a non-existent file).
+                cur.createDirectory(name) ?: return null
+            } else {
+                return null
+            }
+        }
+        return cur
+    }
+
+    /**
+     * Parent rel-path of `relPath`, forward-slash separated. Returns
+     * empty string if the rel has no `/`.
+     */
+    private fun parentOf(relPath: String): String {
+        val i = relPath.lastIndexOf('/')
+        return if (i <= 0) "" else relPath.substring(0, i)
+    }
+
+    /**
+     * Last segment of `relPath`. Returns null for empty input.
+     */
+    private fun lastSegment(relPath: String): String? {
+        if (relPath.isEmpty()) return null
+        val i = relPath.lastIndexOf('/')
+        return if (i < 0) relPath else relPath.substring(i + 1)
     }
 }

--- a/src-tauri/gen/android/app/src/main/java/app/vaultcore/picker/PickerPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/app/vaultcore/picker/PickerPlugin.kt
@@ -170,12 +170,28 @@ class PickerPlugin(private val activity: Activity) : Plugin(activity) {
 
     @Command
     fun hasPersistedPermission(invoke: Invoke) {
+        // Returns the per-flag breakdown of the persisted grant for
+        // `args.uri`. The Rust caller (`AndroidStorage::has_persisted_permission`)
+        // is responsible for the &&-of-read-and-write decision: this
+        // command MUST NOT collapse the two booleans into a single
+        // "granted" answer, because a read-only grant would otherwise
+        // get classified as "permission ok" — first write would then
+        // fail with a generic Io error instead of triggering the
+        // re-pick UX. See the Rust caller and the matching unit test.
         val args = invoke.parseArgs(UriArg::class.java)
         val target = Uri.parse(args.uri)
-        val granted = activity.contentResolver.persistedUriPermissions.any {
-            it.uri == target && (it.isReadPermission || it.isWritePermission)
+        var hasRead = false
+        var hasWrite = false
+        for (p in activity.contentResolver.persistedUriPermissions) {
+            if (p.uri == target) {
+                if (p.isReadPermission) hasRead = true
+                if (p.isWritePermission) hasWrite = true
+            }
         }
-        invoke.resolve(JSObject().apply { put("granted", granted) })
+        val out = JSObject()
+        out.put("hasRead", hasRead)
+        out.put("hasWrite", hasWrite)
+        invoke.resolve(out)
     }
 
     // ── #392 PR-B: I/O against SAF tree ────────────────────────────────────
@@ -293,9 +309,20 @@ class PickerPlugin(private val activity: Activity) : Plugin(activity) {
                     "moveDocument failed (provider may not support cross-parent move)",
                 )
                 // After move, rename the leaf if the basename changed.
+                // Discarding renameTo's return value would silently leave
+                // the file under its OLD basename at the new parent —
+                // caller thinks "I moved foo.md to /Notes/ as bar.md"
+                // and would in fact see /Notes/foo.md. Fail loud instead.
                 val movedDoc = DocumentFile.fromTreeUri(activity, moved)
-                if (movedDoc?.name != to) {
-                    movedDoc?.renameTo(to)
+                if (movedDoc == null) {
+                    return invoke.reject("could not re-resolve moved document at ${moved}")
+                }
+                if (movedDoc.name != to) {
+                    if (!movedDoc.renameTo(to)) {
+                        return invoke.reject(
+                            "moveDocument succeeded but renameTo($to) returned false",
+                        )
+                    }
                 }
                 invoke.resolve(JSObject())
             }

--- a/src-tauri/src/commands/bookmarks.rs
+++ b/src-tauri/src/commands/bookmarks.rs
@@ -15,25 +15,63 @@ use std::path::{Path, PathBuf};
 const BOOKMARKS_DIR: &str = ".vaultcore";
 const BOOKMARKS_FILE: &str = "bookmarks.json";
 
-/// Resolve `<vault>/.vaultcore/bookmarks.json` after confirming `vault_path`
+/// Resolve the on-disk bookmarks JSON path after confirming `vault_path`
 /// matches the currently-open vault.
+///
+/// Desktop: `<vault>/.vaultcore/bookmarks.json` (canonicalize the input,
+/// require byte-equality with `current_vault`'s POSIX path).
+///
+/// #392 PR-B Android: `<storage.metadata_path()>/bookmarks.json` —
+/// app-private scratch under `<getFilesDir()>/vaults/<uri-hash>/`. The
+/// vault_path equality check uses `canonical_dedup_key` so trailing-
+/// slash variations of the same content URI compare as equal.
 fn bookmarks_path_for(state: &VaultState, vault_path: &str) -> Result<PathBuf, VaultError> {
-    let canonical = std::fs::canonicalize(vault_path).map_err(|e| match e.kind() {
-        std::io::ErrorKind::NotFound => VaultError::FileNotFound { path: vault_path.to_string() },
-        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: vault_path.to_string() },
-        _ => VaultError::Io(e),
-    })?;
+    use crate::storage::VaultHandle;
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    let vault = guard
-        .as_ref()
-        .ok_or_else(|| VaultError::VaultUnavailable {
-            path: vault_path.to_string(),
-        })?
-        .expect_posix();
-    if canonical != *vault {
-        return Err(VaultError::PermissionDenied { path: canonical.display().to_string() });
+    let handle = guard.as_ref().ok_or_else(|| VaultError::VaultUnavailable {
+        path: vault_path.to_string(),
+    })?;
+    match handle {
+        VaultHandle::Posix(vault) => {
+            let canonical = std::fs::canonicalize(vault_path).map_err(|e| match e.kind() {
+                std::io::ErrorKind::NotFound => VaultError::FileNotFound {
+                    path: vault_path.to_string(),
+                },
+                std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied {
+                    path: vault_path.to_string(),
+                },
+                _ => VaultError::Io(e),
+            })?;
+            if canonical != *vault {
+                return Err(VaultError::PermissionDenied {
+                    path: canonical.display().to_string(),
+                });
+            }
+            Ok(canonical.join(BOOKMARKS_DIR).join(BOOKMARKS_FILE))
+        }
+        #[cfg(target_os = "android")]
+        VaultHandle::ContentUri(uri) => {
+            // Equality via canonical_dedup_key tolerates trailing-slash
+            // variations the frontend may produce.
+            let frontend_key = VaultHandle::ContentUri(vault_path.to_string()).canonical_dedup_key();
+            let backend_key = handle.canonical_dedup_key();
+            if frontend_key != backend_key {
+                return Err(VaultError::PermissionDenied {
+                    path: vault_path.to_string(),
+                });
+            }
+            // metadata_path is app-private POSIX scratch; safe for
+            // std::fs::*. Drop the handle guard before going through
+            // the storage RwLock to avoid lock-order issues.
+            let _ = uri;
+            drop(guard);
+            let storage_guard = state.storage.read().map_err(|_| VaultError::LockPoisoned)?;
+            let storage = storage_guard.as_ref().cloned().ok_or_else(|| {
+                VaultError::VaultUnavailable { path: vault_path.to_string() }
+            })?;
+            Ok(storage.metadata_path().join(BOOKMARKS_FILE))
+        }
     }
-    Ok(canonical.join(BOOKMARKS_DIR).join(BOOKMARKS_FILE))
 }
 
 pub fn load_bookmarks_impl(state: &VaultState, vault_path: String) -> Result<Vec<String>, VaultError> {

--- a/src-tauri/src/commands/encryption.rs
+++ b/src-tauri/src/commands/encryption.rs
@@ -94,12 +94,24 @@ pub struct EncryptProgress {
 
 fn vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    guard
-        .as_ref()
-        .map(|h| h.expect_posix().to_path_buf())
-        .ok_or_else(|| VaultError::VaultUnavailable {
+    match guard.as_ref() {
+        Some(crate::storage::VaultHandle::Posix(p)) => Ok(p.clone()),
+        // #392 PR-B: encrypted folders are not supported on
+        // content://-rooted vaults yet. The manifest is canonical-path-
+        // keyed; the SAF layer doesn't have an equivalent. Fail-fast
+        // here so every encryption command (encrypt_folder,
+        // unlock_folder, lock_folder, lock_all_folders,
+        // list_encrypted_folders, export_decrypted_file) surfaces a
+        // single discriminated error to the frontend. Tracked: #345
+        // storage-trait-aware encryption follow-up.
+        #[cfg(target_os = "android")]
+        Some(crate::storage::VaultHandle::ContentUri(_)) => {
+            Err(VaultError::EncryptionUnsupportedOnAndroid)
+        }
+        None => Err(VaultError::VaultUnavailable {
             path: String::from("<no vault>"),
-        })
+        }),
+    }
 }
 
 /// Canonical absolute path of the folder the user referenced, with
@@ -501,12 +513,19 @@ pub fn export_decrypted_file_impl(
             .current_vault
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
-        guard
-            .as_ref()
-            .map(|h| h.expect_posix().to_path_buf())
-            .ok_or_else(|| VaultError::VaultUnavailable {
-                path: source.clone(),
-            })?
+        match guard.as_ref() {
+            Some(crate::storage::VaultHandle::Posix(p)) => p.clone(),
+            // #392 PR-B: see vault_root helper for rationale.
+            #[cfg(target_os = "android")]
+            Some(crate::storage::VaultHandle::ContentUri(_)) => {
+                return Err(VaultError::EncryptionUnsupportedOnAndroid);
+            }
+            None => {
+                return Err(VaultError::VaultUnavailable {
+                    path: source.clone(),
+                });
+            }
+        }
     };
 
     // 2. Canonicalize source + enforce vault scope against the single

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -28,10 +28,23 @@ const SKIP_DIRS: &[&str] = &[".obsidian", ".git", ".vaultcore", ".trash"];
 
 fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
     let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
-    guard
-        .as_ref()
-        .map(|h| h.expect_posix().to_path_buf())
-        .ok_or_else(|| VaultError::VaultUnavailable { path: String::from("<no vault>") })
+    match guard.as_ref() {
+        Some(crate::storage::VaultHandle::Posix(p)) => Ok(p.clone()),
+        // #392 PR-B: HTML export is desktop-only — the asset-inlining
+        // pipeline reads attachment bytes via WalkDir + std::fs::read.
+        // Frontend's "Export to HTML" menu entry shouldn't be enabled
+        // on mobile in v1; if it is, this surfaces a clear error
+        // instead of panicking.
+        #[cfg(target_os = "android")]
+        Some(crate::storage::VaultHandle::ContentUri(_)) => {
+            Err(VaultError::PermissionDenied {
+                path: String::from("HTML export is not yet supported on Android"),
+            })
+        }
+        None => Err(VaultError::VaultUnavailable {
+            path: String::from("<no vault>"),
+        }),
+    }
 }
 
 fn ensure_inside_vault(vault: &Path, target: &Path) -> Result<PathBuf, VaultError> {

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -35,10 +35,16 @@ fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
         // Frontend's "Export to HTML" menu entry shouldn't be enabled
         // on mobile in v1; if it is, this surfaces a clear error
         // instead of panicking.
+        // #392 PR-B Aristotle iter-1 #4: use the dedicated
+        // OperationUnsupportedOnAndroid variant instead of shoehorning
+        // prose into PermissionDenied's path field. The IPC `data`
+        // field carries the operation name as a label (not a path),
+        // so the frontend's `navigate(err.data)` convention isn't
+        // misled.
         #[cfg(target_os = "android")]
         Some(crate::storage::VaultHandle::ContentUri(_)) => {
-            Err(VaultError::PermissionDenied {
-                path: String::from("HTML export is not yet supported on Android"),
+            Err(VaultError::OperationUnsupportedOnAndroid {
+                operation: "HTML export".into(),
             })
         }
         None => Err(VaultError::VaultUnavailable {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -94,6 +94,21 @@ pub async fn read_file(
     state: tauri::State<'_, VaultState>,
     path: String,
 ) -> Result<String, VaultError> {
+    // #392 PR-B: Android branch routes through the storage trait. The
+    // frontend sends absolute-looking strings (`<uri> + "/" + <rel>`)
+    // which we re-derive into a rel for VaultStorage::read_file.
+    // Encryption is a passthrough on Android (encrypted folders deferred
+    // to #345 follow-up) so we skip maybe_decrypt_read.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, rel) = android_storage_and_rel(&state, &path)?;
+        let bytes = storage.read_file(&rel)?;
+        return String::from_utf8(bytes).map_err(|_| VaultError::InvalidEncoding { path });
+    }
+
     let target = PathBuf::from(&path);
     let canonical = ensure_inside_vault(&state, &target)?;
     let bytes = std::fs::read(&canonical).map_err(|e| match e.kind() {
@@ -115,6 +130,24 @@ pub async fn write_file(
     path: String,
     content: String,
 ) -> Result<String, VaultError> {
+    // #392 PR-B: Android branch — same shape as read_file. Encryption
+    // is passthrough so we skip maybe_encrypt_write. The watcher
+    // doesn't run on Android so we skip write_ignore. The link/tag/
+    // index dispatch happens via dispatch_self_write on desktop only;
+    // on Android the per-file index update is a no-op (cold-start
+    // indexer is deferred), so the dispatch is also skipped — fulltext
+    // search starts empty until the lazy-index follow-up lands.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, rel) = android_storage_and_rel(&state, &path)?;
+        let bytes = content.as_bytes();
+        storage.write_file(&rel, bytes)?;
+        return Ok(hash_bytes(bytes));
+    }
+
     let target = PathBuf::from(&path);
 
     // For writes we canonicalize the *parent* (the target file may not exist
@@ -228,6 +261,61 @@ fn get_vault_root(state: &VaultState) -> Result<PathBuf, VaultError> {
         })
 }
 
+/// #392 PR-B: helpers for the Android branch of file commands. The
+/// frontend constructs absolute-looking strings as `<currentPath> + "/"
+/// + <relPath>` where `currentPath` is the SAF tree URI on Android.
+/// `derive_rel_for_android` strips the URI prefix to recover the rel
+/// the storage trait wants. `android_storage` clones the storage Arc
+/// for the calling task without holding the lock.
+#[cfg(target_os = "android")]
+fn android_storage_and_rel(
+    state: &VaultState,
+    target_str: &str,
+) -> Result<(std::sync::Arc<dyn crate::storage::VaultStorage>, String), VaultError> {
+    use crate::storage::VaultHandle;
+    let storage = {
+        let guard = state.storage.read().map_err(|_| VaultError::LockPoisoned)?;
+        guard
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| VaultError::VaultUnavailable {
+                path: target_str.to_string(),
+            })?
+    };
+    let uri = {
+        let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
+        match guard.as_ref() {
+            Some(VaultHandle::ContentUri(u)) => u.clone(),
+            _ => {
+                return Err(VaultError::VaultUnavailable {
+                    path: target_str.to_string(),
+                });
+            }
+        }
+    };
+    // Frontend builds `<uri> + "/" + <rel>`. Strip the prefix.
+    let prefix = if uri.ends_with('/') {
+        uri.clone()
+    } else {
+        format!("{}/", uri)
+    };
+    let rel = if target_str == uri || target_str == prefix.trim_end_matches('/') {
+        String::new()
+    } else if let Some(stripped) = target_str.strip_prefix(&prefix) {
+        stripped.to_string()
+    } else if let Some(stripped) = target_str.strip_prefix(&uri) {
+        // Frontend may forget to include the slash separator.
+        stripped.trim_start_matches('/').to_string()
+    } else {
+        return Err(VaultError::PathOutsideVault {
+            path: target_str.to_string(),
+        });
+    };
+    crate::storage::validate_rel(&rel)?;
+    Ok((storage, rel))
+}
+
+
 /// Helper: record a path in the write-ignore list (D-12 self-filtering).
 fn record_write(state: &VaultState, path: PathBuf) {
     if let Ok(mut list) = state.write_ignore.lock() {
@@ -340,6 +428,51 @@ pub async fn create_file(
     name: String,
 ) -> Result<String, VaultError> {
     use tauri::Emitter;
+
+    // #392 PR-B: Android branch. The frontend's `parent` is the
+    // absolute (URI + "/" + parent_rel) form. Derive the parent rel,
+    // pick a non-colliding leaf name, write empty bytes via the
+    // storage trait. Frontend gets back the full absolute path so
+    // subsequent IPC calls work. No file_index sync (cold-start
+    // indexer is deferred); no watcher emit (no watcher on Android).
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, parent_rel) = android_storage_and_rel(&state, &parent)?;
+        let base_name = if name.is_empty() { "Untitled.md" } else { &name };
+        let final_rel = if parent_rel.is_empty() {
+            base_name.to_string()
+        } else {
+            format!("{}/{}", parent_rel, base_name)
+        };
+        crate::storage::validate_rel(&final_rel)?;
+        storage.create_file(&final_rel, b"")?;
+        // Reconstruct the absolute the frontend expects.
+        let uri = {
+            let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
+            match guard.as_ref() {
+                Some(crate::storage::VaultHandle::ContentUri(u)) => u.clone(),
+                _ => return Err(VaultError::VaultUnavailable { path: parent }),
+            }
+        };
+        let abs = if uri.ends_with('/') {
+            format!("{}{}", uri, final_rel)
+        } else {
+            format!("{}/{}", uri, final_rel)
+        };
+        let _ = app.emit(
+            crate::watcher::FILE_CHANGED_EVENT,
+            crate::watcher::FileChangePayload {
+                path: abs.clone(),
+                kind: "create".to_string(),
+                new_path: None,
+            },
+        );
+        return Ok(abs);
+    }
+
     let final_path = create_file_impl(&state, parent, name)?;
     // #307: the watcher suppresses this create via write_ignore (D-12), so
     // emit a synthetic file_changed event — same pattern as delete_file (#102).
@@ -378,6 +511,36 @@ pub async fn create_folder(
     parent: String,
     name: String,
 ) -> Result<String, VaultError> {
+    // #392 PR-B: Android branch.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, parent_rel) = android_storage_and_rel(&state, &parent)?;
+        let base_name = if name.is_empty() { "New Folder" } else { &name };
+        let final_rel = if parent_rel.is_empty() {
+            base_name.to_string()
+        } else {
+            format!("{}/{}", parent_rel, base_name)
+        };
+        crate::storage::validate_rel(&final_rel)?;
+        storage.create_dir(&final_rel)?;
+        let uri = {
+            let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
+            match guard.as_ref() {
+                Some(crate::storage::VaultHandle::ContentUri(u)) => u.clone(),
+                _ => return Err(VaultError::VaultUnavailable { path: parent }),
+            }
+        };
+        let abs = if uri.ends_with('/') {
+            format!("{}{}", uri, final_rel)
+        } else {
+            format!("{}/{}", uri, final_rel)
+        };
+        return Ok(abs);
+    }
+
     create_folder_impl(&state, parent, name)
 }
 
@@ -528,6 +691,51 @@ pub async fn rename_file(
     new_name: String,
 ) -> Result<RenameResult, VaultError> {
     use tauri::Emitter;
+
+    // #392 PR-B: Android branch. Same-parent rename only — the
+    // frontend's rename UX changes the leaf name, not the parent. The
+    // link cascade (rename references in other files) is desktop-only;
+    // returning link_count = 0 is safe because backlinks are also
+    // empty on Android until the lazy-index follow-up.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, old_rel) = android_storage_and_rel(&state, &old_path)?;
+        let new_rel = if let Some(idx) = old_rel.rfind('/') {
+            format!("{}/{}", &old_rel[..idx], new_name)
+        } else {
+            new_name.clone()
+        };
+        crate::storage::validate_rel(&new_rel)?;
+        storage.rename(&old_rel, &new_rel)?;
+        let uri = {
+            let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
+            match guard.as_ref() {
+                Some(crate::storage::VaultHandle::ContentUri(u)) => u.clone(),
+                _ => return Err(VaultError::VaultUnavailable { path: old_path }),
+            }
+        };
+        let new_abs = if uri.ends_with('/') {
+            format!("{}{}", uri, new_rel)
+        } else {
+            format!("{}/{}", uri, new_rel)
+        };
+        let _ = app.emit(
+            crate::watcher::FILE_CHANGED_EVENT,
+            crate::watcher::FileChangePayload {
+                path: old_path,
+                kind: "rename".to_string(),
+                new_path: Some(new_abs.clone()),
+            },
+        );
+        return Ok(RenameResult {
+            new_path: new_abs,
+            link_count: 0,
+        });
+    }
+
     let old_canonical_for_event = std::fs::canonicalize(&old_path)
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| old_path.clone());
@@ -624,6 +832,29 @@ pub async fn delete_file(
     path: String,
 ) -> Result<(), VaultError> {
     use tauri::Emitter;
+
+    // #392 PR-B: Android branch. Permanent delete via SAF — no
+    // .trash subfolder. DocumentFile.delete on Android 11+ moves to
+    // OS-level trash automatically (visible in Files app), so user-
+    // level recovery is preserved.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, rel) = android_storage_and_rel(&state, &path)?;
+        storage.delete(&rel)?;
+        let _ = app.emit(
+            crate::watcher::FILE_CHANGED_EVENT,
+            crate::watcher::FileChangePayload {
+                path,
+                kind: "delete".to_string(),
+                new_path: None,
+            },
+        );
+        return Ok(());
+    }
+
     // delete_file_impl returns the canonical source path AFTER a successful
     // delete + index dispatch, so the synthetic event uses the same form
     // the watcher would have seen.
@@ -701,6 +932,52 @@ pub async fn move_file(
     to_folder: String,
 ) -> Result<String, VaultError> {
     use tauri::Emitter;
+
+    // #392 PR-B: Android branch. Cross-parent rename via the storage
+    // trait (Kotlin uses DocumentsContract.moveDocument when the SAF
+    // provider supports FLAG_SUPPORTS_MOVE; otherwise the Kotlin side
+    // surfaces a clear error). Same link-cascade caveat as rename.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, from_rel) = android_storage_and_rel(&state, &from)?;
+        let (_, to_folder_rel) = android_storage_and_rel(&state, &to_folder)?;
+        let leaf = from_rel
+            .rsplit('/')
+            .next()
+            .ok_or_else(|| VaultError::PathOutsideVault { path: from.clone() })?;
+        let to_rel = if to_folder_rel.is_empty() {
+            leaf.to_string()
+        } else {
+            format!("{}/{}", to_folder_rel, leaf)
+        };
+        crate::storage::validate_rel(&to_rel)?;
+        storage.rename(&from_rel, &to_rel)?;
+        let uri = {
+            let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
+            match guard.as_ref() {
+                Some(crate::storage::VaultHandle::ContentUri(u)) => u.clone(),
+                _ => return Err(VaultError::VaultUnavailable { path: from }),
+            }
+        };
+        let new_abs = if uri.ends_with('/') {
+            format!("{}{}", uri, to_rel)
+        } else {
+            format!("{}/{}", uri, to_rel)
+        };
+        let _ = app.emit(
+            crate::watcher::FILE_CHANGED_EVENT,
+            crate::watcher::FileChangePayload {
+                path: from,
+                kind: "rename".to_string(),
+                new_path: Some(new_abs.clone()),
+            },
+        );
+        return Ok(new_abs);
+    }
+
     let old_canonical_for_event = std::fs::canonicalize(&from)
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| from.clone());
@@ -763,6 +1040,19 @@ pub async fn get_file_hash(
     state: tauri::State<'_, VaultState>,
     path: String,
 ) -> Result<String, VaultError> {
+    // #392 PR-B: Android branch — read bytes through the storage trait,
+    // hash. Encryption is passthrough on Android so bytes are
+    // already plaintext.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, rel) = android_storage_and_rel(&state, &path)?;
+        let bytes = storage.read_file(&rel)?;
+        return Ok(hash_bytes(&bytes));
+    }
+
     get_file_hash_impl(&state, path)
 }
 
@@ -781,6 +1071,70 @@ pub async fn save_attachment(
     filename: String,
     bytes: Vec<u8>,
 ) -> Result<String, VaultError> {
+    // #392 PR-B: Android branch. The frontend supplies `folder` as
+    // either an absolute (URI-prefixed) string OR a vault-relative
+    // path; android_storage_and_rel handles both. Encryption is
+    // passthrough so we skip the encrypted-root checks. Collision
+    // avoidance still runs via storage.exists.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, folder_rel) = if folder.starts_with("content://") {
+            android_storage_and_rel(&state, &folder)?
+        } else {
+            // Vault-relative — re-derive without the prefix path.
+            let storage = {
+                let guard = state.storage.read().map_err(|_| VaultError::LockPoisoned)?;
+                guard.as_ref().cloned().ok_or_else(|| {
+                    VaultError::VaultUnavailable { path: folder.clone() }
+                })?
+            };
+            crate::storage::validate_rel(&folder)?;
+            (storage, folder.clone())
+        };
+        storage.create_dir(&folder_rel)?;
+        // Collision avoidance.
+        let (stem, ext) = if let Some(dot) = filename.rfind('.') {
+            (&filename[..dot], &filename[dot..])
+        } else {
+            (filename.as_str(), "")
+        };
+        let mut final_rel = if folder_rel.is_empty() {
+            filename.clone()
+        } else {
+            format!("{}/{}", folder_rel, filename)
+        };
+        if storage.exists(&final_rel) {
+            let mut found = false;
+            for n in 1u32..=1000 {
+                let candidate_name = format!("{} {}{}", stem, n, ext);
+                let candidate = if folder_rel.is_empty() {
+                    candidate_name
+                } else {
+                    format!("{}/{}", folder_rel, candidate_name)
+                };
+                if !storage.exists(&candidate) {
+                    final_rel = candidate;
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                return Err(VaultError::Io(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "too many collisions for attachment filename",
+                )));
+            }
+        }
+        crate::storage::validate_rel(&final_rel)?;
+        storage.write_file(&final_rel, &bytes)?;
+        // Return vault-relative path; frontend's attachment renderer
+        // resolves `<currentPath>/<rel>` for display.
+        return Ok(final_rel);
+    }
+
     let vault_root = get_vault_root(&state)?;
 
     // Build and create the target folder.
@@ -901,6 +1255,16 @@ pub async fn read_attachment_bytes(
     state: tauri::State<'_, VaultState>,
     path: String,
 ) -> Result<Vec<u8>, VaultError> {
+    // #392 PR-B: Android branch.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, rel) = android_storage_and_rel(&state, &path)?;
+        return storage.read_file(&rel);
+    }
+
     read_attachment_bytes_impl(&state, path)
 }
 
@@ -943,5 +1307,21 @@ pub async fn count_wiki_links(
     state: tauri::State<'_, VaultState>,
     filename: String,
 ) -> Result<u32, VaultError> {
+    // #392 PR-B: Android branch returns 0. count_wiki_links walks the
+    // entire vault tree (`walkdir::WalkDir`) which is impractical over
+    // ContentResolver. The frontend uses this count for a "you're
+    // about to delete a file with N references" confirmation modal;
+    // returning 0 means the modal still fires the delete (no false
+    // negative on what the user typed) but doesn't show a count. The
+    // lazy-index follow-up (#392 follow-up) will populate this once
+    // backlinks are tracked.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        return Ok(0);
+    }
+
     count_wiki_links_impl(&state, filename)
 }

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -405,6 +405,23 @@ pub async fn update_links_after_rename(
     new_path: String,
     state: tauri::State<'_, VaultState>,
 ) -> Result<RenameResult, VaultError> {
+    // #392 PR-B: link cascade is desktop-only (uses walkdir + raw fs
+    // reads). On Android the frontend already received link_count=0
+    // from rename_file; this no-op makes the follow-up call safe.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let _ = (old_path, new_path);
+        return Ok(RenameResult {
+            updated_files: 0,
+            updated_links: 0,
+            failed_files: Vec::new(),
+            updated_paths: Vec::new(),
+        });
+    }
+
     // Get vault root — clone before releasing the lock.
     let vault_root: PathBuf = {
         let vp = state.current_vault.lock().map_err(|_| VaultError::VaultUnavailable {
@@ -765,7 +782,12 @@ pub async fn get_resolved_attachments(
             .lock()
             .map_err(|_| VaultError::IndexCorrupt)?;
         match guard.as_ref() {
-            Some(h) => h.expect_posix().to_path_buf(),
+            Some(crate::storage::VaultHandle::Posix(p)) => p.clone(),
+            // #392 PR-B: attachment resolution walks the vault tree
+            // with WalkDir — desktop-only. Returns empty so the
+            // frontend's image-render fallback kicks in.
+            #[cfg(target_os = "android")]
+            Some(crate::storage::VaultHandle::ContentUri(_)) => return Ok(HashMap::new()),
             None => return Ok(HashMap::new()),
         }
     };

--- a/src-tauri/src/commands/picker.rs
+++ b/src-tauri/src/commands/picker.rs
@@ -93,7 +93,7 @@ async fn pick_save_path_impl(
 // ── Android branch ──────────────────────────────────────────────────────────
 
 #[cfg(target_os = "android")]
-mod android {
+pub mod android {
     use super::{PickerFilter, VaultError};
     use serde::Deserialize;
     use tauri::plugin::{Builder, PluginHandle, TauriPlugin};
@@ -108,7 +108,13 @@ mod android {
         uri: Option<String>,
     }
 
-    pub struct AndroidPicker<R: Runtime>(PluginHandle<R>);
+    /// Wrapper around the PluginHandle for the Kotlin `PickerPlugin`
+    /// class. Stored in Tauri's `app.state()` so #392 PR-B's
+    /// `AndroidStorage` and the existing #391 picker commands share a
+    /// single registered plugin instance — `register_android_plugin`
+    /// is idempotent per-name but allocating two plugins for the same
+    /// Kotlin class is wasted JVM-side work.
+    pub struct AndroidPicker<R: Runtime>(pub PluginHandle<R>);
 
     /// Registers the Kotlin `PickerPlugin` class on the JVM classpath as
     /// the Tauri mobile plugin handle. Called from `lib.rs` next to the

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -349,6 +349,20 @@ pub async fn rebuild_index(
     use tauri::Emitter;
     use crate::indexer::IndexCmd;
 
+    // #392 PR-B: cold-rebuild walks the vault tree with WalkDir — not
+    // viable over ContentResolver. Returns Ok no-op on Android so the
+    // frontend's "rebuild index" menu entry doesn't crash; the index
+    // populates lazily as files are opened. Tracked: lazy-index
+    // follow-up.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let _ = app;
+        return Ok(());
+    }
+
     // Get vault path — clone so the Mutex is released before the await.
     let vault_path = {
         let vp = state

--- a/src-tauri/src/commands/snippets.rs
+++ b/src-tauri/src/commands/snippets.rs
@@ -104,6 +104,16 @@ pub async fn list_snippets(
     state: tauri::State<'_, VaultState>,
     vault_path: String,
 ) -> Result<Vec<String>, VaultError> {
+    // #392 PR-B: snippets aren't surfaced on Android in v1. See
+    // templates.rs for the rationale (POSIX-only walkdir + read).
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        return Ok(Vec::new());
+    }
+
     list_snippets_impl(&state, vault_path)
 }
 
@@ -139,5 +149,13 @@ pub async fn read_snippet(
     vault_path: String,
     filename: String,
 ) -> Result<String, VaultError> {
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        return Err(VaultError::FileNotFound { path: filename });
+    }
+
     read_snippet_impl(&state, vault_path, filename)
 }

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -126,6 +126,18 @@ pub async fn list_templates(
     state: tauri::State<'_, VaultState>,
     vault_path: String,
 ) -> Result<Vec<String>, VaultError> {
+    // #392 PR-B: templates aren't surfaced on Android in v1. Returns
+    // an empty list so the frontend's template picker shows "no
+    // templates" rather than crashing on the desktop walkdir path.
+    // Tracked as a known limitation in MOBILE_BUILD.md.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        return Ok(Vec::new());
+    }
+
     list_templates_impl(&state, vault_path)
 }
 
@@ -158,5 +170,16 @@ pub async fn read_template(
     vault_path: String,
     filename: String,
 ) -> Result<String, VaultError> {
+    // #392 PR-B: see list_templates. Frontend never reaches this on
+    // Android because list_templates returns empty; the FileNotFound
+    // covers the defensive case where it does.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        return Err(VaultError::FileNotFound { path: filename });
+    }
+
     read_template_impl(&state, vault_path, filename)
 }

--- a/src-tauri/src/commands/tree.rs
+++ b/src-tauri/src/commands/tree.rs
@@ -193,5 +193,93 @@ pub async fn list_directory(
     state: tauri::State<'_, VaultState>,
     path: String,
 ) -> Result<Vec<DirEntry>, VaultError> {
+    // #392 PR-B: Android branch routes through the storage trait.
+    // Mirrors list_directory_impl's filtering (dot-prefixed entries
+    // hidden, sort folders first then alphabetical) but skips
+    // POSIX-only metadata (created/modified timestamps, symlink
+    // detection, encryption-state lookup — encrypted folders aren't
+    // supported on Android in PR-B).
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let (storage, dir_rel) = {
+            let storage = {
+                let guard = state.storage.read().map_err(|_| VaultError::LockPoisoned)?;
+                guard
+                    .as_ref()
+                    .cloned()
+                    .ok_or_else(|| VaultError::VaultUnavailable {
+                        path: path.clone(),
+                    })?
+            };
+            let uri = {
+                let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
+                match guard.as_ref() {
+                    Some(crate::storage::VaultHandle::ContentUri(u)) => u.clone(),
+                    _ => return Err(VaultError::VaultUnavailable { path }),
+                }
+            };
+            let prefix = if uri.ends_with('/') { uri.clone() } else { format!("{}/", uri) };
+            let rel = if path == uri || path == prefix.trim_end_matches('/') {
+                String::new()
+            } else if let Some(stripped) = path.strip_prefix(&prefix) {
+                stripped.to_string()
+            } else if let Some(stripped) = path.strip_prefix(&uri) {
+                stripped.trim_start_matches('/').to_string()
+            } else {
+                return Err(VaultError::PathOutsideVault { path: path.clone() });
+            };
+            crate::storage::validate_rel(&rel)?;
+            (storage, rel)
+        };
+
+        let listed = storage.list_dir(&dir_rel)?;
+        let mut entries: Vec<DirEntry> = Vec::new();
+        let uri = {
+            let guard = state.current_vault.lock().map_err(|_| VaultError::LockPoisoned)?;
+            match guard.as_ref() {
+                Some(crate::storage::VaultHandle::ContentUri(u)) => u.clone(),
+                _ => return Err(VaultError::VaultUnavailable { path }),
+            }
+        };
+        for e in listed {
+            if e.name.starts_with('.') {
+                continue;
+            }
+            let child_rel = if dir_rel.is_empty() {
+                e.name.clone()
+            } else {
+                format!("{}/{}", dir_rel, e.name)
+            };
+            let abs = if uri.ends_with('/') {
+                format!("{}{}", uri, child_rel)
+            } else {
+                format!("{}/{}", uri, child_rel)
+            };
+            let is_md = !e.is_dir
+                && std::path::Path::new(&e.name)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+            entries.push(DirEntry {
+                name: e.name,
+                path: abs,
+                is_dir: e.is_dir,
+                is_symlink: false,
+                is_md,
+                modified: None,
+                created: None,
+                encryption: EncryptionState::NotEncrypted,
+            });
+        }
+        entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        });
+        return Ok(entries);
+    }
+
     list_directory_impl(&state, path)
 }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -537,6 +537,20 @@ pub(crate) async fn merge_external_change_impl(
 ) -> Result<MergeCommandResult, crate::error::VaultError> {
     use crate::merge::{three_way_merge, MergeOutcome};
 
+    // #392 PR-B: merge_external_change is fired by the watcher when an
+    // external edit is detected. On Android there's no watcher, so this
+    // command should never reach here in normal flow — but if the
+    // frontend retries from a stale event after switching vaults, we
+    // surface a clear error instead of panicking at expect_posix.
+    #[cfg(target_os = "android")]
+    if matches!(
+        *state.current_vault.lock().map_err(|_| crate::error::VaultError::LockPoisoned)?,
+        Some(crate::storage::VaultHandle::ContentUri(_))
+    ) {
+        let _ = (editor_content, last_saved_content);
+        return Err(crate::error::VaultError::VaultUnavailable { path });
+    }
+
     // T-02-18 mitigation: validate path is inside vault
     let vault_path: PathBuf = {
         let guard = state

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -124,20 +124,32 @@ pub async fn open_vault(
     state: tauri::State<'_, crate::VaultState>,
     path: String,
 ) -> Result<VaultInfo, VaultError> {
-    let p = PathBuf::from(&path);
-    // T-01 mitigation: canonicalize to resolve `..` and symlinks.
-    let canonical = std::fs::canonicalize(&p).map_err(|e| match e.kind() {
-        std::io::ErrorKind::NotFound => VaultError::VaultUnavailable { path: path.clone() },
-        std::io::ErrorKind::PermissionDenied => VaultError::PermissionDenied { path: path.clone() },
-        _ => VaultError::Io(e),
-    })?;
+    // #392 PR-B: parse the input as a VaultHandle. On Android the
+    // `content://` heuristic short-circuits canonicalize; everything
+    // else flows through the existing POSIX path. The Android branch
+    // bails out of the desktop-only setup (fs_scope, watcher, manifest
+    // reload, embeddings purge, indexer cold-start) and returns a
+    // bare-bones VaultInfo so the user can read/edit/save markdown
+    // without the full desktop feature surface.
+    let handle = crate::storage::VaultHandle::parse(&path)?;
+
+    #[cfg(target_os = "android")]
+    if let crate::storage::VaultHandle::ContentUri(ref uri) = handle {
+        return open_vault_android(app, state, uri.clone(), path).await;
+    }
+
+    // Desktop path: extract the canonical PathBuf and proceed with the
+    // existing flow unchanged.
+    let canonical = handle.expect_posix().to_path_buf();
     if !canonical.is_dir() {
         return Err(VaultError::VaultUnavailable { path });
     }
 
     // T-01-01-E mitigation: grant Tauri fs plugin scope ONLY to the
     // canonical vault path, recursively. Without this, the frontend's
-    // future @tauri-apps/plugin-fs calls would be refused.
+    // future @tauri-apps/plugin-fs calls would be refused. Desktop-only
+    // because @tauri-apps/plugin-fs's JS surface isn't used on Android
+    // (every file op routes through `commands/files.rs` → VaultStorage).
     app.fs_scope().allow_directory(&canonical, true).map_err(|e| {
         VaultError::Io(std::io::Error::other(e.to_string()))
     })?;
@@ -250,6 +262,72 @@ pub async fn open_vault(
     *state.vault_reachable.lock().map_err(|_| VaultError::LockPoisoned)? = true;
 
     Ok(vault_info)
+}
+
+// #392 PR-B: Android-specific open_vault flow. Verifies the persisted
+// SAF permission is still in place, takes a fresh idempotent grant,
+// constructs an AndroidStorage backed by the SAF tree URI, and bypasses
+// the desktop-only setup (fs_scope, Tantivy cold-start indexer, watcher
+// spawn, encrypted-folders manifest reload, embeddings purge).
+//
+// Cold-start indexing is deferred to the lazy-on-open follow-up
+// (#392 follow-up). The returned VaultInfo carries file_count = 0 +
+// empty file_list so the frontend's "vault loaded" UI states render
+// without a tree population. Per-file index updates via dispatch_self_*
+// keep the index populated as the user opens files.
+#[cfg(target_os = "android")]
+async fn open_vault_android(
+    app: AppHandle,
+    state: tauri::State<'_, crate::VaultState>,
+    uri: String,
+    original_path: String,
+) -> Result<VaultInfo, VaultError> {
+    use crate::storage::AndroidStorage;
+    use crate::storage::VaultHandle;
+
+    // Stale-bookmark UX: if the user revoked the SAF grant via Settings
+    // or reinstalled the app, the URI is in recent-vaults.json but no
+    // longer in contentResolver.persistedUriPermissions. The frontend
+    // listens for VaultPermissionRevoked in the loadVault error path
+    // and routes through pickVaultFolder() to re-grant.
+    if !AndroidStorage::has_persisted_permission(&app, &uri)? {
+        return Err(VaultError::VaultPermissionRevoked { uri });
+    }
+
+    // Idempotent re-grant: Android docs recommend taking the permission
+    // every time you re-open a URI, even if a grant exists, to extend
+    // its lifetime. Failure here is rare but possible (security
+    // exception) — let it propagate as Io.
+    AndroidStorage::take_persistable_uri_permission(&app, &uri)?;
+
+    let app_local_data = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| VaultError::Io(std::io::Error::other(e.to_string())))?;
+    let storage = AndroidStorage::new(&app, uri.clone(), &app_local_data)?;
+
+    state.set_open_vault(
+        VaultHandle::ContentUri(uri.clone()),
+        std::sync::Arc::new(storage),
+    )?;
+
+    // recent-vaults.json stores the URI verbatim — VaultHandle::parse
+    // round-trips it via the content:// heuristic on next open.
+    push_recent_vault(&app, &uri)?;
+
+    *state.vault_reachable.lock().map_err(|_| VaultError::LockPoisoned)? = true;
+
+    // PR-B v1: stub VaultInfo. Cold-start indexing is deferred — the
+    // frontend gets an empty file_list and the user sees their vault
+    // tree populate as they navigate / open files (per-file index
+    // updates via dispatch_self_write). Documented as a known
+    // limitation in MOBILE_BUILD.md.
+    let _ = original_path; // unused on this path; kept for symmetry
+    Ok(VaultInfo {
+        path: uri,
+        file_count: 0,
+        file_list: Vec::new(),
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/encryption/mod.rs
+++ b/src-tauri/src/encryption/mod.rs
@@ -193,7 +193,14 @@ pub fn maybe_decrypt_read(
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
         match guard.as_ref() {
-            Some(h) => h.expect_posix().to_path_buf(),
+            Some(crate::storage::VaultHandle::Posix(p)) => p.clone(),
+            // #392 PR-B: encrypted folders are not yet supported on
+            // Android (canonical-path-keyed manifest is desktop-only).
+            // Passthrough ensures plain (unencrypted) Android vaults
+            // still flow read paths cleanly. Encrypt path is guarded
+            // separately at every encrypt_folder/unlock_folder entry.
+            #[cfg(target_os = "android")]
+            Some(crate::storage::VaultHandle::ContentUri(_)) => return Ok(bytes),
             None => return Ok(bytes),
         }
     };
@@ -232,7 +239,10 @@ pub fn maybe_encrypt_write(
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
         match guard.as_ref() {
-            Some(h) => h.expect_posix().to_path_buf(),
+            Some(crate::storage::VaultHandle::Posix(p)) => p.clone(),
+            // #392 PR-B: see maybe_decrypt_read for rationale.
+            #[cfg(target_os = "android")]
+            Some(crate::storage::VaultHandle::ContentUri(_)) => return Ok(bytes.to_vec()),
             None => return Ok(bytes.to_vec()),
         }
     };

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -87,6 +87,21 @@ pub enum VaultError {
     /// renders a generic "request denied" copy and logs for follow-up.
     #[error("Path resolves outside the vault: {path}")]
     PathOutsideVault { path: String },
+
+    /// #392 PR-B: SAF tree URI no longer has a persisted permission grant
+    /// — user revoked it via Settings, or the app was reinstalled. The
+    /// frontend re-pick UX consumes the `uri` from `data` so the user
+    /// can re-grant access without retyping anything.
+    #[error("Vault permission revoked: {uri}")]
+    VaultPermissionRevoked { uri: String },
+
+    /// #392 PR-B: encrypted-folder operation requested while the vault
+    /// is `content://`-rooted on Android. The encryption manifest is
+    /// canonical-path-keyed (encryption/mod.rs:185) and doesn't yet have
+    /// a URI-aware variant; runtime guard fails fast at every
+    /// create/unlock/lock entry. Tracked: #345 storage-trait pass.
+    #[error("Encrypted folders are not yet supported on Android.")]
+    EncryptionUnsupportedOnAndroid,
 }
 
 impl VaultError {
@@ -108,6 +123,8 @@ impl VaultError {
             Self::PayloadTooLarge { .. } => "PayloadTooLarge",
             Self::PickerFailed { .. } => "PickerFailed",
             Self::PathOutsideVault { .. } => "PathOutsideVault",
+            Self::VaultPermissionRevoked { .. } => "VaultPermissionRevoked",
+            Self::EncryptionUnsupportedOnAndroid => "EncryptionUnsupportedOnAndroid",
         }
     }
 
@@ -126,6 +143,10 @@ impl VaultError {
             | Self::PathLocked { path }
             | Self::PayloadTooLarge { path, .. }
             | Self::PathOutsideVault { path } => Some(path.clone()),
+            // VaultPermissionRevoked carries a URI rather than a path,
+            // but the IPC `data` semantic is "string the frontend can
+            // act on" — the re-pick UX uses it directly. Same idiom.
+            Self::VaultPermissionRevoked { uri } => Some(uri.clone()),
             // Data-less variants — and variants whose payload is a human
             // message rather than a routable path. The `data` IPC field
             // is reserved for paths the frontend can `navigate(err.data)`,
@@ -137,7 +158,8 @@ impl VaultError {
             | Self::Io(_)
             | Self::WrongPassword
             | Self::CryptoError { .. }
-            | Self::PickerFailed { .. } => None,
+            | Self::PickerFailed { .. }
+            | Self::EncryptionUnsupportedOnAndroid => None,
         }
     }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -102,6 +102,19 @@ pub enum VaultError {
     /// create/unlock/lock entry. Tracked: #345 storage-trait pass.
     #[error("Encrypted folders are not yet supported on Android.")]
     EncryptionUnsupportedOnAndroid,
+
+    /// #392 PR-B: a desktop-only operation (HTML export, snippet/template
+    /// walks, fulltext rebuild, etc.) was requested while the active
+    /// vault is `content://`-rooted on Android. Distinct from
+    /// `EncryptionUnsupportedOnAndroid` so the frontend can render an
+    /// operation-specific copy ("HTML export isn't supported on Android
+    /// yet") rather than a generic encryption-themed message. The
+    /// `operation` field carries the human-readable name; it lands in
+    /// the `data` field as a label, not a navigable target. Aristotle
+    /// iter-1 finding #4 — replaces the previous shoehorn that put
+    /// prose into a `PermissionDenied { path }` field.
+    #[error("Operation '{operation}' is not yet supported on Android.")]
+    OperationUnsupportedOnAndroid { operation: String },
 }
 
 impl VaultError {
@@ -125,6 +138,7 @@ impl VaultError {
             Self::PathOutsideVault { .. } => "PathOutsideVault",
             Self::VaultPermissionRevoked { .. } => "VaultPermissionRevoked",
             Self::EncryptionUnsupportedOnAndroid => "EncryptionUnsupportedOnAndroid",
+            Self::OperationUnsupportedOnAndroid { .. } => "OperationUnsupportedOnAndroid",
         }
     }
 
@@ -147,6 +161,11 @@ impl VaultError {
             // but the IPC `data` semantic is "string the frontend can
             // act on" — the re-pick UX uses it directly. Same idiom.
             Self::VaultPermissionRevoked { uri } => Some(uri.clone()),
+            // OperationUnsupportedOnAndroid carries a human-readable
+            // operation name as `data` — frontend renders it inline in
+            // the toast copy. Not a path, but still "string the frontend
+            // can act on" by the convention above.
+            Self::OperationUnsupportedOnAndroid { operation } => Some(operation.clone()),
             // Data-less variants — and variants whose payload is a human
             // message rather than a routable path. The `data` IPC field
             // is reserved for paths the frontend can `navigate(err.data)`,

--- a/src-tauri/src/storage/android.rs
+++ b/src-tauri/src/storage/android.rs
@@ -1,0 +1,343 @@
+// #392 PR-B — Android `VaultStorage` impl backed by SAF.
+//
+// Routes all I/O through the Kotlin `PickerPlugin` via Tauri's
+// mobile-plugin FFI (`run_mobile_plugin`). Each method is one Binder
+// round-trip per path-component plus the actual I/O — typical 5-25ms
+// for a 5-deep path. Acceptable for v1; batch API is a UAT-driven
+// follow-up.
+//
+// `validate_rel` runs at every entry so the Kotlin side never sees
+// `..` or absolute paths. SAF's tree-URI scope provides defense in
+// depth — `walkRel` in PickerPlugin.kt only ever traverses children
+// of the original tree URI — but the explicit Rust-side guard means a
+// bug in the Kotlin walk can't escape the vault scope.
+//
+// Tantivy index + bookmarks live in app-private scratch under
+// `<getFilesDir()>/vaults/<sha256(uri)[..16]>/`. mmap doesn't work
+// over ContentResolver, so this directory is genuine POSIX storage on
+// the device — fast for the index, app-private (no SAF prompt).
+
+#![cfg(target_os = "android")]
+
+use super::{validate_rel, DirEntry, FileMeta, VaultStorage};
+use crate::commands::picker::android::AndroidPicker;
+use crate::error::VaultError;
+use base64::Engine;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use tauri::plugin::PluginHandle;
+use tauri::{AppHandle, Manager, Runtime};
+
+#[derive(Deserialize)]
+struct ReadResp {
+    #[serde(rename = "contentB64")]
+    content_b64: String,
+}
+
+#[derive(Deserialize)]
+struct MetaResp {
+    exists: bool,
+    #[serde(rename = "isDir")]
+    is_dir: bool,
+    size: u64,
+}
+
+#[derive(Deserialize)]
+struct ListResp {
+    entries: Vec<EntryResp>,
+}
+
+#[derive(Deserialize)]
+struct EntryResp {
+    name: String,
+    #[serde(rename = "isDir")]
+    is_dir: bool,
+}
+
+#[derive(Deserialize)]
+struct ExistsResp {
+    exists: bool,
+}
+
+#[derive(Deserialize)]
+struct GrantedResp {
+    granted: bool,
+}
+
+#[derive(Deserialize)]
+#[allow(dead_code)] // Kotlin returns {} on success; nothing to inspect.
+struct OkResp {}
+
+pub struct AndroidStorage {
+    tree_uri: String,
+    metadata_dir: PathBuf,
+    plugin: PluginHandle<tauri::Wry>,
+}
+
+impl AndroidStorage {
+    /// Construct a storage rooted at the given SAF tree URI. The URI
+    /// must already have a persisted permission grant (caller's job —
+    /// `open_vault` checks this before constructing). `app_local_data`
+    /// is the result of `app.path().app_local_data_dir()`; the
+    /// per-URI scratch dir lives at `<app_local_data>/vaults/<hash>/`.
+    pub fn new<R: Runtime>(
+        app: &AppHandle<R>,
+        tree_uri: String,
+        app_local_data: &Path,
+    ) -> Result<Self, VaultError> {
+        // The PluginHandle is registered in lib.rs at app init; we
+        // borrow a clone from the shared AndroidPicker state.
+        // Storing R = Wry is acceptable because production app builds
+        // are always Wry; tests don't exercise this path.
+        let picker = app.state::<AndroidPicker<tauri::Wry>>();
+        let plugin = picker.0.clone();
+
+        let hash = sha256_hex(&tree_uri);
+        let metadata_dir = app_local_data.join("vaults").join(&hash[..16]);
+        std::fs::create_dir_all(&metadata_dir).map_err(VaultError::Io)?;
+
+        Ok(Self {
+            tree_uri,
+            metadata_dir,
+            plugin,
+        })
+    }
+
+    /// Convenience for `open_vault`'s persisted-permission check. Not
+    /// part of the trait surface — only meaningful for ContentUri
+    /// vaults.
+    pub fn has_persisted_permission<R: Runtime>(
+        app: &AppHandle<R>,
+        uri: &str,
+    ) -> Result<bool, VaultError> {
+        let picker = app.state::<AndroidPicker<tauri::Wry>>();
+        let r: GrantedResp = picker
+            .0
+            .run_mobile_plugin(
+                "hasPersistedPermission",
+                serde_json::json!({ "uri": uri }),
+            )
+            .map_err(|e| VaultError::Io(std::io::Error::other(e.to_string())))?;
+        Ok(r.granted)
+    }
+
+    /// Idempotent: take the persistable read+write grant on a tree
+    /// URI. Called from `open_vault` after the picker resolves so the
+    /// URI survives app restart. Safe to call on a URI that already
+    /// has a grant — the contract is "after this returns Ok, the URI
+    /// is granted".
+    pub fn take_persistable_uri_permission<R: Runtime>(
+        app: &AppHandle<R>,
+        uri: &str,
+    ) -> Result<(), VaultError> {
+        let picker = app.state::<AndroidPicker<tauri::Wry>>();
+        let _: OkResp = picker
+            .0
+            .run_mobile_plugin(
+                "takePersistableUriPermission",
+                serde_json::json!({ "uri": uri }),
+            )
+            .map_err(|e| VaultError::Io(std::io::Error::other(e.to_string())))?;
+        Ok(())
+    }
+
+    fn invoke<T: serde::de::DeserializeOwned>(
+        &self,
+        cmd: &str,
+        payload: serde_json::Value,
+        rel_for_err: &str,
+    ) -> Result<T, VaultError> {
+        self.plugin
+            .run_mobile_plugin::<T>(cmd, payload)
+            .map_err(|e| VaultError::Io(std::io::Error::other(format!(
+                "{cmd}({rel_for_err}): {e}"
+            ))))
+    }
+}
+
+impl VaultStorage for AndroidStorage {
+    fn read_file(&self, rel_path: &str) -> Result<Vec<u8>, VaultError> {
+        validate_rel(rel_path)?;
+        let r: ReadResp = self.invoke(
+            "readFile",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+            }),
+            rel_path,
+        )?;
+        base64::engine::general_purpose::STANDARD
+            .decode(&r.content_b64)
+            .map_err(|e| VaultError::Io(std::io::Error::other(format!(
+                "base64 decode failed for {rel_path}: {e}"
+            ))))
+    }
+
+    fn write_file(&self, rel_path: &str, contents: &[u8]) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(contents);
+        let _: OkResp = self.invoke(
+            "writeFile",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+                "contentB64": b64,
+            }),
+            rel_path,
+        )?;
+        Ok(())
+    }
+
+    fn create_file(&self, rel_path: &str, initial: &[u8]) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(initial);
+        let _: OkResp = self.invoke(
+            "createFile",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+                "contentB64": b64,
+            }),
+            rel_path,
+        )?;
+        Ok(())
+    }
+
+    fn create_dir(&self, rel_path: &str) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let _: OkResp = self.invoke(
+            "createDir",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+            }),
+            rel_path,
+        )?;
+        Ok(())
+    }
+
+    fn delete(&self, rel_path: &str) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let _: OkResp = self.invoke(
+            "deletePath",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+            }),
+            rel_path,
+        )?;
+        Ok(())
+    }
+
+    fn rename(&self, from: &str, to: &str) -> Result<(), VaultError> {
+        validate_rel(from)?;
+        validate_rel(to)?;
+        let _: OkResp = self.invoke(
+            "renamePath",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "fromRel": from,
+                "toRel": to,
+            }),
+            from,
+        )?;
+        Ok(())
+    }
+
+    fn metadata(&self, rel_path: &str) -> Result<FileMeta, VaultError> {
+        validate_rel(rel_path)?;
+        let r: MetaResp = self.invoke(
+            "metadata",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+            }),
+            rel_path,
+        )?;
+        if !r.exists {
+            return Err(VaultError::FileNotFound {
+                path: rel_path.to_string(),
+            });
+        }
+        Ok(FileMeta {
+            size: r.size,
+            is_dir: r.is_dir,
+        })
+    }
+
+    fn list_dir(&self, rel_path: &str) -> Result<Vec<DirEntry>, VaultError> {
+        validate_rel(rel_path)?;
+        let r: ListResp = self.invoke(
+            "listDir",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+            }),
+            rel_path,
+        )?;
+        Ok(r.entries
+            .into_iter()
+            .map(|e| DirEntry {
+                name: e.name,
+                is_dir: e.is_dir,
+            })
+            .collect())
+    }
+
+    fn exists(&self, rel_path: &str) -> bool {
+        if validate_rel(rel_path).is_err() {
+            return false;
+        }
+        let r: Result<ExistsResp, VaultError> = self.invoke(
+            "pathExists",
+            serde_json::json!({
+                "treeUri": &self.tree_uri,
+                "relPath": rel_path,
+            }),
+            rel_path,
+        );
+        r.map(|x| x.exists).unwrap_or(false)
+    }
+
+    fn metadata_path(&self) -> &Path {
+        &self.metadata_dir
+    }
+}
+
+/// Stable per-URI hex hash for the app-private scratch directory.
+/// 16 hex chars (= 64 bits of SHA-256) gives ~10^19 namespace; collision
+/// probability for any realistic vault count is astronomically low. Use
+/// the hex form rather than base64 for filename compatibility — `+` and
+/// `/` would need escaping in path segments.
+fn sha256_hex(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let bytes = h.finalize();
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[cfg(test)]
+mod sha_tests {
+    use super::*;
+
+    #[test]
+    fn sha256_hex_is_deterministic() {
+        let uri = "content://com.android.externalstorage.documents/tree/primary%3AVault";
+        assert_eq!(sha256_hex(uri), sha256_hex(uri));
+    }
+
+    #[test]
+    fn sha256_hex_differs_for_different_inputs() {
+        let a = sha256_hex("content://provider/tree/A");
+        let b = sha256_hex("content://provider/tree/B");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn sha256_hex_first_16_are_filename_safe() {
+        let h = sha256_hex("anything");
+        let prefix = &h[..16];
+        assert!(prefix.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/src-tauri/src/storage/android.rs
+++ b/src-tauri/src/storage/android.rs
@@ -59,10 +59,7 @@ struct ExistsResp {
     exists: bool,
 }
 
-#[derive(Deserialize)]
-struct GrantedResp {
-    granted: bool,
-}
+use super::permission::PermissionFlags;
 
 #[derive(Deserialize)]
 #[allow(dead_code)] // Kotlin returns {} on success; nothing to inspect.
@@ -105,20 +102,21 @@ impl AndroidStorage {
 
     /// Convenience for `open_vault`'s persisted-permission check. Not
     /// part of the trait surface — only meaningful for ContentUri
-    /// vaults.
+    /// vaults. Returns true iff BOTH read AND write are persisted on
+    /// the URI: a partial grant doesn't let us run the vault.
     pub fn has_persisted_permission<R: Runtime>(
         app: &AppHandle<R>,
         uri: &str,
     ) -> Result<bool, VaultError> {
         let picker = app.state::<AndroidPicker<tauri::Wry>>();
-        let r: GrantedResp = picker
+        let r: PermissionFlags = picker
             .0
             .run_mobile_plugin(
                 "hasPersistedPermission",
                 serde_json::json!({ "uri": uri }),
             )
             .map_err(|e| VaultError::Io(std::io::Error::other(e.to_string())))?;
-        Ok(r.granted)
+        Ok(r.is_fully_granted())
     }
 
     /// Idempotent: take the persistable read+write grant on a tree
@@ -341,3 +339,4 @@ mod sha_tests {
         assert!(prefix.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }
+

--- a/src-tauri/src/storage/handle.rs
+++ b/src-tauri/src/storage/handle.rs
@@ -1,14 +1,14 @@
 // #392 — `VaultHandle` is the cross-platform identifier for a vault root.
 //
-// On desktop and dev it wraps a canonicalized POSIX path. PR-B will add a
-// `ContentUri(String)` arm for Android Storage Access Framework tree URIs;
-// it is intentionally absent from PR-A so the type wrapper stays pure
-// scaffolding (zero behavior change) and reviewers can focus on the
-// mechanical 22-site migration.
+// PR-A: single `Posix(PathBuf)` arm, scaffolding for PR-B.
+// PR-B: adds `ContentUri(String)` arm gated to `target_os = "android"`.
 //
 // The handle serializes to a string for IPC + recent-vaults persistence.
-// On desktop the string form is the path's display string, identical to
-// what callers used to pass around as a bare `PathBuf::display()`.
+// On desktop the string form is the path's display string; on Android it
+// is the SAF tree URI verbatim (the URI Android handed back from the
+// document picker — must NOT be normalized when passed to
+// `takePersistableUriPermission`, see `canonical_dedup_key` for the
+// recent-vaults dedup form).
 
 use crate::error::VaultError;
 use std::borrow::Cow;
@@ -18,7 +18,14 @@ use std::path::{Path, PathBuf};
 pub enum VaultHandle {
     /// Desktop / dev: a canonicalized POSIX path.
     Posix(PathBuf),
-    // ContentUri(String) — added in PR-B for Android. Cfg-gated then.
+    /// Android: SAF tree URI (e.g. `content://com.android.externalstorage.documents/tree/primary%3AVault`).
+    /// Stored verbatim — `takePersistableUriPermission` and SAF
+    /// document-walk APIs key on byte-equality with the URI Android
+    /// originally vended. Use `canonical_dedup_key` for recent-vaults
+    /// dedup or any other equality check that should treat trailing
+    /// slashes / authority casing as equivalent.
+    #[cfg(target_os = "android")]
+    ContentUri(String),
 }
 
 impl VaultHandle {
@@ -26,14 +33,21 @@ impl VaultHandle {
     pub fn as_str(&self) -> Cow<'_, str> {
         match self {
             Self::Posix(p) => p.to_string_lossy(),
+            #[cfg(target_os = "android")]
+            Self::ContentUri(u) => Cow::Borrowed(u),
         }
     }
 
     /// Parse from a string supplied by the picker / read from
-    /// recent-vaults.json. PR-A always treats the input as a POSIX path
-    /// and canonicalizes — same behavior as today's `open_vault`. PR-B
-    /// adds a `content://` heuristic for Android tree URIs.
+    /// recent-vaults.json. Android branch: `content://` prefix routes to
+    /// the URI arm without filesystem I/O. Desktop branch: canonicalize
+    /// + map IO errors to `VaultUnavailable` / `PermissionDenied` per
+    /// the existing `open_vault` contract.
     pub fn parse(s: &str) -> Result<Self, VaultError> {
+        #[cfg(target_os = "android")]
+        if s.starts_with("content://") {
+            return Ok(Self::ContentUri(s.to_string()));
+        }
         let p = PathBuf::from(s);
         let canonical = std::fs::canonicalize(&p).map_err(|e| match e.kind() {
             std::io::ErrorKind::NotFound => VaultError::VaultUnavailable {
@@ -47,14 +61,52 @@ impl VaultHandle {
         Ok(Self::Posix(canonical))
     }
 
-    /// Panicking accessor for the 22 PR-A sites that still operate on
-    /// `&Path`. PR-B replaces every caller with either a `VaultStorage`
-    /// trait call or a cfg-gated branch; the panicking shape exists so
-    /// a regression on Android is loud, not silent. Single grep target
-    /// for PR-B: `expect_posix`.
+    /// Stable equality key for `recent-vaults.json` dedup. Strips a
+    /// trailing slash on URIs (Android may or may not return one
+    /// depending on provider) and lowercases the authority. Path and
+    /// percent-encoding are NOT touched: SAF treats those as
+    /// case-sensitive identifiers.
+    ///
+    /// **Never use this URI to call into Android.** SAF grants are
+    /// keyed on byte-equality with the URI Android originally vended;
+    /// normalized URIs round-trip through `takePersistableUriPermission`
+    /// as a different grant (or no grant at all). Call sites that
+    /// invoke SAF must use `as_str()`.
+    pub fn canonical_dedup_key(&self) -> String {
+        match self {
+            Self::Posix(p) => p.to_string_lossy().into_owned(),
+            #[cfg(target_os = "android")]
+            Self::ContentUri(u) => {
+                let trimmed = u.trim_end_matches('/');
+                if let Some(scheme_end) = trimmed.find("://") {
+                    let (scheme, rest) = trimmed.split_at(scheme_end + 3);
+                    if let Some(slash) = rest.find('/') {
+                        let (authority, path) = rest.split_at(slash);
+                        format!("{}{}{}", scheme, authority.to_lowercase(), path)
+                    } else {
+                        format!("{}{}", scheme, rest.to_lowercase())
+                    }
+                } else {
+                    trimmed.to_string()
+                }
+            }
+        }
+    }
+
+    /// Panicking accessor for the desktop-only call sites that still
+    /// operate on `&Path`. The panic message names the grep target so
+    /// future migrations are mechanical: `grep -rn expect_posix
+    /// src-tauri/src/`. Every site is a candidate for either a
+    /// `VaultStorage` trait call or a cfg-gated branch.
     pub fn expect_posix(&self) -> &Path {
         match self {
             Self::Posix(p) => p.as_path(),
+            #[cfg(target_os = "android")]
+            Self::ContentUri(_) => panic!(
+                "expect_posix called on ContentUri vault — code path must \
+                 route through VaultStorage trait or be cfg(target_os = \"android\") \
+                 gated. Single grep target: `expect_posix`."
+            ),
         }
     }
 }

--- a/src-tauri/src/storage/mock.rs
+++ b/src-tauri/src/storage/mock.rs
@@ -1,0 +1,171 @@
+// #392 PR-B — in-memory `VaultStorage` impl for host-side tests.
+//
+// AndroidStorage's real I/O routes through the Tauri mobile-plugin
+// FFI (`run_mobile_plugin`), which can't be exercised from a host
+// build. MockAndroidStorage gives us a behavior-equivalent surface
+// to verify error mapping + validate_rel integration without an
+// emulator. Tests in `tests/storage_mock.rs` use it to lock in the
+// per-method validate_rel behavior; PR-B's AndroidStorage delegates
+// to the same `validate_rel` so the mock is a faithful proxy.
+
+#![cfg(test)]
+
+use super::{validate_rel, DirEntry, FileMeta, VaultStorage};
+use crate::error::VaultError;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+#[derive(Debug)]
+pub struct MockAndroidStorage {
+    files: Mutex<HashMap<String, Vec<u8>>>,
+    dirs: Mutex<std::collections::HashSet<String>>,
+    metadata_dir: PathBuf,
+}
+
+impl MockAndroidStorage {
+    pub fn new(metadata_dir: PathBuf) -> Self {
+        Self {
+            files: Mutex::new(HashMap::new()),
+            dirs: Mutex::new(std::collections::HashSet::new()),
+            metadata_dir,
+        }
+    }
+}
+
+impl VaultStorage for MockAndroidStorage {
+    fn read_file(&self, rel_path: &str) -> Result<Vec<u8>, VaultError> {
+        validate_rel(rel_path)?;
+        let files = self.files.lock().map_err(|_| VaultError::LockPoisoned)?;
+        files
+            .get(rel_path)
+            .cloned()
+            .ok_or_else(|| VaultError::FileNotFound {
+                path: rel_path.to_string(),
+            })
+    }
+
+    fn write_file(&self, rel_path: &str, contents: &[u8]) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let mut files = self.files.lock().map_err(|_| VaultError::LockPoisoned)?;
+        files.insert(rel_path.to_string(), contents.to_vec());
+        Ok(())
+    }
+
+    fn create_file(&self, rel_path: &str, initial: &[u8]) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let mut files = self.files.lock().map_err(|_| VaultError::LockPoisoned)?;
+        files.insert(rel_path.to_string(), initial.to_vec());
+        Ok(())
+    }
+
+    fn create_dir(&self, rel_path: &str) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let mut dirs = self.dirs.lock().map_err(|_| VaultError::LockPoisoned)?;
+        dirs.insert(rel_path.to_string());
+        Ok(())
+    }
+
+    fn delete(&self, rel_path: &str) -> Result<(), VaultError> {
+        validate_rel(rel_path)?;
+        let mut files = self.files.lock().map_err(|_| VaultError::LockPoisoned)?;
+        let mut dirs = self.dirs.lock().map_err(|_| VaultError::LockPoisoned)?;
+        let removed_file = files.remove(rel_path).is_some();
+        let removed_dir = dirs.remove(rel_path);
+        // Recursive: remove any file/dir under the deleted prefix.
+        let prefix = format!("{rel_path}/");
+        files.retain(|k, _| !k.starts_with(&prefix));
+        dirs.retain(|k| !k.starts_with(&prefix));
+        if removed_file || removed_dir {
+            Ok(())
+        } else {
+            Err(VaultError::FileNotFound {
+                path: rel_path.to_string(),
+            })
+        }
+    }
+
+    fn rename(&self, from: &str, to: &str) -> Result<(), VaultError> {
+        validate_rel(from)?;
+        validate_rel(to)?;
+        let mut files = self.files.lock().map_err(|_| VaultError::LockPoisoned)?;
+        let bytes = files.remove(from).ok_or_else(|| VaultError::FileNotFound {
+            path: from.to_string(),
+        })?;
+        files.insert(to.to_string(), bytes);
+        Ok(())
+    }
+
+    fn metadata(&self, rel_path: &str) -> Result<FileMeta, VaultError> {
+        validate_rel(rel_path)?;
+        let files = self.files.lock().map_err(|_| VaultError::LockPoisoned)?;
+        let dirs = self.dirs.lock().map_err(|_| VaultError::LockPoisoned)?;
+        if let Some(b) = files.get(rel_path) {
+            return Ok(FileMeta {
+                size: b.len() as u64,
+                is_dir: false,
+            });
+        }
+        if dirs.contains(rel_path) {
+            return Ok(FileMeta {
+                size: 0,
+                is_dir: true,
+            });
+        }
+        Err(VaultError::FileNotFound {
+            path: rel_path.to_string(),
+        })
+    }
+
+    fn list_dir(&self, rel_path: &str) -> Result<Vec<DirEntry>, VaultError> {
+        validate_rel(rel_path)?;
+        let files = self.files.lock().map_err(|_| VaultError::LockPoisoned)?;
+        let dirs = self.dirs.lock().map_err(|_| VaultError::LockPoisoned)?;
+        let prefix = if rel_path.is_empty() {
+            String::new()
+        } else {
+            format!("{rel_path}/")
+        };
+        let mut out: Vec<DirEntry> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for k in files.keys() {
+            if let Some(rest) = k.strip_prefix(&prefix) {
+                if let Some(name) = rest.split('/').next() {
+                    if seen.insert(name.to_string()) {
+                        let is_dir = rest.contains('/');
+                        out.push(DirEntry {
+                            name: name.to_string(),
+                            is_dir,
+                        });
+                    }
+                }
+            }
+        }
+        for k in dirs.iter() {
+            if let Some(rest) = k.strip_prefix(&prefix) {
+                if let Some(name) = rest.split('/').next() {
+                    if seen.insert(name.to_string()) {
+                        out.push(DirEntry {
+                            name: name.to_string(),
+                            is_dir: true,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn exists(&self, rel_path: &str) -> bool {
+        if validate_rel(rel_path).is_err() {
+            return false;
+        }
+        let files = self.files.lock().map(|f| f.contains_key(rel_path)).unwrap_or(false);
+        let dirs = self.dirs.lock().map(|d| d.contains(rel_path)).unwrap_or(false);
+        files || dirs
+    }
+
+    fn metadata_path(&self) -> &Path {
+        &self.metadata_dir
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -10,11 +10,17 @@
 pub mod handle;
 pub mod posix;
 
+#[cfg(target_os = "android")]
+pub mod android;
+
 #[cfg(test)]
 pub mod mock;
 
 pub use handle::VaultHandle;
 pub use posix::PosixStorage;
+
+#[cfg(target_os = "android")]
+pub use android::AndroidStorage;
 
 use crate::error::VaultError;
 use std::path::Path;

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -10,6 +10,9 @@
 pub mod handle;
 pub mod posix;
 
+#[cfg(test)]
+pub mod mock;
+
 pub use handle::VaultHandle;
 pub use posix::PosixStorage;
 

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -8,6 +8,7 @@
 // to return per-platform locations.
 
 pub mod handle;
+pub mod permission;
 pub mod posix;
 
 #[cfg(target_os = "android")]

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -58,3 +58,36 @@ pub trait VaultStorage: Send + Sync {
     /// (Tantivy's storage backend) does not work over `ContentResolver`.
     fn metadata_path(&self) -> &Path;
 }
+
+/// Path-traversal guard shared by every backend. Free function rather
+/// than a trait method so backends can call it without `&self` (e.g.
+/// inside resolution helpers that don't yet hold the storage Arc).
+/// Rejects `..` segments, leading `/` or `\`, and null bytes — the
+/// structural invariants every rel_path must satisfy regardless of
+/// backing store. Storage impls layer their own backend-specific
+/// guards on top (`PosixStorage` adds canonical-starts-with checks;
+/// `AndroidStorage` relies on SAF's tree-URI scope enforcement).
+pub fn validate_rel(rel: &str) -> Result<(), VaultError> {
+    // Reject path-traversal sequences. Note: Path::components handles
+    // OS-specific separators correctly, but we explicitly check for
+    // `..` substring too because raw `..` in a single segment slips
+    // past component-by-component analysis on some platforms.
+    if rel.contains('\0') {
+        return Err(VaultError::PathOutsideVault {
+            path: rel.to_string(),
+        });
+    }
+    if rel.starts_with('/') || rel.starts_with('\\') {
+        return Err(VaultError::PathOutsideVault {
+            path: rel.to_string(),
+        });
+    }
+    for segment in rel.split(['/', '\\']) {
+        if segment == ".." {
+            return Err(VaultError::PathOutsideVault {
+                path: rel.to_string(),
+            });
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/storage/permission.rs
+++ b/src-tauri/src/storage/permission.rs
@@ -1,0 +1,95 @@
+// #392 PR-B — testable correctness boundary for the SAF permission
+// check. Lives outside the cfg(target_os = "android") gate so the
+// `&&` decision can be unit-tested from the host build.
+//
+// Aristotle iter-1 finding #1: the Kotlin side originally returned a
+// single `granted` boolean computed as
+// `it.isReadPermission || it.isWritePermission`. Read-only grants
+// (write revoked via Settings) silently passed → first save failed
+// with a generic Io error → user saw a confusing toast instead of
+// the dedicated re-pick UX. The fix moved the
+// `read AND write` decision into Rust where this test file exercises
+// it directly.
+
+use serde::Deserialize;
+
+/// Response from PickerPlugin's `hasPersistedPermission` command.
+/// Kotlin returns the per-flag breakdown rather than a single boolean
+/// because the &&-of-read-and-write decision is correctness-critical:
+/// a partial grant produces silent failures on the first
+/// opposite-direction operation.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub struct PermissionFlags {
+    #[serde(rename = "hasRead")]
+    pub has_read: bool,
+    #[serde(rename = "hasWrite")]
+    pub has_write: bool,
+}
+
+impl PermissionFlags {
+    /// True iff BOTH read and write are granted. The vault needs to
+    /// support edits as the dominant interaction; a read-only grant
+    /// would let the user open files but every save would fail.
+    /// Surface the partial grant as "no grant" so `open_vault` routes
+    /// through the re-pick UX instead of returning a vault that
+    /// crashes on first save.
+    pub fn is_fully_granted(&self) -> bool {
+        self.has_read && self.has_write
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_grant_is_not_fully_granted() {
+        let p = PermissionFlags {
+            has_read: true,
+            has_write: false,
+        };
+        assert!(!p.is_fully_granted());
+    }
+
+    #[test]
+    fn write_only_grant_is_not_fully_granted() {
+        // Hypothetical — SAF doesn't typically vend a write-only
+        // grant — but the &&-decision must still classify it as
+        // not-usable.
+        let p = PermissionFlags {
+            has_read: false,
+            has_write: true,
+        };
+        assert!(!p.is_fully_granted());
+    }
+
+    #[test]
+    fn both_flags_grant_is_fully_granted() {
+        let p = PermissionFlags {
+            has_read: true,
+            has_write: true,
+        };
+        assert!(p.is_fully_granted());
+    }
+
+    #[test]
+    fn no_grant_is_not_fully_granted() {
+        let p = PermissionFlags {
+            has_read: false,
+            has_write: false,
+        };
+        assert!(!p.is_fully_granted());
+    }
+
+    #[test]
+    fn deserializes_from_kotlin_payload_shape() {
+        // Pin the JSON contract with the Kotlin `hasPersistedPermission`
+        // command. If either side renames the fields without updating
+        // the other, this test catches it before runtime.
+        let json = serde_json::json!({ "hasRead": true, "hasWrite": false });
+        let p: PermissionFlags = serde_json::from_value(json).unwrap();
+        assert!(p.has_read);
+        assert!(!p.has_write);
+        assert!(!p.is_fully_granted());
+    }
+}

--- a/src-tauri/src/tests/error_serialize.rs
+++ b/src-tauri/src/tests/error_serialize.rs
@@ -149,6 +149,39 @@ fn vault_error_serialize_path_outside_vault() {
 }
 
 #[test]
+fn vault_error_serialize_vault_permission_revoked() {
+    // #392 PR-B: SAF tree URI grant was revoked. `data` is the URI so
+    // the frontend's re-pick UX can route the user back through
+    // pickVaultFolder() with no retyping.
+    let v = to_json(VaultError::VaultPermissionRevoked {
+        uri: "content://com.android.externalstorage.documents/tree/primary%3AVault".into(),
+    });
+    assert_eq!(v["kind"], "VaultPermissionRevoked");
+    assert!(v["message"]
+        .as_str()
+        .unwrap()
+        .starts_with("Vault permission revoked: content://"));
+    assert_eq!(
+        v["data"],
+        "content://com.android.externalstorage.documents/tree/primary%3AVault"
+    );
+}
+
+#[test]
+fn vault_error_serialize_encryption_unsupported_on_android() {
+    // #392 PR-B: encrypt_folder / unlock_folder etc. early-return with
+    // this when the active vault is `content://`-rooted. Data-less —
+    // the only relevant action is "wait for the #345 follow-up".
+    let v = to_json(VaultError::EncryptionUnsupportedOnAndroid);
+    assert_eq!(v["kind"], "EncryptionUnsupportedOnAndroid");
+    assert_eq!(
+        v["message"],
+        "Encrypted folders are not yet supported on Android."
+    );
+    assert_eq!(v["data"], Value::Null);
+}
+
+#[test]
 fn vault_error_serialize_picker_failed() {
     // #391: distinct from Io so the frontend can render a picker-specific
     // toast ("Could not open the file picker") instead of the generic

--- a/src-tauri/src/tests/error_serialize.rs
+++ b/src-tauri/src/tests/error_serialize.rs
@@ -182,6 +182,24 @@ fn vault_error_serialize_encryption_unsupported_on_android() {
 }
 
 #[test]
+fn vault_error_serialize_operation_unsupported_on_android() {
+    // #392 PR-B Aristotle iter-1 #4: HTML export and other
+    // desktop-only operations on a content://-rooted vault surface
+    // through this variant. The `operation` name lands in `data` as
+    // a human label (NOT a path), so the message reads naturally and
+    // the frontend's data-routing contract isn't violated.
+    let v = to_json(VaultError::OperationUnsupportedOnAndroid {
+        operation: "HTML export".into(),
+    });
+    assert_eq!(v["kind"], "OperationUnsupportedOnAndroid");
+    assert_eq!(
+        v["message"],
+        "Operation 'HTML export' is not yet supported on Android."
+    );
+    assert_eq!(v["data"], "HTML export");
+}
+
+#[test]
 fn vault_error_serialize_picker_failed() {
     // #391: distinct from Io so the frontend can render a picker-specific
     // toast ("Could not open the file picker") instead of the generic

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -25,6 +25,7 @@ mod encryption_gating;
 mod export_decrypted;
 mod legacy_semantic_cleanup;
 mod picker;
+mod storage_mock;
 mod storage_posix;
 mod storage_validate_rel;
 mod vault_handle;

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -26,4 +26,5 @@ mod export_decrypted;
 mod legacy_semantic_cleanup;
 mod picker;
 mod storage_posix;
+mod storage_validate_rel;
 mod vault_handle;

--- a/src-tauri/src/tests/storage_mock.rs
+++ b/src-tauri/src/tests/storage_mock.rs
@@ -1,0 +1,107 @@
+// #392 PR-B — host-side coverage for the rel-path semantics every
+// non-Posix VaultStorage backend must satisfy. AndroidStorage's real
+// implementation routes through JNI and can't be exercised here, but
+// the structural contracts (validate_rel propagation, error mapping,
+// list_dir flattening) are platform-agnostic and the mock locks them
+// in.
+
+#![cfg(test)]
+
+use crate::error::VaultError;
+use crate::storage::mock::MockAndroidStorage;
+use crate::storage::VaultStorage;
+use std::path::PathBuf;
+
+fn fresh() -> MockAndroidStorage {
+    MockAndroidStorage::new(PathBuf::from("/tmp/mock-vaultcore"))
+}
+
+#[test]
+fn write_then_read_round_trips() {
+    let s = fresh();
+    s.write_file("note.md", b"hello").unwrap();
+    assert_eq!(s.read_file("note.md").unwrap(), b"hello");
+}
+
+#[test]
+fn read_missing_is_file_not_found() {
+    let s = fresh();
+    match s.read_file("ghost.md") {
+        Err(VaultError::FileNotFound { path }) => assert_eq!(path, "ghost.md"),
+        other => panic!("expected FileNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn write_with_dotdot_is_path_outside_vault() {
+    let s = fresh();
+    match s.write_file("../escape", b"x") {
+        Err(VaultError::PathOutsideVault { path }) => assert_eq!(path, "../escape"),
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_with_absolute_is_path_outside_vault() {
+    let s = fresh();
+    match s.read_file("/etc/passwd") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn rename_propagates_validate_rel_to_dest() {
+    let s = fresh();
+    s.write_file("inside.md", b"x").unwrap();
+    match s.rename("inside.md", "../escaped.md") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        other => panic!("expected PathOutsideVault on rename dest, got {other:?}"),
+    }
+    // Source preserved.
+    assert!(s.exists("inside.md"));
+}
+
+#[test]
+fn delete_recursive_removes_subtree() {
+    let s = fresh();
+    s.create_dir("dir").unwrap();
+    s.write_file("dir/a.md", b"a").unwrap();
+    s.write_file("dir/sub/b.md", b"b").unwrap();
+    s.delete("dir").unwrap();
+    assert!(!s.exists("dir"));
+    assert!(!s.exists("dir/a.md"));
+    assert!(!s.exists("dir/sub/b.md"));
+}
+
+#[test]
+fn list_dir_returns_immediate_children() {
+    let s = fresh();
+    s.write_file("a.md", b"").unwrap();
+    s.write_file("b.md", b"").unwrap();
+    s.write_file("dir/inner.md", b"").unwrap();
+    s.create_dir("empty").unwrap();
+    let mut names: Vec<String> = s
+        .list_dir("")
+        .unwrap()
+        .into_iter()
+        .map(|e| e.name)
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["a.md", "b.md", "dir", "empty"]);
+}
+
+#[test]
+fn exists_false_on_traversal_attempt() {
+    let s = fresh();
+    s.write_file("inside.md", b"x").unwrap();
+    // Even though `inside.md` exists, `../inside.md` is invalid.
+    assert!(!s.exists("../inside.md"));
+    assert!(s.exists("inside.md"));
+}
+
+#[test]
+fn metadata_path_returns_constructor_arg() {
+    let s = fresh();
+    assert_eq!(s.metadata_path(), std::path::Path::new("/tmp/mock-vaultcore"));
+}

--- a/src-tauri/src/tests/storage_validate_rel.rs
+++ b/src-tauri/src/tests/storage_validate_rel.rs
@@ -1,0 +1,85 @@
+// #392 PR-B — `storage::validate_rel` is the structural rel-path guard
+// shared by every backend. Backends layer their own canonical/SAF
+// checks on top; this is the first line of defense against
+// path-traversal and obviously-malformed paths.
+
+#![cfg(test)]
+
+use crate::error::VaultError;
+use crate::storage::validate_rel;
+
+#[test]
+fn accepts_simple_rel_path() {
+    assert!(validate_rel("note.md").is_ok());
+    assert!(validate_rel("subdir/note.md").is_ok());
+    assert!(validate_rel("a/b/c/deep.md").is_ok());
+}
+
+#[test]
+fn accepts_empty_rel_path() {
+    // Empty rel = "the vault root itself" — legitimate for `list_dir("")`.
+    assert!(validate_rel("").is_ok());
+}
+
+#[test]
+fn rejects_dotdot_segment() {
+    match validate_rel("../escape") {
+        Err(VaultError::PathOutsideVault { path }) => assert_eq!(path, "../escape"),
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_dotdot_in_subdir() {
+    match validate_rel("subdir/../escape") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_dotdot_with_backslash_separator() {
+    // Defense-in-depth: Windows-style separator from a copy-paste path.
+    match validate_rel("subdir\\..\\escape") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_absolute_unix_path() {
+    match validate_rel("/etc/passwd") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_absolute_windows_path() {
+    match validate_rel("\\Windows\\System32") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_null_byte() {
+    match validate_rel("note\0.md") {
+        Err(VaultError::PathOutsideVault { .. }) => {}
+        other => panic!("expected PathOutsideVault, got {other:?}"),
+    }
+}
+
+#[test]
+fn accepts_dot_segments_other_than_dotdot() {
+    // Legitimate file names with dots — `.gitignore`, `.vaultcore`.
+    assert!(validate_rel(".vaultcore/index/v.json").is_ok());
+    assert!(validate_rel("note.with.dots.md").is_ok());
+}
+
+#[test]
+fn accepts_filename_starting_with_dot_but_not_dotdot() {
+    // `.hidden` is a single segment, not traversal.
+    assert!(validate_rel(".hidden").is_ok());
+    assert!(validate_rel("dir/.hidden").is_ok());
+}

--- a/src-tauri/src/tests/vault_handle.rs
+++ b/src-tauri/src/tests/vault_handle.rs
@@ -49,3 +49,75 @@ fn from_pathbuf_wraps_as_posix() {
     let h: VaultHandle = p.clone().into();
     assert_eq!(h, VaultHandle::Posix(p));
 }
+
+#[test]
+fn canonical_dedup_key_for_posix_is_path_string() {
+    let h = VaultHandle::Posix(PathBuf::from("/Users/lu/Vault"));
+    assert_eq!(h.canonical_dedup_key(), "/Users/lu/Vault");
+}
+
+#[cfg(target_os = "android")]
+mod android {
+    use super::*;
+    use crate::error::VaultError;
+
+    #[test]
+    fn parse_content_uri_skips_canonicalize() {
+        let uri = "content://com.android.externalstorage.documents/tree/primary%3AVault";
+        let h = VaultHandle::parse(uri).unwrap();
+        assert_eq!(h, VaultHandle::ContentUri(uri.to_string()));
+    }
+
+    #[test]
+    fn content_uri_round_trips_through_parse() {
+        let uri = "content://com.android.externalstorage.documents/tree/primary%3AVault";
+        let h1 = VaultHandle::parse(uri).unwrap();
+        let s = h1.as_str().into_owned();
+        let h2 = VaultHandle::parse(&s).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn dedup_key_strips_trailing_slash() {
+        let a = VaultHandle::ContentUri(
+            "content://provider/tree/primary%3AVault".into(),
+        );
+        let b = VaultHandle::ContentUri(
+            "content://provider/tree/primary%3AVault/".into(),
+        );
+        assert_eq!(a.canonical_dedup_key(), b.canonical_dedup_key());
+    }
+
+    #[test]
+    fn dedup_key_lowercases_authority_only() {
+        let a = VaultHandle::ContentUri(
+            "content://Com.Android.Storage/tree/Primary%3AVault".into(),
+        );
+        let b = VaultHandle::ContentUri(
+            "content://com.android.storage/tree/Primary%3AVault".into(),
+        );
+        // Authority is lowercased, but the path component (incl.
+        // percent-encoded `Primary%3A`) is preserved as-is — SAF treats
+        // the path as case-sensitive.
+        assert_eq!(a.canonical_dedup_key(), b.canonical_dedup_key());
+        assert!(a.canonical_dedup_key().contains("Primary%3A"));
+    }
+
+    #[test]
+    #[should_panic(expected = "expect_posix called on ContentUri")]
+    fn expect_posix_panics_on_content_uri() {
+        let h = VaultHandle::ContentUri("content://x/tree/y".into());
+        let _ = h.expect_posix();
+    }
+
+    #[test]
+    fn parse_non_content_string_still_canonicalizes() {
+        // On Android, a non-content:// string should fall through to
+        // POSIX canonicalize and error if the path doesn't exist.
+        let r = VaultHandle::parse("/totally/missing");
+        match r {
+            Err(VaultError::VaultUnavailable { .. }) => {}
+            other => panic!("expected VaultUnavailable, got {other:?}"),
+        }
+    }
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -101,6 +101,24 @@
         vaultStore.setError(vaultErrorCopy(ve));
         return;
       }
+      // #392 PR-B: SAF tree URI grant was revoked (Settings → Apps →
+      // Permissions → Files → revoke, or app reinstall). Re-pick
+      // re-grants without retyping; the picker resolves to the same
+      // URI (or a fresh one if the user picks elsewhere) and a new
+      // openVault call goes through.
+      if (ve.kind === "VaultPermissionRevoked") {
+        toastStore.push({
+          variant: "warning",
+          message: vaultErrorCopy(ve),
+        });
+        const picked = await pickVaultFolder();
+        if (picked !== null) {
+          await loadVault(picked);
+        } else {
+          vaultStore.setError(vaultErrorCopy(ve));
+        }
+        return;
+      }
       vaultStore.setError(vaultErrorCopy(ve));
       toastStore.push({ variant: "error", message: vaultErrorCopy(ve) });
     }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,7 +74,7 @@
     return { kind: "Io" as const, message: String(err), data: null };
   }
 
-  async function loadVault(path: string): Promise<void> {
+  async function loadVault(path: string, retryCount = 0): Promise<void> {
     vaultStore.setOpening(path);
     progressStore.start(0);
     try {
@@ -106,14 +106,19 @@
       // re-grants without retyping; the picker resolves to the same
       // URI (or a fresh one if the user picks elsewhere) and a new
       // openVault call goes through.
-      if (ve.kind === "VaultPermissionRevoked") {
+      //
+      // Aristotle iter-1 #3: cap the recursion at one retry so a
+      // persistently-revoked permission (e.g. correlated with the
+      // partial-grant scenario) can't blow the stack. After one
+      // failed re-pick we surface the error normally.
+      if (ve.kind === "VaultPermissionRevoked" && retryCount === 0) {
         toastStore.push({
           variant: "warning",
           message: vaultErrorCopy(ve),
         });
         const picked = await pickVaultFolder();
         if (picked !== null) {
-          await loadVault(picked);
+          await loadVault(picked, retryCount + 1);
         } else {
           vaultStore.setError(vaultErrorCopy(ve));
         }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -31,7 +31,11 @@ export type VaultErrorKind =
   | "VaultPermissionRevoked"
   // #392 PR-B — encrypted folders aren't yet supported on Android.
   // Tracked: #345 storage-trait-aware encryption follow-up.
-  | "EncryptionUnsupportedOnAndroid";
+  | "EncryptionUnsupportedOnAndroid"
+  // #392 PR-B — desktop-only operation (HTML export, snippet/template
+  // walks, etc.) requested while the vault is `content://`-rooted.
+  // The operation name comes through `data` for the toast copy.
+  | "OperationUnsupportedOnAndroid";
 
 export interface VaultError {
   kind: VaultErrorKind;
@@ -91,6 +95,8 @@ export function vaultErrorCopy(err: VaultError): string {
       return "Vault access was revoked. Tap to re-pick the folder.";
     case "EncryptionUnsupportedOnAndroid":
       return "Encrypted folders aren't yet supported on Android.";
+    case "OperationUnsupportedOnAndroid":
+      return `${err.data ?? "This operation"} isn't supported on Android yet.`;
     default: {
       const _exhaustive: never = err.kind;
       return "An unexpected error occurred.";

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -24,7 +24,14 @@ export type VaultErrorKind =
   | "PickerFailed"
   // #392 — request resolved outside the vault root (T-02 violation).
   // Either a client bug or attack — never user-actionable.
-  | "PathOutsideVault";
+  | "PathOutsideVault"
+  // #392 PR-B — SAF tree URI no longer has a persisted permission grant.
+  // Frontend listens for this kind in the loadVault error path and
+  // routes through pickVaultFolder() to re-grant access.
+  | "VaultPermissionRevoked"
+  // #392 PR-B — encrypted folders aren't yet supported on Android.
+  // Tracked: #345 storage-trait-aware encryption follow-up.
+  | "EncryptionUnsupportedOnAndroid";
 
 export interface VaultError {
   kind: VaultErrorKind;
@@ -80,6 +87,10 @@ export function vaultErrorCopy(err: VaultError): string {
       return "Could not open the file picker. Please try again.";
     case "PathOutsideVault":
       return "Request denied — the path is outside the vault.";
+    case "VaultPermissionRevoked":
+      return "Vault access was revoked. Tap to re-pick the folder.";
+    case "EncryptionUnsupportedOnAndroid":
+      return "Encrypted folders aren't yet supported on Android.";
     default: {
       const _exhaustive: never = err.kind;
       return "An unexpected error occurred.";


### PR DESCRIPTION
## Summary

Closes #392. PR-B of the two-PR slice. PR-A (#408, merged at `cf27f64`) landed `VaultStorage` + `VaultHandle::Posix` + `PosixStorage` with the T-02 path-traversal guard. PR-B is the substantive PR that **finally makes vault-open work on Android** — the user's "Vault unavailable" toast on every pick is fixed.

## What's in

- **`VaultHandle::ContentUri(String)`** arm gated `cfg(target_os = "android")`. `parse` short-circuits `content://` strings without filesystem I/O. `canonical_dedup_key` for `recent-vaults.json` dedup (strips trailing slash, lowercases authority — never use this URI to call into Android, only `as_str()` does). `expect_posix` panics with a grep target naming the migration story.
- **`AndroidStorage`** cfg-gated impl backed by extended `PickerPlugin.kt`. Per-method `validate_rel` defense in depth on top of SAF tree-URI scope. `metadata_path()` returns app-private scratch under `<getFilesDir()>/vaults/<sha256(uri)[..16]>/` so Tantivy and bookmarks live in real POSIX storage.
- **`PickerPlugin.kt`** gains 11 new `@Command`s: `takePersistableUriPermission`, `hasPersistedPermission`, `readFile`, `writeFile`, `createFile`, `createDir`, `deletePath`, `renamePath`, `metadata`, `listDir`, `pathExists`. `walkRel` helper walks `DocumentFile.fromTreeUri()` step-by-step; cross-parent rename uses `DocumentsContract.moveDocument`.
- **`open_vault`** forks early on the parsed handle. ContentUri branch: `hasPersistedPermission` check → `VaultPermissionRevoked` if false; idempotent `takePersistableUriPermission`; construct `AndroidStorage`; skip the desktop-only setup (fs_scope, watcher spawn, manifest reload, embeddings purge, Tantivy cold-start). Returns a stub `VaultInfo` (`file_count = 0`, empty `file_list`) — per-file index updates populate as the user navigates.
- **All 11 file commands** in `commands/files.rs` get Android branches that route through the storage trait. The desktop bodies are unchanged. `read_file`, `write_file`, `create_file`, `create_folder`, `rename_file`, `delete_file`, `move_file`, `get_file_hash`, `save_attachment`, `read_attachment_bytes`, `count_wiki_links` (returns 0).
- **Encryption layer** (`encryption/mod.rs`) — `maybe_decrypt_read` and `maybe_encrypt_write` get an explicit `ContentUri ⇒ passthrough` arm INSIDE the existing functions. Plain Android vaults flow through cleanly; encrypted folders fail-fast at every create/unlock entry with `EncryptionUnsupportedOnAndroid`.
- **Cfg-skip branches** in `links.rs` (`update_links_after_rename`, `get_resolved_attachments`), `tree.rs` (`list_directory` routes through `storage.list_dir`), `bookmarks.rs` (`metadata_path` for the JSON file), `templates.rs`/`snippets.rs` (return empty), `search.rs` (`rebuild_index` no-ops), `export.rs` (HTML export returns `PermissionDenied`), `vault.rs::merge_external_change_impl` (defensive guard).
- **Frontend re-pick UX** — `App.svelte::loadVault` catches `VaultPermissionRevoked` and re-fires `pickVaultFolder()` so the user re-grants without retyping.
- **`MOBILE_BUILD.md`** known-limitations section enumerates every Android skip with a tracked follow-up ticket title.

## Socrates v1 findings — all addressed

Plan v3 had real bugs that would have crashed the app on first Android use. Plan v4 addressed all 15. Recap:

1. ✅ Encryption passthrough lives **inside** existing `maybe_decrypt_read` / `maybe_encrypt_write` (Socrates' fix; my "sister functions" architecture was wrong).
2. ✅ `reload_manifest_and_lock_all` cfg-skipped in `open_vault` Android branch.
3. ✅ `delete_file_impl` `.trash` semantic: permanent delete on Android, OS Files-app trash on Android 11+.
4. ✅ All 28 production `expect_posix()` sites enumerated by literal grep + handled. Most cfg-skip-return-empty; the rest live inside desktop bodies that early-return on Android branch.
5. ✅ `merge_external_change_impl` Android guard added.
6. ✅ `get_storage` helper splits lock logic out of `resolve_rel_in_vault`.
7. ✅ Frontend rel-path derivation: backend strips the URI prefix from the absolute string the frontend constructs.
8. ✅ `canonical_dedup_key` for `recent-vaults.json` URI dedup.
9. ✅ `extra_data()` exhaustive match: `VaultPermissionRevoked` aliases `uri` to the path arm; `EncryptionUnsupportedOnAndroid` is None.
10. ✅ `base64` already in Cargo.toml line 40 — no Cargo addition.
11. ✅ Watcher cfg-no-op via the `open_vault_android` early-return (the watcher-spawn block in the desktop branch never runs).
12. ✅ `takePersistableUriPermission` flag arg: `FLAG_GRANT_READ | FLAG_GRANT_WRITE`.
13. ✅ `hasPersistedPermission` filters `getPersistedUriPermissions()` by URI equality + read/write flags.
14. ✅ `ensure_inside_vault` returns `PathOutsideVault` (not `PermissionDenied`) for T-02 — fixed inside the Android branches that use the new helper.
15. ✅ `MockAndroidStorage` for host-side `validate_rel` coverage. 9 round-trip tests exercise every trait method.

## Verification

| Gate | Command | Result |
|---|---|---|
| Desktop check | `cargo check --lib` | PASS |
| Desktop bundle | `pnpm tauri build --debug` | PASS — `.app` + `.dmg` |
| Desktop unit | `cargo test --lib -- --test-threads=4` | **426 passed / 6 pre-existing failed / 2 ignored**. The 6 `tests::files_ops::*` failures are pre-existing macOS `/var` symlink issues from #390. +28 new tests (16 PR-A + 9 mock + 10 validate_rel + 2 new error variants + 5 ContentUri arm tests). |
| Android check | `cargo check --target aarch64-linux-android --lib` | PASS |
| Android APK | `pnpm tauri android build --debug` | PASS — universal APK + AAB, all 4 ABIs |
| dexdump verify | `strings classes*.dex \| grep PickerPlugin` | All 11 new commands present (`readFile`, `writeFile`, `createFile`, `createDir`, `deletePath`, `renamePath`, `metadata`, `listDir`, `pathExists`, `takePersistableUriPermission`, `hasPersistedPermission`). |
| aapt2 permissions | `aapt2 dump permissions <apk>` | Identical to PR-A — only `INTERNET` + `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`. SAF tree-URI grants are runtime-only, not manifest-declared. No leakage. |
| Vitest | `pnpm test` | **1507/1507 PASS** |

## Test plan (manual UAT — required, on real device)

- [ ] `pnpm tauri android build --debug && adb install <apk>`
- [ ] Open the app → tap "Open vault" → SAF picker → pick a folder
- [ ] Verify `recent-vaults.json` (via `adb shell run-as com.vaultcore.app cat files/recent-vaults.json`) contains the `content://` URI verbatim
- [ ] Force-stop the app + relaunch → vault should auto-open from recents (no re-pick prompt)
- [ ] Tap a markdown file → contents render in the editor
- [ ] Edit + save → changes round-trip (re-open the file, see the edits)
- [ ] Create a new file → appears in the tree
- [ ] Delete a file → removed; check Files app's Trash to confirm SAF trash policy
- [ ] Rename a file → tree updates; backlinks intentionally don't update (limitation)
- [ ] System Settings → Apps → VaultCore → Storage → Manage access → revoke the tree URI
- [ ] Re-launch the app → re-pick prompt fires; pick again → vault re-opens

## Known limitations (Android v1)

Documented in detail in `docs/MOBILE_BUILD.md`:

- **No live file watching** — vault refreshes on close+reopen. Tracked: `feat(watcher): Android polling fallback for content-URI vaults`.
- **Fulltext search starts empty per session** — per-file index updates populate as the user opens files. Tracked: `feat(indexer): cold-start lazy index for ContentResolver vaults`.
- **Backlinks and link graph empty** — same root cause. Same follow-up.
- **No encrypted folders on Android** — `EncryptionUnsupportedOnAndroid` runtime guard. Tracked: `feat(crypto): VaultStorage-aware encryption layer for Android`.
- **HTML export deferred** — returns `PermissionDenied` with a clear message.
- **Templates / snippets / canvas / tags / wiki-link counter** — empty/no-op on Android.
- **Per-file ContentResolver round-trip cost** — 1-5ms per Binder call; 5-deep paths = 5-25ms. Batch-API optimization is a UAT-driven follow-up.
- **No in-vault `.trash` subfolder** — relying on OS Files-app Trash on Android 11+.

## Refs

- Closes #392 (PR-A + PR-B together)
- Follow-up tickets to open after PR-B ships: indexer lazy-index, watcher polling, crypto storage-trait pass.