### PR TITLE
fix(mobile): UAT pass — sidebar, editor, canvas, recents, scaffold

### DIFF
--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -3,6 +3,7 @@
   "identifier": "mobile-capability",
   "description": "VaultCore Android capabilities",
   "platforms": ["android"],
+  "windows": ["main"],
   "permissions": [
     "core:default",
     "dialog:default",

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -315,15 +315,33 @@ async fn open_vault_android(
         .app_local_data_dir()
         .map_err(|e| VaultError::Io(std::io::Error::other(e.to_string())))?;
     let storage = AndroidStorage::new(&app, uri.clone(), &app_local_data)?;
+    let storage_arc: std::sync::Arc<dyn crate::storage::VaultStorage> =
+        std::sync::Arc::new(storage);
 
     state.set_open_vault(
         VaultHandle::ContentUri(uri.clone()),
-        std::sync::Arc::new(storage),
+        std::sync::Arc::clone(&storage_arc),
     )?;
 
     // recent-vaults.json stores the URI verbatim — VaultHandle::parse
     // round-trips it via the content:// heuristic on next open.
     push_recent_vault(&app, &uri)?;
+
+    // Bootstrap the per-vault home canvas + bundled docs page. The
+    // desktop indexer cold-start handles this for POSIX vaults; on
+    // Android the indexer is skipped (mmap-incompatible), so we run the
+    // storage-trait variants directly. Failures are non-fatal — a logged
+    // warning matches the desktop semantics, and the user can still open
+    // their notes without these auxiliary files.
+    if let Err(e) = crate::indexer::ensure_home_canvas_via_storage(
+        storage_arc.as_ref(),
+        &display_name_from_content_uri(&uri),
+    ) {
+        log::warn!("ensure_home_canvas_via_storage failed: {e:?}");
+    }
+    if let Err(e) = crate::indexer::ensure_docs_page_via_storage(storage_arc.as_ref()) {
+        log::warn!("ensure_docs_page_via_storage failed: {e:?}");
+    }
 
     *state.vault_reachable.lock().map_err(|_| VaultError::LockPoisoned)? = true;
 
@@ -368,6 +386,51 @@ pub async fn repair_vault_index(vault_path: String) -> Result<(), VaultError> {
         let _ = std::fs::remove_file(&version_file);
     }
     Ok(())
+}
+
+// --- Android URI helpers ----------------------------------------------------
+
+/// Extract a human-friendly display name from a SAF tree URI.
+/// `content://com.android.externalstorage.documents/tree/primary%3ATest`
+/// → `"Test"`. Mirrors the frontend's `deriveVaultName` so the seeded
+/// home.canvas welcome heading matches the sidebar label.
+#[cfg(target_os = "android")]
+fn display_name_from_content_uri(uri: &str) -> String {
+    let last = uri.rsplit('/').next().unwrap_or(uri);
+    let decoded = percent_decode(last);
+    match decoded.find(':') {
+        Some(idx) => {
+            let tail = &decoded[idx + 1..];
+            if tail.is_empty() { decoded.clone() } else { tail.to_string() }
+        }
+        None => decoded,
+    }
+}
+
+/// Minimal RFC 3986 percent-decoder for SAF tree-URI segments. Only
+/// %XX hex pairs are decoded — invalid sequences pass through. Output
+/// is treated as UTF-8; non-UTF-8 byte sequences fall back to the raw
+/// input. SAF segments are short (single path component), so a small
+/// allocator is fine.
+#[cfg(target_os = "android")]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
 }
 
 // --- recent-vaults.json persistence -----------------------------------------

--- a/src-tauri/src/indexer/mod.rs
+++ b/src-tauri/src/indexer/mod.rs
@@ -866,6 +866,91 @@ pub fn ensure_home_canvas(vault_path: &Path) -> Result<(), VaultError> {
     Ok(())
 }
 
+/// Storage-trait variant of `ensure_home_canvas` for backends that don't
+/// surface a POSIX-mappable vault root (Android SAF). Writes the same
+/// JSON template through the `VaultStorage` trait using vault-relative
+/// paths, so the file lands in `<tree>/.vaultcore/home.canvas` regardless
+/// of the underlying ContentProvider. Idempotent: skips when the file
+/// already exists.
+pub fn ensure_home_canvas_via_storage(
+    storage: &dyn crate::storage::VaultStorage,
+    display_name: &str,
+) -> Result<(), VaultError> {
+    const REL_PATH: &str = ".vaultcore/home.canvas";
+    if storage.exists(REL_PATH) {
+        return Ok(());
+    }
+    storage.create_dir(".vaultcore")?;
+
+    let welcome_text = format!(
+        "# {}\n\nEdit this canvas — it's your personal home.",
+        display_name
+    );
+    let doc = serde_json::json!({
+        "nodes": [{
+            "id": "welcome",
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "width": 400,
+            "height": 120,
+            "text": welcome_text,
+        }],
+        "edges": [],
+    });
+
+    let mut buf = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"\t");
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    serde::Serialize::serialize(&doc, &mut ser).map_err(|e| {
+        VaultError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+    })?;
+    storage.create_file(REL_PATH, &buf)?;
+    Ok(())
+}
+
+/// Storage-trait variant of `ensure_docs_page` for backends that don't
+/// surface a POSIX-mappable vault root. Reads the head of the existing
+/// file (when present) via the storage trait to compare the embedded
+/// `vaultcore_docs_version` against the running build, and rewrites
+/// only on mismatch — same semantics as the POSIX path, expressed in
+/// vault-relative form.
+pub fn ensure_docs_page_via_storage(
+    storage: &dyn crate::storage::VaultStorage,
+) -> Result<(), VaultError> {
+    const REL_PATH: &str = ".vaultcore/DOCS.md";
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    if storage.exists(REL_PATH) {
+        if let Ok(bytes) = storage.read_file(REL_PATH) {
+            let head_len = bytes.len().min(1024);
+            if let Ok(head) = std::str::from_utf8(&bytes[..head_len]) {
+                let needle = format!("vaultcore_docs_version: \"{}\"", current_version);
+                if head.contains(&needle) {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    storage.create_dir(".vaultcore")?;
+
+    let header = format!(
+        "---\nvaultcore_docs_version: \"{}\"\n---\n\n",
+        current_version
+    );
+    let mut contents = String::with_capacity(header.len() + DOCS_TEMPLATE_BODY.len());
+    contents.push_str(&header);
+    contents.push_str(DOCS_TEMPLATE_BODY);
+
+    if storage.exists(REL_PATH) {
+        storage.write_file(REL_PATH, contents.as_bytes())?;
+    } else {
+        storage.create_file(REL_PATH, contents.as_bytes())?;
+    }
+    Ok(())
+}
+
 /// Bundled docs body. Shipped alongside the binary so the file contents
 /// can be edited as normal Markdown without touching Rust code.
 const DOCS_TEMPLATE_BODY: &str = include_str!("../../resources/DOCS.template.md");

--- a/src/components/Canvas/CanvasView.svelte
+++ b/src/components/Canvas/CanvasView.svelte
@@ -155,6 +155,13 @@
   // the native handler chain.
   let longpressCaptureEl: HTMLElement | null = null;
 
+  // Multi-touch guard: secondary fingers of a pinch carry isPrimary=false.
+  // When one arrives during an active pan/move/edge/resize we abort the
+  // gesture so the node the primary finger landed on doesn't continue
+  // translating mid-pinch. We deliberately track no per-pointer state —
+  // the browser's `isPrimary` flag is the source of truth and survives
+  // pointercancel races that an explicit Set wouldn't.
+
   const MIN_ZOOM = 0.15;
   const MAX_ZOOM = 4;
 
@@ -456,11 +463,44 @@
     zoom = next;
   }
 
+  // Cancel any in-flight gesture and release pointer captures. Used when a
+  // second finger lands during an active pan/move/edge/resize so a pinch
+  // doesn't continue translating the node the first finger happened to
+  // be on. We deliberately do NOT revert in-progress geometry changes —
+  // the doc-watcher's debounced save is fine with the partial state and
+  // pointerup will flush it normally.
+  function abortActiveGesture() {
+    cancelLongpressTimer();
+    longpressCaptureEl = null;
+    if (pointerMode?.kind === "edge") draft = null;
+    pointerMode = null;
+  }
+
   function onViewportPointerDown(e: PointerEvent) {
     if (editingNodeId || editingEdgeId) return;
+    // Secondary-finger guard: a pinch lands a non-primary touch while a
+    // primary-touch gesture is still active. Drop it on the floor so the
+    // node the primary finger captured doesn't keep moving toward the
+    // second finger.
+    if (e.pointerType === "touch" && !e.isPrimary) {
+      abortActiveGesture();
+      return;
+    }
     const isPan = e.button === 1 || (e.button === 0 && spaceHeld);
     if (isPan) {
       e.preventDefault();
+      selectedNodeId = null;
+      selectedEdgeId = null;
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      pointerMode = beginPan(e, { x: camX, y: camY });
+      return;
+    }
+    // Touch on empty viewport → pan immediately. The desktop long-press-to-pan
+    // gesture (#144) doesn't translate to mobile: on touch the natural drag is
+    // a pan, and a tap-and-hold with no drag is a context-menu trigger handled
+    // separately. Bypass the pending-longpress state machine so finger-drag
+    // pans without a 300 ms wait.
+    if (e.pointerType === "touch") {
       selectedNodeId = null;
       selectedEdgeId = null;
       (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
@@ -628,6 +668,12 @@
   function onNodePointerDown(e: PointerEvent, node: CanvasNode) {
     if (editingNodeId === node.id) return;
     if (e.button !== 0 || spaceHeld) return;
+    // Same secondary-finger guard as the viewport handler.
+    if (e.pointerType === "touch" && !e.isPrimary) {
+      e.stopPropagation();
+      abortActiveGesture();
+      return;
+    }
     e.stopPropagation();
     selectedNodeId = node.id;
     selectedEdgeId = null;
@@ -643,6 +689,23 @@
             startY: m.y,
           }))
         : [];
+    // Touch: skip the pending-longpress arc and begin moving immediately.
+    // The pending-longpress fallback only matters on desktop where holding
+    // still flips into pan mode (#144). On touch we always want a finger
+    // drag to translate the node — a stationary touch instead opens the
+    // context menu via the separate longPress action wired on the canvas
+    // surface. Capture the pointer on the node element so subsequent
+    // pointermove events route through `onViewportPointerMove` (which
+    // bubbles up from the captured node).
+    if (e.pointerType === "touch") {
+      try {
+        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      } catch {
+        /* synthetic-test pointer ID */
+      }
+      pointerMode = beginMove(node, e, members);
+      return;
+    }
     // Enter pending-longpress — if the user keeps the pointer still for
     // LONGPRESS_HOLD_MS we flip to pan; if they move past the threshold
     // first, we fall through to beginMove (the original gesture).

--- a/src/components/Editor/EditorPane.svelte
+++ b/src/components/Editor/EditorPane.svelte
@@ -1342,6 +1342,21 @@
     background-color: color-mix(in srgb, var(--color-surface) 70%, transparent) !important;
   }
 
+  /* On mobile the .cm-content document-card sits flush against the gutter
+     because the viewport is narrower than --vc-editor-max-width (720px) and
+     `width: 100%` consumes everything. Carve out 12px on each side so the
+     card visibly floats on the gutter background, matching the existing
+     top/bottom 24px margins. The flex-basis still wins on desktop, so this
+     change is mobile-only. */
+  @media (max-width: 699px) {
+    .vc-editor-content :global(.cm-content) {
+      width: calc(100% - 24px) !important;
+      flex-basis: calc(100% - 24px) !important;
+      margin-left: 12px !important;
+      margin-right: 12px !important;
+    }
+  }
+
   .vc-editor-empty {
     position: absolute;
     inset: 0;

--- a/src/components/Sidebar/Sidebar.svelte
+++ b/src/components/Sidebar/Sidebar.svelte
@@ -21,6 +21,7 @@
     DEFAULT_TREE_STATE,
   } from "../../lib/treeState";
   import { vaultStore } from "../../store/vaultStore";
+  import { viewportStore } from "../../store/viewportStore";
   import { toastStore } from "../../store/toastStore";
   import { progressStore } from "../../store/progressStore";
   import { isVaultError, vaultErrorCopy } from "../../types/errors";
@@ -789,11 +790,27 @@
     return null;
   }
 
-  const vaultName = $derived(
-    $vaultStore.currentPath
-      ? $vaultStore.currentPath.split("/").pop() ?? $vaultStore.currentPath
-      : "No vault",
-  );
+  // Display name derivation:
+  //  - Posix path: last `/`-separated segment ("/Users/foo/Notes" → "Notes")
+  //  - Android content:// URI: take the path leaf, percent-decode, strip the
+  //    common "primary:" / "<storageId>:" prefix that SAF prepends. e.g.
+  //    "content://...documents/tree/primary%3ATest" → "Test".
+  function deriveVaultName(path: string | null | undefined): string {
+    if (!path) return "No vault";
+    if (path.startsWith("content://")) {
+      const last = path.split("/").pop() ?? path;
+      let decoded: string;
+      try {
+        decoded = decodeURIComponent(last);
+      } catch {
+        decoded = last;
+      }
+      const colonIdx = decoded.indexOf(":");
+      return colonIdx >= 0 ? decoded.slice(colonIdx + 1) || decoded : decoded;
+    }
+    return path.split("/").pop() ?? path;
+  }
+  const vaultName = $derived(deriveVaultName($vaultStore.currentPath));
 </script>
 
 <aside class="vc-sidebar" data-testid="sidebar">
@@ -903,23 +920,29 @@
         >
           <FolderPlus size={16} strokeWidth={1.5} />
         </button>
-        <button
-          class="vc-sidebar-action-btn"
-          onclick={() => tabStore.openGraphTab()}
-          aria-label="Open graph"
-          title="Open graph (Cmd/Ctrl+Shift+G)"
-        >
-          <Network size={16} strokeWidth={1.5} />
-        </button>
-        <button
-          class="vc-sidebar-action-btn"
-          onclick={() => { void openDocsPage(); }}
-          aria-label="Open docs"
-          title="Open documentation (Cmd/Ctrl+Shift+/)"
-          data-testid="sidebar-open-docs"
-        >
-          <BookOpen size={16} strokeWidth={1.5} />
-        </button>
+        {#if $viewportStore.mode !== "mobile"}
+          <!-- Graph + Docs are desktop-only on mobile we hide them to keep
+               the action toolbar uncrammed; both are reachable via the
+               command palette / keyboard shortcuts on desktop, neither is
+               in the mobile UX scope per #74. -->
+          <button
+            class="vc-sidebar-action-btn"
+            onclick={() => tabStore.openGraphTab()}
+            aria-label="Open graph"
+            title="Open graph (Cmd/Ctrl+Shift+G)"
+          >
+            <Network size={16} strokeWidth={1.5} />
+          </button>
+          <button
+            class="vc-sidebar-action-btn"
+            onclick={() => { void openDocsPage(); }}
+            aria-label="Open docs"
+            title="Open documentation (Cmd/Ctrl+Shift+/)"
+            data-testid="sidebar-open-docs"
+          >
+            <BookOpen size={16} strokeWidth={1.5} />
+          </button>
+        {/if}
       </div>
     {/if}
   </header>


### PR DESCRIPTION
## Summary

Five UAT findings against the on-device Android build, fixed in one go since they're all small mobile-only changes:

- **Sidebar cramped** — vault name was the raw URL-encoded URI segment (`primary%3ATest` → truncated to "p"); 6 action buttons fought for space inside the 240 px drawer. Decoded the SAF tree URI to its tail name (`Test`) and hid the desktop-only Graph + Docs buttons under `viewportStore.mode !== "mobile"`.
- **Editor flush to gutter** — `.cm-content` consumed the full viewport width on phones because `width: 100%` won out under `--vc-editor-max-width: 720px`. Added a `@media (max-width: 699px)` override that pulls the card in by 12 px on each side.
- **Recent vaults empty after relaunch** — `mobile-capability` had no `windows`/`webviews` scope, so `core:default`'s `allow-listen` permission never bound to the main webview. `event.listen` rejected during `onMount`, the awaited `listenIndexProgress(...)` threw, and `getRecentVaults()` never ran. Added `"windows": ["main"]` to match the desktop capability shape.
- **Home canvas + docs page missing on Android** — desktop seeds `.vaultcore/home.canvas` and `.vaultcore/DOCS.md` from the indexer cold-start, which is skipped on Android (Tantivy uses `mmap` and SAF can't back that). Added storage-trait variants `ensure_home_canvas_via_storage` / `ensure_docs_page_via_storage` and called them from `open_vault_android` so the same files get seeded through the SAF `ContentResolver`. Display name decoded from the content URI so the welcome heading matches the sidebar.
- **Canvas pan + drag broken on touch** — `onViewportPointerDown` only entered pan mode for middle-mouse or `space + left-click`; touch never qualified, so finger-drag did nothing. `onNodePointerDown` went through pending-longpress, so a still finger flipped to pan after 300 ms. Added touch fast-paths that begin pan/move immediately. Pinch problem: a secondary finger landing on a node would drag it. Guarded both handlers with `e.isPrimary` — non-primary touches abort the active gesture.

## Test plan
- [x] Open vault from a fresh Document Picker pick on a phone — vault loads, sidebar shows decoded folder name.
- [x] Force-stop, relaunch — auto-reopen succeeds; if it fails (revoked grant), welcome screen shows the previous vault in "Recent vaults".
- [x] Open the home canvas via the sidebar vault-name button — `.vaultcore/home.canvas` exists with vault-name welcome card.
- [x] Open the docs page from the burger sheet — `.vaultcore/DOCS.md` exists.
- [x] On the home canvas, single-finger drag pans; one-finger drag on a node moves it; pinch with one finger over a node does NOT move the node.
- [x] Editor: open a note, document card has a visible 12 px gutter on each side.