### PR TITLE
feat(sync): LAN P2P vault sync v1 + UI (epic #73)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/d3-force": "^3.0.10",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^24.12.2",
+    "@types/qrcode": "^1.5.6",
     "@wdio/cli": "^9.27.0",
     "@wdio/local-runner": "^9.27.0",
     "@wdio/mocha-framework": "^9.27.0",
@@ -58,6 +59,7 @@
     "graphology": "^0.26.0",
     "lucide-svelte": "^1.0.1",
     "markdown-it": "^14.1.1",
+    "qrcode": "^1.5.4",
     "sigma": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:b": "vite --port 5174 --strictPort",
     "build": "vite build && tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "wdio run ./wdio.conf.ts",
     "test:e2e:build": "VITE_E2E=1 pnpm tauri build && pnpm test:e2e",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "tauri:b": "VAULTCORE_KEYCHAIN_ACCOUNT=device-key-uat-b tauri dev --config src-tauri/tauri.conf.uat-b.json"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       sigma:
         specifier: ^3.0.2
         version: 3.0.2(graphology-types@0.24.8)
@@ -102,6 +105,9 @@ importers:
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@wdio/cli':
         specifier: ^9.27.0
         version: 9.27.0(@types/node@24.12.2)(expect-webdriverio@5.6.5)
@@ -1116,6 +1122,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/sinonjs__fake-timers@8.1.5':
     resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
 
@@ -1415,6 +1424,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
@@ -1456,6 +1469,9 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -1574,6 +1590,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
@@ -1622,6 +1642,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -1826,6 +1849,10 @@ packages:
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
   find-up@5.0.0:
@@ -2208,6 +2235,10 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2358,6 +2389,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2366,6 +2401,10 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
@@ -2373,6 +2412,10 @@ packages:
   p-locate@6.0.0:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
@@ -2452,6 +2495,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2496,6 +2543,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
@@ -2550,6 +2602,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2612,6 +2667,9 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -3014,6 +3072,9 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3066,9 +3127,16 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -3081,6 +3149,10 @@ packages:
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
@@ -4111,6 +4183,10 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 24.12.2
+
   '@types/sinonjs__fake-timers@8.1.5': {}
 
   '@types/stack-utils@2.0.3': {}
@@ -4506,6 +4582,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  camelcase@5.3.1: {}
+
   camelcase@6.3.0: {}
 
   chai@6.2.2: {}
@@ -4561,6 +4639,12 @@ snapshots:
   ci-info@4.4.0: {}
 
   cli-width@4.1.0: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@7.0.4:
     dependencies:
@@ -4684,6 +4768,8 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  decamelize@1.2.0: {}
+
   decamelize@4.0.0: {}
 
   decamelize@6.0.1: {}
@@ -4716,6 +4802,8 @@ snapshots:
   diff@5.2.2: {}
 
   diff@8.0.4: {}
+
+  dijkstrajs@1.0.3: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -4956,6 +5044,11 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -5340,6 +5433,10 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5482,6 +5579,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -5490,6 +5591,10 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -5497,6 +5602,8 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
+
+  p-try@2.2.0: {}
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -5574,6 +5681,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pngjs@5.0.0: {}
+
   postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
@@ -5625,6 +5734,12 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   query-selector-shadow-dom@1.0.1: {}
 
@@ -5689,6 +5804,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -5756,6 +5873,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  set-blocking@2.0.0: {}
 
   setimmediate@1.0.5: {}
 
@@ -6168,6 +6287,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which-module@2.0.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -6209,7 +6330,14 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
 
   yargs-parser@20.2.9: {}
 
@@ -6221,6 +6349,20 @@ snapshots:
       decamelize: 4.0.0
       flat: 5.0.2
       is-plain-obj: 2.1.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@16.2.0:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,6 +19,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +763,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1516,6 +1550,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3259,6 +3303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4132,6 +4188,22 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "sha2",
+ "subtle",
+]
 
 [[package]]
 name = "socket2"
@@ -5389,6 +5461,7 @@ dependencies = [
  "serde_yml",
  "sha2",
  "similar",
+ "snow",
  "tantivy",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -550,6 +550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +569,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -588,7 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -601,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -725,6 +741,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,10 +802,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "datasketches"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -944,6 +1003,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1175,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1632,6 +1733,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,7 +1853,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1894,6 +2006,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2150,6 +2272,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2401,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2499,20 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2 0.5.10",
+]
 
 [[package]]
 name = "measure_time"
@@ -3017,6 +3178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,6 +3767,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,6 +4049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,6 +4104,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -3945,6 +4171,25 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4236,7 +4481,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -4682,7 +4927,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5094,12 +5339,18 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "chacha20poly1305",
+ "data-encoding",
+ "ed25519-dalek",
  "env_logger",
+ "hostname",
+ "keyring",
  "log",
+ "mdns-sd",
  "notify-debouncer-full",
  "nucleo-matcher",
  "pulldown-cmark",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "regex",
  "rusqlite",
@@ -5116,6 +5367,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
  "walkdir",
  "zeroize",
 ]
@@ -5603,6 +5855,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,6 +19,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +209,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -999,6 +1020,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1571,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1561,6 +1603,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2189,6 +2240,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3401,6 +3463,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -5016,6 +5092,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
+ "bincode",
  "chacha20poly1305",
  "env_logger",
  "log",
@@ -5025,6 +5102,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yml",
@@ -5041,6 +5119,12 @@ dependencies = [
  "walkdir",
  "zeroize",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1487,8 +1487,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1731,6 +1733,21 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hmac-sha512"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
 
 [[package]]
 name = "hostname"
@@ -2917,6 +2934,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "pake-cpace"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8ddcfdd79e296ea68ae1cd38285d74f5bac469fe547a5f8d37cdde57234a5a"
+dependencies = [
+ "curve25519-dalek",
+ "getrandom 0.2.17",
+ "hmac-sha512",
 ]
 
 [[package]]
@@ -5342,12 +5370,14 @@ dependencies = [
  "data-encoding",
  "ed25519-dalek",
  "env_logger",
+ "hmac",
  "hostname",
  "keyring",
  "log",
  "mdns-sd",
  "notify-debouncer-full",
  "nucleo-matcher",
+ "pake-cpace",
  "pulldown-cmark",
  "rand 0.8.5",
  "rand_core 0.6.4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -71,6 +71,14 @@ data-encoding = "2"
 # Cryptographic RNG for ed25519-dalek 2.x keygen (OsRng implements RngCore).
 rand_core = { version = "0.6", features = ["getrandom"] }
 
+# #418: PAKE pairing.
+# CPace (libsodium-author Frank Denis / jedisct1) — spec PASSED 2026-05-03.
+pake-cpace = "0.1.7"
+# RFC 2104 HMAC-SHA256 for the post-PAKE key-confirmation step (A2
+# design note: PAKE itself does NOT error on wrong PIN — keys silently
+# diverge — so an explicit MAC exchange is required).
+hmac = "0.12"
+
 [dev-dependencies]
 tempfile = "3"
 # Enable `tauri::test::mock_app()` so unit tests can feed a dummy AppHandle

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,22 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # sync_files / sync_history. Pinned to 1.x — bincode 2 changed the API.
 bincode = "1"
 
+# #417: identity + discovery.
+# Ed25519 signing — used for device keys and (later) capability tokens.
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+# Pure-Rust mDNS for `_vaultcore._tcp.local.` advertise + browse.
+mdns-sd = "0.13"
+# Cross-platform OS keychain (Keychain / CredMgr / Secret Service).
+keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+# Default device name = OS hostname.
+hostname = "0.4"
+# Per-vault UUIDv4 written to `.vaultcore/vault-id`.
+uuid = { version = "1", features = ["v4"] }
+# RFC4648 base32 encoding for `device_id = base32(SHA-256(pubkey)[..16])`.
+data-encoding = "2"
+# Cryptographic RNG for ed25519-dalek 2.x keygen (OsRng implements RngCore).
+rand_core = { version = "0.6", features = ["getrandom"] }
+
 [dev-dependencies]
 tempfile = "3"
 # Enable `tauri::test::mock_app()` so unit tests can feed a dummy AppHandle

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,14 @@ argon2 = "0.5"
 zeroize = { version = "1", features = ["derive"] }
 rand = "0.8"
 
+# #416: sync-state metadata store. `bundled` ships SQLite with the binary
+# so target machines need no system sqlite, matching the "zero external
+# deps" stance for the offline P2P sync stack.
+rusqlite = { version = "0.32", features = ["bundled"] }
+# Compact binary serialization for version vectors stored as BLOBs in
+# sync_files / sync_history. Pinned to 1.x — bincode 2 changed the API.
+bincode = "1"
+
 [dev-dependencies]
 tempfile = "3"
 # Enable `tauri::test::mock_app()` so unit tests can feed a dummy AppHandle

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,6 +79,13 @@ pake-cpace = "0.1.7"
 # diverge — so an explicit MAC exchange is required).
 hmac = "0.12"
 
+# #419: Noise IK transport.
+# `snow` implements the Noise Protocol Framework — XX bootstrap on
+# first sync (mutual key verification), then IK steady-state for
+# subsequent syncs (recipient's static key already known). Pure Rust,
+# no system deps.
+snow = "0.9"
+
 [dev-dependencies]
 tempfile = "3"
 # Enable `tauri::test::mock_app()` so unit tests can feed a dummy AppHandle

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,8 @@
 fn main() {
+    // `ci_no_mdns` is a custom cfg flag set when CI environments block
+    // multicast — used by `tests/sync_e2e.rs` to fall back to direct
+    // peer-address override. Declared here so rustc's check-cfg lint
+    // doesn't warn about it on every build.
+    println!("cargo::rustc-check-cfg=cfg(ci_no_mdns)");
     tauri_build::build();
 }

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- LAN P2P sync (epic #73): mDNS / Noise TCP on local network. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
 

--- a/src-tauri/gen/android/app/src/main/java/com/vaultcore/app/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/vaultcore/app/MainActivity.kt
@@ -1,11 +1,42 @@
 package com.vaultcore.app
 
+import android.content.Context
+import android.net.wifi.WifiManager
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 
 class MainActivity : TauriActivity() {
+  // mDNS multicast lock — Android drops multicast UDP packets by default
+  // unless an app holds a WifiManager.MulticastLock. We acquire it once
+  // in onCreate and release in onDestroy so the Rust-side mdns-sd
+  // advertiser/browser can see peers on the local network.
+  // Held across the activity lifecycle; the cost is a small battery hit
+  // when the app is foregrounded — acceptable for v1 LAN-sync UAT.
+  private var multicastLock: WifiManager.MulticastLock? = null
+
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
+    acquireMulticastLock()
+  }
+
+  override fun onDestroy() {
+    releaseMulticastLock()
+    super.onDestroy()
+  }
+
+  private fun acquireMulticastLock() {
+    if (multicastLock != null) return
+    val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+      ?: return
+    val lock = wifi.createMulticastLock("vaultcore-mdns")
+    lock.setReferenceCounted(false)
+    lock.acquire()
+    multicastLock = lock
+  }
+
+  private fun releaseMulticastLock() {
+    multicastLock?.let { if (it.isHeld) it.release() }
+    multicastLock = null
   }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod templates;
 pub mod export;
 pub mod encryption;
 pub mod picker;
+pub mod sync;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,3 +13,6 @@ pub mod encryption;
 pub mod picker;
 pub mod sync;
 pub mod sync_cmds;
+
+#[cfg(test)]
+mod sync_cmds_pairing_tests;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod export;
 pub mod encryption;
 pub mod picker;
 pub mod sync;
+pub mod sync_cmds;

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -1,27 +1,19 @@
-//! Tauri commands for the LAN sync layer (epic #73).
+//! Legacy sync state used by the v0 toggle (epic #73 sub-issue #417).
 //!
-//! Today this is a thin shim — the only user-facing surface from #417 is
-//! the "Discoverable on this network" toggle. Backend wires the bool into
-//! `VaultState`; the actual mDNS daemon lifecycle is plumbed in #419
-//! (Noise transport + sync wiring), where we have a sync engine to start.
+//! UI-1 superseded the Tauri command surface defined in this file —
+//! `commands::sync_cmds` now owns both `sync_get_discoverable` and
+//! `sync_set_discoverable` and routes them through `SyncRuntime`,
+//! which actually starts/stops the mDNS daemon.
+//!
+//! The `DISCOVERABLE` static stays here so any non-IPC call site that
+//! reads the flag (e.g. transport-layer code in #419) continues to
+//! compile. `SyncRuntime::set_discoverable` mirrors writes into this
+//! static so the two views stay in sync.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 
-/// Single global flag mirroring the user's "Discoverable on this network"
-/// preference. Default `true` per epic #73's "Settings → Sync →
-/// Discoverable on this network (default on)" line.
-///
-/// Held as a process-wide static rather than a `VaultState` field because
-/// the toggle outlives any single open vault — the user might close one
-/// vault and open another while sync stays advertising the new one.
+/// Process-wide mirror of the user's "Discoverable on this network"
+/// preference. Written by [`crate::commands::sync_cmds::SyncRuntime::set_discoverable`];
+/// retained as a separate static so non-IPC consumers can read the flag
+/// without taking a Tauri-state dependency.
 pub static DISCOVERABLE: AtomicBool = AtomicBool::new(true);
-
-#[tauri::command]
-pub fn sync_set_discoverable(enabled: bool) {
-    DISCOVERABLE.store(enabled, Ordering::SeqCst);
-}
-
-#[tauri::command]
-pub fn sync_get_discoverable() -> bool {
-    DISCOVERABLE.load(Ordering::SeqCst)
-}

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -1,0 +1,27 @@
+//! Tauri commands for the LAN sync layer (epic #73).
+//!
+//! Today this is a thin shim — the only user-facing surface from #417 is
+//! the "Discoverable on this network" toggle. Backend wires the bool into
+//! `VaultState`; the actual mDNS daemon lifecycle is plumbed in #419
+//! (Noise transport + sync wiring), where we have a sync engine to start.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Single global flag mirroring the user's "Discoverable on this network"
+/// preference. Default `true` per epic #73's "Settings → Sync →
+/// Discoverable on this network (default on)" line.
+///
+/// Held as a process-wide static rather than a `VaultState` field because
+/// the toggle outlives any single open vault — the user might close one
+/// vault and open another while sync stays advertising the new one.
+pub static DISCOVERABLE: AtomicBool = AtomicBool::new(true);
+
+#[tauri::command]
+pub fn sync_set_discoverable(enabled: bool) {
+    DISCOVERABLE.store(enabled, Ordering::SeqCst);
+}
+
+#[tauri::command]
+pub fn sync_get_discoverable() -> bool {
+    DISCOVERABLE.load(Ordering::SeqCst)
+}

--- a/src-tauri/src/commands/sync_cmds.rs
+++ b/src-tauri/src/commands/sync_cmds.rs
@@ -42,7 +42,10 @@
 //! exclusively from the four events above. See `src/store/syncStore.ts`.
 
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -54,10 +57,17 @@ use crate::sync::capability::{Capability, CapabilityBody, Scope};
 use crate::sync::discovery::{Discovery, MdnsDiscovery, PeerAd, PROTO_VERSION};
 use crate::sync::identity::{Identity, KeyStore, MemoryKeyStore, OsKeychainStore};
 use crate::sync::pairing::{
-    finalize_with_confirmation, key_confirmation_mac, validate_pin, ConfirmedKeys,
+    finalize_with_confirmation, key_confirmation_mac, respond, start_initiator, validate_pin,
     PairingSession, RawSharedKeys, LOCKOUT_AFTER_ATTEMPTS, PIN_EXPIRY_SECS,
 };
-use crate::sync::state::{PeerTrust, SyncState};
+use crate::sync::pairing_engine::{
+    drive_initiator_after_pake, drive_responder_after_pake, exchange_vault_grant_initiator,
+    exchange_vault_grant_responder, PostPairingSession,
+};
+use crate::sync::state::SyncState;
+#[cfg(test)]
+use crate::sync::state::PeerTrust;
+use crate::sync::transport::{generate_static_keypair, NoiseKeypair};
 
 // ─── Event names ─────────────────────────────────────────────────────────
 
@@ -76,6 +86,33 @@ pub const PEERS_DEBOUNCE_MS: u64 = 250;
 /// publish so peers can resolve us. Picked from IANA's user-port range
 /// to avoid `_vaultcore`-vs-`_<other>` collisions on the same network.
 pub const DEFAULT_SYNC_PORT: u16 = 17091;
+
+/// Pairing-handshake port. The initiator binds a TCP listener here for
+/// the duration of an active pairing flow; the responder dials the peer
+/// IP it picked from `sync_list_discovered_peers` on this port. Distinct
+/// from [`DEFAULT_SYNC_PORT`] so the steady-state Noise listener and the
+/// pairing listener can run concurrently. We use a fixed port (rather
+/// than ephemeral + mDNS-TXT advertisement) because:
+///  - Only one pairing flow runs at a time per device, so port
+///    contention is bounded to "two VaultCore instances racing on the
+///    same machine" — rare and cleanly detected as a bind failure.
+///  - It avoids a TXT-record schema change to broadcast the port,
+///    which would ripple through every PeerAd consumer including the
+///    in-tree e2e fixture.
+/// The trade-off (one pairing at a time per host) is documented as the
+/// pragmatic "fixed pairing port" choice from the UI-1.6 task brief.
+pub const DEFAULT_PAIRING_PORT: u16 = 17092;
+
+/// Hard ceiling on how long the pairing worker waits for the peer to
+/// connect / dial / drive PAKE through. Mirrors the PIN expiry (60s) so
+/// a stale flow can't pin a port forever.
+const PAIRING_WORKER_TIMEOUT: Duration = Duration::from_secs(PIN_EXPIRY_SECS as u64);
+
+/// Wall-clock budget for individual socket reads/writes during the PAKE
+/// hello + step exchange. PAKE round-trip is sub-second; 5 s is generous
+/// even on a saturated LAN. Without this a malformed responder could
+/// stall the worker thread indefinitely.
+const PAKE_IO_TIMEOUT: Duration = Duration::from_secs(5);
 
 // ─── DTOs (shape matches `src/store/syncStore.ts`) ───────────────────────
 
@@ -151,26 +188,65 @@ pub struct PeerPairedEventDto {
 /// On `confirm` or `cancel` the entry is removed.
 struct PairingFlow {
     session: PairingSession,
-    #[allow(dead_code)]
     role: PairingRole,
-    /// Peer device id, if known. The initiator learns it from the
-    /// step1 reply payload; the responder learns it from the step1
-    /// packet sent by the initiator.
+    /// Peer device id, if known. The initiator learns it from the hello
+    /// packet exchanged at the top of the PAKE socket; the responder
+    /// receives it from the IPC arg or learns it from the same hello.
     peer_device_id: Option<String>,
     /// Once PAKE step1+step2 have been driven, the raw shared keys
     /// land here awaiting key-confirmation. `None` means PAKE is not
-    /// yet finished. `id_a` / `id_b` on the `RawSharedKeys` carry the
-    /// device id pair, so we don't need a separate `self_device_id`.
+    /// yet finished. Kept around mostly for the test-injection path
+    /// — production code reaches `awaiting_confirmation` only after
+    /// `drive_*_after_pake` has consumed `k2` to derive the long-term
+    /// attestation.
     raw_keys: Option<RawSharedKeys>,
     /// Cached fingerprint we display to the user during confirmation.
-    /// Populated alongside `raw_keys`. Eight base32 chars per spec.
+    /// Computed from the peer's persisted Ed25519 pubkey: the existing
+    /// 8-char base32 prefix used everywhere else in the identity layer.
     peer_fingerprint: Option<String>,
+    /// Worker-thread state. Updated by the worker via the runtime's
+    /// `pairing_sessions` mutex; read by `pairing_step` to render the
+    /// UI.
+    state_kind: PairingState,
+    /// Last PAKE/engine error. Surfaced to the UI when `state_kind ==
+    /// Failed` so the user sees "wrong PIN" vs "network error" copy.
+    error: Option<String>,
+    /// Active post-pairing session — populated when the engine drive
+    /// completes successfully. Held under the same mutex so
+    /// `pairing_grant_vault` can borrow it for the grant exchange.
+    post_pairing: Option<PostPairingSession>,
+    /// Initiator-only: handle to the bound TCP listener so we can drop
+    /// it on cancel. The listener is consumed by the worker once a
+    /// connection arrives. Read in tests to recover the bound port; in
+    /// production it's only kept alive for cleanup ordering.
+    #[allow(dead_code)]
+    listener_handle: Option<Arc<TcpListener>>,
+    /// Worker thread handle. Detaching is fine on cancel — the thread
+    /// observes the dropped session via channel disconnect / socket
+    /// close and exits.
+    worker_handle: Option<JoinHandle<()>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PairingRole {
     Initiator,
     Responder,
+}
+
+/// Coarse-grained pairing state surfaced through `pairing_step`. Mirrors
+/// the four UI screens (`PairingStepDto::kind`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PairingState {
+    /// Worker hasn't completed PAKE+attestation yet.
+    AwaitingPeer,
+    /// PAKE+attestation done; UI shows fingerprint and waits for the
+    /// user to click "Bestätigen".
+    AwaitingConfirmation,
+    /// User confirmed; peer row + capability rows persisted.
+    Complete,
+    /// PAKE/attestation/grant exchange failed. Retry requires starting
+    /// a fresh session.
+    Failed,
 }
 
 // ─── Discovery emission task ──────────────────────────────────────────────
@@ -226,6 +302,11 @@ fn peer_ad_to_dto(ad: &PeerAd) -> DiscoveredPeerDto {
 /// hence `Arc<SyncRuntime>` storage in Tauri's `manage()`.
 pub struct SyncRuntime {
     identity: Identity,
+    /// Per-process Noise static keypair. Generated lazily at runtime
+    /// construction — separate from the Ed25519 long-term identity (Noise
+    /// is happier with native Curve25519 keys, see
+    /// `pairing_engine.rs` module docs).
+    noise_kp: NoiseKeypair,
     /// Mutable display name override. The OS hostname is the default;
     /// users can override via `sync_set_device_name`.
     device_name: Mutex<String>,
@@ -262,6 +343,9 @@ impl SyncRuntime {
 
     fn with_keystore(store: Box<dyn KeyStore>) -> Result<Self, VaultError> {
         let identity = Identity::load_or_create(&*store)?;
+        let noise_kp = generate_static_keypair().map_err(|e| VaultError::SyncState {
+            msg: format!("noise keypair init: {e:?}"),
+        })?;
         let device_name = hostname::get()
             .ok()
             .and_then(|h| h.into_string().ok())
@@ -269,6 +353,7 @@ impl SyncRuntime {
         let discovery = Arc::new(MdnsDiscovery::new()?);
         Ok(Self {
             identity,
+            noise_kp,
             device_name: Mutex::new(device_name),
             discovery,
             discoverable: Mutex::new(false),
@@ -395,8 +480,52 @@ impl SyncRuntime {
     /// Test-only: peek at the active state slot without going through
     /// the IPC layer.
     #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn active_sync_state(&self) -> Option<Arc<SyncState>> {
         self.active_state.lock().ok().and_then(|g| g.clone())
+    }
+
+    /// Test-only: read back the bound port of an initiator session's
+    /// pairing listener. Tests pass `bind_port_override = Some(0)` (so
+    /// each test gets an ephemeral port and can run in parallel), then
+    /// use this to learn what port the responder should dial.
+    #[cfg(test)]
+    pub fn pairing_listener_port_for_test(&self, session_id: &str) -> Option<u16> {
+        let sessions = self.pairing_sessions.lock().ok()?;
+        let flow = sessions.get(session_id)?;
+        let listener = flow.listener_handle.as_ref()?;
+        listener.local_addr().ok().map(|a| a.port())
+    }
+
+    /// Test-only: drive the underlying `PairingSession` to lockout
+    /// without going through PAKE. The IPC-layer lockout test asserts
+    /// that `pairing_step` correctly surfaces a locked-out session as
+    /// `{ kind: failed, attempts_remaining: 0 }`; the *mechanism* by
+    /// which the session reaches that state (3 wire failures vs 3
+    /// in-process record_failure calls) is exercised in
+    /// `pairing_tests::three_failed_attempts_locks_out`. Bypassing the
+    /// wire keeps this layer's test focused on the IPC surface.
+    #[cfg(test)]
+    pub fn force_lockout_for_test(&self, session_id: &str) -> Result<(), VaultError> {
+        use crate::sync::pairing::{finalize_with_confirmation, RawSharedKeys};
+        let sessions = self
+            .pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        let flow = sessions.get(session_id).ok_or_else(|| VaultError::SyncState {
+            msg: format!("unknown pairing session: {session_id}"),
+        })?;
+        let raw = RawSharedKeys {
+            k1: [0u8; 32],
+            k2: [0u8; 32],
+            id_a: "A".into(),
+            id_b: "B".into(),
+        };
+        let bad_mac = [0xFFu8; 32];
+        for _ in 0..LOCKOUT_AFTER_ATTEMPTS {
+            let _ = finalize_with_confirmation(&raw, &bad_mac, &flow.session);
+        }
+        Ok(())
     }
 
     pub fn grant_vault(
@@ -491,26 +620,70 @@ impl SyncRuntime {
 
     // ─── Pairing flow helpers ─────────────────────────────────────────────
 
-    pub fn pairing_start_initiator(&self) -> Result<PairingStartInitiatorDto, VaultError> {
+    /// Initiator entry: bind the pairing listener, generate a PIN, and
+    /// spawn the worker thread that drives PAKE+attestation when the
+    /// responder dials in. Returns immediately with the PIN to display.
+    pub fn pairing_start_initiator(
+        self: &Arc<Self>,
+        pin_override: Option<String>,
+        bind_port_override: Option<u16>,
+    ) -> Result<PairingStartInitiatorDto, VaultError> {
         let session_id = Uuid::new_v4().to_string();
-        let pin = generate_pin_6_digit();
+        let pin = pin_override.unwrap_or_else(generate_pin_6_digit);
         let session = PairingSession::new();
         session.issue_pin()?;
         let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
+
+        // Bind the pairing listener up-front so any port-conflict error
+        // surfaces synchronously rather than asynchronously inside the
+        // worker (where the UI would only see "awaiting_peer" → time out).
+        let bind_port = bind_port_override.unwrap_or(DEFAULT_PAIRING_PORT);
+        let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], bind_port)))
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("bind pairing listener on :{bind_port}: {e}"),
+            })?;
+        listener
+            .set_nonblocking(false)
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("listener configure: {e}"),
+            })?;
+        let listener_arc = Arc::new(listener);
+
         let flow = PairingFlow {
             session,
             role: PairingRole::Initiator,
             peer_device_id: None,
             raw_keys: None,
             peer_fingerprint: None,
+            state_kind: PairingState::AwaitingPeer,
+            error: None,
+            post_pairing: None,
+            listener_handle: Some(Arc::clone(&listener_arc)),
+            worker_handle: None,
         };
         self.pairing_sessions
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?
             .insert(session_id.clone(), flow);
+
+        // Spawn the worker. Holds an Arc<SyncRuntime> so the cleanup +
+        // result-write paths can reach back through the mutex.
+        let runtime = Arc::clone(self);
+        let session_id_for_worker = session_id.clone();
+        let pin_for_worker = pin.clone();
+        let listener_for_worker = listener_arc;
+        let handle = std::thread::spawn(move || {
+            initiator_worker(runtime, session_id_for_worker, listener_for_worker, pin_for_worker);
+        });
+        if let Ok(mut sessions) = self.pairing_sessions.lock() {
+            if let Some(flow) = sessions.get_mut(&session_id) {
+                flow.worker_handle = Some(handle);
+            }
+        }
+
         Ok(PairingStartInitiatorDto {
             session_id,
             pin,
@@ -518,35 +691,101 @@ impl SyncRuntime {
         })
     }
 
+    /// Responder entry: validate PIN, resolve the peer's address, spawn
+    /// the dial+handshake worker. `peer_device_id` selects which
+    /// discovered peer to dial; `peer_addr_override` is a test-only
+    /// shortcut so unit tests can inject a loopback address without
+    /// running mDNS.
     pub fn pairing_start_responder(
-        &self,
+        self: &Arc<Self>,
         pin: &str,
+        peer_device_id: Option<String>,
+        peer_addr_override: Option<SocketAddr>,
     ) -> Result<PairingStartResponderDto, VaultError> {
         validate_pin(pin).map_err(VaultError::from)?;
         let session_id = Uuid::new_v4().to_string();
         let session = PairingSession::new();
         session.issue_pin()?;
+
+        // Address resolution: if the caller didn't pass an override,
+        // we pull the peer's IP from the live discovery snapshot and
+        // dial DEFAULT_PAIRING_PORT (the initiator's bound port). The
+        // override path is for tests; production UI always passes a
+        // peer_device_id and lets discovery resolve.
+        let dial_addr = match peer_addr_override {
+            Some(a) => Some(a),
+            None => match peer_device_id.as_deref() {
+                Some(id) => Some(self.resolve_peer_pairing_addr(id)?),
+                None => None,
+            },
+        };
+
         let flow = PairingFlow {
             session,
             role: PairingRole::Responder,
-            peer_device_id: None,
+            peer_device_id: peer_device_id.clone(),
             raw_keys: None,
             peer_fingerprint: None,
+            state_kind: PairingState::AwaitingPeer,
+            error: None,
+            post_pairing: None,
+            listener_handle: None,
+            worker_handle: None,
         };
         self.pairing_sessions
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?
             .insert(session_id.clone(), flow);
+
+        // The dial+PAKE flow only runs when we have a target address.
+        // Without one (e.g., the legacy frontend that doesn't pass
+        // peer_device_id yet), the session sits in `awaiting_peer`
+        // until cancelled — matches the prior UI-1 stub semantics so
+        // existing PairingModal callers don't regress.
+        if let Some(addr) = dial_addr {
+            let runtime = Arc::clone(self);
+            let session_id_for_worker = session_id.clone();
+            let pin_for_worker = pin.to_string();
+            let handle = std::thread::spawn(move || {
+                responder_worker(runtime, session_id_for_worker, addr, pin_for_worker);
+            });
+            if let Ok(mut sessions) = self.pairing_sessions.lock() {
+                if let Some(flow) = sessions.get_mut(&session_id) {
+                    flow.worker_handle = Some(handle);
+                }
+            }
+        }
+
         Ok(PairingStartResponderDto { session_id })
     }
 
-    /// Drive the PAKE state machine. Today's UI-1 plumbing is a stub
-    /// that returns `awaiting_peer` until transport (#419) carries the
-    /// step packets between devices. Once transport lands, this method
-    /// will accept a base64 payload and dispatch to
-    /// [`start_initiator`] / [`respond`] / [`InitiatorAfterStep1::step3`].
-    /// The method exists today so the IPC contract is stable and UI-3
-    /// can render the spinner while waiting on the peer.
+    /// Map a discovered peer's `device_id` → `SocketAddr` for dialing.
+    /// Uses the first IPv4 address from the mDNS snapshot, paired with
+    /// [`DEFAULT_PAIRING_PORT`]. Returns an error if the peer is not
+    /// currently visible — surfaces as a clear UI message rather than
+    /// a silent worker timeout.
+    fn resolve_peer_pairing_addr(&self, peer_device_id: &str) -> Result<SocketAddr, VaultError> {
+        let snapshot = self.discovery.peers()?;
+        let peer = snapshot
+            .peers
+            .iter()
+            .find(|p| p.device_id == peer_device_id)
+            .ok_or_else(|| VaultError::SyncState {
+                msg: format!("peer not visible in discovery: {peer_device_id}"),
+            })?;
+        let ip = peer
+            .addrs
+            .first()
+            .copied()
+            .ok_or_else(|| VaultError::SyncState {
+                msg: format!("peer has no resolved address: {peer_device_id}"),
+            })?;
+        Ok(SocketAddr::new(ip, DEFAULT_PAIRING_PORT))
+    }
+
+    /// Poll the pairing flow's worker-set state. The UI calls this on a
+    /// short interval after `pairing_start_*` to learn when to advance
+    /// from the spinner to the fingerprint card.
     pub fn pairing_step(
         &self,
         session_id: &str,
@@ -559,6 +798,8 @@ impl SyncRuntime {
         let flow = sessions.get(session_id).ok_or_else(|| VaultError::SyncState {
             msg: format!("unknown pairing session: {session_id}"),
         })?;
+        // Lockout / PIN-expiry trump the worker state — they're the
+        // canonical "fail fast" surfaces.
         if flow.session.is_locked()? {
             return Ok(PairingStepDto {
                 kind: "failed".into(),
@@ -566,73 +807,140 @@ impl SyncRuntime {
                 attempts_remaining: Some(0),
             });
         }
-        if !flow.session.pin_valid()? {
-            return Ok(PairingStepDto {
-                kind: "failed".into(),
-                peer_fingerprint: None,
-                attempts_remaining: Some(0),
-            });
-        }
-        let attempts_remaining = LOCKOUT_AFTER_ATTEMPTS - flow.session.failed_count()?;
+        let attempts_remaining = LOCKOUT_AFTER_ATTEMPTS
+            .saturating_sub(flow.session.failed_count()?);
+        let kind = match flow.state_kind {
+            PairingState::AwaitingPeer => "awaiting_peer",
+            PairingState::AwaitingConfirmation => "awaiting_confirmation",
+            PairingState::Complete => "complete",
+            PairingState::Failed => "failed",
+        };
         Ok(PairingStepDto {
-            kind: "awaiting_peer".into(),
+            kind: kind.into(),
             peer_fingerprint: flow.peer_fingerprint.clone(),
             attempts_remaining: Some(attempts_remaining),
         })
     }
 
-    /// Final confirmation step: persist the peer to `sync_peers` and emit
-    /// `sync://peer-paired`. UI-1 stub: in production this is gated on
-    /// the user clicking "Confirm" after seeing the matching fingerprint;
-    /// transport-layer code (#419) will drive `raw_keys` into the flow
-    /// before this is callable. For UI-1 we accept calls when raw_keys
-    /// is present (from a future transport hook) and otherwise return a
-    /// PairError-shaped error so the UI surfaces a clear failure.
+    /// User confirmed the fingerprint. The engine has already persisted
+    /// the peer row + transitioned the trust state — this just flips the
+    /// UI state to `Complete` and returns the peer's identity for the
+    /// `sync://peer-paired` event. The post-pairing session stays in
+    /// the table so subsequent `pairing_grant_vault` calls can reach the
+    /// open Noise channel.
     pub fn pairing_confirm(&self, session_id: &str) -> Result<PeerPairedEventDto, VaultError> {
         let mut sessions = self
             .pairing_sessions
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
-        let Some(flow) = sessions.remove(session_id) else {
+        let flow = sessions.get_mut(session_id).ok_or_else(|| VaultError::SyncState {
+            msg: format!("unknown pairing session: {session_id}"),
+        })?;
+        if flow.state_kind != PairingState::AwaitingConfirmation {
             return Err(VaultError::SyncState {
-                msg: format!("unknown pairing session: {session_id}"),
+                msg: format!(
+                    "pairing not at confirmation step (state: {:?})",
+                    flow.state_kind
+                ),
             });
-        };
-        let raw = flow.raw_keys.ok_or_else(|| VaultError::SyncState {
-            msg: "pairing not yet at confirmation step (no shared keys)".into(),
-        })?;
-        let peer_id = flow.peer_device_id.ok_or_else(|| VaultError::SyncState {
-            msg: "pairing has no peer device id".into(),
-        })?;
-        let _role = flow.role;
-        // Build our local MAC and feed both into the canonical
-        // confirmation helper so any future change to the MAC layout
-        // doesn't have to be mirrored here. The peer's MAC is delivered
-        // through the transport layer; UI-1 doesn't have that wired yet,
-        // so we self-confirm against our own MAC bytes — once transport
-        // lands, replace the `&local_mac` arg below with the bytes from
-        // the incoming step3/finalize packet.
-        let local_mac = key_confirmation_mac(&raw.k2, &raw.id_a, &raw.id_b);
-        let _confirmed: ConfirmedKeys =
-            finalize_with_confirmation(&raw, &local_mac, &flow.session)
-                .map_err(|e| VaultError::from(e))?;
-        // Persist trust to the active vault's SyncState. If no vault is
-        // open we still return success so the UI flow completes (the
-        // engine wiring task may extend this to defer peer persistence
-        // until vault open) — but typical UAT pairs while a vault is open.
-        let device_name = format!("Peer {peer_id}");
-        if let Ok(active) = self.require_active_state() {
-            active.upsert_peer(
-                &peer_id,
-                &[0u8; 32], // placeholder — transport supplies the long-term pubkey via the noise XX exchange (#419)
-                &device_name,
-                PeerTrust::Trusted,
-            )?;
         }
+        let peer_id = flow
+            .peer_device_id
+            .clone()
+            .ok_or_else(|| VaultError::SyncState {
+                msg: "pairing has no peer device id".into(),
+            })?;
+        flow.state_kind = PairingState::Complete;
+        let device_name = format!("Peer {peer_id}");
         Ok(PeerPairedEventDto {
             device_id: peer_id,
             device_name,
         })
+    }
+
+    /// Vault-grant phase. Borrows the live `PostPairingSession` from the
+    /// flow, runs the role-appropriate `exchange_vault_grant_*`, and
+    /// returns. Capability rows are persisted on both sides as part of
+    /// the engine call.
+    pub fn pairing_grant_vault(
+        &self,
+        session_id: &str,
+        vault_id: &str,
+        scope: Scope,
+    ) -> Result<(), VaultError> {
+        let mut sessions = self
+            .pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        let flow = sessions.get_mut(session_id).ok_or_else(|| VaultError::SyncState {
+            msg: format!("unknown pairing session: {session_id}"),
+        })?;
+        if flow.state_kind != PairingState::Complete
+            && flow.state_kind != PairingState::AwaitingConfirmation
+        {
+            return Err(VaultError::SyncState {
+                msg: format!(
+                    "pairing not ready for vault grant (state: {:?})",
+                    flow.state_kind
+                ),
+            });
+        }
+        let role = flow.role;
+        let peer_id = flow
+            .peer_device_id
+            .clone()
+            .ok_or_else(|| VaultError::SyncState {
+                msg: "pairing has no peer device id".into(),
+            })?;
+        let mut session = flow.post_pairing.take().ok_or_else(|| VaultError::SyncState {
+            msg: "no live post-pairing session (engine never finished)".into(),
+        })?;
+        // Drop the lock while we drive the (potentially blocking) Noise
+        // I/O — releasing this lets `pairing_step` polls keep working
+        // and avoids a deadlock if the peer takes its time on the wire.
+        drop(sessions);
+
+        // The capability body names the issuer's own device id in
+        // `peer_device_id` per the engine's "peer-self-signed" model.
+        let body = CapabilityBody::issue_v1(
+            vault_id.to_string(),
+            self.identity.device_id().to_string(),
+            vault_id.to_string(),
+            scope,
+        );
+        let state = self.require_active_state()?;
+        let signing_key = self.identity.signing_key();
+        let result = match role {
+            PairingRole::Initiator => exchange_vault_grant_initiator(
+                &mut session,
+                signing_key,
+                &body,
+                &peer_id,
+                &state,
+            ),
+            PairingRole::Responder => exchange_vault_grant_responder(
+                &mut session,
+                signing_key,
+                &body,
+                &peer_id,
+                &state,
+            ),
+        };
+
+        // Restore the session so a follow-up grant for a different
+        // vault can reuse the same channel.
+        let put_back = match self.pairing_sessions.lock() {
+            Ok(mut s) => s.get_mut(session_id).map(|flow| {
+                flow.post_pairing = Some(session);
+            }),
+            Err(_) => None,
+        };
+        let _ = put_back;
+
+        result.map_err(|e| VaultError::SyncState {
+            msg: format!("grant exchange failed: {e:?}"),
+        })?;
+        Ok(())
     }
 
     pub fn pairing_cancel(&self, session_id: &str) -> Result<(), VaultError> {
@@ -640,7 +948,21 @@ impl SyncRuntime {
             .pairing_sessions
             .lock()
             .map_err(|_| VaultError::LockPoisoned)?;
-        sessions.remove(session_id);
+        if let Some(flow) = sessions.remove(session_id) {
+            // Drop the post-pairing TcpStream first so the worker thread
+            // (if still in flight) sees EOF and exits promptly. The
+            // listener Arc going out of scope after this releases the
+            // bound pairing port for the next attempt.
+            if let Some(s) = flow.post_pairing {
+                let _ = s.stream.shutdown(Shutdown::Both);
+            }
+            // worker_handle is best-effort joined — if the worker is
+            // wedged on the listener accept, dropping the listener Arc
+            // unblocks it (TcpListener::accept returns an error on
+            // socket close). We don't block the IPC thread on that
+            // join: detach.
+            let _ = flow.worker_handle;
+        }
         Ok(())
     }
 
@@ -708,6 +1030,345 @@ impl Drop for SyncRuntime {
         self.stop_emitter();
         let _ = self.discovery.stop();
     }
+}
+
+// ─── Pairing worker threads ───────────────────────────────────────────────
+//
+// Both workers follow the same shape:
+//   1. Get the plaintext socket (initiator: accept; responder: dial).
+//   2. Hello packet exchange — each side sends `LEN(2) + device_id`.
+//   3. PAKE three-step over the same socket (the only thing safe to
+//      send before keys exist is PAKE itself).
+//   4. Key-confirmation MAC exchange. Mismatch ⇒ feed the wrong MAC into
+//      `finalize_with_confirmation` so the lockout counter advances.
+//   5. Engine: `drive_*_after_pake` runs Noise XX + long-term-key
+//      attestation + peer-trust upsert.
+//   6. Compute peer fingerprint from persisted Ed25519 pubkey, write
+//      `AwaitingConfirmation` + `peer_fingerprint` + `post_pairing` back
+//      into the flow.
+//
+// On any error we set `state_kind = Failed` and stash the error string.
+
+fn initiator_worker(
+    runtime: Arc<SyncRuntime>,
+    session_id: String,
+    listener: Arc<TcpListener>,
+    pin: String,
+) {
+    // Accept with a timeout so a stalled worker can't pin the port
+    // forever. Implemented via `set_nonblocking` + a bounded poll loop
+    // so we observe `pairing_cancel` (which drops the listener Arc
+    // and therefore breaks the accept) within ~50 ms.
+    let stream = match accept_with_deadline(&listener, PAIRING_WORKER_TIMEOUT) {
+        Ok(s) => s,
+        Err(e) => {
+            mark_failed(&runtime, &session_id, format!("accept: {e}"));
+            return;
+        }
+    };
+
+    drive_pake_and_engine(runtime, session_id, stream, pin, PairingRole::Initiator);
+}
+
+fn responder_worker(
+    runtime: Arc<SyncRuntime>,
+    session_id: String,
+    addr: SocketAddr,
+    pin: String,
+) {
+    let stream = match TcpStream::connect_timeout(&addr, PAIRING_WORKER_TIMEOUT) {
+        Ok(s) => s,
+        Err(e) => {
+            mark_failed(&runtime, &session_id, format!("dial {addr}: {e}"));
+            return;
+        }
+    };
+    drive_pake_and_engine(runtime, session_id, stream, pin, PairingRole::Responder);
+}
+
+/// Block on `listener.accept()` for up to `deadline`. Returns the
+/// accepted stream or an error on timeout / cancellation. Polls on a
+/// 50 ms cadence so cancel-via-listener-drop is observed promptly.
+fn accept_with_deadline(
+    listener: &TcpListener,
+    deadline: Duration,
+) -> std::io::Result<TcpStream> {
+    listener.set_nonblocking(true)?;
+    let stop_at = Instant::now() + deadline;
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false)?;
+                return Ok(stream);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= stop_at {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "pairing accept timeout",
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn drive_pake_and_engine(
+    runtime: Arc<SyncRuntime>,
+    session_id: String,
+    mut stream: TcpStream,
+    pin: String,
+    role: PairingRole,
+) {
+    // Read/write timeouts so a hung peer surfaces as `Failed` rather
+    // than a phantom "awaiting_peer" forever. The engine's Noise
+    // handshake also benefits.
+    let _ = stream.set_read_timeout(Some(PAKE_IO_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(PAKE_IO_TIMEOUT));
+    let _ = stream.set_nodelay(true);
+
+    let self_id = runtime.identity.device_id().to_string();
+
+    // Hello: exchange device ids.
+    if let Err(e) = write_len_prefixed(&mut stream, self_id.as_bytes()) {
+        mark_failed(&runtime, &session_id, format!("hello write: {e}"));
+        return;
+    }
+    let peer_id = match read_len_prefixed_string(&mut stream) {
+        Ok(s) => s,
+        Err(e) => {
+            mark_failed(&runtime, &session_id, format!("hello read: {e}"));
+            return;
+        }
+    };
+
+    // Stash peer_id eagerly so `pairing_cancel` / `pairing_step` can
+    // see who we're talking to even before PAKE finishes.
+    if let Ok(mut sessions) = runtime.pairing_sessions.lock() {
+        if let Some(flow) = sessions.get_mut(&session_id) {
+            // Responder may already have a peer_device_id from the IPC
+            // call — assert consistency. Initiator learns it here.
+            if let Some(prior) = flow.peer_device_id.as_deref() {
+                if prior != peer_id {
+                    let msg = format!("hello peer id mismatch: got {peer_id}, expected {prior}");
+                    flow.state_kind = PairingState::Failed;
+                    flow.error = Some(msg);
+                    return;
+                }
+            } else {
+                flow.peer_device_id = Some(peer_id.clone());
+            }
+        } else {
+            // Session vanished (cancelled) — bail.
+            return;
+        }
+    }
+
+    // Drive PAKE. Per the spec, `id_a` is always the initiator's id and
+    // `id_b` the responder's, regardless of which role we're playing.
+    let (id_a, id_b) = match role {
+        PairingRole::Initiator => (self_id.clone(), peer_id.clone()),
+        PairingRole::Responder => (peer_id.clone(), self_id.clone()),
+    };
+
+    let raw_keys = match role {
+        PairingRole::Initiator => {
+            let s1 = match start_initiator(&pin, &id_a, &id_b) {
+                Ok(s) => s,
+                Err(e) => {
+                    mark_failed(&runtime, &session_id, format!("pake start: {e:?}"));
+                    return;
+                }
+            };
+            if let Err(e) = stream.write_all(&s1.step1_packet()) {
+                mark_failed(&runtime, &session_id, format!("step1 write: {e}"));
+                return;
+            }
+            let mut step2 = [0u8; pake_cpace::STEP2_PACKET_BYTES];
+            if let Err(e) = stream.read_exact(&mut step2) {
+                mark_failed(&runtime, &session_id, format!("step2 read: {e}"));
+                return;
+            }
+            match s1.step3(&step2) {
+                Ok(rk) => rk,
+                Err(e) => {
+                    mark_failed(&runtime, &session_id, format!("step3: {e:?}"));
+                    return;
+                }
+            }
+        }
+        PairingRole::Responder => {
+            let mut step1 = [0u8; pake_cpace::STEP1_PACKET_BYTES];
+            if let Err(e) = stream.read_exact(&mut step1) {
+                mark_failed(&runtime, &session_id, format!("step1 read: {e}"));
+                return;
+            }
+            let r = match respond(&step1, &pin, &id_a, &id_b) {
+                Ok(r) => r,
+                Err(e) => {
+                    mark_failed(&runtime, &session_id, format!("respond: {e:?}"));
+                    return;
+                }
+            };
+            if let Err(e) = stream.write_all(&r.step2_packet()) {
+                mark_failed(&runtime, &session_id, format!("step2 write: {e}"));
+                return;
+            }
+            r.raw_keys
+        }
+    };
+
+    // Key-confirmation: send our MAC, receive the peer's, finalize.
+    let local_mac = key_confirmation_mac(&raw_keys.k2, &id_a, &id_b);
+    if let Err(e) = stream.write_all(&local_mac) {
+        mark_failed(&runtime, &session_id, format!("mac write: {e}"));
+        return;
+    }
+    let mut peer_mac = [0u8; 32];
+    if let Err(e) = stream.read_exact(&mut peer_mac) {
+        mark_failed(&runtime, &session_id, format!("mac read: {e}"));
+        return;
+    }
+
+    // We need the session lock briefly to call `finalize_with_confirmation`,
+    // which mutates the lockout counter. Hold the lock only for the
+    // attempt-counter update; release before driving the engine (slow).
+    let confirm_outcome = {
+        let sessions = match runtime.pairing_sessions.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        let Some(flow) = sessions.get(&session_id) else {
+            return;
+        };
+        finalize_with_confirmation(&raw_keys, &peer_mac, &flow.session)
+    };
+    if let Err(e) = confirm_outcome {
+        // Bump the failure state. Lockout (3 strikes) is reflected by
+        // `pairing_step` reading the session's `is_locked` flag.
+        let attempts_remaining_after = match runtime.pairing_sessions.lock() {
+            Ok(s) => s
+                .get(&session_id)
+                .and_then(|f| f.session.failed_count().ok())
+                .map(|n| LOCKOUT_AFTER_ATTEMPTS.saturating_sub(n)),
+            Err(_) => None,
+        };
+        mark_failed(
+            &runtime,
+            &session_id,
+            format!("key confirmation: {e:?} (attempts_remaining≈{attempts_remaining_after:?})"),
+        );
+        return;
+    }
+    let k2 = raw_keys.k2;
+
+    // Now run the engine. This requires an active SyncState — without
+    // one the peer-trust upsert can't persist.
+    let state = match runtime.require_active_state() {
+        Ok(s) => s,
+        Err(e) => {
+            mark_failed(&runtime, &session_id, format!("no active vault: {e:?}"));
+            return;
+        }
+    };
+    let signing_key = runtime.identity.signing_key().clone();
+    let noise_kp = runtime.noise_kp.clone();
+
+    let post = match role {
+        PairingRole::Initiator => drive_initiator_after_pake(
+            &mut stream,
+            &noise_kp,
+            &signing_key,
+            &self_id,
+            &peer_id,
+            &k2,
+            &state,
+        ),
+        PairingRole::Responder => drive_responder_after_pake(
+            &mut stream,
+            &noise_kp,
+            &signing_key,
+            &self_id,
+            &peer_id,
+            &k2,
+            &state,
+        ),
+    };
+    let post = match post {
+        Ok(p) => p,
+        Err(e) => {
+            mark_failed(&runtime, &session_id, format!("engine drive: {e:?}"));
+            return;
+        }
+    };
+
+    // Compute the fingerprint from the peer's persisted long-term
+    // pubkey — the engine just wrote it under PeerTrust::Trusted, so
+    // `peer_pubkey` returns Some.
+    let fingerprint = state
+        .peer_pubkey(&peer_id)
+        .ok()
+        .flatten()
+        .map(|pk| fingerprint_from_pubkey(&pk));
+
+    if let Ok(mut sessions) = runtime.pairing_sessions.lock() {
+        if let Some(flow) = sessions.get_mut(&session_id) {
+            flow.post_pairing = Some(post);
+            flow.peer_fingerprint = fingerprint;
+            flow.raw_keys = Some(raw_keys);
+            flow.state_kind = PairingState::AwaitingConfirmation;
+        }
+    }
+}
+
+fn write_len_prefixed(stream: &mut TcpStream, body: &[u8]) -> std::io::Result<()> {
+    if body.len() > u16::MAX as usize {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "len-prefix payload too large",
+        ));
+    }
+    stream.write_all(&(body.len() as u16).to_be_bytes())?;
+    stream.write_all(body)?;
+    Ok(())
+}
+
+fn read_len_prefixed_string(stream: &mut TcpStream) -> std::io::Result<String> {
+    let mut len_buf = [0u8; 2];
+    stream.read_exact(&mut len_buf)?;
+    let n = u16::from_be_bytes(len_buf) as usize;
+    if n > 256 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "hello id too long",
+        ));
+    }
+    let mut buf = vec![0u8; n];
+    stream.read_exact(&mut buf)?;
+    String::from_utf8(buf).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, format!("hello utf8: {e}"))
+    })
+}
+
+fn mark_failed(runtime: &Arc<SyncRuntime>, session_id: &str, msg: String) {
+    if let Ok(mut sessions) = runtime.pairing_sessions.lock() {
+        if let Some(flow) = sessions.get_mut(session_id) {
+            flow.state_kind = PairingState::Failed;
+            flow.error = Some(msg);
+        }
+    }
+}
+
+/// Same recipe `Identity::pubkey_fp` uses on our own key: derive the
+/// device id (`base32(SHA-256(pubkey)[..16])`) and take the first 8 chars.
+fn fingerprint_from_pubkey(pubkey: &[u8; 32]) -> String {
+    use data_encoding::BASE32_NOPAD;
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(pubkey);
+    let device_id = BASE32_NOPAD.encode(&digest[..16]);
+    device_id.chars().take(8).collect()
 }
 
 fn peer_row_exists(state: &SyncState, peer_device_id: &str) -> Result<bool, VaultError> {
@@ -785,15 +1446,18 @@ pub fn sync_list_paired_peers(
 pub fn sync_pairing_start_initiator(
     runtime: tauri::State<'_, Arc<SyncRuntime>>,
 ) -> Result<PairingStartInitiatorDto, VaultError> {
-    runtime.pairing_start_initiator()
+    runtime.inner().pairing_start_initiator(None, None)
 }
 
 #[tauri::command]
 pub fn sync_pairing_start_responder(
     runtime: tauri::State<'_, Arc<SyncRuntime>>,
     pin: String,
+    peer_device_id: Option<String>,
 ) -> Result<PairingStartResponderDto, VaultError> {
-    runtime.pairing_start_responder(&pin)
+    runtime
+        .inner()
+        .pairing_start_responder(&pin, peer_device_id, None)
 }
 
 #[tauri::command]
@@ -822,6 +1486,19 @@ pub fn sync_pairing_cancel(
     session_id: String,
 ) -> Result<(), VaultError> {
     runtime.pairing_cancel(&session_id)
+}
+
+#[tauri::command]
+pub fn sync_pairing_grant_vault(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    session_id: String,
+    vault_id: String,
+    scope: String,
+) -> Result<(), VaultError> {
+    let parsed = Scope::parse(&scope).ok_or_else(|| VaultError::SyncState {
+        msg: format!("invalid scope: {scope}"),
+    })?;
+    runtime.pairing_grant_vault(&session_id, &vault_id, parsed)
 }
 
 #[tauri::command]
@@ -862,9 +1539,10 @@ pub(crate) use self::testing::*;
 mod testing {
     use super::*;
 
-    /// Test-only constructor that pre-populates a pairing flow with raw
-    /// shared keys so confirmation paths can be exercised without a
-    /// running transport layer. Returns the session id.
+    /// Test-only constructor that pre-populates a pairing flow already
+    /// at the `AwaitingConfirmation` state — bypasses the worker thread
+    /// so unit tests can exercise the `pairing_confirm` path without
+    /// running PAKE or wiring a transport. Returns the session id.
     pub(crate) fn inject_pairing_flow_for_test(
         runtime: &SyncRuntime,
         peer_device_id: &str,
@@ -873,13 +1551,18 @@ mod testing {
         let session_id = Uuid::new_v4().to_string();
         let session = PairingSession::new();
         session.issue_pin()?;
-        let _ = runtime; // identity is captured implicitly through `raw_keys.id_a` / `id_b`.
+        let _ = runtime;
         let flow = PairingFlow {
             session,
             role: PairingRole::Initiator,
             peer_device_id: Some(peer_device_id.to_string()),
             peer_fingerprint: Some(peer_device_id.chars().take(8).collect()),
             raw_keys: Some(raw_keys),
+            state_kind: PairingState::AwaitingConfirmation,
+            error: None,
+            post_pairing: None,
+            listener_handle: None,
+            worker_handle: None,
         };
         runtime
             .pairing_sessions
@@ -1107,34 +1790,41 @@ mod tests {
     #[test]
     fn pairing_start_initiator_returns_session_id_pin_and_expiry() {
         let rt = build_runtime();
-        let dto = rt.pairing_start_initiator().unwrap();
+        let dto = rt.pairing_start_initiator(None, Some(0)).unwrap();
         assert_eq!(dto.pin.len(), 6);
         assert!(dto.pin.chars().all(|c| c.is_ascii_digit()));
         assert!(!dto.session_id.is_empty());
         assert!(dto.expires_at_unix > 0);
+        // Tear down so the worker thread + ephemeral listener exit
+        // promptly rather than dangling for the full PAIRING_WORKER_TIMEOUT.
+        rt.pairing_cancel(&dto.session_id).unwrap();
     }
 
     #[test]
     fn pairing_start_responder_validates_pin() {
         let rt = build_runtime();
         // Non-numeric PIN must reject before the session is created.
-        let err = rt.pairing_start_responder("abcdef").expect_err("non-numeric");
+        let err = rt
+            .pairing_start_responder("abcdef", None, None)
+            .expect_err("non-numeric");
         match err {
             VaultError::SyncState { .. } => {}
             other => panic!("wrong error: {other:?}"),
         }
-        // Valid 6-digit PIN must succeed.
-        let dto = rt.pairing_start_responder("123456").unwrap();
+        // Valid 6-digit PIN with no peer/addr — sits in awaiting_peer.
+        let dto = rt.pairing_start_responder("123456", None, None).unwrap();
         assert!(!dto.session_id.is_empty());
+        rt.pairing_cancel(&dto.session_id).unwrap();
     }
 
     #[test]
     fn pairing_step_returns_awaiting_peer_for_fresh_session() {
         let rt = build_runtime();
-        let started = rt.pairing_start_initiator().unwrap();
+        let started = rt.pairing_start_initiator(None, Some(0)).unwrap();
         let step = rt.pairing_step(&started.session_id, None).unwrap();
         assert_eq!(step.kind, "awaiting_peer");
         assert_eq!(step.attempts_remaining, Some(LOCKOUT_AFTER_ATTEMPTS));
+        rt.pairing_cancel(&started.session_id).unwrap();
     }
 
     #[test]
@@ -1150,7 +1840,7 @@ mod tests {
     #[test]
     fn pairing_cancel_removes_session() {
         let rt = build_runtime();
-        let started = rt.pairing_start_initiator().unwrap();
+        let started = rt.pairing_start_initiator(None, Some(0)).unwrap();
         rt.pairing_cancel(&started.session_id).unwrap();
         // After cancel, step on the same id must error with "unknown".
         let err = rt.pairing_step(&started.session_id, None).unwrap_err();
@@ -1164,18 +1854,19 @@ mod tests {
     }
 
     #[test]
-    fn pairing_confirm_errors_when_no_raw_keys_yet() {
+    fn pairing_confirm_errors_when_not_at_confirmation_step() {
         let rt = build_runtime();
-        let started = rt.pairing_start_initiator().unwrap();
+        let started = rt.pairing_start_initiator(None, Some(0)).unwrap();
         let err = rt.pairing_confirm(&started.session_id).unwrap_err();
         match err {
-            VaultError::SyncState { msg } => assert!(msg.contains("not yet")),
+            VaultError::SyncState { msg } => assert!(msg.contains("confirmation")),
             other => panic!("wrong error: {other:?}"),
         }
+        rt.pairing_cancel(&started.session_id).unwrap();
     }
 
     #[test]
-    fn pairing_confirm_persists_peer_when_keys_present() {
+    fn pairing_confirm_advances_state_to_complete() {
         let rt = build_runtime();
         let tmp = TempDir::new().unwrap();
         let _state = open_active_state(&rt, &tmp);
@@ -1189,13 +1880,9 @@ mod tests {
             inject_pairing_flow_for_test(&rt, "TESTPEERIDXXXXXXX", raw).unwrap();
         let dto = rt.pairing_confirm(&session_id).unwrap();
         assert_eq!(dto.device_id, "TESTPEERIDXXXXXXX");
-        // Peer is now in the trust store (note: pubkey is placeholder
-        // bytes per UI-1's transport-pending caveat, so peer_pubkey()
-        // returns Some for trusted peers regardless of whether keys are
-        // real; the row exists.)
-        let active = rt.active_sync_state().unwrap();
-        let peers = active.list_paired_peers().unwrap();
-        assert!(peers.iter().any(|p| p.peer_device_id == "TESTPEERIDXXXXXXX"));
+        // After confirm, step reports `complete` so the UI advances.
+        let step = rt.pairing_step(&session_id, None).unwrap();
+        assert_eq!(step.kind, "complete");
     }
 
     #[test]

--- a/src-tauri/src/commands/sync_cmds.rs
+++ b/src-tauri/src/commands/sync_cmds.rs
@@ -54,7 +54,7 @@ use uuid::Uuid;
 
 use crate::error::VaultError;
 use crate::sync::capability::{Capability, CapabilityBody, Scope};
-use crate::sync::discovery::{Discovery, MdnsDiscovery, PeerAd, PROTO_VERSION};
+use crate::sync::discovery::{Discovery, DiscoveryImpl, PeerAd, PROTO_VERSION};
 use crate::sync::identity::{Identity, KeyStore, MemoryKeyStore, OsKeychainStore};
 use crate::sync::pairing::{
     finalize_with_confirmation, key_confirmation_mac, respond, start_initiator, validate_pin,
@@ -310,7 +310,7 @@ pub struct SyncRuntime {
     /// Mutable display name override. The OS hostname is the default;
     /// users can override via `sync_set_device_name`.
     device_name: Mutex<String>,
-    discovery: Arc<MdnsDiscovery>,
+    discovery: Arc<DiscoveryImpl>,
     /// Whether the discovery daemon is currently running. Mirrors the
     /// `commands::sync::DISCOVERABLE` static for backwards-compat with
     /// the existing toggle.
@@ -361,7 +361,7 @@ impl SyncRuntime {
             .ok()
             .and_then(|h| h.into_string().ok())
             .unwrap_or_else(|| "VaultCore".to_string());
-        let discovery = Arc::new(MdnsDiscovery::new()?);
+        let discovery = Arc::new(DiscoveryImpl::new()?);
         Ok(Self {
             identity,
             noise_kp,
@@ -1460,15 +1460,50 @@ pub fn sync_pairing_start_initiator(
     runtime.inner().pairing_start_initiator(None, None)
 }
 
+/// Manual peer entry parser (e.g. on Android pre-NSD bridge): the UI
+/// passes an explicit `host:port` (or just `host`, default port appended)
+/// and we dial that directly, bypassing mDNS-resolved discovery. Empty /
+/// whitespace-only strings are treated as `None` so the UI can pass an
+/// uninhabited input field through harmlessly.
+///
+/// Public for the IPC integration tests in `sync_cmds_pairing_tests.rs`
+/// that need to exercise the exact string path the Tauri command takes.
+pub fn parse_peer_addr_string(peer_addr: Option<&str>) -> Result<Option<SocketAddr>, VaultError> {
+    match peer_addr.map(str::trim).filter(|s| !s.is_empty()) {
+        None => Ok(None),
+        Some(s) => {
+            // Bracketed IPv6 form `[::1]:1234` already contains ':' but the
+            // host portion does too — distinguish by trailing `]:port`.
+            let has_explicit_port = if s.starts_with('[') {
+                s.rsplit_once(']').map(|(_, rest)| rest.starts_with(':')).unwrap_or(false)
+            } else {
+                s.contains(':')
+            };
+            let with_port = if has_explicit_port {
+                s.to_string()
+            } else {
+                format!("{}:{}", s, DEFAULT_PAIRING_PORT)
+            };
+            Ok(Some(with_port.parse::<SocketAddr>().map_err(|e| {
+                VaultError::SyncState {
+                    msg: format!("invalid peer_addr: {e}"),
+                }
+            })?))
+        }
+    }
+}
+
 #[tauri::command]
 pub fn sync_pairing_start_responder(
     runtime: tauri::State<'_, Arc<SyncRuntime>>,
     pin: String,
     peer_device_id: Option<String>,
+    peer_addr: Option<String>,
 ) -> Result<PairingStartResponderDto, VaultError> {
+    let parsed = parse_peer_addr_string(peer_addr.as_deref())?;
     runtime
         .inner()
-        .pairing_start_responder(&pin, peer_device_id, None)
+        .pairing_start_responder(&pin, peer_device_id, parsed)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/sync_cmds.rs
+++ b/src-tauri/src/commands/sync_cmds.rs
@@ -1,0 +1,1265 @@
+//! Tauri IPC bridge for the LAN sync layer (UI-1).
+//!
+//! Wires the shipped sync primitives in `crate::sync::*` to the
+//! frontend store. **No new sync logic** lives here — every command is
+//! a thin shim over an existing primitive:
+//!
+//! - identity     → [`crate::sync::identity::Identity`]
+//! - discovery    → [`crate::sync::discovery::MdnsDiscovery`]
+//! - pairing      → [`crate::sync::pairing`] PAKE flow
+//! - peers/grants → [`crate::sync::state::SyncState`]
+//!
+//! ## Runtime ownership
+//!
+//! [`SyncRuntime`] is registered with Tauri at startup and lives for
+//! the whole process. It owns the long-lived mDNS daemon (started lazily
+//! when the user first toggles "discoverable"), the in-memory pairing
+//! session table (keyed by UUID `session_id`), and a slot for the active
+//! vault's [`SyncState`] handle. Paired-peer / grant queries route
+//! through that slot — when no vault is open, the queries return empty
+//! lists rather than erroring (the Settings UI then renders an empty
+//! state).
+//!
+//! ## Event emission
+//!
+//! Four events are emitted from this module:
+//!
+//! - `sync://peers-discovered` — fired by a background poller (250 ms
+//!   debounce) whenever the mDNS browse-thread peer snapshot changes.
+//! - `sync://peer-paired` — fired from [`sync_pairing_confirm`] right
+//!   after the new peer is persisted to `sync_peers`.
+//! - `sync://sync-status` — placeholder; emission will plug in once the
+//!   transport layer wires per-vault status. The IPC + listener surface
+//!   exists so UI-4 can bind without waiting on transport.
+//! - `sync://stale-peer-resurrect` — placeholder for the same reason
+//!   (UI-5 needs the surface).
+//!
+//! ## Frontend contract
+//!
+//! Commands are user-driven — no polling on render. The store
+//! initializes once via [`sync_get_self_identity`] +
+//! [`sync_list_paired_peers`] + [`sync_get_discoverable`], then updates
+//! exclusively from the four events above. See `src/store/syncStore.ts`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use uuid::Uuid;
+
+use crate::error::VaultError;
+use crate::sync::capability::{Capability, CapabilityBody, Scope};
+use crate::sync::discovery::{Discovery, MdnsDiscovery, PeerAd, PROTO_VERSION};
+use crate::sync::identity::{Identity, KeyStore, MemoryKeyStore, OsKeychainStore};
+use crate::sync::pairing::{
+    finalize_with_confirmation, key_confirmation_mac, validate_pin, ConfirmedKeys,
+    PairingSession, RawSharedKeys, LOCKOUT_AFTER_ATTEMPTS, PIN_EXPIRY_SECS,
+};
+use crate::sync::state::{PeerTrust, SyncState};
+
+// ─── Event names ─────────────────────────────────────────────────────────
+
+pub const PEERS_DISCOVERED_EVENT: &str = "sync://peers-discovered";
+pub const PEER_PAIRED_EVENT: &str = "sync://peer-paired";
+pub const SYNC_STATUS_EVENT: &str = "sync://sync-status";
+pub const STALE_PEER_RESURRECT_EVENT: &str = "sync://stale-peer-resurrect";
+
+/// Debounce window for `sync://peers-discovered`. Even if 30 peers come
+/// and go in this window, the frontend sees at most one event with the
+/// final snapshot. Spec says "≤ 250 ms" — using exactly 250 ms.
+pub const PEERS_DEBOUNCE_MS: u64 = 250;
+
+/// Default port advertised in mDNS TXT records. The Noise transport layer
+/// (#419) listens here; the IPC bridge only needs a stable value to
+/// publish so peers can resolve us. Picked from IANA's user-port range
+/// to avoid `_vaultcore`-vs-`_<other>` collisions on the same network.
+pub const DEFAULT_SYNC_PORT: u16 = 17091;
+
+// ─── DTOs (shape matches `src/store/syncStore.ts`) ───────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SelfIdentityDto {
+    pub device_id: String,
+    pub device_name: String,
+    pub pubkey_fingerprint: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultRefDto {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoveredPeerDto {
+    pub device_id: String,
+    pub device_name: String,
+    pub vaults: Vec<VaultRefDto>,
+    pub addr: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GrantDto {
+    pub vault_id: String,
+    pub vault_name: String,
+    pub scope: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PairedPeerDto {
+    pub device_id: String,
+    pub device_name: String,
+    pub last_seen: Option<i64>,
+    pub grants: Vec<GrantDto>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PairingStartInitiatorDto {
+    pub session_id: String,
+    pub pin: String,
+    pub expires_at_unix: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PairingStartResponderDto {
+    pub session_id: String,
+}
+
+/// Outcome of [`sync_pairing_step`]. The UI renders one of four screens
+/// keyed off `kind`: a spinner (`awaiting_peer`), the fingerprint
+/// confirmation card (`awaiting_confirmation`), the success state
+/// (`complete`), or the lockout / wrong-PIN card (`failed`).
+#[derive(Debug, Clone, Serialize)]
+pub struct PairingStepDto {
+    pub kind: String,
+    pub peer_fingerprint: Option<String>,
+    pub attempts_remaining: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PeerPairedEventDto {
+    pub device_id: String,
+    pub device_name: String,
+}
+
+// ─── Pairing session table ────────────────────────────────────────────────
+
+/// In-memory pairing session — one per active flow, keyed by UUID. Held
+/// by [`SyncRuntime::pairing_sessions`] for the duration of the flow.
+/// On `confirm` or `cancel` the entry is removed.
+struct PairingFlow {
+    session: PairingSession,
+    #[allow(dead_code)]
+    role: PairingRole,
+    /// Peer device id, if known. The initiator learns it from the
+    /// step1 reply payload; the responder learns it from the step1
+    /// packet sent by the initiator.
+    peer_device_id: Option<String>,
+    /// Once PAKE step1+step2 have been driven, the raw shared keys
+    /// land here awaiting key-confirmation. `None` means PAKE is not
+    /// yet finished. `id_a` / `id_b` on the `RawSharedKeys` carry the
+    /// device id pair, so we don't need a separate `self_device_id`.
+    raw_keys: Option<RawSharedKeys>,
+    /// Cached fingerprint we display to the user during confirmation.
+    /// Populated alongside `raw_keys`. Eight base32 chars per spec.
+    peer_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PairingRole {
+    Initiator,
+    Responder,
+}
+
+// ─── Discovery emission task ──────────────────────────────────────────────
+
+/// Last-snapshot signature used by the emitter task to decide whether
+/// to fire the debounced event. We hash the sorted device-id list — if
+/// nothing changed peer-set-wise, no event needed.
+fn snapshot_signature(peers: &[DiscoveredPeerDto]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut ids: Vec<&str> = peers.iter().map(|p| p.device_id.as_str()).collect();
+    ids.sort();
+    let mut h = DefaultHasher::new();
+    ids.hash(&mut h);
+    h.finish()
+}
+
+/// Convert a [`PeerAd`] (sync-layer wire shape) into the [`DiscoveredPeerDto`]
+/// the frontend store expects. The first reachable address is rendered as
+/// `host:port` for display; if no addresses came through (mdns-sd
+/// occasionally publishes the TXT before the A record), we emit an empty
+/// string and let the UI render "(no address)".
+fn peer_ad_to_dto(ad: &PeerAd) -> DiscoveredPeerDto {
+    let addr = ad
+        .addrs
+        .first()
+        .map(|ip| format!("{}:{}", ip, ad.port))
+        .unwrap_or_default();
+    DiscoveredPeerDto {
+        device_id: ad.device_id.clone(),
+        device_name: ad.name.clone(),
+        vaults: ad
+            .vaults
+            .iter()
+            .map(|v| VaultRefDto {
+                id: v.id.clone(),
+                name: v.name.clone(),
+            })
+            .collect(),
+        addr,
+    }
+}
+
+// ─── Runtime state ────────────────────────────────────────────────────────
+
+/// Process-wide sync runtime. Constructed once in `lib.rs::run` and
+/// stuffed into Tauri's state.
+///
+/// Concurrency model: every field is `Arc`-cloneable and uses interior
+/// mutability behind a `Mutex`. The mDNS scan thread (owned by
+/// `MdnsDiscovery`) and the debounce-emitter thread we spawn ourselves
+/// both close over Arcs into this struct, so it must outlive both —
+/// hence `Arc<SyncRuntime>` storage in Tauri's `manage()`.
+pub struct SyncRuntime {
+    identity: Identity,
+    /// Mutable display name override. The OS hostname is the default;
+    /// users can override via `sync_set_device_name`.
+    device_name: Mutex<String>,
+    discovery: Arc<MdnsDiscovery>,
+    /// Whether the discovery daemon is currently running. Mirrors the
+    /// `commands::sync::DISCOVERABLE` static for backwards-compat with
+    /// the existing toggle.
+    discoverable: Mutex<bool>,
+    pairing_sessions: Mutex<HashMap<String, PairingFlow>>,
+    /// Slot for the active vault's metadata SyncState. Populated by
+    /// [`SyncRuntime::set_active_sync_state`] when a vault is opened
+    /// (engine wiring is the engine task's job — UI-1 only exposes
+    /// the slot so paired-peer queries return non-empty in that case).
+    active_state: Mutex<Option<Arc<SyncState>>>,
+    /// Shared with the emitter thread so the runtime can be torn down.
+    emitter_stop: Arc<std::sync::atomic::AtomicBool>,
+    emitter_handle: Mutex<Option<std::thread::JoinHandle<()>>>,
+    /// Last-emitted peer snapshot signature so the emitter can skip
+    /// no-op fires (peer set unchanged across the debounce window).
+    last_signature: Arc<Mutex<Option<u64>>>,
+}
+
+impl SyncRuntime {
+    /// Build with the OS keychain backing the identity. Used by `lib.rs`.
+    pub fn new() -> Result<Self, VaultError> {
+        Self::with_keystore(Box::new(OsKeychainStore::default()))
+    }
+
+    /// Test constructor. Drops the OS keychain in favor of an in-memory
+    /// store so unit tests don't touch the developer's real keychain.
+    pub fn new_for_test() -> Result<Self, VaultError> {
+        Self::with_keystore(Box::new(MemoryKeyStore::new()))
+    }
+
+    fn with_keystore(store: Box<dyn KeyStore>) -> Result<Self, VaultError> {
+        let identity = Identity::load_or_create(&*store)?;
+        let device_name = hostname::get()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .unwrap_or_else(|| "VaultCore".to_string());
+        let discovery = Arc::new(MdnsDiscovery::new()?);
+        Ok(Self {
+            identity,
+            device_name: Mutex::new(device_name),
+            discovery,
+            discoverable: Mutex::new(false),
+            pairing_sessions: Mutex::new(HashMap::new()),
+            active_state: Mutex::new(None),
+            emitter_stop: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            emitter_handle: Mutex::new(None),
+            last_signature: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    pub fn self_identity(&self) -> SelfIdentityDto {
+        SelfIdentityDto {
+            device_id: self.identity.device_id().to_string(),
+            device_name: self
+                .device_name
+                .lock()
+                .map(|g| g.clone())
+                .unwrap_or_default(),
+            pubkey_fingerprint: self.identity.pubkey_fp(),
+        }
+    }
+
+    pub fn set_device_name(&self, name: String) -> Result<(), VaultError> {
+        *self
+            .device_name
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)? = name;
+        Ok(())
+    }
+
+    pub fn discoverable(&self) -> bool {
+        self.discoverable
+            .lock()
+            .map(|g| *g)
+            .unwrap_or(false)
+    }
+
+    /// Activate the current advertisement and start the browse thread.
+    /// Idempotent — toggling true twice is a no-op past the first call.
+    pub fn set_discoverable(&self, on: bool) -> Result<(), VaultError> {
+        let mut flag = self
+            .discoverable
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        if *flag == on {
+            return Ok(());
+        }
+        if on {
+            let ad = PeerAd {
+                device_id: self.identity.device_id().to_string(),
+                name: self
+                    .device_name
+                    .lock()
+                    .map_err(|_| VaultError::LockPoisoned)?
+                    .clone(),
+                vaults: Vec::new(),
+                pubkey_fp: self.identity.pubkey_fp(),
+                proto: PROTO_VERSION.to_string(),
+                addrs: Vec::new(),
+                port: DEFAULT_SYNC_PORT,
+            };
+            self.discovery.start(ad)?;
+        } else {
+            self.discovery.stop()?;
+        }
+        *flag = on;
+        // Mirror to the legacy static so existing call sites that read
+        // `commands::sync::DISCOVERABLE` see the same value.
+        crate::commands::sync::DISCOVERABLE.store(on, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub fn list_discovered_peers(&self) -> Result<Vec<DiscoveredPeerDto>, VaultError> {
+        let snapshot = self.discovery.peers()?;
+        Ok(snapshot.peers.iter().map(peer_ad_to_dto).collect())
+    }
+
+    pub fn list_paired_peers(&self) -> Result<Vec<PairedPeerDto>, VaultError> {
+        let guard = self
+            .active_state
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        let Some(state) = guard.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let peers = state.list_paired_peers()?;
+        let mut out = Vec::with_capacity(peers.len());
+        for p in peers {
+            let grants = state
+                .list_grants_for_peer(&p.peer_device_id)?
+                .into_iter()
+                .map(|g| GrantDto {
+                    vault_id: g.local_vault_id.clone(),
+                    // No vault-name registry yet — surface the id so the
+                    // UI can render *something* until UI-2 adds the
+                    // friendly-name resolver. See UI-2 for the upgrade.
+                    vault_name: g.local_vault_id,
+                    scope: g.scope,
+                })
+                .collect();
+            out.push(PairedPeerDto {
+                device_id: p.peer_device_id,
+                device_name: p.peer_name,
+                last_seen: p.last_seen,
+                grants,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Used by `commands/vault.rs::open_vault` (engine wiring task) to
+    /// register the active vault's metadata DB so paired-peer queries
+    /// can read it. UI-1 doesn't call this itself — the slot is just a
+    /// hook for the engine wiring. Tests use it directly.
+    pub fn set_active_sync_state(&self, state: Option<Arc<SyncState>>) -> Result<(), VaultError> {
+        *self
+            .active_state
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)? = state;
+        Ok(())
+    }
+
+    /// Test-only: peek at the active state slot without going through
+    /// the IPC layer.
+    #[cfg(test)]
+    pub(crate) fn active_sync_state(&self) -> Option<Arc<SyncState>> {
+        self.active_state.lock().ok().and_then(|g| g.clone())
+    }
+
+    pub fn grant_vault(
+        &self,
+        peer_device_id: &str,
+        vault_id: &str,
+        scope: Scope,
+    ) -> Result<(), VaultError> {
+        let state = self.require_active_state()?;
+        // Look up the peer's pubkey to ensure they're still trusted —
+        // granting access to a revoked peer is a programming error.
+        let pubkey = state
+            .peer_pubkey(peer_device_id)?
+            .ok_or_else(|| VaultError::SyncState {
+                msg: format!("unknown or revoked peer: {peer_device_id}"),
+            })?;
+        // We sign capabilities with our own device key so the peer can
+        // verify against the pubkey they already have for us.
+        // `peer_vault_id` defaults to the same id — UI-2 may extend this
+        // to take an explicit remote-vault selector.
+        let _ = pubkey; // we sign with self-identity, not peer pubkey
+        let body = CapabilityBody::issue_v1(vault_id, peer_device_id, vault_id, scope);
+        // SigningKey access: Identity owns it but exposes only `sign` —
+        // for the capability we re-derive a SigningKey from raw bytes.
+        // Since we don't expose those bytes from Identity, we use the
+        // sign-blob → Capability::sign manually below.
+        // NOTE: capability layer requires SigningKey. We add a passthrough
+        // helper on Identity below in `signing_key_bytes`.
+        let cap = self.sign_capability(&body)?;
+        state.upsert_vault_grant(&cap)?;
+        Ok(())
+    }
+
+    pub fn revoke_peer(&self, peer_device_id: &str) -> Result<(), VaultError> {
+        let state = self.require_active_state()?;
+        // Reject when the peer doesn't exist at all, so the frontend
+        // surfaces "unknown peer" rather than silently succeeding on a
+        // typo. A peer that's already revoked stays revoked — second
+        // call is a no-op.
+        if state.peer_pubkey(peer_device_id)?.is_none() {
+            // peer_pubkey returns None for revoked too; check sync_peers
+            // directly to differentiate.
+            if !peer_row_exists(&state, peer_device_id)? {
+                return Err(VaultError::SyncState {
+                    msg: format!("unknown peer: {peer_device_id}"),
+                });
+            }
+        }
+        state.revoke_peer(peer_device_id)?;
+        Ok(())
+    }
+
+    pub fn revoke_vault_grant(
+        &self,
+        peer_device_id: &str,
+        vault_id: &str,
+    ) -> Result<(), VaultError> {
+        let state = self.require_active_state()?;
+        let removed = state.disable_vault_grant(vault_id, peer_device_id)?;
+        if !removed {
+            return Err(VaultError::SyncState {
+                msg: format!(
+                    "no enabled grant for peer {peer_device_id} on vault {vault_id}"
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    fn require_active_state(&self) -> Result<Arc<SyncState>, VaultError> {
+        let guard = self
+            .active_state
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        guard.clone().ok_or_else(|| VaultError::SyncState {
+            msg: "no vault is open".into(),
+        })
+    }
+
+    /// Sign a capability body under the device's identity key. Implemented
+    /// here (not on `Identity`) because `Identity` doesn't expose the raw
+    /// signing key — capability signing is the only call site that needs
+    /// it, and inverting the dependency keeps `Identity` minimal.
+    fn sign_capability(&self, body: &CapabilityBody) -> Result<Capability, VaultError> {
+        let body_bytes = body.to_bytes();
+        let sig = self.identity.sign(&body_bytes);
+        Ok(Capability {
+            body: body_bytes,
+            signature: sig.to_vec(),
+        })
+    }
+
+    // ─── Pairing flow helpers ─────────────────────────────────────────────
+
+    pub fn pairing_start_initiator(&self) -> Result<PairingStartInitiatorDto, VaultError> {
+        let session_id = Uuid::new_v4().to_string();
+        let pin = generate_pin_6_digit();
+        let session = PairingSession::new();
+        session.issue_pin()?;
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let flow = PairingFlow {
+            session,
+            role: PairingRole::Initiator,
+            peer_device_id: None,
+            raw_keys: None,
+            peer_fingerprint: None,
+        };
+        self.pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?
+            .insert(session_id.clone(), flow);
+        Ok(PairingStartInitiatorDto {
+            session_id,
+            pin,
+            expires_at_unix: now_secs + PIN_EXPIRY_SECS,
+        })
+    }
+
+    pub fn pairing_start_responder(
+        &self,
+        pin: &str,
+    ) -> Result<PairingStartResponderDto, VaultError> {
+        validate_pin(pin).map_err(VaultError::from)?;
+        let session_id = Uuid::new_v4().to_string();
+        let session = PairingSession::new();
+        session.issue_pin()?;
+        let flow = PairingFlow {
+            session,
+            role: PairingRole::Responder,
+            peer_device_id: None,
+            raw_keys: None,
+            peer_fingerprint: None,
+        };
+        self.pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?
+            .insert(session_id.clone(), flow);
+        Ok(PairingStartResponderDto { session_id })
+    }
+
+    /// Drive the PAKE state machine. Today's UI-1 plumbing is a stub
+    /// that returns `awaiting_peer` until transport (#419) carries the
+    /// step packets between devices. Once transport lands, this method
+    /// will accept a base64 payload and dispatch to
+    /// [`start_initiator`] / [`respond`] / [`InitiatorAfterStep1::step3`].
+    /// The method exists today so the IPC contract is stable and UI-3
+    /// can render the spinner while waiting on the peer.
+    pub fn pairing_step(
+        &self,
+        session_id: &str,
+        _payload: Option<String>,
+    ) -> Result<PairingStepDto, VaultError> {
+        let sessions = self
+            .pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        let flow = sessions.get(session_id).ok_or_else(|| VaultError::SyncState {
+            msg: format!("unknown pairing session: {session_id}"),
+        })?;
+        if flow.session.is_locked()? {
+            return Ok(PairingStepDto {
+                kind: "failed".into(),
+                peer_fingerprint: None,
+                attempts_remaining: Some(0),
+            });
+        }
+        if !flow.session.pin_valid()? {
+            return Ok(PairingStepDto {
+                kind: "failed".into(),
+                peer_fingerprint: None,
+                attempts_remaining: Some(0),
+            });
+        }
+        let attempts_remaining = LOCKOUT_AFTER_ATTEMPTS - flow.session.failed_count()?;
+        Ok(PairingStepDto {
+            kind: "awaiting_peer".into(),
+            peer_fingerprint: flow.peer_fingerprint.clone(),
+            attempts_remaining: Some(attempts_remaining),
+        })
+    }
+
+    /// Final confirmation step: persist the peer to `sync_peers` and emit
+    /// `sync://peer-paired`. UI-1 stub: in production this is gated on
+    /// the user clicking "Confirm" after seeing the matching fingerprint;
+    /// transport-layer code (#419) will drive `raw_keys` into the flow
+    /// before this is callable. For UI-1 we accept calls when raw_keys
+    /// is present (from a future transport hook) and otherwise return a
+    /// PairError-shaped error so the UI surfaces a clear failure.
+    pub fn pairing_confirm(&self, session_id: &str) -> Result<PeerPairedEventDto, VaultError> {
+        let mut sessions = self
+            .pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        let Some(flow) = sessions.remove(session_id) else {
+            return Err(VaultError::SyncState {
+                msg: format!("unknown pairing session: {session_id}"),
+            });
+        };
+        let raw = flow.raw_keys.ok_or_else(|| VaultError::SyncState {
+            msg: "pairing not yet at confirmation step (no shared keys)".into(),
+        })?;
+        let peer_id = flow.peer_device_id.ok_or_else(|| VaultError::SyncState {
+            msg: "pairing has no peer device id".into(),
+        })?;
+        let _role = flow.role;
+        // Build our local MAC and feed both into the canonical
+        // confirmation helper so any future change to the MAC layout
+        // doesn't have to be mirrored here. The peer's MAC is delivered
+        // through the transport layer; UI-1 doesn't have that wired yet,
+        // so we self-confirm against our own MAC bytes — once transport
+        // lands, replace the `&local_mac` arg below with the bytes from
+        // the incoming step3/finalize packet.
+        let local_mac = key_confirmation_mac(&raw.k2, &raw.id_a, &raw.id_b);
+        let _confirmed: ConfirmedKeys =
+            finalize_with_confirmation(&raw, &local_mac, &flow.session)
+                .map_err(|e| VaultError::from(e))?;
+        // Persist trust to the active vault's SyncState. If no vault is
+        // open we still return success so the UI flow completes (the
+        // engine wiring task may extend this to defer peer persistence
+        // until vault open) — but typical UAT pairs while a vault is open.
+        let device_name = format!("Peer {peer_id}");
+        if let Ok(active) = self.require_active_state() {
+            active.upsert_peer(
+                &peer_id,
+                &[0u8; 32], // placeholder — transport supplies the long-term pubkey via the noise XX exchange (#419)
+                &device_name,
+                PeerTrust::Trusted,
+            )?;
+        }
+        Ok(PeerPairedEventDto {
+            device_id: peer_id,
+            device_name,
+        })
+    }
+
+    pub fn pairing_cancel(&self, session_id: &str) -> Result<(), VaultError> {
+        let mut sessions = self
+            .pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        sessions.remove(session_id);
+        Ok(())
+    }
+
+    // ─── Emitter task lifecycle ───────────────────────────────────────────
+
+    /// Spawn the long-lived task that polls the mDNS peer snapshot and
+    /// emits `sync://peers-discovered` when it changes (debounced 250ms).
+    /// Idempotent: calling twice replaces the prior thread with a fresh
+    /// one (used by tests; production calls once at startup).
+    pub fn start_emitter<R: tauri::Runtime>(self: &Arc<Self>, app: AppHandle<R>) {
+        let stop = Arc::clone(&self.emitter_stop);
+        stop.store(false, std::sync::atomic::Ordering::SeqCst);
+        let last_sig = Arc::clone(&self.last_signature);
+        let runtime = Arc::clone(self);
+        let handle = std::thread::spawn(move || {
+            let interval = Duration::from_millis(PEERS_DEBOUNCE_MS);
+            let mut last_tick = Instant::now();
+            while !stop.load(std::sync::atomic::Ordering::SeqCst) {
+                // Sleep in 50 ms slices so stop is observed promptly.
+                if last_tick.elapsed() < interval {
+                    std::thread::sleep(Duration::from_millis(50));
+                    continue;
+                }
+                last_tick = Instant::now();
+                // Discovery may not be running yet — skip silently.
+                if !runtime.discoverable() {
+                    continue;
+                }
+                let peers = match runtime.list_discovered_peers() {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+                let sig = snapshot_signature(&peers);
+                let mut lg = match last_sig.lock() {
+                    Ok(g) => g,
+                    Err(_) => continue,
+                };
+                if lg.as_ref() == Some(&sig) {
+                    continue;
+                }
+                *lg = Some(sig);
+                drop(lg);
+                let _ = app.emit(PEERS_DISCOVERED_EVENT, &peers);
+            }
+        });
+        if let Ok(mut g) = self.emitter_handle.lock() {
+            *g = Some(handle);
+        }
+    }
+
+    /// Tear down the emitter thread. Used by tests and process shutdown.
+    pub fn stop_emitter(&self) {
+        self.emitter_stop
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut g) = self.emitter_handle.lock() {
+            if let Some(h) = g.take() {
+                let _ = h.join();
+            }
+        }
+    }
+}
+
+impl Drop for SyncRuntime {
+    fn drop(&mut self) {
+        self.stop_emitter();
+        let _ = self.discovery.stop();
+    }
+}
+
+fn peer_row_exists(state: &SyncState, peer_device_id: &str) -> Result<bool, VaultError> {
+    let conn = state.lock_conn()?;
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sync_peers WHERE peer_device_id = ?1",
+            rusqlite::params![peer_device_id],
+            |r| r.get(0),
+        )
+        .map_err(|e| VaultError::SyncState {
+            msg: format!("sqlite: {e}"),
+        })?;
+    Ok(n > 0)
+}
+
+/// Generate a 6-digit numeric PIN. Uses [`rand::Rng`] under the hood —
+/// `OsRng` would also work but `thread_rng` is fine for a 1-in-a-million
+/// guess space that's already lockout-protected after 3 attempts.
+fn generate_pin_6_digit() -> String {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    let n: u32 = rng.gen_range(0..1_000_000);
+    format!("{n:06}")
+}
+
+// ─── Tauri command handlers ──────────────────────────────────────────────
+
+#[tauri::command]
+pub fn sync_get_self_identity(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+) -> Result<SelfIdentityDto, VaultError> {
+    Ok(runtime.self_identity())
+}
+
+#[tauri::command]
+pub fn sync_set_device_name(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    name: String,
+) -> Result<(), VaultError> {
+    runtime.set_device_name(name)
+}
+
+/// Replaces the v0 `commands::sync::sync_get_discoverable` shim — the
+/// new bridge owns the daemon lifecycle, so the static-flag value
+/// alone is no longer the source of truth.
+#[tauri::command]
+pub fn sync_get_discoverable(runtime: tauri::State<'_, Arc<SyncRuntime>>) -> bool {
+    runtime.discoverable()
+}
+
+#[tauri::command]
+pub fn sync_set_discoverable(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    on: bool,
+) -> Result<(), VaultError> {
+    runtime.set_discoverable(on)
+}
+
+#[tauri::command]
+pub fn sync_list_discovered_peers(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+) -> Result<Vec<DiscoveredPeerDto>, VaultError> {
+    runtime.list_discovered_peers()
+}
+
+#[tauri::command]
+pub fn sync_list_paired_peers(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+) -> Result<Vec<PairedPeerDto>, VaultError> {
+    runtime.list_paired_peers()
+}
+
+#[tauri::command]
+pub fn sync_pairing_start_initiator(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+) -> Result<PairingStartInitiatorDto, VaultError> {
+    runtime.pairing_start_initiator()
+}
+
+#[tauri::command]
+pub fn sync_pairing_start_responder(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    pin: String,
+) -> Result<PairingStartResponderDto, VaultError> {
+    runtime.pairing_start_responder(&pin)
+}
+
+#[tauri::command]
+pub fn sync_pairing_step(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    session_id: String,
+    payload: Option<String>,
+) -> Result<PairingStepDto, VaultError> {
+    runtime.pairing_step(&session_id, payload)
+}
+
+#[tauri::command]
+pub fn sync_pairing_confirm<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    session_id: String,
+) -> Result<(), VaultError> {
+    let dto = runtime.pairing_confirm(&session_id)?;
+    let _ = app.emit(PEER_PAIRED_EVENT, &dto);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn sync_pairing_cancel(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    session_id: String,
+) -> Result<(), VaultError> {
+    runtime.pairing_cancel(&session_id)
+}
+
+#[tauri::command]
+pub fn sync_grant_vault(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    peer_device_id: String,
+    vault_id: String,
+    scope: String,
+) -> Result<(), VaultError> {
+    let parsed = Scope::parse(&scope).ok_or_else(|| VaultError::SyncState {
+        msg: format!("invalid scope: {scope}"),
+    })?;
+    runtime.grant_vault(&peer_device_id, &vault_id, parsed)
+}
+
+#[tauri::command]
+pub fn sync_revoke_peer(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    peer_device_id: String,
+) -> Result<(), VaultError> {
+    runtime.revoke_peer(&peer_device_id)
+}
+
+#[tauri::command]
+pub fn sync_revoke_vault_grant(
+    runtime: tauri::State<'_, Arc<SyncRuntime>>,
+    peer_device_id: String,
+    vault_id: String,
+) -> Result<(), VaultError> {
+    runtime.revoke_vault_grant(&peer_device_id, &vault_id)
+}
+
+// Re-exports for tests.
+#[cfg(test)]
+pub(crate) use self::testing::*;
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+
+    /// Test-only constructor that pre-populates a pairing flow with raw
+    /// shared keys so confirmation paths can be exercised without a
+    /// running transport layer. Returns the session id.
+    pub(crate) fn inject_pairing_flow_for_test(
+        runtime: &SyncRuntime,
+        peer_device_id: &str,
+        raw_keys: RawSharedKeys,
+    ) -> Result<String, VaultError> {
+        let session_id = Uuid::new_v4().to_string();
+        let session = PairingSession::new();
+        session.issue_pin()?;
+        let _ = runtime; // identity is captured implicitly through `raw_keys.id_a` / `id_b`.
+        let flow = PairingFlow {
+            session,
+            role: PairingRole::Initiator,
+            peer_device_id: Some(peer_device_id.to_string()),
+            peer_fingerprint: Some(peer_device_id.chars().take(8).collect()),
+            raw_keys: Some(raw_keys),
+        };
+        runtime
+            .pairing_sessions
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?
+            .insert(session_id.clone(), flow);
+        Ok(session_id)
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::clock::TestClock;
+    use crate::sync::discovery::AdvertisedVault;
+    use crate::sync::history::HistoryConfig;
+    use crate::sync::state::SyncState;
+    use ed25519_dalek::SigningKey;
+    use rand_core::RngCore;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn build_runtime() -> Arc<SyncRuntime> {
+        Arc::new(SyncRuntime::new_for_test().expect("runtime"))
+    }
+
+    fn open_active_state(rt: &SyncRuntime, tmp: &TempDir) -> Arc<SyncState> {
+        let metadata = tmp.path().join(".vaultcore");
+        std::fs::create_dir_all(&metadata).unwrap();
+        let state = Arc::new(
+            SyncState::open_with(
+                &metadata,
+                rt.identity.device_id().to_string(),
+                Arc::new(TestClock::new(1_700_000_000)),
+                HistoryConfig::default(),
+            )
+            .expect("open sync state"),
+        );
+        rt.set_active_sync_state(Some(Arc::clone(&state))).unwrap();
+        state
+    }
+
+    fn fresh_signing_key() -> SigningKey {
+        let mut bytes = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut bytes);
+        SigningKey::from_bytes(&bytes)
+    }
+
+    fn pair_test_peer(state: &SyncState, peer_id: &str) {
+        let owner = fresh_signing_key();
+        let pk = owner.verifying_key().to_bytes();
+        state
+            .upsert_peer(peer_id, &pk, "Test Peer", PeerTrust::Trusted)
+            .unwrap();
+    }
+
+    // ─── identity ────────────────────────────────────────────────────────
+
+    #[test]
+    fn self_identity_returns_stable_id_across_calls() {
+        let rt = build_runtime();
+        let a = rt.self_identity();
+        let b = rt.self_identity();
+        assert_eq!(a.device_id, b.device_id);
+        assert_eq!(a.pubkey_fingerprint.len(), 8);
+        // device_id is base32 of SHA-256(pubkey)[..16] → 26 chars.
+        assert_eq!(a.device_id.len(), 26);
+        assert!(!a.device_name.is_empty());
+    }
+
+    #[test]
+    fn set_device_name_overrides_default() {
+        let rt = build_runtime();
+        rt.set_device_name("Bob's Laptop".into()).unwrap();
+        assert_eq!(rt.self_identity().device_name, "Bob's Laptop");
+    }
+
+    // ─── discoverable toggle ─────────────────────────────────────────────
+
+    #[test]
+    fn set_discoverable_is_idempotent() {
+        let rt = build_runtime();
+        assert!(!rt.discoverable());
+        rt.set_discoverable(true).unwrap();
+        assert!(rt.discoverable());
+        // Second call must not error.
+        rt.set_discoverable(true).unwrap();
+        assert!(rt.discoverable());
+        rt.set_discoverable(false).unwrap();
+        assert!(!rt.discoverable());
+        rt.set_discoverable(false).unwrap();
+        assert!(!rt.discoverable());
+    }
+
+    #[test]
+    fn list_discovered_peers_empty_when_idle() {
+        let rt = build_runtime();
+        // Daemon hasn't been started yet — the snapshot is empty, not an error.
+        let peers = rt.list_discovered_peers().unwrap();
+        assert!(peers.is_empty());
+    }
+
+    // ─── paired peers / grants ───────────────────────────────────────────
+
+    #[test]
+    fn list_paired_peers_returns_empty_when_no_vault_open() {
+        let rt = build_runtime();
+        let peers = rt.list_paired_peers().unwrap();
+        assert!(peers.is_empty(), "no vault → empty list, not an error");
+    }
+
+    #[test]
+    fn list_paired_peers_returns_persisted_peers() {
+        let rt = build_runtime();
+        let tmp = TempDir::new().unwrap();
+        let state = open_active_state(&rt, &tmp);
+        pair_test_peer(&state, "PEERAAAAAAAAAAAAAAAAAA");
+        pair_test_peer(&state, "PEERBBBBBBBBBBBBBBBBBB");
+        let peers = rt.list_paired_peers().unwrap();
+        assert_eq!(peers.len(), 2);
+        assert_eq!(peers[0].device_id, "PEERAAAAAAAAAAAAAAAAAA");
+        assert_eq!(peers[0].device_name, "Test Peer");
+        assert!(peers[0].grants.is_empty(), "no grant issued yet");
+    }
+
+    #[test]
+    fn grant_vault_persists_capability_and_surfaces_in_paired_peers() {
+        let rt = build_runtime();
+        let tmp = TempDir::new().unwrap();
+        let state = open_active_state(&rt, &tmp);
+        pair_test_peer(&state, "PEERAAAAAAAAAAAAAAAAAA");
+        rt.grant_vault("PEERAAAAAAAAAAAAAAAAAA", "vault-xyz", Scope::ReadWrite)
+            .unwrap();
+        let peers = rt.list_paired_peers().unwrap();
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].grants.len(), 1);
+        assert_eq!(peers[0].grants[0].vault_id, "vault-xyz");
+        assert_eq!(peers[0].grants[0].scope, "read+write");
+    }
+
+    #[test]
+    fn grant_vault_rejects_unknown_peer() {
+        let rt = build_runtime();
+        let tmp = TempDir::new().unwrap();
+        let _state = open_active_state(&rt, &tmp);
+        let err = rt
+            .grant_vault("UNKNOWNPEERID", "vault-xyz", Scope::Read)
+            .expect_err("unknown peer must error");
+        match err {
+            VaultError::SyncState { msg } => {
+                assert!(msg.contains("unknown") || msg.contains("revoked"))
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revoke_vault_grant_disables_row_and_errors_when_absent() {
+        let rt = build_runtime();
+        let tmp = TempDir::new().unwrap();
+        let state = open_active_state(&rt, &tmp);
+        pair_test_peer(&state, "PEERAAAAAAAAAAAAAAAAAA");
+        rt.grant_vault("PEERAAAAAAAAAAAAAAAAAA", "v1", Scope::Read)
+            .unwrap();
+        rt.revoke_vault_grant("PEERAAAAAAAAAAAAAAAAAA", "v1")
+            .unwrap();
+        let peers = rt.list_paired_peers().unwrap();
+        assert_eq!(peers[0].grants.len(), 0, "revoked grant must drop");
+        // Second revoke: now the row is disabled, the call must error.
+        let err = rt
+            .revoke_vault_grant("PEERAAAAAAAAAAAAAAAAAA", "v1")
+            .expect_err("revoking absent grant must error");
+        match err {
+            VaultError::SyncState { .. } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revoke_peer_marks_revoked_and_disables_all_grants() {
+        let rt = build_runtime();
+        let tmp = TempDir::new().unwrap();
+        let state = open_active_state(&rt, &tmp);
+        pair_test_peer(&state, "PEERAAAAAAAAAAAAAAAAAA");
+        rt.grant_vault("PEERAAAAAAAAAAAAAAAAAA", "v1", Scope::Read)
+            .unwrap();
+        rt.grant_vault("PEERAAAAAAAAAAAAAAAAAA", "v2", Scope::ReadWrite)
+            .unwrap();
+        rt.revoke_peer("PEERAAAAAAAAAAAAAAAAAA").unwrap();
+        // Revoked peer must NOT show in list_paired_peers (only Trusted).
+        let peers = rt.list_paired_peers().unwrap();
+        assert!(peers.is_empty(), "revoked peer hidden from list");
+    }
+
+    #[test]
+    fn revoke_peer_rejects_unknown_id() {
+        let rt = build_runtime();
+        let tmp = TempDir::new().unwrap();
+        let _state = open_active_state(&rt, &tmp);
+        let err = rt
+            .revoke_peer("NEVERSEENPEERID")
+            .expect_err("unknown peer must error");
+        match err {
+            VaultError::SyncState { msg } => assert!(msg.contains("unknown")),
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grant_vault_errors_when_no_vault_open() {
+        let rt = build_runtime();
+        let err = rt
+            .grant_vault("PEER", "v1", Scope::Read)
+            .expect_err("no vault → error");
+        match err {
+            VaultError::SyncState { msg } => assert!(msg.contains("no vault")),
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    // ─── pairing flow ────────────────────────────────────────────────────
+
+    #[test]
+    fn pairing_start_initiator_returns_session_id_pin_and_expiry() {
+        let rt = build_runtime();
+        let dto = rt.pairing_start_initiator().unwrap();
+        assert_eq!(dto.pin.len(), 6);
+        assert!(dto.pin.chars().all(|c| c.is_ascii_digit()));
+        assert!(!dto.session_id.is_empty());
+        assert!(dto.expires_at_unix > 0);
+    }
+
+    #[test]
+    fn pairing_start_responder_validates_pin() {
+        let rt = build_runtime();
+        // Non-numeric PIN must reject before the session is created.
+        let err = rt.pairing_start_responder("abcdef").expect_err("non-numeric");
+        match err {
+            VaultError::SyncState { .. } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+        // Valid 6-digit PIN must succeed.
+        let dto = rt.pairing_start_responder("123456").unwrap();
+        assert!(!dto.session_id.is_empty());
+    }
+
+    #[test]
+    fn pairing_step_returns_awaiting_peer_for_fresh_session() {
+        let rt = build_runtime();
+        let started = rt.pairing_start_initiator().unwrap();
+        let step = rt.pairing_step(&started.session_id, None).unwrap();
+        assert_eq!(step.kind, "awaiting_peer");
+        assert_eq!(step.attempts_remaining, Some(LOCKOUT_AFTER_ATTEMPTS));
+    }
+
+    #[test]
+    fn pairing_step_errors_on_unknown_session() {
+        let rt = build_runtime();
+        let err = rt.pairing_step("not-a-real-session", None).unwrap_err();
+        match err {
+            VaultError::SyncState { msg } => assert!(msg.contains("unknown")),
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pairing_cancel_removes_session() {
+        let rt = build_runtime();
+        let started = rt.pairing_start_initiator().unwrap();
+        rt.pairing_cancel(&started.session_id).unwrap();
+        // After cancel, step on the same id must error with "unknown".
+        let err = rt.pairing_step(&started.session_id, None).unwrap_err();
+        assert!(matches!(err, VaultError::SyncState { .. }));
+    }
+
+    #[test]
+    fn pairing_cancel_is_idempotent_for_unknown_id() {
+        let rt = build_runtime();
+        rt.pairing_cancel("never-existed").unwrap();
+    }
+
+    #[test]
+    fn pairing_confirm_errors_when_no_raw_keys_yet() {
+        let rt = build_runtime();
+        let started = rt.pairing_start_initiator().unwrap();
+        let err = rt.pairing_confirm(&started.session_id).unwrap_err();
+        match err {
+            VaultError::SyncState { msg } => assert!(msg.contains("not yet")),
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pairing_confirm_persists_peer_when_keys_present() {
+        let rt = build_runtime();
+        let tmp = TempDir::new().unwrap();
+        let _state = open_active_state(&rt, &tmp);
+        let raw = RawSharedKeys {
+            k1: [0xAB; 32],
+            k2: [0xCD; 32],
+            id_a: rt.identity.device_id().to_string(),
+            id_b: "TESTPEERIDXXXXXXX".into(),
+        };
+        let session_id =
+            inject_pairing_flow_for_test(&rt, "TESTPEERIDXXXXXXX", raw).unwrap();
+        let dto = rt.pairing_confirm(&session_id).unwrap();
+        assert_eq!(dto.device_id, "TESTPEERIDXXXXXXX");
+        // Peer is now in the trust store (note: pubkey is placeholder
+        // bytes per UI-1's transport-pending caveat, so peer_pubkey()
+        // returns Some for trusted peers regardless of whether keys are
+        // real; the row exists.)
+        let active = rt.active_sync_state().unwrap();
+        let peers = active.list_paired_peers().unwrap();
+        assert!(peers.iter().any(|p| p.peer_device_id == "TESTPEERIDXXXXXXX"));
+    }
+
+    #[test]
+    fn pairing_confirm_errors_on_unknown_session() {
+        let rt = build_runtime();
+        let err = rt.pairing_confirm("not-a-session").unwrap_err();
+        match err {
+            VaultError::SyncState { msg } => assert!(msg.contains("unknown")),
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    // ─── DTO snapshot conversion ─────────────────────────────────────────
+
+    #[test]
+    fn peer_ad_to_dto_renders_addr_as_host_port() {
+        let ad = PeerAd {
+            device_id: "ABCDEFGHIJKLMNOPQRSTUVWX".into(),
+            name: "Alice".into(),
+            vaults: vec![AdvertisedVault {
+                id: "v1".into(),
+                name: "Notes".into(),
+            }],
+            pubkey_fp: "ABCDEFGH".into(),
+            proto: PROTO_VERSION.to_string(),
+            addrs: vec!["192.168.1.10".parse().unwrap()],
+            port: 17091,
+        };
+        let dto = peer_ad_to_dto(&ad);
+        assert_eq!(dto.device_id, "ABCDEFGHIJKLMNOPQRSTUVWX");
+        assert_eq!(dto.device_name, "Alice");
+        assert_eq!(dto.addr, "192.168.1.10:17091");
+        assert_eq!(dto.vaults.len(), 1);
+        assert_eq!(dto.vaults[0].name, "Notes");
+    }
+
+    #[test]
+    fn peer_ad_to_dto_emits_empty_addr_when_no_addresses() {
+        let ad = PeerAd {
+            device_id: "X".into(),
+            name: "X".into(),
+            vaults: vec![],
+            pubkey_fp: "X".into(),
+            proto: PROTO_VERSION.to_string(),
+            addrs: vec![],
+            port: 17091,
+        };
+        let dto = peer_ad_to_dto(&ad);
+        assert_eq!(dto.addr, "");
+    }
+
+    #[test]
+    fn snapshot_signature_stable_under_reorder() {
+        let mk = |id: &str| DiscoveredPeerDto {
+            device_id: id.into(),
+            device_name: "x".into(),
+            vaults: vec![],
+            addr: "".into(),
+        };
+        let a = vec![mk("A"), mk("B"), mk("C")];
+        let b = vec![mk("C"), mk("A"), mk("B")];
+        assert_eq!(snapshot_signature(&a), snapshot_signature(&b));
+        let c = vec![mk("A"), mk("B")];
+        assert_ne!(snapshot_signature(&a), snapshot_signature(&c));
+    }
+}
+

--- a/src-tauri/src/commands/sync_cmds.rs
+++ b/src-tauri/src/commands/sync_cmds.rs
@@ -331,8 +331,19 @@ pub struct SyncRuntime {
 
 impl SyncRuntime {
     /// Build with the OS keychain backing the identity. Used by `lib.rs`.
+    ///
+    /// Honors `VAULTCORE_KEYCHAIN_ACCOUNT` if set — overrides the keychain
+    /// account name so two dev instances on the same host can pull
+    /// distinct device identities (two-on-one-host UAT). Production users
+    /// never set this; default behavior is unchanged.
     pub fn new() -> Result<Self, VaultError> {
-        Self::with_keystore(Box::new(OsKeychainStore::default()))
+        let store: Box<dyn KeyStore> = match std::env::var("VAULTCORE_KEYCHAIN_ACCOUNT") {
+            Ok(account) if !account.is_empty() => {
+                Box::new(OsKeychainStore::with_account(account))
+            }
+            _ => Box::new(OsKeychainStore::default()),
+        };
+        Self::with_keystore(store)
     }
 
     /// Test constructor. Drops the OS keychain in favor of an in-memory

--- a/src-tauri/src/commands/sync_cmds_pairing_tests.rs
+++ b/src-tauri/src/commands/sync_cmds_pairing_tests.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
-use crate::commands::sync_cmds::SyncRuntime;
+use crate::commands::sync_cmds::{parse_peer_addr_string, SyncRuntime, DEFAULT_PAIRING_PORT};
 use crate::sync::capability::Scope;
 use crate::sync::clock::TestClock;
 use crate::sync::history::HistoryConfig;
@@ -288,4 +288,180 @@ fn grant_vault_after_pair_persists_capability_on_both_sides() {
 
     a.pairing_cancel(&sid_a).unwrap();
     b.pairing_cancel(&sid_b).unwrap();
+}
+
+// ─── UI-7: manual peer-addr entry path (Android pre-NSD bridge) ────────────
+//
+// The UI on Android can't see peers through mDNS today, so the user types
+// the other device's IP into a text field and hits "Mit IP koppeln". The
+// IPC command parses that string into a SocketAddr and dials. These tests
+// cover the parser plus a full pairing run that goes through that exact
+// string-keyed path — the manual UAT case the human couldn't drive on the
+// phone.
+
+#[test]
+fn parse_peer_addr_appends_default_port_when_only_host_supplied() {
+    let parsed = parse_peer_addr_string(Some("127.0.0.1")).unwrap();
+    assert_eq!(parsed, Some(SocketAddr::from(([127, 0, 0, 1], DEFAULT_PAIRING_PORT))));
+}
+
+#[test]
+fn parse_peer_addr_keeps_explicit_port() {
+    let parsed = parse_peer_addr_string(Some("192.168.1.42:9999")).unwrap();
+    assert_eq!(parsed, Some(SocketAddr::from(([192, 168, 1, 42], 9999))));
+}
+
+#[test]
+fn parse_peer_addr_treats_blank_as_none() {
+    assert!(parse_peer_addr_string(None).unwrap().is_none());
+    assert!(parse_peer_addr_string(Some("")).unwrap().is_none());
+    assert!(parse_peer_addr_string(Some("   ")).unwrap().is_none());
+}
+
+#[test]
+fn parse_peer_addr_trims_surrounding_whitespace() {
+    let parsed = parse_peer_addr_string(Some("  10.0.0.5  ")).unwrap();
+    assert_eq!(parsed, Some(SocketAddr::from(([10, 0, 0, 5], DEFAULT_PAIRING_PORT))));
+}
+
+#[test]
+fn parse_peer_addr_rejects_garbage() {
+    let err = parse_peer_addr_string(Some("not-an-ip:99999999")).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(msg.contains("invalid peer_addr"), "got: {msg}");
+}
+
+#[test]
+fn parse_peer_addr_handles_bracketed_ipv6() {
+    let parsed = parse_peer_addr_string(Some("[::1]:1234")).unwrap();
+    let sa = parsed.expect("Some");
+    assert_eq!(sa.port(), 1234);
+    assert!(sa.is_ipv6());
+
+    let parsed_bare = parse_peer_addr_string(Some("[::1]")).unwrap();
+    let sa_bare = parsed_bare.expect("Some");
+    assert_eq!(sa_bare.port(), DEFAULT_PAIRING_PORT);
+    assert!(sa_bare.is_ipv6());
+}
+
+/// End-to-end repro of the Android-flow the human couldn't drive: the
+/// initiator binds an ephemeral port (substituting for a fixed
+/// `DEFAULT_PAIRING_PORT` since CI may run multiple cases in parallel),
+/// then the responder pairs by passing the address as a *string* through
+/// the same parser the Tauri command uses. This is the path the
+/// `MobileSettingsSheet` "Mit IP koppeln" button takes when the user
+/// types `127.0.0.1` (or `127.0.0.1:<port>`) and hits the button.
+#[test]
+fn manual_addr_string_path_completes_full_pairing() {
+    let a = build_runtime();
+    let b = build_runtime();
+    let tmp_a = TempDir::new().unwrap();
+    let tmp_b = TempDir::new().unwrap();
+    let _state_a = open_active_state(&a, &tmp_a);
+    let _state_b = open_active_state(&b, &tmp_b);
+
+    // Initiator side (Mac in the user's case): user clicked "Neues Gerät
+    // koppeln…" → "Dieses Gerät zeigt den PIN". The PIN renders, the
+    // listener binds.
+    let pin = "987654";
+    let init_dto = a
+        .pairing_start_initiator(Some(pin.into()), Some(0))
+        .expect("start initiator");
+    let port = a
+        .pairing_listener_port_for_test(&init_dto.session_id)
+        .expect("listener port available");
+
+    // Responder side (Phone in the user's case): user typed
+    // "127.0.0.1:<port>" into the manual field and hit "Mit IP koppeln".
+    // The Tauri command runs `parse_peer_addr_string` on that input, then
+    // calls `pairing_start_responder` with the parsed addr.
+    let typed_addr = format!("127.0.0.1:{port}");
+    let parsed_addr = parse_peer_addr_string(Some(&typed_addr))
+        .expect("string parses")
+        .expect("Some(addr)");
+    let resp_dto = b
+        .pairing_start_responder(pin, Some(a.self_identity().device_id), Some(parsed_addr))
+        .expect("start responder via manual addr");
+
+    // Both sides reach awaiting_confirmation — proves PAKE+attestation ran.
+    assert!(
+        wait_for_kind(&a, &init_dto.session_id, "awaiting_confirmation", PAIR_DEADLINE),
+        "initiator must reach awaiting_confirmation via manual-addr path"
+    );
+    assert!(
+        wait_for_kind(&b, &resp_dto.session_id, "awaiting_confirmation", PAIR_DEADLINE),
+        "responder must reach awaiting_confirmation via manual-addr path"
+    );
+
+    // User clicks "Bestätigen" on both sides → both go to complete.
+    let _ = a.pairing_confirm(&init_dto.session_id).unwrap();
+    let _ = b.pairing_confirm(&resp_dto.session_id).unwrap();
+    assert_eq!(
+        a.pairing_step(&init_dto.session_id, None).unwrap().kind,
+        "complete"
+    );
+    assert_eq!(
+        b.pairing_step(&resp_dto.session_id, None).unwrap().kind,
+        "complete"
+    );
+}
+
+/// Same as above but the responder supplies the host *without* a port,
+/// matching the user typing just `192.168.1.42` and relying on the
+/// `DEFAULT_PAIRING_PORT` default. Asserts the parser-side contract only —
+/// the full pairing path with 17092 is covered manually by the human UAT.
+#[test]
+fn host_only_string_falls_back_to_default_port() {
+    let parsed = parse_peer_addr_string(Some("127.0.0.1"))
+        .expect("parses")
+        .expect("Some");
+    assert_eq!(parsed.port(), DEFAULT_PAIRING_PORT);
+    assert_eq!(parsed.ip().to_string(), "127.0.0.1");
+}
+
+/// Wrong PIN entered in the manual-addr flow — the responder's PAKE step
+/// derives a different k2, the key-confirmation MAC mismatches, and
+/// `pairing_step` flips to `failed` with `attempts_remaining` decremented.
+/// Replicates the negative path UAT step 13 ("falscher PIN") that the
+/// human couldn't drive on the phone.
+#[test]
+fn manual_addr_wrong_pin_fails_at_key_confirmation() {
+    let a = build_runtime();
+    let b = build_runtime();
+    let tmp_a = TempDir::new().unwrap();
+    let tmp_b = TempDir::new().unwrap();
+    let _ = open_active_state(&a, &tmp_a);
+    let _ = open_active_state(&b, &tmp_b);
+
+    let init_dto = a
+        .pairing_start_initiator(Some("111111".into()), Some(0))
+        .expect("start initiator");
+    let port = a
+        .pairing_listener_port_for_test(&init_dto.session_id)
+        .expect("listener port");
+
+    let typed = format!("127.0.0.1:{port}");
+    let parsed = parse_peer_addr_string(Some(&typed)).unwrap().unwrap();
+
+    // Responder types the wrong PIN.
+    let resp_dto = b
+        .pairing_start_responder("222222", Some(a.self_identity().device_id), Some(parsed))
+        .expect("start responder with wrong pin");
+
+    // Engine surfaces failure on both sides.
+    assert!(
+        wait_for_kind(&b, &resp_dto.session_id, "failed", PAIR_DEADLINE),
+        "responder must surface 'failed' on PIN mismatch"
+    );
+    let step_b = b.pairing_step(&resp_dto.session_id, None).unwrap();
+    assert_eq!(step_b.kind, "failed");
+    assert_eq!(
+        step_b.attempts_remaining,
+        Some(LOCKOUT_AFTER_ATTEMPTS - 1),
+        "one failed attempt → N-1 remaining"
+    );
+
+    // Initiator listener may still be hanging; cancel both to clean up.
+    let _ = a.pairing_cancel(&init_dto.session_id);
+    let _ = b.pairing_cancel(&resp_dto.session_id);
 }

--- a/src-tauri/src/commands/sync_cmds_pairing_tests.rs
+++ b/src-tauri/src/commands/sync_cmds_pairing_tests.rs
@@ -1,0 +1,291 @@
+//! UI-1.6 — IPC pairing-engine integration tests.
+//!
+//! Two `SyncRuntime`s, both backed by `MemoryKeyStore`, paired over real
+//! loopback TCP through the Tauri IPC surface. No mocks: the same
+//! `pairing_step` / `pairing_confirm` / `pairing_grant_vault` entry points
+//! the UI calls drive PAKE → Noise XX → long-term-key attestation →
+//! capability exchange end-to-end.
+//!
+//! The initiator's pairing listener binds an ephemeral port (passed in
+//! through the test-only `bind_port_override` arg on `pairing_start_initiator`)
+//! and the responder's worker dials it directly via `peer_addr_override`.
+//! Production resolves the same address via mDNS — the test bypass keeps
+//! the suite mDNS-free while exercising the same crypto + state machine.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+use crate::commands::sync_cmds::SyncRuntime;
+use crate::sync::capability::Scope;
+use crate::sync::clock::TestClock;
+use crate::sync::history::HistoryConfig;
+use crate::sync::pairing::LOCKOUT_AFTER_ATTEMPTS;
+use crate::sync::state::SyncState;
+
+/// PAKE+attestation completes well under a second on loopback; allow 5 s
+/// for slow CI. If it ever takes longer the test fails fast rather than
+/// hanging the suite.
+const PAIR_DEADLINE: Duration = Duration::from_secs(5);
+
+fn build_runtime() -> Arc<SyncRuntime> {
+    Arc::new(SyncRuntime::new_for_test().expect("runtime"))
+}
+
+fn open_active_state(rt: &SyncRuntime, tmp: &TempDir) -> Arc<SyncState> {
+    let metadata = tmp.path().join(".vaultcore");
+    std::fs::create_dir_all(&metadata).unwrap();
+    let state = Arc::new(
+        SyncState::open_with(
+            &metadata,
+            rt.self_identity().device_id,
+            Arc::new(TestClock::new(1_700_000_000)),
+            HistoryConfig::default(),
+        )
+        .expect("open sync state"),
+    );
+    rt.set_active_sync_state(Some(Arc::clone(&state))).unwrap();
+    state
+}
+
+/// Block until `pairing_step` reports `kind == expected`, or `deadline`
+/// elapses. Polls every 25 ms — fast enough to feel real-time, slow enough
+/// to keep CI CPU usage trivial.
+fn wait_for_kind(
+    rt: &SyncRuntime,
+    session_id: &str,
+    expected: &str,
+    deadline: Duration,
+) -> bool {
+    let stop_at = Instant::now() + deadline;
+    while Instant::now() < stop_at {
+        if let Ok(step) = rt.pairing_step(session_id, None) {
+            if step.kind == expected {
+                return true;
+            }
+            if step.kind == "failed" && expected != "failed" {
+                return false;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    false
+}
+
+/// Bring up two runtimes, kick off pairing on both sides, return
+/// (initiator_session_id, responder_session_id, port). Both sides must
+/// reach `awaiting_confirmation` before the helper returns.
+fn pair_through_ipc(
+    a: &Arc<SyncRuntime>,
+    b: &Arc<SyncRuntime>,
+    pin: &str,
+) -> (String, String, u16) {
+    // Bind an ephemeral pairing port on A (test-port=0) so multiple test
+    // cases can run in parallel without clashing on DEFAULT_PAIRING_PORT.
+    let init_dto = a
+        .pairing_start_initiator(Some(pin.into()), Some(0))
+        .expect("start initiator");
+    let port = pairing_listener_port(a, &init_dto.session_id);
+    let dial_addr: SocketAddr = ([127, 0, 0, 1], port).into();
+
+    let resp_dto = b
+        .pairing_start_responder(
+            pin,
+            Some(a.self_identity().device_id),
+            Some(dial_addr),
+        )
+        .expect("start responder");
+    (init_dto.session_id, resp_dto.session_id, port)
+}
+
+/// Test-only: dig the bound listener port out of the initiator session.
+/// We re-export the listener Arc through a public test-helper on
+/// SyncRuntime to avoid leaking PairingFlow internals.
+fn pairing_listener_port(rt: &SyncRuntime, session_id: &str) -> u16 {
+    rt.pairing_listener_port_for_test(session_id)
+        .expect("listener port available immediately after start")
+}
+
+#[test]
+fn two_runtimes_pair_via_ipc_round_trip() {
+    let a = build_runtime();
+    let b = build_runtime();
+    let tmp_a = TempDir::new().unwrap();
+    let tmp_b = TempDir::new().unwrap();
+    let state_a = open_active_state(&a, &tmp_a);
+    let state_b = open_active_state(&b, &tmp_b);
+
+    let (sid_a, sid_b, _port) = pair_through_ipc(&a, &b, "246810");
+
+    // Both workers must converge to awaiting_confirmation.
+    assert!(
+        wait_for_kind(&a, &sid_a, "awaiting_confirmation", PAIR_DEADLINE),
+        "initiator must reach awaiting_confirmation"
+    );
+    assert!(
+        wait_for_kind(&b, &sid_b, "awaiting_confirmation", PAIR_DEADLINE),
+        "responder must reach awaiting_confirmation"
+    );
+
+    // Fingerprint surfaces on both sides.
+    let step_a = a.pairing_step(&sid_a, None).unwrap();
+    let step_b = b.pairing_step(&sid_b, None).unwrap();
+    assert!(
+        step_a.peer_fingerprint.as_deref().map(|s| s.len() == 8).unwrap_or(false),
+        "initiator fingerprint must be 8-char base32 prefix, got {:?}",
+        step_a.peer_fingerprint
+    );
+    assert!(step_b.peer_fingerprint.is_some());
+
+    // Engine has already persisted both peer rows under PeerTrust::Trusted.
+    let pk_b_on_a = state_a
+        .peer_pubkey(&b.self_identity().device_id)
+        .unwrap()
+        .expect("B's pubkey on A");
+    assert_eq!(pk_b_on_a.len(), 32);
+    let pk_a_on_b = state_b
+        .peer_pubkey(&a.self_identity().device_id)
+        .unwrap()
+        .expect("A's pubkey on B");
+    assert_eq!(pk_a_on_b.len(), 32);
+
+    // User confirms on both sides → both transition to `complete`.
+    let _ = a.pairing_confirm(&sid_a).unwrap();
+    let _ = b.pairing_confirm(&sid_b).unwrap();
+    assert_eq!(a.pairing_step(&sid_a, None).unwrap().kind, "complete");
+    assert_eq!(b.pairing_step(&sid_b, None).unwrap().kind, "complete");
+
+    a.pairing_cancel(&sid_a).unwrap();
+    b.pairing_cancel(&sid_b).unwrap();
+}
+
+#[test]
+fn mismatched_pin_increments_lockout_via_ipc() {
+    let a = build_runtime();
+    let b = build_runtime();
+    let tmp_a = TempDir::new().unwrap();
+    let tmp_b = TempDir::new().unwrap();
+    let _state_a = open_active_state(&a, &tmp_a);
+    let _state_b = open_active_state(&b, &tmp_b);
+
+    // Initiator uses "111111", responder uses "222222" — PAKE itself
+    // succeeds (it doesn't error on wrong PIN, keys silently diverge),
+    // but the key-confirmation MAC must fail.
+    let init_dto = a
+        .pairing_start_initiator(Some("111111".into()), Some(0))
+        .expect("start initiator");
+    let port = pairing_listener_port(&a, &init_dto.session_id);
+    let dial_addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    let resp_dto = b
+        .pairing_start_responder(
+            "222222",
+            Some(a.self_identity().device_id),
+            Some(dial_addr),
+        )
+        .expect("start responder");
+
+    // Both sides must reach `failed` (key-confirmation mismatch).
+    assert!(
+        wait_for_kind(&a, &init_dto.session_id, "failed", PAIR_DEADLINE),
+        "initiator must reach failed on PIN mismatch"
+    );
+    let step_a = a.pairing_step(&init_dto.session_id, None).unwrap();
+    assert_eq!(step_a.kind, "failed");
+    // After one failure, attempts_remaining must have decreased from
+    // LOCKOUT_AFTER_ATTEMPTS (3) to 2.
+    assert_eq!(
+        step_a.attempts_remaining,
+        Some(LOCKOUT_AFTER_ATTEMPTS - 1),
+        "first failure must consume one attempt"
+    );
+
+    a.pairing_cancel(&init_dto.session_id).unwrap();
+    b.pairing_cancel(&resp_dto.session_id).unwrap();
+}
+
+#[test]
+fn three_failed_attempts_locks_out_pairing_step() {
+    let a = build_runtime();
+    let init_dto = a
+        .pairing_start_initiator(Some("111111".into()), Some(0))
+        .expect("start initiator");
+    // Drive the underlying PairingSession to lockout via the test-only
+    // helper. `pairing_tests::three_failed_attempts_locks_out` already
+    // covers the wire-driven lockout path at the unit-test level — this
+    // test focuses on whether `pairing_step` correctly surfaces a
+    // locked-out session through the IPC.
+    a.force_lockout_for_test(&init_dto.session_id)
+        .expect("force lockout");
+    let step = a.pairing_step(&init_dto.session_id, None).unwrap();
+    assert_eq!(step.kind, "failed");
+    assert_eq!(step.attempts_remaining, Some(0));
+    a.pairing_cancel(&init_dto.session_id).unwrap();
+}
+
+#[test]
+fn pairing_cancel_closes_stream_and_drops_session() {
+    let a = build_runtime();
+    let tmp_a = TempDir::new().unwrap();
+    let _state_a = open_active_state(&a, &tmp_a);
+    let init_dto = a
+        .pairing_start_initiator(Some("314159".into()), Some(0))
+        .expect("start initiator");
+    a.pairing_cancel(&init_dto.session_id).unwrap();
+    // Session must be gone — pairing_step returns "unknown".
+    let err = a
+        .pairing_step(&init_dto.session_id, None)
+        .expect_err("session must be dropped");
+    match err {
+        crate::error::VaultError::SyncState { msg } => assert!(msg.contains("unknown")),
+        other => panic!("wrong error: {other:?}"),
+    }
+}
+
+#[test]
+fn grant_vault_after_pair_persists_capability_on_both_sides() {
+    let a = build_runtime();
+    let b = build_runtime();
+    let tmp_a = TempDir::new().unwrap();
+    let tmp_b = TempDir::new().unwrap();
+    let state_a = open_active_state(&a, &tmp_a);
+    let state_b = open_active_state(&b, &tmp_b);
+
+    let (sid_a, sid_b, _port) = pair_through_ipc(&a, &b, "424242");
+
+    assert!(wait_for_kind(&a, &sid_a, "awaiting_confirmation", PAIR_DEADLINE));
+    assert!(wait_for_kind(&b, &sid_b, "awaiting_confirmation", PAIR_DEADLINE));
+
+    // Confirm before the grant to mirror the UI flow (user clicks
+    // "Bestätigen", then grant exchange runs).
+    let _ = a.pairing_confirm(&sid_a).unwrap();
+    let _ = b.pairing_confirm(&sid_b).unwrap();
+
+    // Run the grant exchange in two threads so initiator-send-first /
+    // responder-recv-first don't deadlock on the same IPC thread.
+    let b_t = Arc::clone(&b);
+    let sid_b_t = sid_b.clone();
+    let h_b = std::thread::spawn(move || {
+        b_t.pairing_grant_vault(&sid_b_t, "vault-shared", Scope::ReadWrite)
+            .expect("b grant")
+    });
+    a.pairing_grant_vault(&sid_a, "vault-shared", Scope::ReadWrite)
+        .expect("a grant");
+    h_b.join().expect("b thread");
+
+    // Each side now holds the *peer's* signed cap for "vault-shared".
+    let cap_a = state_a
+        .vault_grant("vault-shared", &b.self_identity().device_id)
+        .unwrap()
+        .expect("A holds B's cap");
+    let cap_b = state_b
+        .vault_grant("vault-shared", &a.self_identity().device_id)
+        .unwrap()
+        .expect("B holds A's cap");
+    assert!(!cap_a.signature.is_empty());
+    assert!(!cap_b.signature.is_empty());
+
+    a.pairing_cancel(&sid_a).unwrap();
+    b.pairing_cancel(&sid_b).unwrap();
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -115,6 +115,13 @@ pub enum VaultError {
     /// prose into a `PermissionDenied { path }` field.
     #[error("Operation '{operation}' is not yet supported on Android.")]
     OperationUnsupportedOnAndroid { operation: String },
+
+    /// #416: sync-state SQLite / serialization / blob-store failure.
+    /// Catch-all for the sync metadata layer; carries a plain message
+    /// because the frontend never routes on it (sync runs in the
+    /// background and surfaces a status bar, not a per-error toast).
+    #[error("Sync state error: {msg}")]
+    SyncState { msg: String },
 }
 
 impl VaultError {
@@ -139,6 +146,7 @@ impl VaultError {
             Self::VaultPermissionRevoked { .. } => "VaultPermissionRevoked",
             Self::EncryptionUnsupportedOnAndroid => "EncryptionUnsupportedOnAndroid",
             Self::OperationUnsupportedOnAndroid { .. } => "OperationUnsupportedOnAndroid",
+            Self::SyncState { .. } => "SyncState",
         }
     }
 
@@ -178,7 +186,8 @@ impl VaultError {
             | Self::WrongPassword
             | Self::CryptoError { .. }
             | Self::PickerFailed { .. }
-            | Self::EncryptionUnsupportedOnAndroid => None,
+            | Self::EncryptionUnsupportedOnAndroid
+            | Self::SyncState { .. } => None,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -260,6 +260,7 @@ pub fn run() {
             commands::sync_cmds::sync_pairing_step,
             commands::sync_cmds::sync_pairing_confirm,
             commands::sync_cmds::sync_pairing_cancel,
+            commands::sync_cmds::sync_pairing_grant_vault,
             commands::sync_cmds::sync_grant_vault,
             commands::sync_cmds::sync_revoke_peer,
             commands::sync_cmds::sync_revoke_vault_grant,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod merge;
 pub mod indexer;
 pub mod encryption;
 pub mod storage;
+pub mod sync;
 
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -225,6 +225,8 @@ pub fn run() {
             commands::encryption::export_decrypted_file,
             commands::picker::pick_vault_folder,
             commands::picker::pick_save_path,
+            commands::sync::sync_set_discoverable,
+            commands::sync::sync_get_discoverable,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -164,15 +164,39 @@ pub fn run() {
     {
         builder = builder.plugin(commands::picker::android_init());
     }
+    // #UI-1: bring up the sync runtime (identity, mDNS, pairing sessions)
+    // before the Tauri builder consumes the closure. Identity load can
+    // genuinely fail (keychain locked) — log and skip the runtime in that
+    // case rather than aborting startup. The IPC commands all gate on
+    // `tauri::State<'_, Arc<SyncRuntime>>` so a missing manage() means
+    // those commands return a clean "state not found" error which the
+    // frontend renders as "sync unavailable". Non-sync features are
+    // unaffected.
+    let sync_runtime = match commands::sync_cmds::SyncRuntime::new() {
+        Ok(r) => Some(std::sync::Arc::new(r)),
+        Err(e) => {
+            log::warn!("sync runtime unavailable: {e}");
+            None
+        }
+    };
+
     builder
         .manage(VaultState::default())
-        .setup(|app| {
+        .setup(move |app| {
             // #353 one-shot: the removed semantic-search toggle persisted
             // its state in `<app_data_dir>/semantic-enabled.json`. Purge
             // that file on boot so upgraded installs leave no traces.
             // Best-effort — missing file is the common case.
             if let Ok(dir) = app.path().app_data_dir() {
                 commands::vault::purge_legacy_semantic_toggle_file(&dir);
+            }
+            // #UI-1: register the sync runtime in Tauri state and start
+            // the debounced peers-discovered emitter. The emitter
+            // observes `runtime.discoverable()` and only fires while
+            // mDNS is active, so it's safe to start unconditionally.
+            if let Some(rt) = sync_runtime.clone() {
+                rt.start_emitter(app.handle().clone());
+                app.manage(rt);
             }
             Ok(())
         })
@@ -225,8 +249,20 @@ pub fn run() {
             commands::encryption::export_decrypted_file,
             commands::picker::pick_vault_folder,
             commands::picker::pick_save_path,
-            commands::sync::sync_set_discoverable,
-            commands::sync::sync_get_discoverable,
+            commands::sync_cmds::sync_get_self_identity,
+            commands::sync_cmds::sync_set_device_name,
+            commands::sync_cmds::sync_get_discoverable,
+            commands::sync_cmds::sync_set_discoverable,
+            commands::sync_cmds::sync_list_discovered_peers,
+            commands::sync_cmds::sync_list_paired_peers,
+            commands::sync_cmds::sync_pairing_start_initiator,
+            commands::sync_cmds::sync_pairing_start_responder,
+            commands::sync_cmds::sync_pairing_step,
+            commands::sync_cmds::sync_pairing_confirm,
+            commands::sync_cmds::sync_pairing_cancel,
+            commands::sync_cmds::sync_grant_vault,
+            commands::sync_cmds::sync_revoke_peer,
+            commands::sync_cmds::sync_revoke_vault_grant,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/sync/capability.rs
+++ b/src-tauri/src/sync/capability.rs
@@ -1,0 +1,150 @@
+//! Per-vault capability tokens (epic #73 sub-issue #418).
+//!
+//! Tokens are **the** security boundary for cross-device sync: every
+//! request to read or write a vault validates a `Capability` issued by
+//! the vault owner. Device-trust (PAKE pairing) authenticates *who* is
+//! talking; capabilities authorize *what* they can access.
+//!
+//! Reserved fields (`format_version`, `requires_unlock`, `wrapped_key`,
+//! `expires_at`) ride along on the struct even though v1 sets them to
+//! null/0 — forward-flex for unforeseen future per-grant gating.
+//! **Do not remove them.**
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+use crate::error::VaultError;
+
+/// Sync access level. Stored as TEXT in `sync_vault_grants.scope`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Scope {
+    Read,
+    ReadWrite,
+}
+
+impl Scope {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::ReadWrite => "read+write",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "read" => Some(Self::Read),
+            "read+write" => Some(Self::ReadWrite),
+            _ => None,
+        }
+    }
+}
+
+/// Token body — bincode-serialized + signed. Field order is
+/// **load-bearing** for signature stability; do not reorder. Add new
+/// fields after `wrapped_key` and bump `format_version`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityBody {
+    pub local_vault_id: String,
+    pub peer_device_id: String,
+    pub peer_vault_id: String,
+    pub scope: Scope,
+    pub format_version: u32,
+    pub requires_unlock: u32,
+    pub wrapped_key: Option<Vec<u8>>,
+    pub expires_at: Option<i64>,
+}
+
+impl CapabilityBody {
+    /// v1 issuance: `format_version = 1`, no unlock requirement, no wrapped
+    /// key, no explicit expiry. The reserved fields are kept on the wire
+    /// so future v2 verifiers can refuse v1 tokens or vice versa cleanly.
+    pub fn issue_v1(
+        local_vault_id: impl Into<String>,
+        peer_device_id: impl Into<String>,
+        peer_vault_id: impl Into<String>,
+        scope: Scope,
+    ) -> Self {
+        Self {
+            local_vault_id: local_vault_id.into(),
+            peer_device_id: peer_device_id.into(),
+            peer_vault_id: peer_vault_id.into(),
+            scope,
+            format_version: 1,
+            requires_unlock: 0,
+            wrapped_key: None,
+            expires_at: None,
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("bincode of CapabilityBody is infallible")
+    }
+}
+
+/// Signed token. `body` is bincode bytes (so the signature covers the
+/// exact byte layout — re-serializing on the verifier side would risk
+/// drift if a future bincode revision changed encoding). `signature`
+/// is the Ed25519 signature (64 bytes) of `body` under the issuing
+/// device's key — held as `Vec<u8>` because serde lacks a default
+/// `[u8; 64]` impl; the verifier reconstructs the fixed-size signature
+/// at check time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capability {
+    pub body: Vec<u8>,
+    pub signature: Vec<u8>,
+}
+
+impl Capability {
+    /// Sign `body` under `signing_key` and emit a transmittable token.
+    pub fn sign(body: &CapabilityBody, signing_key: &SigningKey) -> Self {
+        let body_bytes = body.to_bytes();
+        let sig = signing_key.sign(&body_bytes);
+        Self {
+            body: body_bytes,
+            signature: sig.to_bytes().to_vec(),
+        }
+    }
+
+    /// Verify the signature under `pubkey`. Decodes the body on success
+    /// so the caller can act on the parsed fields.
+    pub fn verify(&self, pubkey: &VerifyingKey) -> Result<CapabilityBody, VaultError> {
+        if self.signature.len() != 64 {
+            return Err(VaultError::SyncState {
+                msg: format!("capability signature wrong length: {}", self.signature.len()),
+            });
+        }
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes.copy_from_slice(&self.signature);
+        let sig = Signature::from_bytes(&sig_bytes);
+        pubkey
+            .verify(&self.body, &sig)
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("capability signature: {e}"),
+            })?;
+        let body: CapabilityBody =
+            bincode::deserialize(&self.body).map_err(|e| VaultError::SyncState {
+                msg: format!("capability body decode: {e}"),
+            })?;
+        if body.format_version != 1 {
+            return Err(VaultError::SyncState {
+                msg: format!(
+                    "unsupported capability format_version {}",
+                    body.format_version
+                ),
+            });
+        }
+        Ok(body)
+    }
+
+    /// Wire-format encode the whole token (body + signature) as a single
+    /// blob suitable for the `capability_token` BLOB column.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("bincode of Capability is infallible")
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, VaultError> {
+        bincode::deserialize(bytes).map_err(|e| VaultError::SyncState {
+            msg: format!("capability decode: {e}"),
+        })
+    }
+}

--- a/src-tauri/src/sync/clock.rs
+++ b/src-tauri/src/sync/clock.rs
@@ -1,0 +1,57 @@
+//! Injectable wall clock for time-dependent code paths (PIN expiry,
+//! tombstone TTL, history retention timestamps). Production uses
+//! `SystemClock`; tests use `TestClock` and call `advance` instead of
+//! `std::thread::sleep`.
+
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub trait Clock: Send + Sync {
+    /// Wall time in seconds since UNIX epoch. Seconds (not millis) match
+    /// the SQLite `INTEGER` columns in epic #73's schema (`paired_at`,
+    /// `last_seen`, `expires_at`, `retained_at`, `last_synced_wall_time`).
+    fn now_secs(&self) -> i64;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_secs(&self) -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+    }
+}
+
+/// Test-only clock with manual advance. Internally locked so a `&Clock`
+/// reference shared across threads still observes a monotonic value
+/// after `advance`.
+#[derive(Debug)]
+pub struct TestClock {
+    secs: Mutex<i64>,
+}
+
+impl TestClock {
+    pub fn new(initial_secs: i64) -> Self {
+        Self {
+            secs: Mutex::new(initial_secs),
+        }
+    }
+
+    pub fn advance(&self, by: Duration) {
+        let mut g = self.secs.lock().expect("test clock mutex");
+        *g += by.as_secs() as i64;
+    }
+
+    pub fn set(&self, secs: i64) {
+        *self.secs.lock().expect("test clock mutex") = secs;
+    }
+}
+
+impl Clock for TestClock {
+    fn now_secs(&self) -> i64 {
+        *self.secs.lock().expect("test clock mutex")
+    }
+}

--- a/src-tauri/src/sync/conflict.rs
+++ b/src-tauri/src/sync/conflict.rs
@@ -1,0 +1,237 @@
+//! Conflict resolution for concurrent writes (epic #73 sub-issue #420).
+//!
+//! Two paths:
+//!   - **3-way merge** when the GCA (greatest common ancestor) is in
+//!     `sync_history`. Calls `crate::merge::three_way_merge` directly —
+//!     the editor's `merge_external_change` Tauri command is left
+//!     untouched (different semantics: editor-side disk-conflict vs.
+//!     network-arrival).
+//!   - **Conflict copy** when the GCA isn't in history (long divergence
+//!     beyond the last-2-versions LRU window). Writes a copy with the
+//!     Obsidian-compatible filename
+//!     `note (conflict from <peer-name> YYYY-MM-DD HH:MM).md` and keeps
+//!     the local file untouched.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::VaultError;
+use crate::merge::{three_way_merge, MergeOutcome};
+
+use super::state::{FileRecord, SyncState};
+use super::{ContentHash, VersionVector};
+
+/// What the resolver decided. The caller (engine) acts on the result —
+/// writing the merged content, registering write-ignore, etc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveOutcome {
+    /// Clean 3-way merge produced a single canonical content. Caller
+    /// writes it to the working file and persists the merged VV.
+    Merged {
+        merged_content: String,
+        merged_vv: VersionVector,
+    },
+    /// 3-way merge found overlapping edits → keep local + write a
+    /// conflict copy of the remote.
+    OverlapKeptLocal {
+        copy_path: PathBuf,
+        copy_content: Vec<u8>,
+    },
+    /// History didn't contain the GCA → fall back to conflict copy.
+    /// Same disk action as `OverlapKeptLocal` but distinct so the UI
+    /// can render different copy ("we couldn't auto-merge" vs.
+    /// "your changes overlapped").
+    NoBaseInHistory {
+        copy_path: PathBuf,
+        copy_content: Vec<u8>,
+    },
+}
+
+/// Resolve a concurrent write. Caller has already determined the VVs
+/// are concurrent (via `SyncState::apply_remote_write` returning
+/// `ApplyOutcome::Conflict`). `local` is the on-disk content; `remote`
+/// the inbound bytes. `peer_name` is the human-readable name used in
+/// the conflict-copy filename.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve(
+    state: &SyncState,
+    vault_id: &str,
+    rel_path: &Path,
+    local_record: &FileRecord,
+    local_content: &[u8],
+    remote_content: &[u8],
+    remote_vv: &VersionVector,
+    peer_name: &str,
+) -> Result<ResolveOutcome, VaultError> {
+    // GCA = per-peer min of the two VVs. Look up its content hash via
+    // the history retained for this `(vault_id, path)`.
+    let gca = local_record.version_vector.gca(remote_vv);
+    let path_str = rel_path.to_string_lossy().to_string();
+    let base_bytes = match find_base_in_history(state, vault_id, &path_str, &gca)? {
+        Some(b) => b,
+        None => {
+            return Ok(ResolveOutcome::NoBaseInHistory {
+                copy_path: conflict_copy_path(rel_path, peer_name, state),
+                copy_content: remote_content.to_vec(),
+            });
+        }
+    };
+
+    // 3-way merge over UTF-8. Bail to conflict-copy if any side isn't
+    // valid UTF-8 (binary attachment) — the editor merge function only
+    // makes sense on text.
+    let local_str = match std::str::from_utf8(local_content) {
+        Ok(s) => s,
+        Err(_) => {
+            return Ok(ResolveOutcome::NoBaseInHistory {
+                copy_path: conflict_copy_path(rel_path, peer_name, state),
+                copy_content: remote_content.to_vec(),
+            });
+        }
+    };
+    let remote_str = match std::str::from_utf8(remote_content) {
+        Ok(s) => s,
+        Err(_) => {
+            return Ok(ResolveOutcome::NoBaseInHistory {
+                copy_path: conflict_copy_path(rel_path, peer_name, state),
+                copy_content: remote_content.to_vec(),
+            });
+        }
+    };
+    let base_str = match std::str::from_utf8(&base_bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            return Ok(ResolveOutcome::NoBaseInHistory {
+                copy_path: conflict_copy_path(rel_path, peer_name, state),
+                copy_content: remote_content.to_vec(),
+            });
+        }
+    };
+
+    match three_way_merge(base_str, local_str, remote_str) {
+        MergeOutcome::Clean(merged) => {
+            // Merged VV is the per-peer max of the two parents — we
+            // observe both prior writes after this resolution.
+            let merged_vv = vv_max(&local_record.version_vector, remote_vv);
+            Ok(ResolveOutcome::Merged {
+                merged_content: merged,
+                merged_vv,
+            })
+        }
+        MergeOutcome::Conflict(_kept_local) => Ok(ResolveOutcome::OverlapKeptLocal {
+            copy_path: conflict_copy_path(rel_path, peer_name, state),
+            copy_content: remote_content.to_vec(),
+        }),
+    }
+}
+
+/// Look up the base content for the GCA. The GCA's exact content hash
+/// isn't directly stored in `sync_files` (which only holds the latest);
+/// we walk history rows for `(vault_id, path)` and pick the one whose
+/// VV equals the GCA. If none matches, return None.
+fn find_base_in_history(
+    state: &SyncState,
+    vault_id: &str,
+    path: &str,
+    gca: &VersionVector,
+) -> Result<Option<Vec<u8>>, VaultError> {
+    let conn = state.lock_conn()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT content_hash, version_vector FROM sync_history
+             WHERE vault_id = ?1 AND path = ?2",
+        )
+        .map_err(|e| VaultError::SyncState {
+            msg: format!("sqlite: {e}"),
+        })?;
+    let mut rows = stmt
+        .query(rusqlite::params![vault_id, path])
+        .map_err(|e| VaultError::SyncState {
+            msg: format!("sqlite: {e}"),
+        })?;
+    while let Some(row) = rows.next().map_err(|e| VaultError::SyncState {
+        msg: format!("sqlite: {e}"),
+    })? {
+        let hash_bytes: Vec<u8> = row.get(0).map_err(|e| VaultError::SyncState {
+            msg: format!("sqlite: {e}"),
+        })?;
+        let vv_bytes: Vec<u8> = row.get(1).map_err(|e| VaultError::SyncState {
+            msg: format!("sqlite: {e}"),
+        })?;
+        let vv = VersionVector::from_bytes(&vv_bytes)?;
+        if &vv == gca {
+            if hash_bytes.len() != 32 {
+                continue;
+            }
+            let mut h: ContentHash = [0; 32];
+            h.copy_from_slice(&hash_bytes);
+            drop(rows);
+            drop(stmt);
+            drop(conn);
+            return state.get_history(vault_id, path, &h);
+        }
+    }
+    Ok(None)
+}
+
+fn vv_max(a: &VersionVector, b: &VersionVector) -> VersionVector {
+    let mut out = a.0.clone();
+    for (peer, &c) in &b.0 {
+        let entry = out.entry(peer.clone()).or_insert(0);
+        if c > *entry {
+            *entry = c;
+        }
+    }
+    VersionVector(out)
+}
+
+/// Obsidian-compatible conflict-copy path:
+///   `<stem> (conflict from <peer-name> YYYY-MM-DD HH:MM)<.ext>`
+///
+/// `state.clock()` supplies the timestamp so tests can pin the format
+/// without relying on real wall time. UTC is used to keep the filename
+/// stable across timezones.
+pub fn conflict_copy_path(rel: &Path, peer_name: &str, state: &SyncState) -> PathBuf {
+    let now_secs = state.clock().now_secs();
+    let stamp = format_timestamp_utc(now_secs);
+    let parent = rel.parent().map(|p| p.to_path_buf());
+    let stem = rel.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();
+    let ext = rel.extension().map(|e| e.to_string_lossy().to_string());
+    let new_name = match ext {
+        Some(e) => format!("{stem} (conflict from {peer_name} {stamp}).{e}"),
+        None => format!("{stem} (conflict from {peer_name} {stamp})"),
+    };
+    match parent {
+        Some(p) if !p.as_os_str().is_empty() => p.join(new_name),
+        _ => PathBuf::from(new_name),
+    }
+}
+
+/// Format `secs_since_epoch` as `YYYY-MM-DD HH:MM` UTC. Manual
+/// implementation so we avoid pulling `chrono` or `time` for one call
+/// site; algorithm is the standard civil-date breakdown.
+fn format_timestamp_utc(secs: i64) -> String {
+    let days_from_epoch = secs.div_euclid(86_400);
+    let secs_of_day = secs.rem_euclid(86_400) as u32;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let (y, m, d) = civil_from_days(days_from_epoch);
+    format!("{y:04}-{m:02}-{d:02} {hour:02}:{minute:02}")
+}
+
+/// Convert days-since-1970-01-01 to (year, month, day) UTC. Algorithm
+/// from Howard Hinnant's "civil_from_days" reference implementation
+/// (public domain). The shift by 719_468 anchors day 0 to 0000-03-01,
+/// which collapses the leap-year math into a clean 400-year era cycle.
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u32; // [0, 146_096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
+}

--- a/src-tauri/src/sync/discovery.rs
+++ b/src-tauri/src/sync/discovery.rs
@@ -1,0 +1,312 @@
+//! Cross-platform device discovery (epic #73 sub-issue #417).
+//!
+//! Desktop (macOS / Windows / Linux): `mdns-sd` advertises and browses
+//! `_vaultcore._tcp.local.`. Android (out of scope for the desktop bar)
+//! is a JNI bridge — currently a stub that panics if instantiated; the
+//! NSD JNI work lands separately, integration-tested only on emulator.
+//!
+//! TXT record schema (epic-locked):
+//!   device_id  — base32 device identifier
+//!   name       — human-readable device name (default OS hostname)
+//!   vaults     — JSON array of `{id, name}`
+//!   pubkey_fp  — 8-char fingerprint
+//!   proto      — wire-protocol version, currently "1"
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::VaultError;
+
+pub const SERVICE_TYPE: &str = "_vaultcore._tcp.local.";
+pub const PROTO_VERSION: &str = "1";
+
+/// Per-vault advertisement payload — paired peers see one row per
+/// `(device_id, vault_id)` so they can tap "sync this vault" in the UI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdvertisedVault {
+    pub id: String,
+    pub name: String,
+}
+
+/// Self-description broadcast by `Discovery::start`. Reused for the
+/// "what we observe from peers" struct because the wire format is
+/// symmetric — the only difference is direction of travel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerAd {
+    pub device_id: String,
+    pub name: String,
+    pub vaults: Vec<AdvertisedVault>,
+    pub pubkey_fp: String,
+    pub proto: String,
+    /// Reachable address(es). Populated from the mDNS A/AAAA records on
+    /// receive; ignored on advertise (the advertiser passes its TCP port
+    /// separately and `mdns-sd` resolves the local addresses).
+    pub addrs: Vec<std::net::IpAddr>,
+    pub port: u16,
+}
+
+/// Snapshot returned by `Discovery::peers`. Cheap to clone — peers list
+/// is single-digit in practice.
+#[derive(Debug, Clone, Default)]
+pub struct PeerSnapshot {
+    pub peers: Vec<PeerAd>,
+}
+
+pub trait Discovery: Send + Sync {
+    /// Begin advertising `self_ad` and browsing for peers. Idempotent:
+    /// calling start twice is a no-op (or refresh — impl decision).
+    fn start(&self, self_ad: PeerAd) -> Result<(), VaultError>;
+    /// Stop advertising + browsing. Used when the user toggles
+    /// "Discoverable on this network" off in Settings.
+    fn stop(&self) -> Result<(), VaultError>;
+    /// Current observed peers (excluding self).
+    fn peers(&self) -> Result<PeerSnapshot, VaultError>;
+}
+
+// ─── Desktop impl ─────────────────────────────────────────────────────
+
+#[cfg(not(target_os = "android"))]
+pub use desktop::MdnsDiscovery;
+
+#[cfg(not(target_os = "android"))]
+mod desktop {
+    use super::*;
+    use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+    use std::collections::HashMap;
+    use std::net::IpAddr;
+    use std::sync::{Mutex, RwLock};
+    use std::thread;
+
+    const TXT_DEVICE_ID: &str = "device_id";
+    const TXT_NAME: &str = "name";
+    const TXT_VAULTS: &str = "vaults";
+    const TXT_PUBKEY_FP: &str = "pubkey_fp";
+    const TXT_PROTO: &str = "proto";
+
+    pub struct MdnsDiscovery {
+        daemon: ServiceDaemon,
+        /// Service fullname registered with the daemon — kept around so
+        /// `stop` can unregister.
+        registered: Mutex<Option<String>>,
+        /// Latest peer snapshot, updated by the browse thread.
+        peers: Arc<RwLock<HashMap<String, PeerAd>>>,
+        /// Our own device_id — filtered out of the peers snapshot so the
+        /// UI never shows "you" as a discoverable target.
+        self_device_id: Mutex<Option<String>>,
+        browse_handle: Mutex<Option<thread::JoinHandle<()>>>,
+        stop_browse: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl MdnsDiscovery {
+        pub fn new() -> Result<Self, VaultError> {
+            let daemon = ServiceDaemon::new().map_err(|e| VaultError::SyncState {
+                msg: format!("mdns daemon init: {e}"),
+            })?;
+            Ok(Self {
+                daemon,
+                registered: Mutex::new(None),
+                peers: Arc::new(RwLock::new(HashMap::new())),
+                self_device_id: Mutex::new(None),
+                browse_handle: Mutex::new(None),
+                stop_browse: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            })
+        }
+    }
+
+    impl Discovery for MdnsDiscovery {
+        fn start(&self, self_ad: PeerAd) -> Result<(), VaultError> {
+            // Record our own device_id so the browse thread can skip it.
+            *self
+                .self_device_id
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)? = Some(self_ad.device_id.clone());
+
+            // Build TXT record map. `vaults` carries JSON so it survives
+            // intact on the wire.
+            let vaults_json =
+                serde_json::to_string(&self_ad.vaults).map_err(|e| VaultError::SyncState {
+                    msg: format!("serialize vaults TXT: {e}"),
+                })?;
+            let mut txt: HashMap<String, String> = HashMap::new();
+            txt.insert(TXT_DEVICE_ID.into(), self_ad.device_id.clone());
+            txt.insert(TXT_NAME.into(), self_ad.name.clone());
+            txt.insert(TXT_VAULTS.into(), vaults_json);
+            txt.insert(TXT_PUBKEY_FP.into(), self_ad.pubkey_fp.clone());
+            txt.insert(TXT_PROTO.into(), self_ad.proto.clone());
+
+            // Service instance name = device_id; mdns-sd uses it to
+            // disambiguate multiple advertisers on the same host.
+            let host = format!("{}.local.", self_ad.device_id);
+            let info = ServiceInfo::new(
+                SERVICE_TYPE,
+                &self_ad.device_id,
+                &host,
+                "",
+                self_ad.port,
+                Some(txt),
+            )
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("mdns ServiceInfo: {e}"),
+            })?
+            .enable_addr_auto();
+
+            let fullname = info.get_fullname().to_string();
+            self.daemon
+                .register(info)
+                .map_err(|e| VaultError::SyncState {
+                    msg: format!("mdns register: {e}"),
+                })?;
+            *self
+                .registered
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)? = Some(fullname);
+
+            // Spawn a browse thread that drains ServiceEvents into our
+            // peers map. The thread terminates when `stop_browse` is set.
+            let receiver = self
+                .daemon
+                .browse(SERVICE_TYPE)
+                .map_err(|e| VaultError::SyncState {
+                    msg: format!("mdns browse: {e}"),
+                })?;
+            let peers = Arc::clone(&self.peers);
+            let stop_flag = Arc::clone(&self.stop_browse);
+            stop_flag.store(false, std::sync::atomic::Ordering::SeqCst);
+            let self_id = self_ad.device_id.clone();
+            let handle = thread::spawn(move || {
+                while !stop_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                    // Bounded poll so we observe `stop_flag` periodically
+                    // even under quiet networks.
+                    let evt = match receiver.recv_timeout(std::time::Duration::from_millis(250)) {
+                        Ok(e) => e,
+                        Err(_) => continue,
+                    };
+                    match evt {
+                        ServiceEvent::ServiceResolved(info) => {
+                            let txt: HashMap<String, String> = info
+                                .get_properties()
+                                .iter()
+                                .map(|p| (p.key().to_string(), p.val_str().to_string()))
+                                .collect();
+                            let device_id = match txt.get(TXT_DEVICE_ID) {
+                                Some(s) => s.clone(),
+                                None => continue,
+                            };
+                            // Filter out our own advertisement.
+                            if device_id == self_id {
+                                continue;
+                            }
+                            let vaults = txt
+                                .get(TXT_VAULTS)
+                                .and_then(|s| {
+                                    serde_json::from_str::<Vec<AdvertisedVault>>(s).ok()
+                                })
+                                .unwrap_or_default();
+                            let ad = PeerAd {
+                                device_id: device_id.clone(),
+                                name: txt.get(TXT_NAME).cloned().unwrap_or_default(),
+                                vaults,
+                                pubkey_fp: txt.get(TXT_PUBKEY_FP).cloned().unwrap_or_default(),
+                                proto: txt.get(TXT_PROTO).cloned().unwrap_or_default(),
+                                addrs: info.get_addresses().iter().copied().collect::<Vec<IpAddr>>(),
+                                port: info.get_port(),
+                            };
+                            if let Ok(mut g) = peers.write() {
+                                g.insert(device_id, ad);
+                            }
+                        }
+                        ServiceEvent::ServiceRemoved(_, fullname) => {
+                            // fullname is `<instance>.<service>.<domain>`;
+                            // the instance segment is the device_id we used.
+                            if let Some(instance) = fullname.split('.').next() {
+                                if let Ok(mut g) = peers.write() {
+                                    g.remove(instance);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            });
+            *self
+                .browse_handle
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)? = Some(handle);
+            Ok(())
+        }
+
+        fn stop(&self) -> Result<(), VaultError> {
+            if let Some(name) = self
+                .registered
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?
+                .take()
+            {
+                let _ = self.daemon.unregister(&name);
+            }
+            self.stop_browse
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            if let Some(h) = self
+                .browse_handle
+                .lock()
+                .map_err(|_| VaultError::LockPoisoned)?
+                .take()
+            {
+                let _ = h.join();
+            }
+            self.peers
+                .write()
+                .map_err(|_| VaultError::LockPoisoned)?
+                .clear();
+            Ok(())
+        }
+
+        fn peers(&self) -> Result<PeerSnapshot, VaultError> {
+            let g = self.peers.read().map_err(|_| VaultError::LockPoisoned)?;
+            Ok(PeerSnapshot {
+                peers: g.values().cloned().collect(),
+            })
+        }
+    }
+
+    impl Drop for MdnsDiscovery {
+        fn drop(&mut self) {
+            let _ = self.stop();
+            let _ = self.daemon.shutdown();
+        }
+    }
+}
+
+// ─── Android stub ─────────────────────────────────────────────────────
+
+#[cfg(target_os = "android")]
+pub use android::AndroidDiscovery;
+
+#[cfg(target_os = "android")]
+mod android {
+    use super::*;
+
+    /// Android NSD JNI bridge — integration-tested only on emulator
+    /// (epic #73 spec). Stubbed for now; the JNI bindings land in a
+    /// follow-up.
+    pub struct AndroidDiscovery;
+
+    impl AndroidDiscovery {
+        pub fn new() -> Result<Self, VaultError> {
+            Ok(Self)
+        }
+    }
+
+    impl Discovery for AndroidDiscovery {
+        fn start(&self, _self_ad: PeerAd) -> Result<(), VaultError> {
+            unimplemented!("Android NSD JNI bridge — follow-up ticket")
+        }
+        fn stop(&self) -> Result<(), VaultError> {
+            unimplemented!("Android NSD JNI bridge — follow-up ticket")
+        }
+        fn peers(&self) -> Result<PeerSnapshot, VaultError> {
+            unimplemented!("Android NSD JNI bridge — follow-up ticket")
+        }
+    }
+}

--- a/src-tauri/src/sync/discovery.rs
+++ b/src-tauri/src/sync/discovery.rs
@@ -64,21 +64,24 @@ pub trait Discovery: Send + Sync {
     fn peers(&self) -> Result<PeerSnapshot, VaultError>;
 }
 
-// ─── Desktop impl ─────────────────────────────────────────────────────
+// ─── mdns-sd impl (works on desktop + Android) ─────────────────────────
+//
+// `mdns-sd` is pure Rust over UDP multicast — no Avahi-on-Linux dep, no
+// platform service. On Android we additionally need a `WifiManager
+// .MulticastLock` (acquired in `MainActivity.onCreate`) plus the
+// `CHANGE_WIFI_MULTICAST_STATE` + `ACCESS_WIFI_STATE` manifest perms,
+// otherwise the OS silently drops multicast packets.
 
-#[cfg(not(target_os = "android"))]
 pub use desktop::MdnsDiscovery;
 
-/// Platform-default discovery implementation. Desktop targets get the
-/// real `mdns-sd` advertiser/browser; Android falls back to a no-op
-/// stub until the NSD JNI bridge ships (epic #73 follow-up). Lets
-/// `sync_cmds::SyncRuntime` hold one type across platforms.
-#[cfg(not(target_os = "android"))]
+/// Platform-default discovery implementation. Same `mdns-sd`-backed
+/// `MdnsDiscovery` everywhere — Android works as long as the activity
+/// holds a `MulticastLock`. The `AndroidDiscovery` no-op stub below
+/// stays compiled out unless the multicast path proves unworkable
+/// on a given device, in which case `DiscoveryImpl` can be flipped
+/// back to it as a graceful fallback.
 pub type DiscoveryImpl = MdnsDiscovery;
-#[cfg(target_os = "android")]
-pub type DiscoveryImpl = AndroidDiscovery;
 
-#[cfg(not(target_os = "android"))]
 mod desktop {
     use super::*;
     use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
@@ -287,18 +290,20 @@ mod desktop {
     }
 }
 
-// ─── Android stub ─────────────────────────────────────────────────────
+// ─── Android no-op fallback ───────────────────────────────────────────
+//
+// Compiled out by default — `DiscoveryImpl` resolves to `MdnsDiscovery`
+// universally now that the activity holds a `MulticastLock`. Kept around
+// in case a device proves to drop multicast even with the lock; flip
+// `DiscoveryImpl` to this type as the graceful fallback (the manual
+// peer-addr entry on the SYNCHRONISIERUNG screen still pairs without
+// discovery).
 
 #[cfg(target_os = "android")]
-pub use android::AndroidDiscovery;
-
-#[cfg(target_os = "android")]
+#[allow(dead_code)]
 mod android {
     use super::*;
 
-    /// Android NSD JNI bridge — integration-tested only on emulator
-    /// (epic #73 spec). Stubbed for now; the JNI bindings land in a
-    /// follow-up.
     pub struct AndroidDiscovery;
 
     impl AndroidDiscovery {

--- a/src-tauri/src/sync/discovery.rs
+++ b/src-tauri/src/sync/discovery.rs
@@ -69,6 +69,15 @@ pub trait Discovery: Send + Sync {
 #[cfg(not(target_os = "android"))]
 pub use desktop::MdnsDiscovery;
 
+/// Platform-default discovery implementation. Desktop targets get the
+/// real `mdns-sd` advertiser/browser; Android falls back to a no-op
+/// stub until the NSD JNI bridge ships (epic #73 follow-up). Lets
+/// `sync_cmds::SyncRuntime` hold one type across platforms.
+#[cfg(not(target_os = "android"))]
+pub type DiscoveryImpl = MdnsDiscovery;
+#[cfg(target_os = "android")]
+pub type DiscoveryImpl = AndroidDiscovery;
+
 #[cfg(not(target_os = "android"))]
 mod desktop {
     use super::*;
@@ -299,14 +308,18 @@ mod android {
     }
 
     impl Discovery for AndroidDiscovery {
+        // Stubs intentionally Ok-and-empty rather than `unimplemented!()`
+        // so the app boots, the Settings → SYNCHRONISIERUNG section
+        // renders, and the user can pair via manual peer entry while
+        // the NSD JNI bridge lands separately.
         fn start(&self, _self_ad: PeerAd) -> Result<(), VaultError> {
-            unimplemented!("Android NSD JNI bridge — follow-up ticket")
+            Ok(())
         }
         fn stop(&self) -> Result<(), VaultError> {
-            unimplemented!("Android NSD JNI bridge — follow-up ticket")
+            Ok(())
         }
         fn peers(&self) -> Result<PeerSnapshot, VaultError> {
-            unimplemented!("Android NSD JNI bridge — follow-up ticket")
+            Ok(PeerSnapshot::default())
         }
     }
 }

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -1,0 +1,395 @@
+//! Sync engine — applies and broadcasts `ChangeEvent`s.
+//!
+//! Two responsibilities:
+//!   - **Outbound:** `on_local_write` records the write in `SyncState`,
+//!     bumps the VV, and produces a `ChangeEvent` ready to broadcast.
+//!     Callers (the watcher hook in `lib.rs`) feed in raw write events;
+//!     this module decides whether to emit, what VV to attach, and which
+//!     peers receive it (filtered by capability grant).
+//!   - **Inbound:** `apply_remote_event` validates the peer's
+//!     capability, runs the dominance check, and routes the event to one
+//!     of {discard, fast-forward, mark-for-merge}. **Critical
+//!     invariant:** every fast-forward registers in `WriteIgnoreList`
+//!     *before* the disk write so the watcher doesn't double-fire on its
+//!     own change.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::error::VaultError;
+use crate::WriteIgnoreList;
+
+use super::capability::Scope;
+use super::protocol::{ChangeEvent, ChangeKind};
+use super::state::SyncState;
+use super::{ApplyOutcome, ContentHash};
+
+/// What the engine wants the caller to do after `apply_remote_event`.
+/// The engine is metadata-only — it never touches the working tree;
+/// the caller (watcher / vault open path) performs the disk side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InboundDecision {
+    /// Drop the event — local already dominates.
+    Discard,
+    /// Overwrite the local file with `content`. The caller MUST first
+    /// register `path` in `WriteIgnoreList`.
+    FastForward {
+        path: PathBuf,
+        content: Vec<u8>,
+        content_hash: ContentHash,
+    },
+    /// First-time arrival of a path we'd never seen — same disk action
+    /// as FastForward but UI may want to surface it differently
+    /// ("Bob shared note.md").
+    Created {
+        path: PathBuf,
+        content: Vec<u8>,
+        content_hash: ContentHash,
+    },
+    /// Concurrent writes — caller invokes the merge path (#420).
+    NeedsMerge {
+        path: PathBuf,
+        remote_content: Vec<u8>,
+        remote_hash: ContentHash,
+    },
+    /// Rename event — caller updates the on-disk path and link graph.
+    Rename {
+        from: PathBuf,
+        to: PathBuf,
+    },
+    /// Delete event — caller deletes on disk + records a tombstone.
+    Delete {
+        path: PathBuf,
+    },
+    /// Capability check failed; caller should log + drop. The connection
+    /// itself stays open since this is a single-event authz failure.
+    Rejected {
+        reason: RejectReason,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectReason {
+    NoGrant,
+    InvalidSignature,
+    ScopeInsufficient,
+    UnknownPeer,
+}
+
+/// Engine handle. Holds the metadata store, the shared write-ignore
+/// list, and the (optional) sync-batch gate that suppresses per-file
+/// indexer dispatch during catch-up reconciliation.
+pub struct SyncEngine {
+    state: Arc<SyncState>,
+    write_ignore: Arc<Mutex<WriteIgnoreList>>,
+    batch_gate: Arc<SyncBatchGate>,
+    /// Filesystem root the working tree lives under; remote paths are
+    /// resolved against this when registering with `WriteIgnoreList`.
+    /// `None` while no vault is open.
+    vault_root: Mutex<Option<PathBuf>>,
+}
+
+impl SyncEngine {
+    pub fn new(state: Arc<SyncState>, write_ignore: Arc<Mutex<WriteIgnoreList>>) -> Self {
+        Self {
+            state,
+            write_ignore,
+            batch_gate: Arc::new(SyncBatchGate::new()),
+            vault_root: Mutex::new(None),
+        }
+    }
+
+    pub fn set_vault_root(&self, root: PathBuf) -> Result<(), VaultError> {
+        *self
+            .vault_root
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)? = Some(root);
+        Ok(())
+    }
+
+    pub fn batch_gate(&self) -> &SyncBatchGate {
+        &self.batch_gate
+    }
+
+    pub fn state(&self) -> &SyncState {
+        &self.state
+    }
+
+    /// Outbound: build a `ChangeEvent` for a local write. Records the
+    /// new VV in `SyncState` and returns the event ready to broadcast.
+    pub fn on_local_write(
+        &self,
+        vault_id: &str,
+        path: PathBuf,
+        content: Vec<u8>,
+        content_hash: ContentHash,
+    ) -> Result<ChangeEvent, VaultError> {
+        let path_str = path.to_string_lossy().to_string();
+        let vv = self
+            .state
+            .record_local_write(vault_id, &path_str, content_hash, &content)?;
+        Ok(ChangeEvent {
+            vault_id: vault_id.to_string(),
+            path,
+            kind: ChangeKind::Upserted { content },
+            source_peer: self.state.self_peer().to_string(),
+            version_vector: vv,
+            content_hash,
+        })
+    }
+
+    /// Inbound: validate the peer's capability + apply the dominance
+    /// rule. Returns the action the caller should take on the working
+    /// tree. **Does not** itself touch disk; that's the caller's job
+    /// (so the watcher's `WriteIgnoreList` registration sits in the
+    /// right call site).
+    pub fn apply_remote_event(
+        &self,
+        event: &ChangeEvent,
+        peer_device_id: &str,
+    ) -> Result<InboundDecision, VaultError> {
+        // Capability check — security boundary per epic #73's
+        // "every cross-device sync operation validates a per-vault
+        // capability before serving data".
+        match self.check_capability(&event.vault_id, peer_device_id, &event.kind)? {
+            CapCheck::Ok => {}
+            CapCheck::Reject(r) => return Ok(InboundDecision::Rejected { reason: r }),
+        }
+
+        let path_str = event.path.to_string_lossy().to_string();
+
+        match &event.kind {
+            ChangeKind::Upserted { content } => {
+                let outcome = self.state.apply_remote_write(
+                    &event.vault_id,
+                    &path_str,
+                    event.content_hash,
+                    event.version_vector.clone(),
+                    content,
+                )?;
+                let abs = self.absolute_path(&event.path)?;
+                Ok(match outcome {
+                    ApplyOutcome::Discard => InboundDecision::Discard,
+                    ApplyOutcome::FastForward => {
+                        self.register_write_ignore(&abs)?;
+                        InboundDecision::FastForward {
+                            path: abs,
+                            content: content.clone(),
+                            content_hash: event.content_hash,
+                        }
+                    }
+                    ApplyOutcome::Created => {
+                        self.register_write_ignore(&abs)?;
+                        InboundDecision::Created {
+                            path: abs,
+                            content: content.clone(),
+                            content_hash: event.content_hash,
+                        }
+                    }
+                    ApplyOutcome::Conflict => InboundDecision::NeedsMerge {
+                        path: abs,
+                        remote_content: content.clone(),
+                        remote_hash: event.content_hash,
+                    },
+                })
+            }
+            ChangeKind::Renamed { from } => {
+                let abs_from = self.absolute_path(from)?;
+                let abs_to = self.absolute_path(&event.path)?;
+                // Rename is a metadata-only op for the watcher; still
+                // register both endpoints so neither side fires a
+                // spurious watcher event.
+                self.register_write_ignore(&abs_from)?;
+                self.register_write_ignore(&abs_to)?;
+                Ok(InboundDecision::Rename {
+                    from: abs_from,
+                    to: abs_to,
+                })
+            }
+            ChangeKind::Deleted => {
+                let abs = self.absolute_path(&event.path)?;
+                self.register_write_ignore(&abs)?;
+                Ok(InboundDecision::Delete { path: abs })
+            }
+        }
+    }
+
+    fn check_capability(
+        &self,
+        vault_id: &str,
+        peer_device_id: &str,
+        kind: &ChangeKind,
+    ) -> Result<CapCheck, VaultError> {
+        let Some(grant) = self.state.vault_grant(vault_id, peer_device_id)? else {
+            return Ok(CapCheck::Reject(RejectReason::NoGrant));
+        };
+        let Some(pubkey_bytes) = self.state.peer_pubkey(peer_device_id)? else {
+            return Ok(CapCheck::Reject(RejectReason::UnknownPeer));
+        };
+        let pubkey = ed25519_dalek::VerifyingKey::from_bytes(&pubkey_bytes).map_err(|e| {
+            VaultError::SyncState {
+                msg: format!("peer pubkey decode: {e}"),
+            }
+        })?;
+        let body = match grant.verify(&pubkey) {
+            Ok(b) => b,
+            Err(_) => return Ok(CapCheck::Reject(RejectReason::InvalidSignature)),
+        };
+        // Read+write events require the ReadWrite scope.
+        let needs_write = matches!(
+            kind,
+            ChangeKind::Upserted { .. } | ChangeKind::Deleted | ChangeKind::Renamed { .. }
+        );
+        if needs_write && body.scope != Scope::ReadWrite {
+            return Ok(CapCheck::Reject(RejectReason::ScopeInsufficient));
+        }
+        // Sanity: grant must reference the same vault we're applying to.
+        if body.local_vault_id != vault_id {
+            return Ok(CapCheck::Reject(RejectReason::NoGrant));
+        }
+        Ok(CapCheck::Ok)
+    }
+
+    /// Resolve a vault-relative path against the configured vault root.
+    /// **Does NOT** canonicalize — the file may not exist yet (Created /
+    /// FastForward). Caller's `validate_rel`-equivalent guard is the
+    /// last line of defense; we add a defensive `..` check here too.
+    fn absolute_path(&self, rel: &std::path::Path) -> Result<PathBuf, VaultError> {
+        let g = self
+            .vault_root
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        let root = g.as_ref().ok_or_else(|| VaultError::SyncState {
+            msg: "sync engine has no vault_root configured".into(),
+        })?;
+        let rel_str = rel.to_string_lossy();
+        if rel_str.contains("..") {
+            return Err(VaultError::PathOutsideVault {
+                path: rel_str.to_string(),
+            });
+        }
+        Ok(root.join(rel))
+    }
+
+    /// **Critical invariant** (epic #73 D-12): register the write before
+    /// the watcher could possibly observe it. Must be called from
+    /// `apply_remote_event`, never from the caller post-write.
+    fn register_write_ignore(&self, abs_path: &std::path::Path) -> Result<(), VaultError> {
+        let mut g = self
+            .write_ignore
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        g.record(abs_path.to_path_buf());
+        Ok(())
+    }
+
+    /// Test hook: did the engine register `path` in WriteIgnoreList?
+    /// Used by the property test that pins the BEFORE-the-write invariant.
+    #[cfg(test)]
+    pub fn is_write_ignored(&self, abs_path: &PathBuf) -> Result<bool, VaultError> {
+        let g = self
+            .write_ignore
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        Ok(g.should_ignore(abs_path))
+    }
+}
+
+enum CapCheck {
+    Ok,
+    Reject(RejectReason),
+}
+
+// ─── SyncBatchGate ─────────────────────────────────────────────────────
+
+/// Indexer-suppression marker. Wrapped around catch-up reconciliation
+/// pulls so per-file `IndexCmd::AddFile` doesn't saturate the queue.
+/// Between `begin` and `end`, callers register affected paths via
+/// `note_change`; `end` returns the list so the caller can either
+/// dispatch a single bulk update or — if oversized — `IndexCmd::Rebuild`.
+pub struct SyncBatchGate {
+    inner: Mutex<BatchGateInner>,
+}
+
+struct BatchGateInner {
+    /// Vault id under reconciliation, or None if no batch is open.
+    /// Multiple vaults may be reconciling concurrently in theory, but
+    /// in practice sync runs one vault at a time and a single in-flight
+    /// batch is sufficient for v1.
+    open: Option<String>,
+    /// Paths affected during this batch. `HashSet` so duplicates collapse.
+    affected: std::collections::HashSet<PathBuf>,
+}
+
+/// If a batch ends with more than this many distinct affected paths,
+/// the caller should issue `IndexCmd::Rebuild` instead of N updates.
+pub const BATCH_REBUILD_THRESHOLD: usize = 1000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchOutcome {
+    /// Apply per-file index updates for these paths.
+    Bulk(Vec<PathBuf>),
+    /// Affected count exceeds the threshold — issue a full Rebuild.
+    Rebuild { affected_count: usize },
+}
+
+impl SyncBatchGate {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(BatchGateInner {
+                open: None,
+                affected: std::collections::HashSet::new(),
+            }),
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.inner
+            .lock()
+            .map(|g| g.open.is_some())
+            .unwrap_or(false)
+    }
+
+    pub fn open_vault(&self) -> Option<String> {
+        self.inner.lock().ok().and_then(|g| g.open.clone())
+    }
+
+    pub fn begin(&self, vault_id: &str) -> Result<(), VaultError> {
+        let mut g = self.inner.lock().map_err(|_| VaultError::LockPoisoned)?;
+        g.open = Some(vault_id.to_string());
+        g.affected.clear();
+        Ok(())
+    }
+
+    pub fn note_change(&self, path: PathBuf) -> Result<(), VaultError> {
+        let mut g = self.inner.lock().map_err(|_| VaultError::LockPoisoned)?;
+        if g.open.is_some() {
+            g.affected.insert(path);
+        }
+        Ok(())
+    }
+
+    /// True iff a batch is currently open. Used by the indexer-dispatch
+    /// hook to decide whether to send a per-file `IndexCmd` or buffer.
+    pub fn should_suppress_dispatch(&self) -> bool {
+        self.is_open()
+    }
+
+    pub fn end(&self) -> Result<BatchOutcome, VaultError> {
+        let mut g = self.inner.lock().map_err(|_| VaultError::LockPoisoned)?;
+        g.open = None;
+        let n = g.affected.len();
+        let paths: Vec<PathBuf> = g.affected.drain().collect();
+        Ok(if n > BATCH_REBUILD_THRESHOLD {
+            BatchOutcome::Rebuild { affected_count: n }
+        } else {
+            BatchOutcome::Bulk(paths)
+        })
+    }
+}
+
+impl Default for SyncBatchGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src-tauri/src/sync/engine.rs
+++ b/src-tauri/src/sync/engine.rs
@@ -209,6 +209,15 @@ impl SyncEngine {
             ChangeKind::Deleted => {
                 let abs = self.absolute_path(&event.path)?;
                 self.register_write_ignore(&abs)?;
+                // Symmetry with `apply_remote_write`: the engine persists
+                // sync-state on inbound. The matching tombstone row keeps
+                // `is_tombstoned` consistent across peers and lets GC
+                // expire it after `TOMBSTONE_TTL_SECS`.
+                self.state.tombstones().record_delete(
+                    &event.vault_id,
+                    &path_str,
+                    &event.version_vector,
+                )?;
                 Ok(InboundDecision::Delete { path: abs })
             }
         }

--- a/src-tauri/src/sync/history.rs
+++ b/src-tauri/src/sync/history.rs
@@ -1,0 +1,106 @@
+//! Content-addressed blob store under `<metadata>/sync-history/<hash[..2]>/<hash>`.
+//!
+//! Stores up to `retain_per_file` versions per `(vault_id, path)` (LRU
+//! eviction is handled in [`super::state`]). The on-disk layout is
+//! sharded by the first two hex chars of the SHA-256 to keep any one
+//! directory bounded even on vaults with many distinct revisions.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::ContentHash;
+
+/// Per-file version retention. v1 keeps the last 2 (epic #73 spec).
+#[derive(Debug, Clone, Copy)]
+pub struct HistoryConfig {
+    pub retain_per_file: usize,
+}
+
+impl Default for HistoryConfig {
+    fn default() -> Self {
+        Self { retain_per_file: 2 }
+    }
+}
+
+#[derive(Debug)]
+pub struct History {
+    root: PathBuf,
+    config: HistoryConfig,
+}
+
+impl History {
+    pub fn new(root: PathBuf, config: HistoryConfig) -> Self {
+        Self { root, config }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn config(&self) -> HistoryConfig {
+        self.config
+    }
+
+    /// Write a blob keyed by `content_hash`. Returns the path relative to
+    /// `root` so it can be stored in the `blob_path` column. Idempotent —
+    /// if the blob already exists with matching content the write is
+    /// skipped.
+    pub fn put_blob(&self, content_hash: ContentHash, content: &[u8]) -> io::Result<PathBuf> {
+        let (shard, name) = shard_for(&content_hash);
+        let abs_dir = self.root.join(&shard);
+        fs::create_dir_all(&abs_dir)?;
+        let abs_path = abs_dir.join(&name);
+        if !abs_path.exists() {
+            // Atomic-write via tmp + rename so a crash mid-write never
+            // leaves a half-written blob under its real hash name.
+            let tmp = abs_dir.join(format!(".{name}.tmp"));
+            fs::write(&tmp, content)?;
+            fs::rename(&tmp, &abs_path)?;
+        }
+        Ok(PathBuf::from(shard).join(name))
+    }
+
+    pub fn read_blob(&self, rel: &Path) -> io::Result<Vec<u8>> {
+        fs::read(self.root.join(rel))
+    }
+
+    /// Best-effort: walk the on-disk shards and delete blobs not
+    /// referenced by `live_rel_paths`. Caller passes the set of
+    /// blob-paths still referenced from `sync_history` after eviction.
+    pub fn gc_orphans(&self, live_rel_paths: &std::collections::HashSet<PathBuf>) -> io::Result<usize> {
+        if !self.root.exists() {
+            return Ok(0);
+        }
+        let mut removed = 0;
+        for shard_entry in fs::read_dir(&self.root)? {
+            let shard_entry = shard_entry?;
+            if !shard_entry.file_type()?.is_dir() {
+                continue;
+            }
+            let shard_name = shard_entry.file_name();
+            let shard_path = shard_entry.path();
+            for blob_entry in fs::read_dir(&shard_path)? {
+                let blob_entry = blob_entry?;
+                let file_name = blob_entry.file_name();
+                // Skip in-flight `.<name>.tmp` files from `put_blob`.
+                if file_name.to_string_lossy().starts_with('.') {
+                    continue;
+                }
+                let rel = PathBuf::from(&shard_name).join(&file_name);
+                if !live_rel_paths.contains(&rel) && blob_entry.path().is_file() {
+                    fs::remove_file(blob_entry.path())?;
+                    removed += 1;
+                }
+            }
+        }
+        Ok(removed)
+    }
+}
+
+/// `("ab", "abcdef…")` — two-char shard + full hex name.
+fn shard_for(hash: &ContentHash) -> (String, String) {
+    let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+    let shard = hex[..2].to_string();
+    (shard, hex)
+}

--- a/src-tauri/src/sync/identity.rs
+++ b/src-tauri/src/sync/identity.rs
@@ -81,6 +81,19 @@ impl Default for OsKeychainStore {
     }
 }
 
+impl OsKeychainStore {
+    /// Construct with a custom keychain account name. Used by
+    /// `SyncRuntime::new` when `VAULTCORE_KEYCHAIN_ACCOUNT` is set —
+    /// lets two dev instances on the same host pull distinct device
+    /// identities for two-on-one-host UAT.
+    pub fn with_account(account: impl Into<String>) -> Self {
+        Self {
+            service: KEYCHAIN_SERVICE.to_string(),
+            account: account.into(),
+        }
+    }
+}
+
 impl KeyStore for OsKeychainStore {
     fn get(&self) -> Result<Option<[u8; 32]>, VaultError> {
         let entry = keyring::Entry::new(&self.service, &self.account).map_err(keyring_err)?;

--- a/src-tauri/src/sync/identity.rs
+++ b/src-tauri/src/sync/identity.rs
@@ -1,0 +1,189 @@
+//! Per-device Ed25519 identity (epic #73 sub-issue #417).
+//!
+//! Private key persists in the OS keychain (Keychain on macOS, Credential
+//! Manager on Windows, Secret Service on Linux, Keystore on Android via the
+//! `keyring` crate's platform impls). Public key is held in memory and
+//! re-derived from the private key on each load.
+//!
+//! `device_id = base32(SHA-256(pubkey)[..16])` per the epic's identity
+//! layer. Stable across launches of the same install — derives a fresh
+//! keypair on first use, then reads the same key on every subsequent
+//! `Identity::load_or_create` call.
+
+use std::sync::Mutex;
+
+use data_encoding::BASE32_NOPAD;
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use crate::error::VaultError;
+
+/// Keychain service identifier — shared across all VaultCore installs of
+/// the user. Matches the spec's "service `com.vaultcore.sync`" wording.
+pub const KEYCHAIN_SERVICE: &str = "com.vaultcore.sync";
+/// Account name within `KEYCHAIN_SERVICE` for the device key.
+pub const KEYCHAIN_ACCOUNT: &str = "device-key";
+
+/// Persistent backing store for the device's private key bytes.
+///
+/// Production wires `OsKeychainStore` to the platform keychain via the
+/// `keyring` crate. Tests inject `MemoryKeyStore` to avoid touching the
+/// developer's real keychain (and to run in CI where no GUI session
+/// exists to unlock Keychain on macOS).
+pub trait KeyStore: Send + Sync {
+    /// Return the stored private-key bytes, or `None` if none has been
+    /// written yet. Errors are *infrastructure* errors (keychain locked,
+    /// IPC failed) — distinct from "key absent".
+    fn get(&self) -> Result<Option<[u8; 32]>, VaultError>;
+    /// Persist the private-key bytes. Overwrites any prior value.
+    fn put(&self, key: &[u8; 32]) -> Result<(), VaultError>;
+}
+
+/// In-memory keystore for tests. Holds bytes behind a `Mutex` so a single
+/// instance can back multiple `Identity::load_or_create` calls and still
+/// see the persisted key.
+#[derive(Debug, Default)]
+pub struct MemoryKeyStore {
+    inner: Mutex<Option<[u8; 32]>>,
+}
+
+impl MemoryKeyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl KeyStore for MemoryKeyStore {
+    fn get(&self) -> Result<Option<[u8; 32]>, VaultError> {
+        Ok(*self.inner.lock().map_err(|_| VaultError::LockPoisoned)?)
+    }
+
+    fn put(&self, key: &[u8; 32]) -> Result<(), VaultError> {
+        *self.inner.lock().map_err(|_| VaultError::LockPoisoned)? = Some(*key);
+        Ok(())
+    }
+}
+
+/// OS keychain backed `KeyStore`. Stores the 32-byte ed25519 secret as a
+/// base64 string in the keychain "password" slot — keyring's API works in
+/// strings, not raw bytes.
+pub struct OsKeychainStore {
+    service: String,
+    account: String,
+}
+
+impl Default for OsKeychainStore {
+    fn default() -> Self {
+        Self {
+            service: KEYCHAIN_SERVICE.to_string(),
+            account: KEYCHAIN_ACCOUNT.to_string(),
+        }
+    }
+}
+
+impl KeyStore for OsKeychainStore {
+    fn get(&self) -> Result<Option<[u8; 32]>, VaultError> {
+        let entry = keyring::Entry::new(&self.service, &self.account).map_err(keyring_err)?;
+        match entry.get_password() {
+            Ok(s) => {
+                use base64::Engine;
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(s.as_bytes())
+                    .map_err(|e| VaultError::SyncState {
+                        msg: format!("decode keychain entry: {e}"),
+                    })?;
+                if bytes.len() != 32 {
+                    return Err(VaultError::SyncState {
+                        msg: format!("keychain entry wrong length: {}", bytes.len()),
+                    });
+                }
+                let mut out = [0u8; 32];
+                out.copy_from_slice(&bytes);
+                Ok(Some(out))
+            }
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(keyring_err(e)),
+        }
+    }
+
+    fn put(&self, key: &[u8; 32]) -> Result<(), VaultError> {
+        use base64::Engine;
+        let entry = keyring::Entry::new(&self.service, &self.account).map_err(keyring_err)?;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(key);
+        entry.set_password(&encoded).map_err(keyring_err)?;
+        Ok(())
+    }
+}
+
+fn keyring_err(e: keyring::Error) -> VaultError {
+    VaultError::SyncState {
+        msg: format!("keychain: {e}"),
+    }
+}
+
+/// In-memory device identity. Built once at sync-engine startup; carried
+/// in the sync state.
+pub struct Identity {
+    signing: SigningKey,
+    verifying: VerifyingKey,
+    device_id: String,
+}
+
+impl Identity {
+    /// Load the device key from `store`, or generate + persist a fresh
+    /// one if absent. Idempotent: subsequent calls with the same store
+    /// yield the same `device_id`.
+    pub fn load_or_create(store: &dyn KeyStore) -> Result<Self, VaultError> {
+        let secret_bytes = match store.get()? {
+            Some(b) => b,
+            None => {
+                use rand_core::RngCore;
+                let mut bytes = [0u8; 32];
+                rand_core::OsRng.fill_bytes(&mut bytes);
+                store.put(&bytes)?;
+                bytes
+            }
+        };
+        let signing = SigningKey::from_bytes(&secret_bytes);
+        let verifying = signing.verifying_key();
+        let device_id = derive_device_id(&verifying);
+        Ok(Self {
+            signing,
+            verifying,
+            device_id,
+        })
+    }
+
+    pub fn device_id(&self) -> &str {
+        &self.device_id
+    }
+
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.verifying.to_bytes()
+    }
+
+    /// Short fingerprint advertised in mDNS TXT records. First 8 bytes of
+    /// the device-id base32 string — enough to distinguish at a glance
+    /// without bloating the broadcast.
+    pub fn pubkey_fp(&self) -> String {
+        self.device_id.chars().take(8).collect()
+    }
+
+    /// Sign a message under the device's private key. Used during
+    /// pairing to bind the long-term Ed25519 key to the PAKE session.
+    pub fn sign(&self, msg: &[u8]) -> [u8; 64] {
+        self.signing.sign(msg).to_bytes()
+    }
+
+    pub fn verifying_key(&self) -> &VerifyingKey {
+        &self.verifying
+    }
+}
+
+/// `device_id = base32(SHA-256(pubkey)[..16])` per the epic. Returned in
+/// canonical RFC 4648 base32 with no padding — short, case-insensitive,
+/// safe for DNS / mDNS TXT records.
+pub fn derive_device_id(pubkey: &VerifyingKey) -> String {
+    let digest = Sha256::digest(pubkey.to_bytes());
+    BASE32_NOPAD.encode(&digest[..16])
+}

--- a/src-tauri/src/sync/identity.rs
+++ b/src-tauri/src/sync/identity.rs
@@ -178,6 +178,14 @@ impl Identity {
     pub fn verifying_key(&self) -> &VerifyingKey {
         &self.verifying
     }
+
+    /// Borrow the underlying `SigningKey` for callers that need to hand
+    /// it to crypto APIs (capability signing, `pairing_engine::drive_*`).
+    /// Stays inside the crate — outside callers should go through
+    /// [`Identity::sign`] for opaque signing.
+    pub(crate) fn signing_key(&self) -> &SigningKey {
+        &self.signing
+    }
 }
 
 /// `device_id = base32(SHA-256(pubkey)[..16])` per the epic. Returned in

--- a/src-tauri/src/sync/merkle.rs
+++ b/src-tauri/src/sync/merkle.rs
@@ -1,0 +1,501 @@
+//! Per-vault Merkle hash tree (epic #73 sub-issue #420).
+//!
+//! Layout:
+//!   - Leaf node: `(rel_path, file_hash)`. `file_hash = SHA-256(content)`.
+//!   - Folder node: `SHA-256(concat(sorted name||child_hash entries))`.
+//!     "Sorted" = lexicographic by `name` so traversal order is
+//!     deterministic across peers.
+//!   - Vault root: hash of the top-level folder ("").
+//!
+//! Incremental update strategy:
+//!   On every local write, recompute only the changed file's folder
+//!   chain up to the root (O(depth), ≈5–10 hashes for typical vaults).
+//!   The full vault recomputes only on first index / repair.
+//!
+//! Persistence: rows in `sync_merkle_nodes`. One row per node, keyed by
+//! `(vault_id, node_path)` where the empty string `""` denotes the root
+//! folder.
+
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+
+use rusqlite::{params, OptionalExtension};
+use sha2::{Digest, Sha256};
+
+use crate::error::VaultError;
+
+use super::state::SyncState;
+use super::ContentHash;
+
+/// Node kind tag stored alongside the hash so descent can short-circuit
+/// at file boundaries without a separate metadata lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    File,
+    Folder,
+}
+
+impl NodeKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Folder => "folder",
+        }
+    }
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "file" => Some(Self::File),
+            "folder" => Some(Self::Folder),
+            _ => None,
+        }
+    }
+}
+
+/// Snapshot of one node, returned by `MerkleTree::node` and used by
+/// the descent protocol on the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MerkleNode {
+    pub path: String,
+    pub kind: NodeKind,
+    pub hash: ContentHash,
+}
+
+/// Vault-scoped Merkle helper bound to a `SyncState`. Stateless — every
+/// call hits SQLite. Keep one `MerkleTree` per vault; the per-call
+/// overhead is one prepared-statement lookup and is well below the
+/// 5ms-per-write target.
+pub struct MerkleTree<'a> {
+    state: &'a SyncState,
+    vault_id: String,
+}
+
+impl<'a> MerkleTree<'a> {
+    pub fn new(state: &'a SyncState, vault_id: impl Into<String>) -> Self {
+        Self {
+            state,
+            vault_id: vault_id.into(),
+        }
+    }
+
+    pub fn vault_id(&self) -> &str {
+        &self.vault_id
+    }
+
+    /// Read the current root hash. `None` if the vault has no nodes yet
+    /// (peer compares None vs `Some` and treats either side's None as
+    /// "send everything").
+    pub fn root(&self) -> Result<Option<ContentHash>, VaultError> {
+        match self.node("")? {
+            Some(n) => Ok(Some(n.hash)),
+            None => Ok(None),
+        }
+    }
+
+    /// Look up a node by path (`""` = root, `"notes"` = top-level folder,
+    /// `"notes/a.md"` = file).
+    pub fn node(&self, path: &str) -> Result<Option<MerkleNode>, VaultError> {
+        let conn = self.state.lock_conn()?;
+        let row: Option<(String, Vec<u8>)> = conn
+            .query_row(
+                "SELECT kind, hash FROM sync_merkle_nodes
+                 WHERE vault_id = ?1 AND node_path = ?2",
+                params![&self.vault_id, path],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        let Some((kind_s, hash_bytes)) = row else {
+            return Ok(None);
+        };
+        let kind = NodeKind::parse(&kind_s).ok_or_else(|| VaultError::SyncState {
+            msg: format!("invalid merkle kind {kind_s} for {path}"),
+        })?;
+        if hash_bytes.len() != 32 {
+            return Err(VaultError::SyncState {
+                msg: format!("merkle hash wrong length: {}", hash_bytes.len()),
+            });
+        }
+        let mut h: ContentHash = [0; 32];
+        h.copy_from_slice(&hash_bytes);
+        Ok(Some(MerkleNode {
+            path: path.to_string(),
+            kind,
+            hash: h,
+        }))
+    }
+
+    /// Children of a folder node, returned sorted by name (matches the
+    /// hash-input order so the descent protocol sees deterministic
+    /// output across peers).
+    pub fn children(&self, folder: &str) -> Result<Vec<MerkleNode>, VaultError> {
+        let conn = self.state.lock_conn()?;
+        let prefix = if folder.is_empty() {
+            String::new()
+        } else {
+            format!("{folder}/")
+        };
+        // Direct children only — i.e. `node_path` starts with `prefix`
+        // and contains exactly one more `/` than `prefix`.
+        let mut stmt = conn
+            .prepare(
+                "SELECT node_path, kind, hash FROM sync_merkle_nodes
+                 WHERE vault_id = ?1 AND parent_path = ?2 AND node_path != ?2
+                 ORDER BY node_path",
+            )
+            .map_err(sqlite_err)?;
+        let mut rows = stmt
+            .query(params![&self.vault_id, folder])
+            .map_err(sqlite_err)?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().map_err(sqlite_err)? {
+            let path: String = row.get(0).map_err(sqlite_err)?;
+            let kind_s: String = row.get(1).map_err(sqlite_err)?;
+            let hash_bytes: Vec<u8> = row.get(2).map_err(sqlite_err)?;
+            // Defensive: skip non-direct children. Shouldn't happen with
+            // the parent_path filter, but guards against future schema
+            // bugs that might accidentally over-include.
+            if !path.starts_with(&prefix) {
+                continue;
+            }
+            let kind = NodeKind::parse(&kind_s).ok_or_else(|| VaultError::SyncState {
+                msg: format!("invalid merkle kind {kind_s}"),
+            })?;
+            if hash_bytes.len() != 32 {
+                return Err(VaultError::SyncState {
+                    msg: "merkle hash wrong length".into(),
+                });
+            }
+            let mut h: ContentHash = [0; 32];
+            h.copy_from_slice(&hash_bytes);
+            let _ = prefix; // reference to suppress warning when prefix unused above
+            out.push(MerkleNode {
+                path,
+                kind,
+                hash: h,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Apply an upsert (write or rename-into) for `rel_path` with the
+    /// given content hash. Walks the folder chain upward, recomputing
+    /// each ancestor's hash from its children.
+    pub fn upsert_file(&self, rel_path: &str, content_hash: ContentHash) -> Result<(), VaultError> {
+        let conn = self.state.lock_conn()?;
+        let tx = conn.unchecked_transaction().map_err(sqlite_err)?;
+        let parent = parent_of(rel_path);
+        upsert_node(&tx, &self.vault_id, rel_path, &parent, NodeKind::File, &content_hash)?;
+        rebuild_chain(&tx, &self.vault_id, &parent)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(())
+    }
+
+    /// Remove a file node and rebuild the folder chain.
+    pub fn remove_file(&self, rel_path: &str) -> Result<(), VaultError> {
+        let conn = self.state.lock_conn()?;
+        let tx = conn.unchecked_transaction().map_err(sqlite_err)?;
+        tx.execute(
+            "DELETE FROM sync_merkle_nodes WHERE vault_id = ?1 AND node_path = ?2",
+            params![&self.vault_id, rel_path],
+        )
+        .map_err(sqlite_err)?;
+        let parent = parent_of(rel_path);
+        rebuild_chain(&tx, &self.vault_id, &parent)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(())
+    }
+
+    /// Bulk recompute from a `(rel_path, content_hash)` iterator.
+    /// Used on first index or repair. Wipes existing nodes for this
+    /// vault first, then walks the input to insert files + rebuild
+    /// folders bottom-up.
+    pub fn rebuild_full<I>(&self, files: I) -> Result<(), VaultError>
+    where
+        I: IntoIterator<Item = (String, ContentHash)>,
+    {
+        let conn = self.state.lock_conn()?;
+        let tx = conn.unchecked_transaction().map_err(sqlite_err)?;
+        tx.execute(
+            "DELETE FROM sync_merkle_nodes WHERE vault_id = ?1",
+            params![&self.vault_id],
+        )
+        .map_err(sqlite_err)?;
+        // Collect leaves grouped by parent dir so we can build folders bottom-up.
+        let mut by_parent: BTreeMap<String, Vec<(String, ContentHash)>> = BTreeMap::new();
+        for (path, h) in files {
+            let parent = parent_of(&path);
+            by_parent.entry(parent).or_default().push((path, h));
+        }
+        // Insert leaves.
+        for (parent, leaves) in &by_parent {
+            for (path, h) in leaves {
+                upsert_node(&tx, &self.vault_id, path, parent, NodeKind::File, h)?;
+            }
+        }
+        // Walk every directory implied by the inputs (including ancestors)
+        // and rebuild folder hashes deepest-first.
+        let mut all_dirs: BTreeMap<String, ()> = BTreeMap::new();
+        all_dirs.insert(String::new(), ());
+        for parent in by_parent.keys() {
+            let mut cur = parent.clone();
+            loop {
+                all_dirs.insert(cur.clone(), ());
+                if cur.is_empty() {
+                    break;
+                }
+                cur = parent_of(&cur);
+            }
+        }
+        // Sort by component depth descending. The depth count includes
+        // the segment count, NOT just slashes — `""` has depth 0,
+        // `"d1"` depth 1, `"d2/d2"` depth 2. Without this, root ("")
+        // and a top-level dir like "d1" would tie at "0 slashes" and
+        // sort unstably; root could be computed before its children.
+        let mut deepest_first: Vec<String> = all_dirs.into_keys().collect();
+        deepest_first.sort_by_key(|d| {
+            let depth = if d.is_empty() {
+                0
+            } else {
+                d.split('/').count()
+            };
+            std::cmp::Reverse(depth)
+        });
+        for dir in deepest_first {
+            recompute_folder(&tx, &self.vault_id, &dir)?;
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(())
+    }
+}
+
+// ─── Reconciliation descent ───────────────────────────────────────────
+
+/// One step of the descent protocol. Caller starts at `""` (root); on
+/// hash-mismatch the protocol descends into each differing folder until
+/// it bottoms out at file leaves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffStep {
+    /// Subtree hashes match — no further descent needed.
+    Equal,
+    /// Two folders differ. Caller compares their child lists and
+    /// recurses into mismatched entries.
+    FolderDiffer {
+        folder: String,
+        local: Vec<MerkleNode>,
+        remote_children: Vec<MerkleNode>,
+    },
+    /// Two file hashes differ — emit the path for the change-event pull.
+    FilePathDiffers(String),
+    /// File present locally but not remotely (or vice versa).
+    OnlyLocal(String),
+    OnlyRemote(String),
+}
+
+/// Compute the differing file paths between `local` (this side's tree)
+/// and a `peer_node_lookup` callback that returns the peer's node at a
+/// given path. Used by the test suite and by the eventual remote-driven
+/// descent loop in the sync engine.
+pub fn diff_paths(
+    local: &MerkleTree<'_>,
+    peer_node: &mut dyn FnMut(&str) -> Option<MerkleNode>,
+) -> Result<Vec<String>, VaultError> {
+    let mut out = Vec::new();
+    descend(local, "", peer_node, &mut out)?;
+    Ok(out)
+}
+
+fn descend(
+    local: &MerkleTree<'_>,
+    folder: &str,
+    peer_node: &mut dyn FnMut(&str) -> Option<MerkleNode>,
+    out: &mut Vec<String>,
+) -> Result<(), VaultError> {
+    let local_self = local.node(folder)?;
+    let peer_self = peer_node(folder);
+    match (local_self.as_ref(), peer_self.as_ref()) {
+        (Some(l), Some(r)) if l.hash == r.hash => return Ok(()),
+        (None, None) => return Ok(()),
+        _ => {}
+    }
+    let local_children = local.children(folder)?;
+    let local_index: BTreeMap<&str, &MerkleNode> =
+        local_children.iter().map(|n| (n.path.as_str(), n)).collect();
+    // Collect peer children at this folder by probing each known local
+    // path + relying on the caller to supply peer-only paths via the
+    // `OnlyRemote` branch (handled by the engine — out of scope here).
+    let mut seen: BTreeMap<&str, bool> = BTreeMap::new();
+    for (path, ln) in &local_index {
+        let peer_n = peer_node(path);
+        seen.insert(path, true);
+        match (ln.kind, peer_n.as_ref()) {
+            (NodeKind::File, Some(rn)) if rn.kind == NodeKind::File => {
+                if ln.hash != rn.hash {
+                    out.push(path.to_string());
+                }
+            }
+            (NodeKind::File, None) => {
+                out.push(path.to_string()); // peer is missing this file.
+            }
+            (NodeKind::Folder, Some(rn)) if rn.kind == NodeKind::Folder => {
+                if ln.hash != rn.hash {
+                    descend(local, path, peer_node, out)?;
+                }
+            }
+            (NodeKind::Folder, None) => {
+                // Whole subtree needs to be sent to peer. Walk locally
+                // and emit every leaf path.
+                emit_subtree_files(local, path, out)?;
+            }
+            // Type mismatch: emit as file diff so the engine resolves
+            // (e.g. someone replaced a folder with a file of the same
+            // name — vanishingly rare on Markdown vaults but defensive).
+            _ => out.push(path.to_string()),
+        }
+    }
+    Ok(())
+}
+
+fn emit_subtree_files(
+    local: &MerkleTree<'_>,
+    folder: &str,
+    out: &mut Vec<String>,
+) -> Result<(), VaultError> {
+    for child in local.children(folder)? {
+        match child.kind {
+            NodeKind::File => out.push(child.path),
+            NodeKind::Folder => emit_subtree_files(local, &child.path, out)?,
+        }
+    }
+    Ok(())
+}
+
+// ─── Internals ────────────────────────────────────────────────────────
+
+fn sqlite_err(e: rusqlite::Error) -> VaultError {
+    VaultError::SyncState {
+        msg: format!("sqlite: {e}"),
+    }
+}
+
+fn parent_of(path: &str) -> String {
+    if path.is_empty() {
+        return String::new();
+    }
+    let p = Path::new(path);
+    let mut comps: Vec<&str> = p
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(s) => Some(s.to_str().unwrap_or("")),
+            _ => None,
+        })
+        .collect();
+    if comps.len() <= 1 {
+        return String::new();
+    }
+    comps.pop();
+    comps.join("/")
+}
+
+fn upsert_node(
+    tx: &rusqlite::Transaction<'_>,
+    vault_id: &str,
+    path: &str,
+    parent: &str,
+    kind: NodeKind,
+    hash: &ContentHash,
+) -> Result<(), VaultError> {
+    tx.execute(
+        "INSERT INTO sync_merkle_nodes (vault_id, node_path, parent_path, kind, hash)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(vault_id, node_path) DO UPDATE SET
+             parent_path = excluded.parent_path,
+             kind = excluded.kind,
+             hash = excluded.hash",
+        params![vault_id, path, parent, kind.as_str(), &hash[..]],
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+/// Recompute folder hash by hashing every direct child's `name||hash`
+/// (`name` = last component of `node_path`).
+fn recompute_folder(
+    tx: &rusqlite::Transaction<'_>,
+    vault_id: &str,
+    folder: &str,
+) -> Result<(), VaultError> {
+    let mut stmt = tx
+        .prepare(
+            "SELECT node_path, hash FROM sync_merkle_nodes
+             WHERE vault_id = ?1 AND parent_path = ?2 AND node_path != ?2
+             ORDER BY node_path",
+        )
+        .map_err(sqlite_err)?;
+    let mut rows = stmt
+        .query(params![vault_id, folder])
+        .map_err(sqlite_err)?;
+    let mut hasher = Sha256::new();
+    let mut child_count = 0usize;
+    while let Some(row) = rows.next().map_err(sqlite_err)? {
+        let path: String = row.get(0).map_err(sqlite_err)?;
+        let hash_bytes: Vec<u8> = row.get(1).map_err(sqlite_err)?;
+        let name = last_component(&path);
+        hasher.update(name.as_bytes());
+        hasher.update([0u8]); // separator — keeps `name`+hash field-distinguishable.
+        hasher.update(&hash_bytes);
+        child_count += 1;
+    }
+    drop(rows);
+    drop(stmt);
+    if child_count == 0 {
+        // Empty folder. Still keep a node so descent has something to
+        // compare against; hash is SHA-256 of the literal empty string
+        // (deterministic, peer-comparable).
+        let h: ContentHash = Sha256::digest(b"").into();
+        upsert_node(tx, vault_id, folder, &parent_of(folder), NodeKind::Folder, &h)?;
+        return Ok(());
+    }
+    let h: ContentHash = hasher.finalize().into();
+    let parent = parent_of(folder);
+    upsert_node(tx, vault_id, folder, &parent, NodeKind::Folder, &h)?;
+    Ok(())
+}
+
+fn rebuild_chain(
+    tx: &rusqlite::Transaction<'_>,
+    vault_id: &str,
+    start_dir: &str,
+) -> Result<(), VaultError> {
+    let mut cur = start_dir.to_string();
+    loop {
+        recompute_folder(tx, vault_id, &cur)?;
+        if cur.is_empty() {
+            break;
+        }
+        cur = parent_of(&cur);
+    }
+    Ok(())
+}
+
+fn last_component(path: &str) -> String {
+    if path.is_empty() {
+        return String::new();
+    }
+    Path::new(path)
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string())
+}
+
+/// Convenience: hash a file's content into the canonical leaf hash.
+pub fn hash_file_content(content: &[u8]) -> ContentHash {
+    let h = Sha256::digest(content);
+    let mut out: ContentHash = [0; 32];
+    out.copy_from_slice(&h);
+    out
+}
+
+/// Suppress unused-import warning for `PathBuf` — included for callers
+/// that round-trip `Path`/`PathBuf` through this module's helpers.
+#[allow(dead_code)]
+fn _path_kind_check(_p: PathBuf) {}

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -13,11 +13,14 @@
 pub mod capability;
 pub mod clock;
 pub mod discovery;
+pub mod engine;
 pub mod history;
 pub mod identity;
 pub mod pairing;
+pub mod protocol;
 pub mod state;
 pub mod tombstone;
+pub mod transport;
 pub mod vault_id;
 
 #[cfg(test)]

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -19,6 +19,7 @@ pub mod history;
 pub mod identity;
 pub mod merkle;
 pub mod pairing;
+pub mod pairing_engine;
 pub mod protocol;
 pub mod state;
 pub mod tombstone;

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -10,10 +10,12 @@
 //! live in this module so identity / pairing / transport sub-modules can
 //! depend on them without circular references.
 
+pub mod capability;
 pub mod clock;
 pub mod discovery;
 pub mod history;
 pub mod identity;
+pub mod pairing;
 pub mod state;
 pub mod tombstone;
 pub mod vault_id;

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -1,0 +1,117 @@
+//! LAN P2P sync layer (epic #73).
+//!
+//! Module map:
+//!   state.rs       — sync-state.sqlite schema + migrations + apply/record APIs
+//!   history.rs     — content-addressed last-2-versions LRU history blob store
+//!   tombstone.rs   — 30-day TTL deletion records + GC
+//!   clock.rs       — injectable wall clock for time-dependent tests
+//!
+//! Wire-format types (`PeerId`, `VaultId`, `VersionVector`, `ContentHash`)
+//! live in this module so identity / pairing / transport sub-modules can
+//! depend on them without circular references.
+
+pub mod clock;
+pub mod history;
+pub mod state;
+pub mod tombstone;
+
+#[cfg(test)]
+pub mod tests;
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Stable per-device identifier — `base32(SHA-256(ed25519_pubkey)[..16])`
+/// per epic #73's identity layer. Stored as a plain `String` so `BTreeMap`
+/// ordering matches lexicographic byte order and round-trips through
+/// SQLite TEXT columns without a custom codec.
+pub type PeerId = String;
+
+/// Per-vault UUIDv4 stored at `.vaultcore/vault-id`. Held as `String`
+/// (canonical hyphenated form) for the same SQLite-friendly reason.
+pub type VaultId = String;
+
+/// SHA-256 of file content. 32 raw bytes; SQLite stores it as BLOB.
+pub type ContentHash = [u8; 32];
+
+/// `{peer_id → counter}` per epic #73's multi-master conflict topology.
+/// `BTreeMap` (not `HashMap`) so the bincode-serialized BLOB is stable
+/// across runs and platforms — equality checks downstream rely on the
+/// canonical byte representation.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct VersionVector(pub BTreeMap<PeerId, u64>);
+
+impl VersionVector {
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Increment `self`'s counter for `peer` (creating the entry if absent).
+    /// Used on every local write before persisting `(content_hash, vv)`.
+    pub fn increment(&mut self, peer: &str) {
+        *self.0.entry(peer.to_string()).or_insert(0) += 1;
+    }
+
+    /// Returns true iff `self ≥ other` for every peer in `other` (i.e. `self`
+    /// dominates `other` per epic #73's "if vv_local ≥ vv_remote → discard"
+    /// rule). Note: peers present only in `self` don't disqualify dominance —
+    /// they represent later writes the other side simply hasn't seen yet.
+    pub fn dominates(&self, other: &Self) -> bool {
+        for (peer, &c_other) in &other.0 {
+            let c_self = self.0.get(peer).copied().unwrap_or(0);
+            if c_self < c_other {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// True iff neither vector dominates the other → concurrent writes
+    /// → 3-way merge required.
+    pub fn concurrent_with(&self, other: &Self) -> bool {
+        !self.dominates(other) && !other.dominates(self)
+    }
+
+    /// Greatest common ancestor: per-peer `min`. Used to look up the base
+    /// content for the 3-way merge when two writes are concurrent.
+    pub fn gca(&self, other: &Self) -> Self {
+        let mut out = BTreeMap::new();
+        for peer in self.0.keys().chain(other.0.keys()) {
+            let a = self.0.get(peer).copied().unwrap_or(0);
+            let b = other.0.get(peer).copied().unwrap_or(0);
+            let m = a.min(b);
+            if m > 0 {
+                out.insert(peer.clone(), m);
+            }
+        }
+        Self(out)
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("VersionVector bincode serialize is infallible for BTreeMap<String, u64>")
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, crate::error::VaultError> {
+        bincode::deserialize(bytes).map_err(|e| crate::error::VaultError::SyncState {
+            msg: format!("decode version vector: {e}"),
+        })
+    }
+}
+
+/// Outcome of `apply_remote_write`. Decision-only — the caller decides
+/// what to do with the new content (overwrite the working file, write a
+/// conflict copy, etc.).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    /// Remote dominates — caller should overwrite the local file with the
+    /// remote content and persist the new VV.
+    FastForward,
+    /// Local dominates — caller should drop the remote write.
+    Discard,
+    /// Concurrent — caller must perform the 3-way merge using the base
+    /// content fetched from `history` (or, if the GCA isn't in history,
+    /// fall back to a conflict-copy file).
+    Conflict,
+    /// First time we've seen this `(vault_id, path)` — apply remote as-is.
+    Created,
+}

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -12,10 +12,12 @@
 
 pub mod capability;
 pub mod clock;
+pub mod conflict;
 pub mod discovery;
 pub mod engine;
 pub mod history;
 pub mod identity;
+pub mod merkle;
 pub mod pairing;
 pub mod protocol;
 pub mod state;

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -11,9 +11,12 @@
 //! depend on them without circular references.
 
 pub mod clock;
+pub mod discovery;
 pub mod history;
+pub mod identity;
 pub mod state;
 pub mod tombstone;
+pub mod vault_id;
 
 #[cfg(test)]
 pub mod tests;

--- a/src-tauri/src/sync/pairing.rs
+++ b/src-tauri/src/sync/pairing.rs
@@ -1,0 +1,315 @@
+//! PAKE-based device pairing (epic #73 sub-issue #418).
+//!
+//! Flow per epic and the A2 design note:
+//!
+//! 1. UI gates: PIN must be 6-digit numeric. Enforced *before* PAKE
+//!    because CPace accepts arbitrary input.
+//! 2. PAKE three-step. Initiator runs `start_initiator` → step1 packet.
+//!    Responder runs `respond` → step2 packet + provisional keys.
+//!    Initiator runs `step3` on the step2 packet → final keys.
+//! 3. **Key-confirmation (REQUIRED).** Each side computes
+//!    `HMAC-SHA256(k2, device_id_a || device_id_b)` and exchanges.
+//!    Mismatch → abort + bump lockout. PAKE itself does NOT error on
+//!    wrong PIN (keys silently diverge), so without this we'd accept
+//!    nonsense session keys.
+//!
+//! State store: `PairingSession` holds attempt counters + an injectable
+//! clock for the 60s expiry / 3-attempt lockout.
+
+use std::sync::{Arc, Mutex};
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::error::VaultError;
+
+use super::clock::{Clock, SystemClock};
+
+/// 6-digit numeric PIN. Required by epic — enforced before PAKE.
+pub const PIN_LEN: usize = 6;
+/// PIN expires 60s after creation.
+pub const PIN_EXPIRY_SECS: i64 = 60;
+/// Lockout after this many consecutive failed key-confirmations.
+pub const LOCKOUT_AFTER_ATTEMPTS: u32 = 3;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Reasons pairing can fail. Each maps to a distinct UI copy — the
+/// frontend renders "wrong PIN" vs "PIN expired" vs "locked out, wait
+/// 60s" differently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PairError {
+    InvalidPin,
+    PinExpired,
+    LockedOut,
+    PakeFailed(String),
+    KeyConfirmationFailed,
+}
+
+impl From<PairError> for VaultError {
+    fn from(e: PairError) -> Self {
+        VaultError::SyncState {
+            msg: format!("pairing: {e:?}"),
+        }
+    }
+}
+
+/// PAKE shared keys after a successful run + key-confirmation. `k1` is
+/// reserved for the long-term-key exchange step; `k2` is consumed by
+/// the key-confirmation MAC and must NOT be reused after that.
+#[derive(Debug, Clone, Copy)]
+pub struct ConfirmedKeys {
+    pub k1: [u8; 32],
+}
+
+/// Session-state for a pairing attempt. Carries the lockout counter +
+/// PIN issue time so the same session can re-prompt for the PIN within
+/// the 60s window without re-running PAKE wire setup.
+pub struct PairingSession {
+    /// Wall-time (seconds since epoch) at which the current PIN was issued.
+    pin_issued_at: Mutex<Option<i64>>,
+    /// Failed-attempt counter. Reset on success, frozen after lockout.
+    failed_attempts: Mutex<u32>,
+    /// Whether the session is locked out. Once true, no further attempts
+    /// are accepted on this session — the user must restart pairing.
+    locked: Mutex<bool>,
+    clock: Arc<dyn Clock>,
+}
+
+impl PairingSession {
+    pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            pin_issued_at: Mutex::new(None),
+            failed_attempts: Mutex::new(0),
+            locked: Mutex::new(false),
+            clock,
+        }
+    }
+
+    /// Mark a fresh PIN as issued *now*. Resets the expiry timer; does
+    /// NOT clear the lockout counter (a locked-out session stays locked
+    /// even if the operator regenerates the PIN — they must restart).
+    pub fn issue_pin(&self) -> Result<(), VaultError> {
+        if *self.locked.lock().map_err(|_| VaultError::LockPoisoned)? {
+            return Err(PairError::LockedOut.into());
+        }
+        *self.pin_issued_at.lock().map_err(|_| VaultError::LockPoisoned)? =
+            Some(self.clock.now_secs());
+        Ok(())
+    }
+
+    /// True iff the most recently issued PIN is still within its 60s window.
+    pub fn pin_valid(&self) -> Result<bool, VaultError> {
+        let issued = *self.pin_issued_at.lock().map_err(|_| VaultError::LockPoisoned)?;
+        Ok(match issued {
+            None => false,
+            Some(t) => self.clock.now_secs() - t < PIN_EXPIRY_SECS,
+        })
+    }
+
+    pub fn is_locked(&self) -> Result<bool, VaultError> {
+        Ok(*self.locked.lock().map_err(|_| VaultError::LockPoisoned)?)
+    }
+
+    pub fn failed_count(&self) -> Result<u32, VaultError> {
+        Ok(*self
+            .failed_attempts
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?)
+    }
+
+    fn record_failure(&self) -> Result<u32, VaultError> {
+        let mut g = self
+            .failed_attempts
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)?;
+        *g += 1;
+        let n = *g;
+        drop(g);
+        if n >= LOCKOUT_AFTER_ATTEMPTS {
+            *self.locked.lock().map_err(|_| VaultError::LockPoisoned)? = true;
+        }
+        Ok(n)
+    }
+
+    fn clear_on_success(&self) -> Result<(), VaultError> {
+        *self
+            .failed_attempts
+            .lock()
+            .map_err(|_| VaultError::LockPoisoned)? = 0;
+        Ok(())
+    }
+}
+
+impl Default for PairingSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// PIN sanity check — must be exactly 6 ASCII digits. Runs *before*
+/// PAKE because CPace accepts arbitrary input (including empty) and
+/// would silently produce a session key for any of them.
+pub fn validate_pin(pin: &str) -> Result<(), PairError> {
+    if pin.len() != PIN_LEN {
+        return Err(PairError::InvalidPin);
+    }
+    if !pin.chars().all(|c| c.is_ascii_digit()) {
+        return Err(PairError::InvalidPin);
+    }
+    Ok(())
+}
+
+// ─── PAKE three-step wrappers ──────────────────────────────────────────
+
+/// Initiator side, post-step1. Holds the CPace state internally so the
+/// caller doesn't have to thread the inner type around.
+pub struct InitiatorAfterStep1 {
+    inner: pake_cpace::Step1Out,
+    id_a: String,
+    id_b: String,
+}
+
+impl InitiatorAfterStep1 {
+    pub fn step1_packet(&self) -> [u8; pake_cpace::STEP1_PACKET_BYTES] {
+        self.inner.packet()
+    }
+
+    /// Finish PAKE on the initiator side using the responder's step2 packet.
+    /// Returns the raw shared keys — caller MUST run [`key_confirmation`]
+    /// before trusting them.
+    pub fn step3(
+        self,
+        step2_packet: &[u8; pake_cpace::STEP2_PACKET_BYTES],
+    ) -> Result<RawSharedKeys, PairError> {
+        let sk = self
+            .inner
+            .step3(step2_packet)
+            .map_err(|e| PairError::PakeFailed(format!("{e:?}")))?;
+        Ok(RawSharedKeys {
+            k1: sk.k1,
+            k2: sk.k2,
+            id_a: self.id_a,
+            id_b: self.id_b,
+        })
+    }
+}
+
+/// Responder side after step2. Carries provisional shared keys; caller
+/// MUST run [`key_confirmation`] before trusting them.
+pub struct ResponderAfterStep2 {
+    pub raw_keys: RawSharedKeys,
+    step2_packet: [u8; pake_cpace::STEP2_PACKET_BYTES],
+}
+
+impl ResponderAfterStep2 {
+    pub fn step2_packet(&self) -> [u8; pake_cpace::STEP2_PACKET_BYTES] {
+        self.step2_packet
+    }
+}
+
+/// Raw PAKE output — *not* trusted until key-confirmation succeeds.
+pub struct RawSharedKeys {
+    pub k1: [u8; 32],
+    pub k2: [u8; 32],
+    pub id_a: String,
+    pub id_b: String,
+}
+
+/// Initiator side: send the PIN, the long-form id strings, and our
+/// device_id.
+pub fn start_initiator(
+    pin: &str,
+    id_a: &str,
+    id_b: &str,
+) -> Result<InitiatorAfterStep1, PairError> {
+    validate_pin(pin)?;
+    let s1 = pake_cpace::CPace::step1::<&[u8]>(pin, id_a, id_b, None)
+        .map_err(|e| PairError::PakeFailed(format!("{e:?}")))?;
+    Ok(InitiatorAfterStep1 {
+        inner: s1,
+        id_a: id_a.to_string(),
+        id_b: id_b.to_string(),
+    })
+}
+
+/// Responder side: ingest step1 + return step2 packet + provisional keys.
+pub fn respond(
+    step1_packet: &[u8; pake_cpace::STEP1_PACKET_BYTES],
+    pin: &str,
+    id_a: &str,
+    id_b: &str,
+) -> Result<ResponderAfterStep2, PairError> {
+    validate_pin(pin)?;
+    let s2 = pake_cpace::CPace::step2::<&[u8]>(step1_packet, pin, id_a, id_b, None)
+        .map_err(|e| PairError::PakeFailed(format!("{e:?}")))?;
+    let sk = s2.shared_keys();
+    Ok(ResponderAfterStep2 {
+        raw_keys: RawSharedKeys {
+            k1: sk.k1,
+            k2: sk.k2,
+            id_a: id_a.to_string(),
+            id_b: id_b.to_string(),
+        },
+        step2_packet: s2.packet(),
+    })
+}
+
+// ─── Key confirmation ──────────────────────────────────────────────────
+
+/// `HMAC-SHA256(k2, device_id_a || device_id_b)` per the epic's A2
+/// design note. PAKE itself does NOT error on wrong PIN — keys silently
+/// diverge. Both sides compute this MAC and exchange; mismatch ⇒ abort
+/// and bump the lockout counter.
+pub fn key_confirmation_mac(k2: &[u8; 32], id_a: &str, id_b: &str) -> [u8; 32] {
+    let mut mac = HmacSha256::new_from_slice(k2).expect("HMAC accepts any key length");
+    mac.update(id_a.as_bytes());
+    mac.update(id_b.as_bytes());
+    let out = mac.finalize().into_bytes();
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&out);
+    buf
+}
+
+/// Check the peer's MAC against our locally-computed one. Constant-time
+/// compare via `subtle` (transitive dep through ed25519-dalek). On
+/// mismatch the caller MUST `record_failure` on the session.
+///
+/// Returns the *confirmed* k1 on success — k2 has been consumed by the
+/// MAC step and must not be reused.
+pub fn finalize_with_confirmation(
+    raw: &RawSharedKeys,
+    peer_mac: &[u8; 32],
+    session: &PairingSession,
+) -> Result<ConfirmedKeys, PairError> {
+    if session.is_locked().map_err(|_| PairError::LockedOut)? {
+        return Err(PairError::LockedOut);
+    }
+    if !session.pin_valid().map_err(|_| PairError::PinExpired)? {
+        return Err(PairError::PinExpired);
+    }
+    let local_mac = key_confirmation_mac(&raw.k2, &raw.id_a, &raw.id_b);
+    if !ct_eq(&local_mac, peer_mac) {
+        let _ = session.record_failure();
+        return Err(PairError::KeyConfirmationFailed);
+    }
+    let _ = session.clear_on_success();
+    Ok(ConfirmedKeys { k1: raw.k1 })
+}
+
+/// Constant-time byte slice equality. Avoids leaking timing info on the
+/// MAC compare.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}

--- a/src-tauri/src/sync/pairing_engine.rs
+++ b/src-tauri/src/sync/pairing_engine.rs
@@ -1,0 +1,475 @@
+//! Post-PAKE pairing driver (epic #73, UI-1.5).
+//!
+//! `pairing.rs` ends at "both sides agree on `k1`/`k2` and a key-confirmation
+//! MAC matches". This module picks up there:
+//!
+//! 1. **Noise XX bootstrap.** Each side opens a Noise XX channel using its
+//!    Curve25519 noise static (held separately from the Ed25519 long-term
+//!    identity — Noise is happier with native Curve25519 keys).
+//! 2. **Long-term key attestation.** Inside the encrypted channel, each
+//!    side sends `(ed25519_pubkey, HMAC-SHA256(k2, ed25519_pubkey))`. The
+//!    HMAC under the just-derived PAKE session key is what binds the
+//!    long-term identity to *this* pairing flow — without it a network
+//!    attacker who could MITM Noise (impossible without the static keys
+//!    they don't yet have, but defensive depth) couldn't substitute their
+//!    own Ed25519 key. After verification the peer's pubkey is persisted
+//!    via `state.upsert_peer(.., PeerTrust::Trusted)`.
+//! 3. **Vault grant exchange.** Optional follow-up step (separate entry
+//!    points). Each side sends a peer-self-signed `Capability` for a
+//!    chosen vault and stores the *peer's* signed cap on its DB. Body
+//!    layout matches `engine_tests::pair_peer_with_grant`: the issuer's
+//!    cap names the issuer's own device id in `peer_device_id`, signed
+//!    by the issuer's long-term key.
+//!
+//! ## Wire format (engine-internal, post-Noise-handshake)
+//!
+//! Noise messages on the wire are u16-length-prefixed, identical to
+//! `transport.rs::drive_handshake`. The plaintext payload of each Noise
+//! message is a bincode-serialized `EngineFrame`. We do **not** layer a
+//! frame-length prefix on top — engine frames are tiny (≤ 200 bytes) and
+//! always fit in one Noise message.
+//!
+//! ## Re-pair short-circuit
+//!
+//! If the local DB already has a `Trusted` row for the peer's device id
+//! whose stored Ed25519 pubkey matches what the peer attested, we skip
+//! the upsert (the row is already correct) and return
+//! `PairingOutcome { short_circuited: true, reason: Some("already-paired") }`.
+//! UI-3 surfaces this as the "one-tap re-grant" code path.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+use ed25519_dalek::SigningKey;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use snow::TransportState;
+
+use crate::error::VaultError;
+
+use super::capability::{Capability, CapabilityBody};
+use super::state::{PeerTrust, SyncState};
+use super::transport::{drive_handshake, xx_initiator, xx_responder, NoiseKeypair, TransportError};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Reason string returned in `PairingOutcome::reason` when the engine
+/// detects the peer is already trusted with a matching pubkey and
+/// short-circuits the trust upsert. UI-3 keys its "already paired"
+/// banner off this constant.
+pub const ALREADY_PAIRED: &str = "already-paired";
+
+/// Engine-internal protocol frames. Sent over the Noise XX channel,
+/// bincode-serialized into the plaintext of a single Noise message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum EngineFrame {
+    /// Long-term Ed25519 pubkey + HMAC-SHA256(k2, pubkey). The HMAC under
+    /// the PAKE-derived session key proves the sender knew the PIN.
+    LongTermAttest {
+        ed25519_pubkey: [u8; 32],
+        mac: [u8; 32],
+    },
+    /// Peer-self-signed capability — `body.peer_device_id` is the issuer's
+    /// own device id and `signature` is over `body` under the issuer's
+    /// Ed25519 key.
+    VaultGrant { capability_bytes: Vec<u8> },
+}
+
+/// What the caller gets back from the post-PAKE driver.
+#[derive(Debug, Clone)]
+pub struct PairingOutcome {
+    /// True iff the engine detected an existing trusted peer row with a
+    /// matching pubkey and skipped the upsert. UI surfaces a different
+    /// confirmation copy when this fires.
+    pub short_circuited: bool,
+    /// Optional machine-readable reason — `Some("already-paired")` when
+    /// `short_circuited`, `None` otherwise.
+    pub reason: Option<String>,
+}
+
+/// Carries the post-bootstrap encrypted state forward so the caller can
+/// continue using the channel for grant exchange (or, in the production
+/// path, hand it off to the sync engine for the first sync). `outcome`
+/// reports whether trust persistence ran or short-circuited.
+#[derive(Debug)]
+pub struct PostPairingSession {
+    pub stream: TcpStream,
+    pub transport: TransportState,
+    pub outcome: PairingOutcome,
+}
+
+impl PostPairingSession {
+    /// Convenience: forwards `outcome.short_circuited` so call sites that
+    /// only care about the re-pair flag don't have to dig.
+    pub fn short_circuited(&self) -> bool {
+        self.outcome.short_circuited
+    }
+}
+
+impl std::ops::Deref for PostPairingSession {
+    type Target = PairingOutcome;
+    fn deref(&self) -> &Self::Target {
+        &self.outcome
+    }
+}
+
+#[derive(Debug)]
+pub enum PairingEngineError {
+    Io(std::io::Error),
+    Transport(TransportError),
+    /// Peer's HMAC over its long-term key didn't verify under our `k2`.
+    /// Pairing must abort — either the network was tampered or the peer
+    /// derived a different `k2` (PIN mismatch).
+    AttestationMismatch,
+    /// Peer's vault-grant capability didn't verify under the long-term
+    /// key we just persisted for them.
+    GrantVerification(String),
+    /// Local DB write failed. Wrap rather than `From<VaultError>` so the
+    /// caller can pattern-match the engine-specific failure modes
+    /// distinct from "DB went away".
+    State(VaultError),
+    /// Engine frame serialization / decoding failure — only fires on
+    /// genuinely corrupt wire input.
+    Codec(String),
+}
+
+impl From<std::io::Error> for PairingEngineError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+impl From<TransportError> for PairingEngineError {
+    fn from(e: TransportError) -> Self {
+        Self::Transport(e)
+    }
+}
+impl From<VaultError> for PairingEngineError {
+    fn from(e: VaultError) -> Self {
+        Self::State(e)
+    }
+}
+
+// ─── Noise message I/O ────────────────────────────────────────────────────
+
+const NOISE_MAX_MSG: usize = 65535;
+
+fn send_engine_frame(
+    stream: &mut TcpStream,
+    state: &mut TransportState,
+    frame: &EngineFrame,
+) -> Result<(), PairingEngineError> {
+    let body = bincode::serialize(frame)
+        .map_err(|e| PairingEngineError::Codec(format!("encode: {e}")))?;
+    if body.len() > NOISE_MAX_MSG - 16 {
+        // Engine frames are tiny in v1 — overflow here is a programming bug.
+        return Err(PairingEngineError::Codec(format!(
+            "engine frame too large: {} bytes",
+            body.len()
+        )));
+    }
+    let mut ct = [0u8; NOISE_MAX_MSG];
+    let n = state
+        .write_message(&body, &mut ct)
+        .map_err(TransportError::Noise)?;
+    stream.write_all(&(n as u16).to_be_bytes())?;
+    stream.write_all(&ct[..n])?;
+    Ok(())
+}
+
+fn recv_engine_frame(
+    stream: &mut TcpStream,
+    state: &mut TransportState,
+) -> Result<EngineFrame, PairingEngineError> {
+    let mut len_buf = [0u8; 2];
+    stream.read_exact(&mut len_buf)?;
+    let n = u16::from_be_bytes(len_buf) as usize;
+    let mut ct = vec![0u8; n];
+    stream.read_exact(&mut ct)?;
+    let mut pt = [0u8; NOISE_MAX_MSG];
+    let plain_len = state
+        .read_message(&ct, &mut pt)
+        .map_err(TransportError::Noise)?;
+    let frame: EngineFrame = bincode::deserialize(&pt[..plain_len])
+        .map_err(|e| PairingEngineError::Codec(format!("decode: {e}")))?;
+    Ok(frame)
+}
+
+// ─── Long-term key attestation ────────────────────────────────────────────
+
+fn long_term_attest_mac(k2: &[u8; 32], ed25519_pubkey: &[u8; 32]) -> [u8; 32] {
+    let mut mac = HmacSha256::new_from_slice(k2).expect("HMAC accepts any key length");
+    mac.update(ed25519_pubkey);
+    let out = mac.finalize().into_bytes();
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&out);
+    buf
+}
+
+/// Constant-time byte slice equality. Same routine as `pairing.rs::ct_eq`
+/// — duplicated rather than crossing the module boundary because this
+/// single use isn't worth a `pub(crate)` carve-out on a security-relevant
+/// helper. The cost (32-byte XOR) is negligible.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Persist the peer's pubkey + name under `PeerTrust::Trusted`. If the
+/// stored row already names this peer with the *same* pubkey, the upsert
+/// is a no-op and we report `short_circuited = true` so the UI can render
+/// the "already paired — re-grant" path.
+fn persist_peer_trust(
+    state: &SyncState,
+    peer_device_id: &str,
+    peer_pubkey: &[u8; 32],
+    display_name: &str,
+) -> Result<PairingOutcome, VaultError> {
+    if let Some(existing) = state.peer_pubkey(peer_device_id)? {
+        if ct_eq(&existing, peer_pubkey) {
+            return Ok(PairingOutcome {
+                short_circuited: true,
+                reason: Some(ALREADY_PAIRED.to_string()),
+            });
+        }
+    }
+    state.upsert_peer(peer_device_id, peer_pubkey, display_name, PeerTrust::Trusted)?;
+    Ok(PairingOutcome {
+        short_circuited: false,
+        reason: None,
+    })
+}
+
+// ─── Public entry points ──────────────────────────────────────────────────
+
+/// Initiator side — runs Noise XX as the dialing peer, then exchanges
+/// long-term key attestations. Returns the live `PostPairingSession` so
+/// the caller can continue with vault-grant exchange or sync.
+///
+/// `peer_device_id` is the responder's device id, learned from the
+/// pairing flow's PAKE step (each side already has it as part of `id_a`/
+/// `id_b`).
+pub fn drive_initiator_after_pake(
+    stream: &mut TcpStream,
+    noise_kp: &NoiseKeypair,
+    signing_key: &SigningKey,
+    self_device_id: &str,
+    peer_device_id: &str,
+    k2: &[u8; 32],
+    state: &SyncState,
+) -> Result<PostPairingSession, PairingEngineError> {
+    let hs = xx_initiator(&noise_kp.private)?;
+    let (mut transport, _remote_static) = drive_handshake(hs, stream, true)?;
+
+    let outcome = exchange_attestations(
+        stream,
+        &mut transport,
+        signing_key,
+        self_device_id,
+        peer_device_id,
+        k2,
+        state,
+    )?;
+    Ok(PostPairingSession {
+        stream: stream.try_clone()?,
+        transport,
+        outcome,
+    })
+}
+
+/// Responder side — accepts Noise XX as the listening peer.
+pub fn drive_responder_after_pake(
+    stream: &mut TcpStream,
+    noise_kp: &NoiseKeypair,
+    signing_key: &SigningKey,
+    self_device_id: &str,
+    peer_device_id: &str,
+    k2: &[u8; 32],
+    state: &SyncState,
+) -> Result<PostPairingSession, PairingEngineError> {
+    let hs = xx_responder(&noise_kp.private)?;
+    let (mut transport, _remote_static) = drive_handshake(hs, stream, false)?;
+
+    let outcome = exchange_attestations(
+        stream,
+        &mut transport,
+        signing_key,
+        self_device_id,
+        peer_device_id,
+        k2,
+        state,
+    )?;
+    Ok(PostPairingSession {
+        stream: stream.try_clone()?,
+        transport,
+        outcome,
+    })
+}
+
+/// Send our attestation, receive theirs, verify, persist. Mirrors on
+/// both sides — the order (send-then-recv) is symmetric over a duplex
+/// Noise channel: the snow `TransportState` API allows interleaved
+/// read_message / write_message because XX is fully bidirectional once
+/// finished. Initiator sends first, responder reads first; we mirror by
+/// always sending then reading on both sides — Noise tracks send/recv
+/// counters separately so neither blocks the other on a fresh transport.
+fn exchange_attestations(
+    stream: &mut TcpStream,
+    transport: &mut TransportState,
+    signing_key: &SigningKey,
+    self_device_id: &str,
+    peer_device_id: &str,
+    k2: &[u8; 32],
+    state: &SyncState,
+) -> Result<PairingOutcome, PairingEngineError> {
+    // Build + send our attestation.
+    let our_pk = signing_key.verifying_key().to_bytes();
+    let our_mac = long_term_attest_mac(k2, &our_pk);
+    send_engine_frame(
+        stream,
+        transport,
+        &EngineFrame::LongTermAttest {
+            ed25519_pubkey: our_pk,
+            mac: our_mac,
+        },
+    )?;
+
+    // Receive + verify the peer's.
+    let frame = recv_engine_frame(stream, transport)?;
+    let (peer_pk, peer_mac) = match frame {
+        EngineFrame::LongTermAttest {
+            ed25519_pubkey,
+            mac,
+        } => (ed25519_pubkey, mac),
+        _ => {
+            return Err(PairingEngineError::Codec(
+                "expected LongTermAttest as first engine frame".into(),
+            ))
+        }
+    };
+    let expected = long_term_attest_mac(k2, &peer_pk);
+    if !ct_eq(&expected, &peer_mac) {
+        return Err(PairingEngineError::AttestationMismatch);
+    }
+
+    let display_name = format!("Peer {peer_device_id}");
+    let outcome = persist_peer_trust(state, peer_device_id, &peer_pk, &display_name)?;
+    let _ = self_device_id; // bound for symmetry with future log instrumentation.
+    Ok(outcome)
+}
+
+/// Initiator-side vault grant exchange. Sends our peer-self-signed cap
+/// for `body`, then receives + verifies the peer's. Body must already
+/// have `body.peer_device_id == self_device_id` (the issuer's id), per
+/// the engine_tests::pair_peer_with_grant convention — we sanity-check
+/// it before signing so a caller that swapped the field doesn't ship
+/// a mis-bound cap to disk.
+pub fn exchange_vault_grant_initiator(
+    session: &mut PostPairingSession,
+    signing_key: &SigningKey,
+    body: &CapabilityBody,
+    peer_device_id: &str,
+    state: &SyncState,
+) -> Result<(), PairingEngineError> {
+    do_grant_exchange(session, signing_key, body, peer_device_id, state, true)
+}
+
+/// Responder-side vault grant exchange. Receives the peer's grant first,
+/// then sends ours. Reading first on the responder side mirrors the
+/// initiator's send-first ordering and avoids a head-of-line block where
+/// both sides are simultaneously trying to write before reading.
+pub fn exchange_vault_grant_responder(
+    session: &mut PostPairingSession,
+    signing_key: &SigningKey,
+    body: &CapabilityBody,
+    peer_device_id: &str,
+    state: &SyncState,
+) -> Result<(), PairingEngineError> {
+    do_grant_exchange(session, signing_key, body, peer_device_id, state, false)
+}
+
+fn do_grant_exchange(
+    session: &mut PostPairingSession,
+    signing_key: &SigningKey,
+    body: &CapabilityBody,
+    peer_device_id: &str,
+    state: &SyncState,
+    initiator: bool,
+) -> Result<(), PairingEngineError> {
+    // Sign our cap. body.peer_device_id is the *issuer's* own device id —
+    // we don't bind that here (the caller asserts it), but we'll fail
+    // verify() loud and clear if it's wrong.
+    let cap = Capability::sign(body, signing_key);
+
+    if initiator {
+        send_engine_frame(
+            &mut session.stream,
+            &mut session.transport,
+            &EngineFrame::VaultGrant {
+                capability_bytes: cap.to_bytes(),
+            },
+        )?;
+        let frame = recv_engine_frame(&mut session.stream, &mut session.transport)?;
+        receive_grant(state, peer_device_id, frame)?;
+    } else {
+        let frame = recv_engine_frame(&mut session.stream, &mut session.transport)?;
+        receive_grant(state, peer_device_id, frame)?;
+        send_engine_frame(
+            &mut session.stream,
+            &mut session.transport,
+            &EngineFrame::VaultGrant {
+                capability_bytes: cap.to_bytes(),
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn receive_grant(
+    state: &SyncState,
+    peer_device_id: &str,
+    frame: EngineFrame,
+) -> Result<(), PairingEngineError> {
+    let cap_bytes = match frame {
+        EngineFrame::VaultGrant { capability_bytes } => capability_bytes,
+        _ => {
+            return Err(PairingEngineError::Codec(
+                "expected VaultGrant frame in grant phase".into(),
+            ))
+        }
+    };
+    let cap = Capability::from_bytes(&cap_bytes)?;
+
+    // Verify under the peer's pubkey we just persisted. If the peer wasn't
+    // persisted (caller skipped attestation step), peer_pubkey returns
+    // None and we reject — fail closed.
+    let peer_pk_bytes = state.peer_pubkey(peer_device_id)?.ok_or_else(|| {
+        PairingEngineError::GrantVerification(format!(
+            "peer {peer_device_id} not trusted; cannot accept grant"
+        ))
+    })?;
+    let peer_vk = ed25519_dalek::VerifyingKey::from_bytes(&peer_pk_bytes).map_err(|e| {
+        PairingEngineError::GrantVerification(format!("decode peer pubkey: {e}"))
+    })?;
+    let body = cap
+        .verify(&peer_vk)
+        .map_err(|e| PairingEngineError::GrantVerification(format!("{e:?}")))?;
+    // The cap's `peer_device_id` field carries the *issuer's* own id by
+    // engine_tests::pair_peer_with_grant convention — assert it here so
+    // a misbound cap is caught at trust-store time rather than silently
+    // rotting until first sync.
+    if body.peer_device_id != peer_device_id {
+        return Err(PairingEngineError::GrantVerification(format!(
+            "cap.peer_device_id {} != expected issuer id {}",
+            body.peer_device_id, peer_device_id
+        )));
+    }
+    state.upsert_vault_grant(&cap)?;
+    Ok(())
+}

--- a/src-tauri/src/sync/protocol.rs
+++ b/src-tauri/src/sync/protocol.rs
@@ -1,0 +1,105 @@
+//! Sync wire format (epic #73).
+//!
+//! Length-prefixed bincode frames over the Noise-encrypted TCP channel.
+//! Each frame is `[u32 BE length][bincode-encoded SyncFrame]`. The
+//! length prefix bounds memory allocation — frames over `MAX_FRAME_BYTES`
+//! are rejected before allocation.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::{ContentHash, PeerId, VaultId, VersionVector};
+
+/// Hard cap on a single frame's payload length. 64 MiB — enough for the
+/// largest plausible note (with image embeds) without exposing an OOM
+/// avenue on a misbehaving peer.
+pub const MAX_FRAME_BYTES: u32 = 64 * 1024 * 1024;
+
+/// Top-level sync protocol message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SyncFrame {
+    /// Per-file change broadcast on a local write or replayed during
+    /// catch-up reconciliation.
+    Change(ChangeEvent),
+    /// Marker emitted around mass-reconciliation pulls so the receiver
+    /// can suppress per-file IndexCmd dispatch.
+    BatchBegin { vault_id: VaultId },
+    BatchEnd { vault_id: VaultId },
+    /// Peer identifies itself + presents its capability for a given vault.
+    /// Sent immediately after the Noise handshake completes.
+    Hello {
+        peer_id: PeerId,
+        vault_id: VaultId,
+        /// Bincode-serialized `Capability` token signed by the vault owner.
+        capability_bytes: Vec<u8>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeEvent {
+    pub vault_id: VaultId,
+    pub path: PathBuf,
+    pub kind: ChangeKind,
+    pub source_peer: PeerId,
+    pub version_vector: VersionVector,
+    pub content_hash: ContentHash,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChangeKind {
+    Upserted { content: Vec<u8> },
+    Renamed { from: PathBuf },
+    Deleted,
+}
+
+/// Bincode-serialize + length-prefix a `SyncFrame`. Used by tests and
+/// by the transport sender. Returns `Vec<u8>` rather than writing into
+/// a writer so the caller can pipeline frame composition + Noise
+/// encryption + socket write independently.
+pub fn encode_frame(frame: &SyncFrame) -> Result<Vec<u8>, FrameError> {
+    let body = bincode::serialize(frame).map_err(|e| FrameError::Serialize(e.to_string()))?;
+    if body.len() as u64 > MAX_FRAME_BYTES as u64 {
+        return Err(FrameError::TooLarge {
+            len: body.len(),
+            cap: MAX_FRAME_BYTES,
+        });
+    }
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Decode a length-prefixed frame from a single buffer. Caller is
+/// responsible for ensuring the buffer holds a complete frame (the
+/// transport read loop refills it as needed).
+pub fn decode_frame(buf: &[u8]) -> Result<(SyncFrame, usize), FrameError> {
+    if buf.len() < 4 {
+        return Err(FrameError::Short);
+    }
+    let len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    if len > MAX_FRAME_BYTES {
+        return Err(FrameError::TooLarge {
+            len: len as usize,
+            cap: MAX_FRAME_BYTES,
+        });
+    }
+    let total = 4 + len as usize;
+    if buf.len() < total {
+        return Err(FrameError::Short);
+    }
+    let frame: SyncFrame = bincode::deserialize(&buf[4..total])
+        .map_err(|e| FrameError::Deserialize(e.to_string()))?;
+    Ok((frame, total))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrameError {
+    /// Buffer doesn't contain a complete frame yet — caller should read more.
+    Short,
+    /// Frame announces a length over `MAX_FRAME_BYTES`.
+    TooLarge { len: usize, cap: u32 },
+    Serialize(String),
+    Deserialize(String),
+}

--- a/src-tauri/src/sync/state.rs
+++ b/src-tauri/src/sync/state.rs
@@ -1,0 +1,473 @@
+//! Sync metadata store backed by a single SQLite database
+//! (`<vault>/.vaultcore/sync-state.sqlite`).
+//!
+//! Schema is the verbatim epic #73 specification — `PRAGMA user_version = 1`.
+//! Adding a column or table requires bumping `user_version` and adding a
+//! `migrate_v1_to_v2` arm in [`SyncState::open`]; never edit the v1 SQL.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::error::VaultError;
+
+use super::clock::{Clock, SystemClock};
+use super::history::{History, HistoryConfig};
+use super::tombstone::Tombstones;
+use super::{ApplyOutcome, ContentHash, PeerId, VaultId, VersionVector};
+
+/// Current schema version. Bump and add a migration arm if the schema
+/// changes; never mutate the v1 SQL in place.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Subdirectory under `.vaultcore/` that backs the content-addressed
+/// history blob store.
+const HISTORY_DIRNAME: &str = "sync-history";
+
+/// Full v1 schema, exactly as specified in epic #73. Wrapped in a
+/// transaction at open-time. **Do not edit** — to evolve the schema,
+/// bump `SCHEMA_VERSION` and add a `migrate_v1_to_v2` step.
+const SCHEMA_V1: &str = r#"
+CREATE TABLE IF NOT EXISTS sync_files (
+  vault_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  content_hash BLOB NOT NULL,
+  version_vector BLOB NOT NULL,
+  last_synced_wall_time INTEGER NOT NULL,
+  PRIMARY KEY (vault_id, path)
+);
+
+CREATE TABLE IF NOT EXISTS sync_peers (
+  peer_device_id TEXT PRIMARY KEY,
+  peer_pubkey BLOB NOT NULL,
+  peer_name TEXT NOT NULL,
+  paired_at INTEGER NOT NULL,
+  last_seen INTEGER,
+  trust_state TEXT NOT NULL,
+  superseded_by TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sync_vault_grants (
+  local_vault_id TEXT NOT NULL,
+  peer_device_id TEXT NOT NULL,
+  peer_vault_id TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  capability_token BLOB NOT NULL,
+  format_version INTEGER NOT NULL DEFAULT 1,
+  requires_unlock INTEGER NOT NULL DEFAULT 0,
+  wrapped_key BLOB,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (local_vault_id, peer_device_id)
+);
+
+CREATE TABLE IF NOT EXISTS sync_history (
+  vault_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  content_hash BLOB NOT NULL,
+  version_vector BLOB NOT NULL,
+  blob_path TEXT NOT NULL,
+  retained_at INTEGER NOT NULL,
+  PRIMARY KEY (vault_id, path, content_hash)
+);
+
+CREATE TABLE IF NOT EXISTS sync_tombstones (
+  vault_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  deleted_at_vv BLOB NOT NULL,
+  expires_at INTEGER NOT NULL,
+  PRIMARY KEY (vault_id, path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tombstones_expires ON sync_tombstones(expires_at);
+CREATE INDEX IF NOT EXISTS idx_history_retained ON sync_history(vault_id, path, retained_at);
+"#;
+
+/// Per-file row from `sync_files`. Returned by the read APIs the sync
+/// engine uses to decide fast-forward / discard / 3-way merge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRecord {
+    pub vault_id: VaultId,
+    pub path: String,
+    pub content_hash: ContentHash,
+    pub version_vector: VersionVector,
+    pub last_synced_wall_time: i64,
+}
+
+/// Top-level handle bundling the SQLite connection, history blob store,
+/// and tombstone helper. The caller threads a single `SyncState` through
+/// the sync stack; concurrency is handled by the wrapped `Mutex`
+/// (throughput is not on the critical path of editor latency).
+pub struct SyncState {
+    conn: Mutex<Connection>,
+    history: History,
+    clock: Arc<dyn Clock>,
+    /// Stable owning peer id (`device_id`). Stored here so
+    /// `record_local_write` can increment the right slot of the VV
+    /// without the caller threading it through every call site.
+    self_peer: PeerId,
+}
+
+impl SyncState {
+    /// Open or create the sync-state DB at `vault_metadata_dir/sync-state.sqlite`.
+    /// `vault_metadata_dir` is the path returned by `VaultStorage::metadata_path()`
+    /// (i.e. `<vault>/.vaultcore` on desktop). The history blob store is
+    /// created at `<vault_metadata_dir>/sync-history/`.
+    pub fn open(
+        vault_metadata_dir: &Path,
+        self_peer: PeerId,
+    ) -> Result<Self, VaultError> {
+        Self::open_with(
+            vault_metadata_dir,
+            self_peer,
+            Arc::new(SystemClock),
+            HistoryConfig::default(),
+        )
+    }
+
+    /// Test-friendly variant that accepts an injectable clock + history config.
+    pub fn open_with(
+        vault_metadata_dir: &Path,
+        self_peer: PeerId,
+        clock: Arc<dyn Clock>,
+        history_cfg: HistoryConfig,
+    ) -> Result<Self, VaultError> {
+        std::fs::create_dir_all(vault_metadata_dir).map_err(VaultError::Io)?;
+        let db_path = vault_metadata_dir.join("sync-state.sqlite");
+        let history_root = vault_metadata_dir.join(HISTORY_DIRNAME);
+
+        let conn = Connection::open(&db_path).map_err(sqlite_err)?;
+        Self::initialize_schema(&conn)?;
+
+        let history = History::new(history_root, history_cfg);
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+            history,
+            clock,
+            self_peer,
+        })
+    }
+
+    /// Apply the v1 schema if `user_version` is 0; verify it matches
+    /// `SCHEMA_VERSION` otherwise. Future migrations dispatch off the
+    /// existing `user_version` here.
+    fn initialize_schema(conn: &Connection) -> Result<(), VaultError> {
+        let current: u32 = conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .map_err(sqlite_err)?;
+
+        if current == 0 {
+            conn.execute_batch(SCHEMA_V1).map_err(sqlite_err)?;
+            conn.pragma_update(None, "user_version", SCHEMA_VERSION)
+                .map_err(sqlite_err)?;
+        } else if current != SCHEMA_VERSION {
+            return Err(VaultError::SyncState {
+                msg: format!(
+                    "unsupported sync-state schema version {current} (expected {SCHEMA_VERSION})"
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn schema_version(&self) -> Result<u32, VaultError> {
+        let conn = self.lock_conn()?;
+        conn.pragma_query_value(None, "user_version", |row| row.get(0))
+            .map_err(sqlite_err)
+    }
+
+    pub fn self_peer(&self) -> &str {
+        &self.self_peer
+    }
+
+    pub fn history(&self) -> &History {
+        &self.history
+    }
+
+    /// Tombstone helper bound to this DB connection. Re-issued cheaply on
+    /// each call (`Tombstones` borrows `&self`).
+    pub fn tombstones(&self) -> Tombstones<'_> {
+        Tombstones::new(self)
+    }
+
+    // ─── Read APIs ───────────────────────────────────────────────────────
+
+    /// Fetch the `(content_hash, vv)` for a tracked file, if any.
+    pub fn get_file(
+        &self,
+        vault_id: &str,
+        path: &str,
+    ) -> Result<Option<FileRecord>, VaultError> {
+        let conn = self.lock_conn()?;
+        conn.query_row(
+            "SELECT vault_id, path, content_hash, version_vector, last_synced_wall_time
+             FROM sync_files WHERE vault_id = ?1 AND path = ?2",
+            params![vault_id, path],
+            row_to_file_record,
+        )
+        .optional()
+        .map_err(sqlite_err)
+    }
+
+    // ─── Write APIs ──────────────────────────────────────────────────────
+
+    /// Record a local write. Reads the current VV (or zero if absent),
+    /// increments `self_peer`'s counter, persists `(content_hash, vv)`,
+    /// and copies the bytes into the history blob store with LRU
+    /// eviction.
+    ///
+    /// Returns the new VV so callers can broadcast it to peers without a
+    /// second round-trip to the DB.
+    pub fn record_local_write(
+        &self,
+        vault_id: &str,
+        path: &str,
+        content_hash: ContentHash,
+        content: &[u8],
+    ) -> Result<VersionVector, VaultError> {
+        let now = self.clock.now_secs();
+        let mut vv = self
+            .get_file(vault_id, path)?
+            .map(|r| r.version_vector)
+            .unwrap_or_default();
+        vv.increment(&self.self_peer);
+        let vv_bytes = vv.to_bytes();
+
+        // History record: write the blob first, then the index row, so a
+        // crash between the two leaves an orphan blob (cheap to GC) rather
+        // than a dangling DB pointer.
+        let blob_rel = self
+            .history
+            .put_blob(content_hash, content)
+            .map_err(VaultError::Io)?;
+
+        let conn = self.lock_conn()?;
+        let tx = conn_transaction(&conn)?;
+        tx.execute(
+            "INSERT INTO sync_files (vault_id, path, content_hash, version_vector, last_synced_wall_time)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(vault_id, path) DO UPDATE SET
+                 content_hash = excluded.content_hash,
+                 version_vector = excluded.version_vector,
+                 last_synced_wall_time = excluded.last_synced_wall_time",
+            params![vault_id, path, &content_hash[..], &vv_bytes, now],
+        )
+        .map_err(sqlite_err)?;
+        upsert_history_row(&tx, vault_id, path, &content_hash, &vv_bytes, &blob_rel, now)?;
+        evict_history_lru(&tx, vault_id, path, self.history.config().retain_per_file)?;
+        tx.commit().map_err(sqlite_err)?;
+        // Best-effort: prune blob files whose index rows just got deleted.
+        // Failure here is non-fatal — `History::gc_orphans` cleans up next pass.
+        Ok(vv)
+    }
+
+    /// Apply a remote write decision. Does NOT touch the working file —
+    /// the caller is responsible for that (this layer is metadata-only).
+    /// On `FastForward` / `Created`, the new `(content_hash, vv)` is
+    /// persisted and the supplied bytes are stashed in history.
+    pub fn apply_remote_write(
+        &self,
+        vault_id: &str,
+        path: &str,
+        remote_hash: ContentHash,
+        remote_vv: VersionVector,
+        remote_content: &[u8],
+    ) -> Result<ApplyOutcome, VaultError> {
+        let now = self.clock.now_secs();
+        let existing = self.get_file(vault_id, path)?;
+
+        let outcome = match &existing {
+            None => ApplyOutcome::Created,
+            Some(local) if local.version_vector == remote_vv => {
+                // Identical VV → already in sync; treat as discard.
+                return Ok(ApplyOutcome::Discard);
+            }
+            Some(local) if local.version_vector.dominates(&remote_vv) => ApplyOutcome::Discard,
+            Some(local) if remote_vv.dominates(&local.version_vector) => ApplyOutcome::FastForward,
+            Some(_) => ApplyOutcome::Conflict,
+        };
+
+        if matches!(outcome, ApplyOutcome::Discard | ApplyOutcome::Conflict) {
+            // Concurrent: also stash the remote blob in history so the
+            // 3-way merge call site can fetch it by hash. Cheap and
+            // bounded by LRU eviction.
+            if matches!(outcome, ApplyOutcome::Conflict) {
+                let blob_rel = self
+                    .history
+                    .put_blob(remote_hash, remote_content)
+                    .map_err(VaultError::Io)?;
+                let conn = self.lock_conn()?;
+                let tx = conn_transaction(&conn)?;
+                upsert_history_row(
+                    &tx,
+                    vault_id,
+                    path,
+                    &remote_hash,
+                    &remote_vv.to_bytes(),
+                    &blob_rel,
+                    now,
+                )?;
+                evict_history_lru(&tx, vault_id, path, self.history.config().retain_per_file)?;
+                tx.commit().map_err(sqlite_err)?;
+            }
+            return Ok(outcome);
+        }
+
+        // FastForward or Created: persist and stash blob.
+        let vv_bytes = remote_vv.to_bytes();
+        let blob_rel = self
+            .history
+            .put_blob(remote_hash, remote_content)
+            .map_err(VaultError::Io)?;
+
+        let conn = self.lock_conn()?;
+        let tx = conn_transaction(&conn)?;
+        tx.execute(
+            "INSERT INTO sync_files (vault_id, path, content_hash, version_vector, last_synced_wall_time)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(vault_id, path) DO UPDATE SET
+                 content_hash = excluded.content_hash,
+                 version_vector = excluded.version_vector,
+                 last_synced_wall_time = excluded.last_synced_wall_time",
+            params![vault_id, path, &remote_hash[..], &vv_bytes, now],
+        )
+        .map_err(sqlite_err)?;
+        upsert_history_row(&tx, vault_id, path, &remote_hash, &vv_bytes, &blob_rel, now)?;
+        evict_history_lru(&tx, vault_id, path, self.history.config().retain_per_file)?;
+        tx.commit().map_err(sqlite_err)?;
+
+        Ok(outcome)
+    }
+
+    /// Look up a historical version's blob bytes by content hash.
+    /// Returns `None` if the hash isn't in this file's retention window
+    /// — caller should fall back to conflict-copy semantics.
+    pub fn get_history(
+        &self,
+        vault_id: &str,
+        path: &str,
+        content_hash: &ContentHash,
+    ) -> Result<Option<Vec<u8>>, VaultError> {
+        let conn = self.lock_conn()?;
+        let blob_path: Option<String> = conn
+            .query_row(
+                "SELECT blob_path FROM sync_history
+                 WHERE vault_id = ?1 AND path = ?2 AND content_hash = ?3",
+                params![vault_id, path, &content_hash[..]],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        let Some(rel) = blob_path else {
+            return Ok(None);
+        };
+        drop(conn);
+        let bytes = self
+            .history
+            .read_blob(Path::new(&rel))
+            .map_err(VaultError::Io)?;
+        Ok(Some(bytes))
+    }
+
+    // ─── Internals shared with sibling submodules ─────────────────────────
+
+    pub(crate) fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>, VaultError> {
+        self.conn.lock().map_err(|_| VaultError::LockPoisoned)
+    }
+
+    pub(crate) fn clock(&self) -> &dyn Clock {
+        self.clock.as_ref()
+    }
+
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+fn sqlite_err(e: rusqlite::Error) -> VaultError {
+    VaultError::SyncState {
+        msg: format!("sqlite: {e}"),
+    }
+}
+
+fn row_to_file_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileRecord> {
+    let vault_id: String = row.get(0)?;
+    let path: String = row.get(1)?;
+    let hash_bytes: Vec<u8> = row.get(2)?;
+    let vv_bytes: Vec<u8> = row.get(3)?;
+    let last_synced_wall_time: i64 = row.get(4)?;
+    let mut content_hash: ContentHash = [0; 32];
+    if hash_bytes.len() != 32 {
+        return Err(rusqlite::Error::InvalidColumnType(
+            2,
+            "content_hash must be 32 bytes".into(),
+            rusqlite::types::Type::Blob,
+        ));
+    }
+    content_hash.copy_from_slice(&hash_bytes);
+    let vv = VersionVector::from_bytes(&vv_bytes).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Blob, Box::new(e))
+    })?;
+    Ok(FileRecord {
+        vault_id,
+        path,
+        content_hash,
+        version_vector: vv,
+        last_synced_wall_time,
+    })
+}
+
+fn conn_transaction(conn: &Connection) -> Result<rusqlite::Transaction<'_>, VaultError> {
+    // SAFETY: `Connection::unchecked_transaction` borrows `&self` to start a
+    // transaction; needed because we hold a `MutexGuard<'_, Connection>` and
+    // `Connection::transaction` requires `&mut self`.
+    conn.unchecked_transaction().map_err(sqlite_err)
+}
+
+fn upsert_history_row(
+    tx: &rusqlite::Transaction<'_>,
+    vault_id: &str,
+    path: &str,
+    content_hash: &ContentHash,
+    vv_bytes: &[u8],
+    blob_rel: &Path,
+    retained_at: i64,
+) -> Result<(), VaultError> {
+    let blob_path_str = blob_rel.to_string_lossy().to_string();
+    tx.execute(
+        "INSERT INTO sync_history (vault_id, path, content_hash, version_vector, blob_path, retained_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(vault_id, path, content_hash) DO UPDATE SET
+             version_vector = excluded.version_vector,
+             blob_path = excluded.blob_path,
+             retained_at = excluded.retained_at",
+        params![vault_id, path, &content_hash[..], vv_bytes, blob_path_str, retained_at],
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+/// Keep only the `keep` most recently retained history rows per
+/// `(vault_id, path)`; delete the rest. Blob files orphaned by this
+/// step are cleaned by `History::gc_orphans`, which the caller can run
+/// opportunistically.
+fn evict_history_lru(
+    tx: &rusqlite::Transaction<'_>,
+    vault_id: &str,
+    path: &str,
+    keep: usize,
+) -> Result<(), VaultError> {
+    tx.execute(
+        "DELETE FROM sync_history
+         WHERE vault_id = ?1 AND path = ?2
+           AND content_hash NOT IN (
+               SELECT content_hash FROM sync_history
+               WHERE vault_id = ?1 AND path = ?2
+               ORDER BY retained_at DESC
+               LIMIT ?3
+           )",
+        params![vault_id, path, keep as i64],
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}

--- a/src-tauri/src/sync/state.rs
+++ b/src-tauri/src/sync/state.rs
@@ -191,6 +191,128 @@ impl SyncState {
         Tombstones::new(self)
     }
 
+    // ─── Peer trust store (sync_peers) ────────────────────────────────────
+
+    /// Insert or update a peer record. Used by the pairing flow on
+    /// successful PAKE + key-confirmation to persist the peer's
+    /// long-term Ed25519 pubkey.
+    pub fn upsert_peer(
+        &self,
+        peer_device_id: &str,
+        peer_pubkey: &[u8; 32],
+        peer_name: &str,
+        trust_state: PeerTrust,
+    ) -> Result<(), VaultError> {
+        let now = self.clock.now_secs();
+        let conn = self.lock_conn()?;
+        conn.execute(
+            "INSERT INTO sync_peers (peer_device_id, peer_pubkey, peer_name, paired_at, last_seen, trust_state, superseded_by)
+             VALUES (?1, ?2, ?3, ?4, NULL, ?5, NULL)
+             ON CONFLICT(peer_device_id) DO UPDATE SET
+                 peer_pubkey = excluded.peer_pubkey,
+                 peer_name = excluded.peer_name,
+                 trust_state = excluded.trust_state",
+            rusqlite::params![peer_device_id, &peer_pubkey[..], peer_name, now, trust_state.as_str()],
+        )
+        .map_err(sqlite_err)?;
+        Ok(())
+    }
+
+    /// Look up the peer's pubkey for capability-signature verification.
+    /// Returns `None` if the peer is unknown or revoked.
+    pub fn peer_pubkey(&self, peer_device_id: &str) -> Result<Option<[u8; 32]>, VaultError> {
+        let conn = self.lock_conn()?;
+        let row: Option<(Vec<u8>, String)> = conn
+            .query_row(
+                "SELECT peer_pubkey, trust_state FROM sync_peers WHERE peer_device_id = ?1",
+                rusqlite::params![peer_device_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        let Some((bytes, trust)) = row else {
+            return Ok(None);
+        };
+        if trust != PeerTrust::Trusted.as_str() {
+            return Ok(None);
+        }
+        if bytes.len() != 32 {
+            return Err(VaultError::SyncState {
+                msg: format!("peer_pubkey wrong length: {}", bytes.len()),
+            });
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        Ok(Some(out))
+    }
+
+    // ─── Capability grants (sync_vault_grants) ────────────────────────────
+
+    /// Persist a signed `Capability` as a row in `sync_vault_grants`.
+    /// `local_vault_id` and `peer_device_id` are the primary key —
+    /// re-issuing replaces the prior token.
+    pub fn upsert_vault_grant(
+        &self,
+        capability: &super::capability::Capability,
+    ) -> Result<(), VaultError> {
+        let body = bincode::deserialize::<super::capability::CapabilityBody>(&capability.body)
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("capability body decode: {e}"),
+            })?;
+        let token_bytes = capability.to_bytes();
+        let conn = self.lock_conn()?;
+        conn.execute(
+            "INSERT INTO sync_vault_grants (
+                local_vault_id, peer_device_id, peer_vault_id, scope,
+                capability_token, format_version, requires_unlock, wrapped_key, enabled
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1)
+             ON CONFLICT(local_vault_id, peer_device_id) DO UPDATE SET
+                 peer_vault_id = excluded.peer_vault_id,
+                 scope = excluded.scope,
+                 capability_token = excluded.capability_token,
+                 format_version = excluded.format_version,
+                 requires_unlock = excluded.requires_unlock,
+                 wrapped_key = excluded.wrapped_key,
+                 enabled = 1",
+            rusqlite::params![
+                body.local_vault_id,
+                body.peer_device_id,
+                body.peer_vault_id,
+                body.scope.as_str(),
+                token_bytes,
+                body.format_version,
+                body.requires_unlock,
+                body.wrapped_key,
+            ],
+        )
+        .map_err(sqlite_err)?;
+        Ok(())
+    }
+
+    /// Fetch the `Capability` for a `(local_vault_id, peer_device_id)` pair
+    /// if one is enabled. Returns `None` if the grant is missing or
+    /// disabled — caller treats that as "no access".
+    pub fn vault_grant(
+        &self,
+        local_vault_id: &str,
+        peer_device_id: &str,
+    ) -> Result<Option<super::capability::Capability>, VaultError> {
+        let conn = self.lock_conn()?;
+        let row: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT capability_token FROM sync_vault_grants
+                 WHERE local_vault_id = ?1 AND peer_device_id = ?2 AND enabled = 1",
+                rusqlite::params![local_vault_id, peer_device_id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        let Some(bytes) = row else {
+            return Ok(None);
+        };
+        Ok(Some(super::capability::Capability::from_bytes(&bytes)?))
+    }
+
     // ─── Read APIs ───────────────────────────────────────────────────────
 
     /// Fetch the `(content_hash, vv)` for a tracked file, if any.
@@ -379,7 +501,24 @@ impl SyncState {
     pub(crate) fn clock(&self) -> &dyn Clock {
         self.clock.as_ref()
     }
+}
 
+/// `sync_peers.trust_state` values per epic schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerTrust {
+    Trusted,
+    Revoked,
+    Superseded,
+}
+
+impl PeerTrust {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::Revoked => "revoked",
+            Self::Superseded => "superseded",
+        }
+    }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/src-tauri/src/sync/state.rs
+++ b/src-tauri/src/sync/state.rs
@@ -81,6 +81,20 @@ CREATE TABLE IF NOT EXISTS sync_tombstones (
 
 CREATE INDEX IF NOT EXISTS idx_tombstones_expires ON sync_tombstones(expires_at);
 CREATE INDEX IF NOT EXISTS idx_history_retained ON sync_history(vault_id, path, retained_at);
+
+-- #420: per-vault Merkle hash tree backing catch-up reconciliation.
+-- One row per node: `node_path = ""` is the root folder. `parent_path`
+-- is the index used by the descent protocol to fetch direct children
+-- in O(children).
+CREATE TABLE IF NOT EXISTS sync_merkle_nodes (
+  vault_id TEXT NOT NULL,
+  node_path TEXT NOT NULL,
+  parent_path TEXT NOT NULL,
+  kind TEXT NOT NULL,                   -- 'file' | 'folder'
+  hash BLOB NOT NULL,
+  PRIMARY KEY (vault_id, node_path)
+);
+CREATE INDEX IF NOT EXISTS idx_merkle_parent ON sync_merkle_nodes(vault_id, parent_path);
 "#;
 
 /// Per-file row from `sync_files`. Returned by the read APIs the sync

--- a/src-tauri/src/sync/state.rs
+++ b/src-tauri/src/sync/state.rs
@@ -327,6 +327,112 @@ impl SyncState {
         Ok(Some(super::capability::Capability::from_bytes(&bytes)?))
     }
 
+    /// Enumerate every `Trusted` peer with its display name + last-seen
+    /// timestamp. Used by the IPC bridge's `sync_list_paired_peers`
+    /// command to populate the Settings → Sync paired-devices list.
+    /// Revoked / superseded peers are excluded from the response.
+    pub fn list_paired_peers(&self) -> Result<Vec<PairedPeerRecord>, VaultError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT peer_device_id, peer_name, last_seen
+                 FROM sync_peers
+                 WHERE trust_state = ?1
+                 ORDER BY peer_device_id",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![PeerTrust::Trusted.as_str()], |r| {
+                Ok(PairedPeerRecord {
+                    peer_device_id: r.get(0)?,
+                    peer_name: r.get(1)?,
+                    last_seen: r.get::<_, Option<i64>>(2)?,
+                })
+            })
+            .map_err(sqlite_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(sqlite_err)?);
+        }
+        Ok(out)
+    }
+
+    /// All enabled grants issued to `peer_device_id` across every
+    /// `local_vault_id` tracked by this DB. Returns `(local_vault_id,
+    /// peer_vault_id, scope)` triples in stable lexicographic order.
+    pub fn list_grants_for_peer(
+        &self,
+        peer_device_id: &str,
+    ) -> Result<Vec<GrantRecord>, VaultError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT local_vault_id, peer_vault_id, scope
+                 FROM sync_vault_grants
+                 WHERE peer_device_id = ?1 AND enabled = 1
+                 ORDER BY local_vault_id",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![peer_device_id], |r| {
+                Ok(GrantRecord {
+                    local_vault_id: r.get(0)?,
+                    peer_vault_id: r.get(1)?,
+                    scope: r.get(2)?,
+                })
+            })
+            .map_err(sqlite_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(sqlite_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Disable the grant for `(local_vault_id, peer_device_id)`. The row
+    /// stays in the table so re-grant retains the previous wrapped_key
+    /// (if any) without needing a new key-exchange round-trip; capability
+    /// validation skips disabled rows via the `enabled = 1` predicate
+    /// already in `vault_grant`.
+    pub fn disable_vault_grant(
+        &self,
+        local_vault_id: &str,
+        peer_device_id: &str,
+    ) -> Result<bool, VaultError> {
+        let conn = self.lock_conn()?;
+        let n = conn
+            .execute(
+                "UPDATE sync_vault_grants SET enabled = 0
+                 WHERE local_vault_id = ?1 AND peer_device_id = ?2 AND enabled = 1",
+                rusqlite::params![local_vault_id, peer_device_id],
+            )
+            .map_err(sqlite_err)?;
+        Ok(n > 0)
+    }
+
+    /// Mark a peer's trust state as `Revoked` and disable every grant
+    /// row for that peer in one transaction. Used by
+    /// `sync_revoke_peer` when the user removes a paired device entirely
+    /// rather than per-vault. Returns the number of grants affected.
+    pub fn revoke_peer(&self, peer_device_id: &str) -> Result<usize, VaultError> {
+        let conn = self.lock_conn()?;
+        let tx = conn_transaction(&conn)?;
+        tx.execute(
+            "UPDATE sync_peers SET trust_state = ?1
+             WHERE peer_device_id = ?2",
+            rusqlite::params![PeerTrust::Revoked.as_str(), peer_device_id],
+        )
+        .map_err(sqlite_err)?;
+        let n = tx
+            .execute(
+                "UPDATE sync_vault_grants SET enabled = 0 WHERE peer_device_id = ?1",
+                rusqlite::params![peer_device_id],
+            )
+            .map_err(sqlite_err)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(n)
+    }
+
     // ─── Read APIs ───────────────────────────────────────────────────────
 
     /// Fetch the `(content_hash, vv)` for a tracked file, if any.
@@ -515,6 +621,27 @@ impl SyncState {
     pub(crate) fn clock(&self) -> &dyn Clock {
         self.clock.as_ref()
     }
+}
+
+/// Row returned by [`SyncState::list_paired_peers`]. Shape mirrors the
+/// columns the IPC bridge cares about (id, display name, last-seen) —
+/// the long-term pubkey isn't needed by the UI and is kept off the wire
+/// to avoid accidentally surfacing it through frontend-side logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairedPeerRecord {
+    pub peer_device_id: String,
+    pub peer_name: String,
+    pub last_seen: Option<i64>,
+}
+
+/// Row returned by [`SyncState::list_grants_for_peer`]. Carries the raw
+/// `scope` string straight from the column so the IPC layer can pass it
+/// to `Scope::parse` without re-deserializing the full capability blob.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrantRecord {
+    pub local_vault_id: String,
+    pub peer_vault_id: String,
+    pub scope: String,
 }
 
 /// `sync_peers.trust_state` values per epic schema.

--- a/src-tauri/src/sync/tests/conflict_tests.rs
+++ b/src-tauri/src/sync/tests/conflict_tests.rs
@@ -1,0 +1,279 @@
+//! TDD coverage for #420 conflict resolution + tombstone propagation
+//! + rename dispatch.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use ed25519_dalek::SigningKey;
+use rand_core::RngCore;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+use crate::sync::capability::{Capability, CapabilityBody, Scope};
+use crate::sync::clock::TestClock;
+use crate::sync::conflict::{conflict_copy_path, resolve, ResolveOutcome};
+use crate::sync::engine::{InboundDecision, SyncEngine};
+use crate::sync::history::HistoryConfig;
+use crate::sync::protocol::{ChangeEvent, ChangeKind};
+use crate::sync::state::{PeerTrust, SyncState};
+use crate::sync::tombstone::TOMBSTONE_TTL_SECS;
+use crate::sync::{ContentHash, VersionVector};
+use crate::WriteIgnoreList;
+
+const SELF_PEER: &str = "SELFPEER";
+const REMOTE_PEER: &str = "PEER";
+const VAULT: &str = "vault-uuid";
+
+fn h(content: &[u8]) -> ContentHash {
+    let d = Sha256::digest(content);
+    let mut o: ContentHash = [0; 32];
+    o.copy_from_slice(&d);
+    o
+}
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand_core::OsRng.fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+fn build_state(tmp: &TempDir, t0: i64) -> Arc<SyncState> {
+    let metadata = tmp.path().join(".vaultcore");
+    std::fs::create_dir_all(&metadata).unwrap();
+    Arc::new(
+        SyncState::open_with(
+            &metadata,
+            SELF_PEER.into(),
+            Arc::new(TestClock::new(t0)),
+            HistoryConfig::default(),
+        )
+        .unwrap(),
+    )
+}
+
+#[test]
+fn conflict_three_way_merge_uses_history_gca() {
+    let tmp = TempDir::new().unwrap();
+    let state = build_state(&tmp, 1_700_000_000);
+    let path = "notes/a.md";
+
+    // Establish a base via local write — creates VV {self:1} and stores
+    // base bytes in history.
+    let base = "alpha\nbeta\ngamma\n";
+    state
+        .record_local_write(VAULT, path, h(base.as_bytes()), base.as_bytes())
+        .unwrap();
+
+    // Local edit (left): VV {self:2}.
+    let left = "alpha edited locally\nbeta\ngamma\n";
+    state
+        .record_local_write(VAULT, path, h(left.as_bytes()), left.as_bytes())
+        .unwrap();
+
+    // Remote edit (right) concurrent w/ first local: VV {self:1, remote:1}
+    // — the GCA is therefore {self:1}, which is still in history.
+    let right = "alpha\nbeta\ngamma edited remotely\n";
+    let remote_vv = VersionVector(
+        [(SELF_PEER.into(), 1u64), (REMOTE_PEER.into(), 1u64)]
+            .into_iter()
+            .collect(),
+    );
+
+    let local_record = state.get_file(VAULT, path).unwrap().unwrap();
+    let outcome = resolve(
+        &state,
+        VAULT,
+        Path::new(path),
+        &local_record,
+        left.as_bytes(),
+        right.as_bytes(),
+        &remote_vv,
+        "Bob",
+    )
+    .unwrap();
+
+    match outcome {
+        ResolveOutcome::Merged { merged_content, merged_vv } => {
+            assert!(merged_content.contains("alpha edited locally"));
+            assert!(merged_content.contains("gamma edited remotely"));
+            // Merged VV must dominate both inputs.
+            assert!(merged_vv.dominates(&local_record.version_vector));
+            assert!(merged_vv.dominates(&remote_vv));
+        }
+        other => panic!("expected Merged, got {other:?}"),
+    }
+}
+
+#[test]
+fn conflict_copy_named_obsidian_compatible_when_gca_missing() {
+    let tmp = TempDir::new().unwrap();
+    // Pin clock to a known instant so we can assert the formatted stamp
+    // exactly. 2026-05-03 14:22 UTC = 1_777_818_120.
+    let t0: i64 = 1_777_818_120;
+    let state = build_state(&tmp, t0);
+    let path = "notes/work.md";
+
+    // Local write at VV {self:1}, but we DON'T retain history old enough
+    // to satisfy the GCA — push two extra writes so v1 falls out of the
+    // last-2 LRU window.
+    state
+        .record_local_write(VAULT, path, h(b"v1"), b"v1")
+        .unwrap();
+    state
+        .record_local_write(VAULT, path, h(b"v2"), b"v2")
+        .unwrap();
+    state
+        .record_local_write(VAULT, path, h(b"v3"), b"v3")
+        .unwrap();
+    let local_record = state.get_file(VAULT, path).unwrap().unwrap();
+    // Ask for resolution against a remote whose VV's GCA points at v1 —
+    // which is no longer in history.
+    let remote_vv = VersionVector(
+        [(SELF_PEER.into(), 1u64), (REMOTE_PEER.into(), 1u64)]
+            .into_iter()
+            .collect(),
+    );
+
+    let outcome = resolve(
+        &state,
+        VAULT,
+        Path::new(path),
+        &local_record,
+        b"v3",
+        b"divergent",
+        &remote_vv,
+        "Bob",
+    )
+    .unwrap();
+
+    match outcome {
+        ResolveOutcome::NoBaseInHistory { copy_path, copy_content } => {
+            // Obsidian-compatible filename per epic #73 lock.
+            let s = copy_path.to_string_lossy().to_string();
+            assert!(s.starts_with("notes/work (conflict from Bob "), "got: {s}");
+            assert!(s.contains("2026-05-03"), "stamp must be 2026-05-03, got: {s}");
+            assert!(s.contains("14:22"), "stamp must be 14:22, got: {s}");
+            assert!(s.ends_with(").md"), "must preserve extension, got: {s}");
+            assert_eq!(copy_content, b"divergent");
+        }
+        other => panic!("expected NoBaseInHistory, got {other:?}"),
+    }
+}
+
+#[test]
+fn conflict_copy_path_format_round_trips() {
+    let tmp = TempDir::new().unwrap();
+    // 2026-05-03 14:22 UTC.
+    let state = build_state(&tmp, 1_777_818_120);
+    let p = conflict_copy_path(Path::new("a/b/note.md"), "Lucas's iPhone", &state);
+    assert_eq!(
+        p,
+        PathBuf::from("a/b/note (conflict from Lucas's iPhone 2026-05-03 14:22).md")
+    );
+
+    let p2 = conflict_copy_path(Path::new("toplevel.md"), "Bob", &state);
+    assert_eq!(
+        p2,
+        PathBuf::from("toplevel (conflict from Bob 2026-05-03 14:22).md")
+    );
+}
+
+#[test]
+fn tombstone_propagation_persists_with_30d_expiry() {
+    let tmp = TempDir::new().unwrap();
+    let t0: i64 = 1_700_000_000;
+    let state = build_state(&tmp, t0);
+    let mut vv = VersionVector::new();
+    vv.increment(SELF_PEER);
+    state
+        .tombstones()
+        .record_delete(VAULT, "deleted.md", &vv)
+        .unwrap();
+
+    // Row is live, expires_at is +30d.
+    assert!(state.tombstones().is_tombstoned(VAULT, "deleted.md").unwrap());
+
+    // Direct DB inspection: expires_at = t0 + 30d.
+    let conn = state.lock_conn().unwrap();
+    let expires_at: i64 = conn
+        .query_row(
+            "SELECT expires_at FROM sync_tombstones WHERE vault_id = ?1 AND path = ?2",
+            rusqlite::params![VAULT, "deleted.md"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(expires_at, t0 + TOMBSTONE_TTL_SECS);
+}
+
+#[test]
+fn tombstone_gc_removes_expired() {
+    let tmp = TempDir::new().unwrap();
+    let t0: i64 = 1_700_000_000;
+    let clock = Arc::new(TestClock::new(t0));
+    let state = Arc::new(
+        SyncState::open_with(
+            &tmp.path().join(".vaultcore"),
+            SELF_PEER.into(),
+            clock.clone(),
+            HistoryConfig::default(),
+        )
+        .unwrap(),
+    );
+    let mut vv = VersionVector::new();
+    vv.increment(SELF_PEER);
+    state.tombstones().record_delete(VAULT, "a.md", &vv).unwrap();
+    state.tombstones().record_delete(VAULT, "b.md", &vv).unwrap();
+
+    // Advance to past TTL — both should GC.
+    clock.set(t0 + TOMBSTONE_TTL_SECS + 1);
+    let removed = state.tombstones().gc().unwrap();
+    assert_eq!(removed, 2);
+    assert!(!state.tombstones().is_tombstoned(VAULT, "a.md").unwrap());
+    assert!(!state.tombstones().is_tombstoned(VAULT, "b.md").unwrap());
+}
+
+#[test]
+fn rename_dispatches_single_renamekind() {
+    // Spec: a single Renamed event must produce a single Rename
+    // decision (not a Delete + Create pair). Verifies the engine's
+    // ChangeKind::Renamed branch.
+    let tmp = TempDir::new().unwrap();
+    let state = build_state(&tmp, 1_700_000_000);
+    let owner = fresh_signing_key();
+    state
+        .upsert_peer(
+            REMOTE_PEER,
+            &owner.verifying_key().to_bytes(),
+            "Remote",
+            PeerTrust::Trusted,
+        )
+        .unwrap();
+    let body = CapabilityBody::issue_v1(VAULT, REMOTE_PEER, "remote-vault", Scope::ReadWrite);
+    let cap = Capability::sign(&body, &owner);
+    state.upsert_vault_grant(&cap).unwrap();
+
+    let wi = Arc::new(Mutex::new(WriteIgnoreList::default()));
+    let engine = SyncEngine::new(state, wi);
+    engine.set_vault_root(tmp.path().to_path_buf()).unwrap();
+
+    let mut vv = VersionVector::new();
+    vv.increment(REMOTE_PEER);
+    let evt = ChangeEvent {
+        vault_id: VAULT.into(),
+        path: PathBuf::from("renamed/new.md"),
+        kind: ChangeKind::Renamed {
+            from: PathBuf::from("renamed/old.md"),
+        },
+        source_peer: REMOTE_PEER.into(),
+        version_vector: vv,
+        content_hash: h(b"renamed-content"),
+    };
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    match decision {
+        InboundDecision::Rename { from, to } => {
+            assert_eq!(from, tmp.path().join("renamed/old.md"));
+            assert_eq!(to, tmp.path().join("renamed/new.md"));
+        }
+        other => panic!("expected single Rename decision, got {other:?}"),
+    }
+}

--- a/src-tauri/src/sync/tests/discovery_tests.rs
+++ b/src-tauri/src/sync/tests/discovery_tests.rs
@@ -1,0 +1,75 @@
+//! TDD coverage for #417 discovery layer (desktop mDNS).
+//!
+//! Skipped on Android — there's nothing to exercise without a JNI bridge.
+
+#![cfg(not(target_os = "android"))]
+
+use std::time::{Duration, Instant};
+
+use crate::sync::discovery::{
+    AdvertisedVault, Discovery, MdnsDiscovery, PeerAd, PROTO_VERSION,
+};
+
+fn ad(device_id: &str, name: &str, port: u16) -> PeerAd {
+    PeerAd {
+        device_id: device_id.to_string(),
+        name: name.to_string(),
+        vaults: vec![AdvertisedVault {
+            id: "vault-uuid-test".into(),
+            name: "Test Vault".into(),
+        }],
+        pubkey_fp: device_id.chars().take(8).collect(),
+        proto: PROTO_VERSION.to_string(),
+        addrs: Vec::new(),
+        port,
+    }
+}
+
+/// Two `MdnsDiscovery` instances on loopback should observe each other
+/// within 5s. Uses two distinct daemon instances so each registers its
+/// own service entry on the same machine (mdns-sd handles loopback).
+#[test]
+fn mdns_advertiser_and_listener_loopback_finds_each_other() {
+    let alice = MdnsDiscovery::new().expect("alice daemon");
+    let bob = MdnsDiscovery::new().expect("bob daemon");
+
+    alice
+        .start(ad("ALICEDEVICEIDXXXX", "Alice", 17091))
+        .expect("alice start");
+    bob.start(ad("BOBDEVICEIDXXXXXX", "Bob", 17092))
+        .expect("bob start");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut alice_sees_bob = false;
+    let mut bob_sees_alice = false;
+    while Instant::now() < deadline && !(alice_sees_bob && bob_sees_alice) {
+        std::thread::sleep(Duration::from_millis(150));
+        let asnap = alice.peers().expect("alice peers");
+        let bsnap = bob.peers().expect("bob peers");
+        if asnap.peers.iter().any(|p| p.device_id == "BOBDEVICEIDXXXXXX") {
+            alice_sees_bob = true;
+        }
+        if bsnap.peers.iter().any(|p| p.device_id == "ALICEDEVICEIDXXXX") {
+            bob_sees_alice = true;
+        }
+    }
+
+    let _ = alice.stop();
+    let _ = bob.stop();
+
+    assert!(alice_sees_bob, "alice must discover bob within 5s");
+    assert!(bob_sees_alice, "bob must discover alice within 5s");
+}
+
+/// Cheap, deterministic test of `start`/`stop` symmetry: starting +
+/// stopping must not panic and must leave the peers list empty.
+#[test]
+fn start_stop_cycle_is_idempotent() {
+    let d = MdnsDiscovery::new().expect("daemon");
+    d.start(ad("CYCLEDEVICEIDXXXX", "Cycle", 17093))
+        .expect("start");
+    let _ = d.peers().expect("peers after start");
+    d.stop().expect("stop");
+    let snap = d.peers().expect("peers after stop");
+    assert!(snap.peers.is_empty(), "peers must clear on stop");
+}

--- a/src-tauri/src/sync/tests/engine_tests.rs
+++ b/src-tauri/src/sync/tests/engine_tests.rs
@@ -1,0 +1,406 @@
+//! TDD coverage for #419 sync engine + WriteIgnoreList invariant.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use ed25519_dalek::SigningKey;
+use rand_core::RngCore;
+use tempfile::TempDir;
+
+use crate::sync::capability::{Capability, CapabilityBody, Scope};
+use crate::sync::clock::TestClock;
+use crate::sync::engine::{
+    BatchOutcome, InboundDecision, RejectReason, SyncBatchGate, SyncEngine,
+    BATCH_REBUILD_THRESHOLD,
+};
+use crate::sync::history::HistoryConfig;
+use crate::sync::protocol::{ChangeEvent, ChangeKind};
+use crate::sync::state::{PeerTrust, SyncState};
+use crate::sync::VersionVector;
+use crate::WriteIgnoreList;
+
+const SELF_PEER: &str = "SELFDEVICEIDXXXX";
+const REMOTE_PEER: &str = "PEERDEVICEIDXXXX";
+const VAULT: &str = "vault-uuid";
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand_core::OsRng.fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+fn h(byte: u8) -> [u8; 32] {
+    let mut o = [0u8; 32];
+    o[0] = byte;
+    o
+}
+
+fn build_engine(tmp: &TempDir) -> (SyncEngine, Arc<SyncState>, Arc<Mutex<WriteIgnoreList>>) {
+    let metadata = tmp.path().join(".vaultcore");
+    std::fs::create_dir_all(&metadata).unwrap();
+    let state = Arc::new(
+        SyncState::open_with(
+            &metadata,
+            SELF_PEER.to_string(),
+            Arc::new(TestClock::new(1_700_000_000)),
+            HistoryConfig::default(),
+        )
+        .unwrap(),
+    );
+    let wi = Arc::new(Mutex::new(WriteIgnoreList::default()));
+    let engine = SyncEngine::new(state.clone(), wi.clone());
+    engine.set_vault_root(tmp.path().to_path_buf()).unwrap();
+    (engine, state, wi)
+}
+
+/// Persist a peer + a ReadWrite capability so the engine accepts events
+/// from `REMOTE_PEER`. Returns the owner key (caller may issue more
+/// capabilities later).
+fn pair_peer_with_grant(state: &SyncState) -> SigningKey {
+    let owner = fresh_signing_key();
+    let pk = owner.verifying_key().to_bytes();
+    state
+        .upsert_peer(REMOTE_PEER, &pk, "Remote", PeerTrust::Trusted)
+        .unwrap();
+    let body = CapabilityBody::issue_v1(VAULT, REMOTE_PEER, "remote-vault", Scope::ReadWrite);
+    let cap = Capability::sign(&body, &owner);
+    state.upsert_vault_grant(&cap).unwrap();
+    owner
+}
+
+fn evt_upsert(content: &[u8], hash: [u8; 32], vv: VersionVector) -> ChangeEvent {
+    ChangeEvent {
+        vault_id: VAULT.into(),
+        path: PathBuf::from("notes/a.md"),
+        kind: ChangeKind::Upserted {
+            content: content.to_vec(),
+        },
+        source_peer: REMOTE_PEER.into(),
+        version_vector: vv,
+        content_hash: hash,
+    }
+}
+
+#[test]
+fn engine_discards_dominated_remote_event() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+    pair_peer_with_grant(&state);
+
+    // Bring local up to {self: 2}.
+    state
+        .record_local_write(VAULT, "notes/a.md", h(0x10), b"v1")
+        .unwrap();
+    state
+        .record_local_write(VAULT, "notes/a.md", h(0x11), b"v2")
+        .unwrap();
+
+    // Remote arrives with stale {self: 1}.
+    let stale_vv = VersionVector(
+        [(SELF_PEER.into(), 1u64)].into_iter().collect(),
+    );
+    let evt = evt_upsert(b"stale", h(0xEE), stale_vv);
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    assert_eq!(decision, InboundDecision::Discard);
+
+    // No write-ignore was registered (no disk write would happen).
+    let abs = tmp.path().join("notes/a.md");
+    assert!(!engine.is_write_ignored(&abs).unwrap());
+}
+
+#[test]
+fn engine_fast_forwards_when_remote_dominates() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+    pair_peer_with_grant(&state);
+
+    state
+        .record_local_write(VAULT, "notes/a.md", h(0x10), b"v1")
+        .unwrap();
+
+    // Remote dominates: includes self's counter and adds its own.
+    let mut remote_vv = VersionVector(
+        [(SELF_PEER.into(), 1u64)].into_iter().collect(),
+    );
+    remote_vv.0.insert(REMOTE_PEER.into(), 5);
+    let evt = evt_upsert(b"newer", h(0x22), remote_vv);
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    let abs = tmp.path().join("notes/a.md");
+    match decision {
+        InboundDecision::FastForward { path, content, content_hash } => {
+            assert_eq!(path, abs);
+            assert_eq!(content, b"newer");
+            assert_eq!(content_hash, h(0x22));
+        }
+        other => panic!("expected FastForward, got {other:?}"),
+    }
+
+    // CRITICAL invariant: write_ignore was registered BEFORE the disk
+    // write would happen (the engine returns the path with it pre-set).
+    assert!(
+        engine.is_write_ignored(&abs).unwrap(),
+        "write_ignore must be registered before sync-pull write (D-12)"
+    );
+}
+
+#[test]
+fn engine_marks_concurrent_for_merge() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+    pair_peer_with_grant(&state);
+
+    state
+        .record_local_write(VAULT, "notes/a.md", h(0x10), b"local")
+        .unwrap();
+    let remote_vv = VersionVector(
+        [(REMOTE_PEER.into(), 1u64)].into_iter().collect(),
+    );
+    let evt = evt_upsert(b"remote", h(0x33), remote_vv);
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    let abs = tmp.path().join("notes/a.md");
+    match decision {
+        InboundDecision::NeedsMerge {
+            path,
+            remote_content,
+            remote_hash,
+        } => {
+            assert_eq!(path, abs);
+            assert_eq!(remote_content, b"remote");
+            assert_eq!(remote_hash, h(0x33));
+        }
+        other => panic!("expected NeedsMerge, got {other:?}"),
+    }
+
+    // Concurrent path does NOT register write_ignore — merge runs in
+    // the editor and the merge result will register on its own write.
+    assert!(!engine.is_write_ignored(&abs).unwrap());
+}
+
+#[test]
+fn capability_required_to_accept_event() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, _state, _wi) = build_engine(&tmp);
+    // No peer paired, no grant issued.
+
+    let vv = VersionVector(
+        [(REMOTE_PEER.into(), 1u64)].into_iter().collect(),
+    );
+    let evt = evt_upsert(b"unauthorized", h(0x44), vv);
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    assert_eq!(
+        decision,
+        InboundDecision::Rejected {
+            reason: RejectReason::NoGrant
+        }
+    );
+}
+
+#[test]
+fn capability_with_wrong_signature_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+
+    // Peer paired under one Ed25519 key but capability signed under another.
+    let peer_key = fresh_signing_key();
+    let pk = peer_key.verifying_key().to_bytes();
+    state
+        .upsert_peer(REMOTE_PEER, &pk, "Remote", PeerTrust::Trusted)
+        .unwrap();
+    let attacker_key = fresh_signing_key();
+    let body = CapabilityBody::issue_v1(VAULT, REMOTE_PEER, "remote-vault", Scope::ReadWrite);
+    let cap = Capability::sign(&body, &attacker_key);
+    state.upsert_vault_grant(&cap).unwrap();
+
+    let vv = VersionVector(
+        [(REMOTE_PEER.into(), 1u64)].into_iter().collect(),
+    );
+    let evt = evt_upsert(b"forged", h(0x55), vv);
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    assert_eq!(
+        decision,
+        InboundDecision::Rejected {
+            reason: RejectReason::InvalidSignature
+        }
+    );
+}
+
+#[test]
+fn read_only_grant_rejects_write_event() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+    let owner = fresh_signing_key();
+    state
+        .upsert_peer(
+            REMOTE_PEER,
+            &owner.verifying_key().to_bytes(),
+            "Remote",
+            PeerTrust::Trusted,
+        )
+        .unwrap();
+    // Read-only grant.
+    let body = CapabilityBody::issue_v1(VAULT, REMOTE_PEER, "remote-vault", Scope::Read);
+    let cap = Capability::sign(&body, &owner);
+    state.upsert_vault_grant(&cap).unwrap();
+
+    let vv = VersionVector(
+        [(REMOTE_PEER.into(), 1u64)].into_iter().collect(),
+    );
+    let evt = evt_upsert(b"writeattempt", h(0x66), vv);
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    assert_eq!(
+        decision,
+        InboundDecision::Rejected {
+            reason: RejectReason::ScopeInsufficient
+        }
+    );
+}
+
+/// Property test: every fast-forward / created / delete / rename
+/// inbound event registers `WriteIgnoreList` BEFORE the engine returns,
+/// for any randomized path-segment composition. Asserts the
+/// "BEFORE-the-write, never AFTER" invariant epic #73 calls load-bearing.
+#[test]
+fn write_ignore_list_registered_before_sync_pull_write() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+    pair_peer_with_grant(&state);
+
+    // 30 randomized paths in a single batch — overkill on purpose.
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    for i in 0..30u32 {
+        let depth: usize = rng.gen_range(0..=3);
+        let mut rel = PathBuf::new();
+        for _ in 0..depth {
+            let seg: u32 = rng.gen();
+            rel.push(format!("d{seg}"));
+        }
+        rel.push(format!("note-{i}.md"));
+
+        let mut vv = VersionVector::new();
+        vv.increment(REMOTE_PEER);
+
+        let evt = ChangeEvent {
+            vault_id: VAULT.into(),
+            path: rel.clone(),
+            kind: ChangeKind::Upserted {
+                content: vec![i as u8],
+            },
+            source_peer: REMOTE_PEER.into(),
+            version_vector: vv,
+            content_hash: h(i as u8),
+        };
+        let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+        let abs = tmp.path().join(&rel);
+        match decision {
+            InboundDecision::FastForward { path, .. }
+            | InboundDecision::Created { path, .. }
+            | InboundDecision::Delete { path } => {
+                assert_eq!(path, abs);
+                assert!(
+                    engine.is_write_ignored(&abs).unwrap(),
+                    "abs {abs:?} must be in WriteIgnoreList before disk write (D-12)"
+                );
+            }
+            InboundDecision::Rename { from, to } => {
+                assert!(engine.is_write_ignored(&from).unwrap());
+                assert!(engine.is_write_ignored(&to).unwrap());
+            }
+            InboundDecision::NeedsMerge { .. } => {
+                // Merge path: no ignore registration (merge result writes
+                // through editor + registers itself).
+            }
+            InboundDecision::Discard | InboundDecision::Rejected { .. } => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn sync_batch_markers_suppress_per_file_indexcmd() {
+    let gate = SyncBatchGate::new();
+    assert!(!gate.should_suppress_dispatch());
+
+    gate.begin("vault-x").unwrap();
+    assert!(gate.should_suppress_dispatch());
+    assert_eq!(gate.open_vault().as_deref(), Some("vault-x"));
+
+    for i in 0..50u32 {
+        gate.note_change(PathBuf::from(format!("note-{i}.md"))).unwrap();
+    }
+    let outcome = gate.end().unwrap();
+    match outcome {
+        BatchOutcome::Bulk(paths) => assert_eq!(paths.len(), 50),
+        BatchOutcome::Rebuild { .. } => panic!("50 < threshold; should be Bulk"),
+    }
+    assert!(!gate.should_suppress_dispatch());
+
+    // Over the threshold → Rebuild.
+    gate.begin("vault-y").unwrap();
+    for i in 0..(BATCH_REBUILD_THRESHOLD + 1) {
+        gate.note_change(PathBuf::from(format!("p{i}.md"))).unwrap();
+    }
+    let outcome2 = gate.end().unwrap();
+    match outcome2 {
+        BatchOutcome::Rebuild { affected_count } => {
+            assert_eq!(affected_count, BATCH_REBUILD_THRESHOLD + 1);
+        }
+        BatchOutcome::Bulk(_) => panic!("over threshold should yield Rebuild"),
+    }
+}
+
+#[test]
+fn delete_event_registers_write_ignore_and_returns_path() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+    pair_peer_with_grant(&state);
+
+    let mut vv = VersionVector::new();
+    vv.increment(REMOTE_PEER);
+    let evt = ChangeEvent {
+        vault_id: VAULT.into(),
+        path: PathBuf::from("gone.md"),
+        kind: ChangeKind::Deleted,
+        source_peer: REMOTE_PEER.into(),
+        version_vector: vv,
+        content_hash: h(0x77),
+    };
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    let abs = tmp.path().join("gone.md");
+    match decision {
+        InboundDecision::Delete { path } => assert_eq!(path, abs),
+        other => panic!("expected Delete, got {other:?}"),
+    }
+    assert!(engine.is_write_ignored(&abs).unwrap());
+}
+
+#[test]
+fn rename_event_registers_both_endpoints() {
+    let tmp = TempDir::new().unwrap();
+    let (engine, state, _wi) = build_engine(&tmp);
+    pair_peer_with_grant(&state);
+
+    let mut vv = VersionVector::new();
+    vv.increment(REMOTE_PEER);
+    let evt = ChangeEvent {
+        vault_id: VAULT.into(),
+        path: PathBuf::from("new.md"),
+        kind: ChangeKind::Renamed {
+            from: PathBuf::from("old.md"),
+        },
+        source_peer: REMOTE_PEER.into(),
+        version_vector: vv,
+        content_hash: h(0x88),
+    };
+    let decision = engine.apply_remote_event(&evt, REMOTE_PEER).unwrap();
+    let abs_from = tmp.path().join("old.md");
+    let abs_to = tmp.path().join("new.md");
+    match decision {
+        InboundDecision::Rename { from, to } => {
+            assert_eq!(from, abs_from);
+            assert_eq!(to, abs_to);
+        }
+        other => panic!("expected Rename, got {other:?}"),
+    }
+    assert!(engine.is_write_ignored(&abs_from).unwrap());
+    assert!(engine.is_write_ignored(&abs_to).unwrap());
+}

--- a/src-tauri/src/sync/tests/identity_tests.rs
+++ b/src-tauri/src/sync/tests/identity_tests.rs
@@ -1,0 +1,82 @@
+//! TDD coverage for #417 identity layer.
+
+use crate::sync::identity::{derive_device_id, Identity, MemoryKeyStore};
+use crate::sync::vault_id;
+
+use tempfile::TempDir;
+
+#[test]
+fn device_id_is_stable_across_loads() {
+    // First call: generates + persists.
+    let store = MemoryKeyStore::new();
+    let id1 = Identity::load_or_create(&store).expect("load_or_create #1");
+    let did1 = id1.device_id().to_string();
+    let pub1 = id1.public_key_bytes();
+
+    // Second call against the same store: must yield the *same* device_id.
+    let id2 = Identity::load_or_create(&store).expect("load_or_create #2");
+    assert_eq!(id2.device_id(), did1, "device_id must be stable");
+    assert_eq!(id2.public_key_bytes(), pub1, "pubkey must be stable");
+
+    // device_id derivation is deterministic from the pubkey.
+    let derived = derive_device_id(id2.verifying_key());
+    assert_eq!(derived, did1);
+
+    // A *different* store yields a *different* device_id (no shared global state).
+    let store_other = MemoryKeyStore::new();
+    let id_other = Identity::load_or_create(&store_other).expect("other store");
+    assert_ne!(id_other.device_id(), did1);
+
+    // pubkey_fp is the first 8 chars of device_id.
+    assert_eq!(id1.pubkey_fp(), &did1[..8]);
+}
+
+#[test]
+fn vault_id_generated_on_first_call_and_persists() {
+    let tmp = TempDir::new().unwrap();
+    let metadata_dir = tmp.path().join(".vaultcore");
+
+    let id1 = vault_id::load_or_create(&metadata_dir).expect("first load");
+    // Canonical hyphenated UUIDv4 is 36 chars including dashes.
+    assert_eq!(id1.len(), 36);
+    assert_eq!(id1.matches('-').count(), 4);
+
+    // File must exist on disk.
+    let path = metadata_dir.join("vault-id");
+    assert!(path.exists(), "vault-id file must be created");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(raw.trim(), id1);
+
+    // Second call returns the same id (no rotation).
+    let id2 = vault_id::load_or_create(&metadata_dir).expect("second load");
+    assert_eq!(id1, id2, "vault-id must persist across calls");
+
+    // Tolerates trailing whitespace / newline a user might paste in.
+    std::fs::write(&path, format!("{id1}\n")).unwrap();
+    let id3 = vault_id::load_or_create(&metadata_dir).expect("post-newline load");
+    assert_eq!(id1, id3);
+
+    // Corrupt content surfaces as an error, never as silent regeneration.
+    std::fs::write(&path, "not-a-uuid").unwrap();
+    let res = vault_id::load_or_create(&metadata_dir);
+    assert!(res.is_err(), "corrupt vault-id must error");
+}
+
+#[test]
+fn signing_round_trips() {
+    use ed25519_dalek::{Signature, Verifier};
+
+    let store = MemoryKeyStore::new();
+    let id = Identity::load_or_create(&store).unwrap();
+
+    let msg = b"pair-handshake-001";
+    let sig_bytes = id.sign(msg);
+    let sig = Signature::from_bytes(&sig_bytes);
+    id.verifying_key()
+        .verify(msg, &sig)
+        .expect("self signature must verify");
+
+    // Tampering breaks verification.
+    let tampered = b"pair-handshake-002";
+    assert!(id.verifying_key().verify(tampered, &sig).is_err());
+}

--- a/src-tauri/src/sync/tests/merkle_tests.rs
+++ b/src-tauri/src/sync/tests/merkle_tests.rs
@@ -1,0 +1,171 @@
+//! TDD coverage for #420 Merkle reconciliation.
+
+use std::sync::Arc;
+
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+use tempfile::TempDir;
+
+use crate::sync::clock::TestClock;
+use crate::sync::history::HistoryConfig;
+use crate::sync::merkle::{diff_paths, hash_file_content, MerkleNode, MerkleTree, NodeKind};
+use crate::sync::state::SyncState;
+
+const VAULT: &str = "vault-uuid";
+
+fn open_state(tmp: &TempDir) -> Arc<SyncState> {
+    Arc::new(
+        SyncState::open_with(
+            tmp.path(),
+            "SELFPEER".into(),
+            Arc::new(TestClock::new(1_700_000_000)),
+            HistoryConfig::default(),
+        )
+        .unwrap(),
+    )
+}
+
+#[test]
+fn merkle_root_changes_only_when_content_changes() {
+    let tmp = TempDir::new().unwrap();
+    let state = open_state(&tmp);
+    let tree = MerkleTree::new(&state, VAULT);
+
+    tree.upsert_file("notes/a.md", hash_file_content(b"hello")).unwrap();
+    let r1 = tree.root().unwrap().expect("root after first upsert");
+
+    // Re-upsert with the same content → identical root.
+    tree.upsert_file("notes/a.md", hash_file_content(b"hello")).unwrap();
+    let r2 = tree.root().unwrap().unwrap();
+    assert_eq!(r1, r2, "identical content must not change root");
+
+    // Different content → different root.
+    tree.upsert_file("notes/a.md", hash_file_content(b"world")).unwrap();
+    let r3 = tree.root().unwrap().unwrap();
+    assert_ne!(r1, r3, "content change must propagate to root");
+
+    // Adding a sibling under the same folder → different root.
+    tree.upsert_file("notes/b.md", hash_file_content(b"second")).unwrap();
+    let r4 = tree.root().unwrap().unwrap();
+    assert_ne!(r3, r4);
+
+    // Removing the sibling → root reverts to r3.
+    tree.remove_file("notes/b.md").unwrap();
+    let r5 = tree.root().unwrap().unwrap();
+    assert_eq!(r3, r5, "removing a file must restore the prior root");
+}
+
+/// Property test: incremental upserts must produce the same root as a
+/// full rebuild from the final file set, for any randomized order.
+#[test]
+fn merkle_incremental_update_matches_full_recompute() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    for trial in 0..16 {
+        let tmp = TempDir::new().unwrap();
+        let state = open_state(&tmp);
+        let tree = MerkleTree::new(&state, VAULT);
+
+        // Random vault: 3-25 files spread across 1-4 dirs.
+        let n_files = rng.gen_range(3..=25);
+        let mut files: Vec<(String, [u8; 32])> = (0..n_files)
+            .map(|i| {
+                let depth = rng.gen_range(0..=2);
+                let mut path = String::new();
+                for _ in 0..depth {
+                    let dir = rng.gen_range(0..=3);
+                    path.push_str(&format!("d{dir}/"));
+                }
+                path.push_str(&format!("note-{trial}-{i}.md"));
+                let content: Vec<u8> = (0..rng.gen_range(1..32)).map(|_| rng.r#gen()).collect();
+                (path, hash_file_content(&content))
+            })
+            .collect();
+
+        // Path-collision dedup.
+        files.sort_by(|a, b| a.0.cmp(&b.0));
+        files.dedup_by(|a, b| a.0 == b.0);
+
+        // Apply incrementally in a randomized order.
+        let mut order: Vec<usize> = (0..files.len()).collect();
+        order.shuffle(&mut rng);
+        for &i in &order {
+            tree.upsert_file(&files[i].0, files[i].1).unwrap();
+        }
+        let incremental = tree.root().unwrap().unwrap();
+
+        // Full rebuild from the same input.
+        let other_tmp = TempDir::new().unwrap();
+        let state2 = open_state(&other_tmp);
+        let tree2 = MerkleTree::new(&state2, VAULT);
+        tree2.rebuild_full(files.iter().cloned()).unwrap();
+        let full = tree2.root().unwrap().unwrap();
+
+        assert_eq!(
+            incremental, full,
+            "trial {trial}: incremental != full rebuild on input {files:?}"
+        );
+    }
+}
+
+#[test]
+fn merkle_descent_finds_differing_paths_only() {
+    let tmp_a = TempDir::new().unwrap();
+    let tmp_b = TempDir::new().unwrap();
+    let state_a = open_state(&tmp_a);
+    let state_b = open_state(&tmp_b);
+    let tree_a = MerkleTree::new(&state_a, VAULT);
+    let tree_b = MerkleTree::new(&state_b, VAULT);
+
+    // Common files.
+    for (path, content) in [
+        ("notes/a.md", "alpha"),
+        ("notes/b.md", "beta"),
+        ("daily/2026-05-03.md", "today"),
+    ] {
+        let h = hash_file_content(content.as_bytes());
+        tree_a.upsert_file(path, h).unwrap();
+        tree_b.upsert_file(path, h).unwrap();
+    }
+
+    // Divergent file: A has "alpha-v2", B has "alpha".
+    tree_a.upsert_file("notes/a.md", hash_file_content(b"alpha-v2")).unwrap();
+
+    // File only in B: notes/c.md (peer is missing it on A's side).
+    tree_b.upsert_file("notes/c.md", hash_file_content(b"gamma")).unwrap();
+
+    // A descends and emits paths where it differs from B's view.
+    let mut peer = |p: &str| tree_b.node(p).ok().flatten();
+    let differing = diff_paths(&tree_a, &mut peer).unwrap();
+    // Differing must include `notes/a.md` (content mismatch). It must
+    // NOT include `notes/b.md` or `daily/2026-05-03.md`.
+    assert!(differing.contains(&"notes/a.md".to_string()));
+    assert!(!differing.contains(&"notes/b.md".to_string()));
+    assert!(!differing.contains(&"daily/2026-05-03.md".to_string()));
+}
+
+#[test]
+fn merkle_children_returns_direct_children_only() {
+    let tmp = TempDir::new().unwrap();
+    let state = open_state(&tmp);
+    let tree = MerkleTree::new(&state, VAULT);
+    tree.upsert_file("notes/a.md", hash_file_content(b"a")).unwrap();
+    tree.upsert_file("notes/sub/b.md", hash_file_content(b"b")).unwrap();
+    tree.upsert_file("daily/d.md", hash_file_content(b"d")).unwrap();
+
+    let root_children: Vec<MerkleNode> = tree.children("").unwrap();
+    let names: Vec<&str> = root_children.iter().map(|c| c.path.as_str()).collect();
+    assert!(names.contains(&"notes"), "names: {names:?}");
+    assert!(names.contains(&"daily"), "names: {names:?}");
+    // No file leaves at root level.
+    for c in &root_children {
+        assert_eq!(c.kind, NodeKind::Folder, "root children must be folders, got {c:?}");
+    }
+
+    let notes_children: Vec<MerkleNode> = tree.children("notes").unwrap();
+    let notes_names: Vec<&str> = notes_children.iter().map(|c| c.path.as_str()).collect();
+    assert!(notes_names.contains(&"notes/a.md"));
+    assert!(notes_names.contains(&"notes/sub"));
+    // notes/sub/b.md is two levels deep — NOT in notes/'s direct children.
+    assert!(!notes_names.contains(&"notes/sub/b.md"));
+}
+

--- a/src-tauri/src/sync/tests/mod.rs
+++ b/src-tauri/src/sync/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod state_tests;

--- a/src-tauri/src/sync/tests/mod.rs
+++ b/src-tauri/src/sync/tests/mod.rs
@@ -3,6 +3,7 @@ pub mod discovery_tests;
 pub mod engine_tests;
 pub mod identity_tests;
 pub mod merkle_tests;
+pub mod pairing_engine_tests;
 pub mod pairing_tests;
 pub mod state_tests;
 pub mod transport_tests;

--- a/src-tauri/src/sync/tests/mod.rs
+++ b/src-tauri/src/sync/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod discovery_tests;
 pub mod identity_tests;
+pub mod pairing_tests;
 pub mod state_tests;

--- a/src-tauri/src/sync/tests/mod.rs
+++ b/src-tauri/src/sync/tests/mod.rs
@@ -1,6 +1,8 @@
+pub mod conflict_tests;
 pub mod discovery_tests;
 pub mod engine_tests;
 pub mod identity_tests;
+pub mod merkle_tests;
 pub mod pairing_tests;
 pub mod state_tests;
 pub mod transport_tests;

--- a/src-tauri/src/sync/tests/mod.rs
+++ b/src-tauri/src/sync/tests/mod.rs
@@ -1,4 +1,6 @@
 pub mod discovery_tests;
+pub mod engine_tests;
 pub mod identity_tests;
 pub mod pairing_tests;
 pub mod state_tests;
+pub mod transport_tests;

--- a/src-tauri/src/sync/tests/mod.rs
+++ b/src-tauri/src/sync/tests/mod.rs
@@ -1,1 +1,3 @@
+pub mod discovery_tests;
+pub mod identity_tests;
 pub mod state_tests;

--- a/src-tauri/src/sync/tests/pairing_engine_tests.rs
+++ b/src-tauri/src/sync/tests/pairing_engine_tests.rs
@@ -1,0 +1,400 @@
+//! TDD coverage for #418/UI-1.5 pairing engine integration.
+//!
+//! Each test runs two real in-process devices over loopback TCP — no
+//! mocks. The initiator side of each scenario `connect`s to the listener
+//! the responder thread spawns, so timing is identical to what UI-6
+//! manual UAT will exercise. This file exclusively drives the new
+//! engine entry points; the legacy inline `pair_and_connect` in
+//! `tests/sync_e2e.rs` is the regression check after the same logic is
+//! folded into the engine.
+
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::thread;
+
+use ed25519_dalek::SigningKey;
+use rand_core::RngCore;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+use crate::sync::capability::{CapabilityBody, Scope};
+use crate::sync::clock::TestClock;
+use crate::sync::history::HistoryConfig;
+use crate::sync::pairing::{
+    finalize_with_confirmation, key_confirmation_mac, respond, start_initiator, PairingSession,
+};
+use crate::sync::pairing_engine::{
+    drive_initiator_after_pake, drive_responder_after_pake, exchange_vault_grant_initiator,
+    exchange_vault_grant_responder, PairingEngineError, ALREADY_PAIRED,
+};
+use crate::sync::state::SyncState;
+use crate::sync::transport::{generate_static_keypair, NoiseKeypair};
+
+const PIN: &str = "246810";
+const VAULT_A: &str = "vault-uuid-a";
+const VAULT_B: &str = "vault-uuid-b";
+
+/// One end of an in-process pair. Carries the long-term Ed25519 key
+/// (used to sign the long-term-key-attestation MAC + the cap), the
+/// Curve25519 noise static (used by the XX handshake), the device id,
+/// and an open `SyncState` rooted at a tempdir.
+struct Side {
+    device_id: String,
+    signing_key: SigningKey,
+    noise_kp: NoiseKeypair,
+    state: Arc<SyncState>,
+    _tmp: TempDir,
+}
+
+impl Side {
+    fn new() -> Self {
+        let tmp = TempDir::new().unwrap();
+        let metadata = tmp.path().join(".vaultcore");
+        std::fs::create_dir_all(&metadata).unwrap();
+        let signing_key = fresh_signing_key();
+        let device_id = derive_device_id(&signing_key);
+        let noise_kp = generate_static_keypair().unwrap();
+        let state = Arc::new(
+            SyncState::open_with(
+                &metadata,
+                device_id.clone(),
+                Arc::new(TestClock::new(1_700_000_000)),
+                HistoryConfig::default(),
+            )
+            .unwrap(),
+        );
+        Self {
+            device_id,
+            signing_key,
+            noise_kp,
+            state,
+            _tmp: tmp,
+        }
+    }
+}
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand_core::OsRng.fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+fn derive_device_id(sk: &SigningKey) -> String {
+    use data_encoding::BASE32_NOPAD;
+    let pubkey = sk.verifying_key().to_bytes();
+    let digest = Sha256::digest(pubkey);
+    BASE32_NOPAD.encode(&digest[..16])
+}
+
+/// Run PAKE in-process between two sides. Returns `(k2_a, k2_b)` so each
+/// side can produce its own MAC and then finalize. PAKE itself is
+/// already covered by `pairing_tests`; this helper just stages the
+/// post-PAKE state the engine driver consumes.
+fn run_pake(a: &Side, b: &Side) -> ([u8; 32], [u8; 32]) {
+    let session_a = PairingSession::new();
+    let session_b = PairingSession::new();
+    session_a.issue_pin().unwrap();
+    session_b.issue_pin().unwrap();
+
+    let initiator = start_initiator(PIN, &a.device_id, &b.device_id).unwrap();
+    let s1 = initiator.step1_packet();
+    let responder = respond(&s1, PIN, &a.device_id, &b.device_id).unwrap();
+    let s2 = responder.step2_packet();
+    let raw_a = initiator.step3(&s2).unwrap();
+    let raw_b = responder.raw_keys;
+
+    let mac_b = key_confirmation_mac(&raw_b.k2, &a.device_id, &b.device_id);
+    let mac_a = key_confirmation_mac(&raw_a.k2, &a.device_id, &b.device_id);
+    finalize_with_confirmation(&raw_a, &mac_b, &session_a).unwrap();
+    finalize_with_confirmation(&raw_b, &mac_a, &session_b).unwrap();
+
+    (raw_a.k2, raw_b.k2)
+}
+
+#[test]
+fn two_in_process_devices_complete_full_pairing_handshake() {
+    let a = Arc::new(Side::new());
+    let b = Arc::new(Side::new());
+    let (k2_a, k2_b) = run_pake(&a, &b);
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let b_for_thread = Arc::clone(&b);
+    let a_id_for_thread = a.device_id.clone();
+    let resp = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        drive_responder_after_pake(
+            &mut stream,
+            &b_for_thread.noise_kp,
+            &b_for_thread.signing_key,
+            &b_for_thread.device_id,
+            &a_id_for_thread,
+            &k2_b,
+            &b_for_thread.state,
+        )
+        .unwrap();
+    });
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    let outcome = drive_initiator_after_pake(
+        &mut stream,
+        &a.noise_kp,
+        &a.signing_key,
+        &a.device_id,
+        &b.device_id,
+        &k2_a,
+        &a.state,
+    )
+    .unwrap();
+    resp.join().unwrap();
+
+    assert!(!outcome.short_circuited);
+    // A's DB now has B's long-term Ed25519 pubkey under PeerTrust::Trusted.
+    let stored_pk = a.state.peer_pubkey(&b.device_id).unwrap().unwrap();
+    assert_eq!(stored_pk, b.signing_key.verifying_key().to_bytes());
+}
+
+#[test]
+fn pairing_persists_peer_trust_after_xx_bootstrap_on_both_sides() {
+    let a = Arc::new(Side::new());
+    let b = Arc::new(Side::new());
+    let (k2_a, k2_b) = run_pake(&a, &b);
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let b_t = Arc::clone(&b);
+    let a_id_t = a.device_id.clone();
+    let resp = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        drive_responder_after_pake(
+            &mut stream,
+            &b_t.noise_kp,
+            &b_t.signing_key,
+            &b_t.device_id,
+            &a_id_t,
+            &k2_b,
+            &b_t.state,
+        )
+        .unwrap();
+    });
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    drive_initiator_after_pake(
+        &mut stream,
+        &a.noise_kp,
+        &a.signing_key,
+        &a.device_id,
+        &b.device_id,
+        &k2_a,
+        &a.state,
+    )
+    .unwrap();
+    resp.join().unwrap();
+
+    // Each side has the *peer's* long-term Ed25519 pubkey persisted under
+    // PeerTrust::Trusted. peer_pubkey returns Some only for trusted rows.
+    let pk_b_on_a = a.state.peer_pubkey(&b.device_id).unwrap().unwrap();
+    assert_eq!(pk_b_on_a, b.signing_key.verifying_key().to_bytes());
+    let pk_a_on_b = b.state.peer_pubkey(&a.device_id).unwrap().unwrap();
+    assert_eq!(pk_a_on_b, a.signing_key.verifying_key().to_bytes());
+}
+
+#[test]
+fn pairing_grant_exchange_persists_caps_on_both_sides() {
+    let a = Arc::new(Side::new());
+    let b = Arc::new(Side::new());
+    let (k2_a, k2_b) = run_pake(&a, &b);
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let b_t = Arc::clone(&b);
+    let a_id_t = a.device_id.clone();
+    let resp = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut session = drive_responder_after_pake(
+            &mut stream,
+            &b_t.noise_kp,
+            &b_t.signing_key,
+            &b_t.device_id,
+            &a_id_t,
+            &k2_b,
+            &b_t.state,
+        )
+        .unwrap();
+        // After bootstrap, B grants A access to VAULT_B and waits for A's
+        // matching grant. Both rows land in the local DB.
+        let body = CapabilityBody::issue_v1(VAULT_B, &b_t.device_id, VAULT_B, Scope::ReadWrite);
+        exchange_vault_grant_responder(
+            &mut session,
+            &b_t.signing_key,
+            &body,
+            &a_id_t,
+            &b_t.state,
+        )
+        .unwrap();
+    });
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    let mut session = drive_initiator_after_pake(
+        &mut stream,
+        &a.noise_kp,
+        &a.signing_key,
+        &a.device_id,
+        &b.device_id,
+        &k2_a,
+        &a.state,
+    )
+    .unwrap();
+    let body = CapabilityBody::issue_v1(VAULT_A, &a.device_id, VAULT_A, Scope::ReadWrite);
+    exchange_vault_grant_initiator(
+        &mut session,
+        &a.signing_key,
+        &body,
+        &b.device_id,
+        &a.state,
+    )
+    .unwrap();
+    resp.join().unwrap();
+
+    // A holds the cap B issued (signed under B's key, body identifies B as
+    // the peer_device_id of the issuer — matches engine_tests::pair_peer_with_grant).
+    let cap_on_a = a.state.vault_grant(VAULT_B, &b.device_id).unwrap().unwrap();
+    let body_on_a = cap_on_a.verify(&b.signing_key.verifying_key()).unwrap();
+    assert_eq!(body_on_a.local_vault_id, VAULT_B);
+    assert_eq!(body_on_a.peer_device_id, b.device_id);
+
+    // B holds the cap A issued.
+    let cap_on_b = b.state.vault_grant(VAULT_A, &a.device_id).unwrap().unwrap();
+    let body_on_b = cap_on_b.verify(&a.signing_key.verifying_key()).unwrap();
+    assert_eq!(body_on_b.local_vault_id, VAULT_A);
+    assert_eq!(body_on_b.peer_device_id, a.device_id);
+}
+
+#[test]
+fn pairing_aborts_cleanly_when_long_term_key_signature_invalid() {
+    // The responder will try to attest under a *fresh* k2 (different
+    // from the one A used) — the HMAC verifier on the initiator side
+    // must reject and return an error rather than persisting trust.
+    let a = Arc::new(Side::new());
+    let b = Arc::new(Side::new());
+    let (k2_a, _k2_b) = run_pake(&a, &b);
+    let bogus_k2 = [0xFFu8; 32];
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let b_t = Arc::clone(&b);
+    let a_id_t = a.device_id.clone();
+    let resp = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        // Run with a wrong k2 — mac verification on the *initiator* side
+        // must fail. The responder's own send/recv may complete or error
+        // depending on which side detects first; either is fine.
+        let _ = drive_responder_after_pake(
+            &mut stream,
+            &b_t.noise_kp,
+            &b_t.signing_key,
+            &b_t.device_id,
+            &a_id_t,
+            &bogus_k2,
+            &b_t.state,
+        );
+    });
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    let err = drive_initiator_after_pake(
+        &mut stream,
+        &a.noise_kp,
+        &a.signing_key,
+        &a.device_id,
+        &b.device_id,
+        &k2_a,
+        &a.state,
+    )
+    .expect_err("must abort on attest mismatch");
+    let _ = resp.join();
+    assert!(matches!(err, PairingEngineError::AttestationMismatch));
+    // No peer was persisted on A.
+    assert!(a.state.peer_pubkey(&b.device_id).unwrap().is_none());
+}
+
+#[test]
+fn second_pairing_attempt_with_already_paired_peer_short_circuits_to_one_tap_grant() {
+    // Pair once over a real socket so both sides have full peer rows.
+    let a = Arc::new(Side::new());
+    let b = Arc::new(Side::new());
+    let (k2_a, k2_b) = run_pake(&a, &b);
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let b_t = Arc::clone(&b);
+    let a_id_t = a.device_id.clone();
+    let resp = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        drive_responder_after_pake(
+            &mut stream,
+            &b_t.noise_kp,
+            &b_t.signing_key,
+            &b_t.device_id,
+            &a_id_t,
+            &k2_b,
+            &b_t.state,
+        )
+        .unwrap();
+    });
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    drive_initiator_after_pake(
+        &mut stream,
+        &a.noise_kp,
+        &a.signing_key,
+        &a.device_id,
+        &b.device_id,
+        &k2_a,
+        &a.state,
+    )
+    .unwrap();
+    resp.join().unwrap();
+    assert!(a.state.peer_pubkey(&b.device_id).unwrap().is_some());
+
+    // Second attempt — by spec, the engine recognizes the peer is already
+    // trusted and returns `short_circuited = true` with reason
+    // `ALREADY_PAIRED` *without* tearing down + re-binding peer rows.
+    let (k2_a_2, k2_b_2) = run_pake(&a, &b);
+    let listener2 = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port2 = listener2.local_addr().unwrap().port();
+    let b_t2 = Arc::clone(&b);
+    let a_id_t2 = a.device_id.clone();
+    let resp2 = thread::spawn(move || {
+        let (mut stream, _) = listener2.accept().unwrap();
+        drive_responder_after_pake(
+            &mut stream,
+            &b_t2.noise_kp,
+            &b_t2.signing_key,
+            &b_t2.device_id,
+            &a_id_t2,
+            &k2_b_2,
+            &b_t2.state,
+        )
+        .unwrap();
+    });
+    let mut stream2 = TcpStream::connect(("127.0.0.1", port2)).unwrap();
+    let outcome = drive_initiator_after_pake(
+        &mut stream2,
+        &a.noise_kp,
+        &a.signing_key,
+        &a.device_id,
+        &b.device_id,
+        &k2_a_2,
+        &a.state,
+    )
+    .unwrap();
+    resp2.join().unwrap();
+    assert!(outcome.short_circuited);
+    assert_eq!(outcome.reason.as_deref(), Some(ALREADY_PAIRED));
+    // The persisted pubkey is unchanged (the second flow was a no-op
+    // beyond the handshake itself).
+    assert_eq!(
+        a.state.peer_pubkey(&b.device_id).unwrap().unwrap(),
+        b.signing_key.verifying_key().to_bytes()
+    );
+}

--- a/src-tauri/src/sync/tests/pairing_tests.rs
+++ b/src-tauri/src/sync/tests/pairing_tests.rs
@@ -1,0 +1,190 @@
+//! TDD coverage for #418 PAKE pairing + capability tokens.
+
+use std::sync::Arc;
+
+use ed25519_dalek::SigningKey;
+use rand_core::RngCore;
+
+use crate::sync::capability::{Capability, CapabilityBody, Scope};
+use crate::sync::clock::TestClock;
+use crate::sync::pairing::{
+    finalize_with_confirmation, key_confirmation_mac, respond, start_initiator, validate_pin,
+    PairError, PairingSession, LOCKOUT_AFTER_ATTEMPTS, PIN_EXPIRY_SECS,
+};
+
+const ID_A: &str = "DEVICEAAAAAAAAAA";
+const ID_B: &str = "DEVICEBBBBBBBBBB";
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand_core::OsRng.fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+#[test]
+fn matching_pin_derives_identical_session_key() {
+    let pin = "123456";
+
+    let initiator = start_initiator(pin, ID_A, ID_B).expect("start");
+    let s1 = initiator.step1_packet();
+
+    let responder = respond(&s1, pin, ID_A, ID_B).expect("respond");
+    let s2 = responder.step2_packet();
+
+    let raw_init = initiator.step3(&s2).expect("step3");
+    let raw_resp = responder.raw_keys;
+
+    // Both sides derive the same k1 + k2.
+    assert_eq!(raw_init.k1, raw_resp.k1);
+    assert_eq!(raw_init.k2, raw_resp.k2);
+
+    // Key-confirmation MAC matches across sides.
+    let mac_init = key_confirmation_mac(&raw_init.k2, ID_A, ID_B);
+    let mac_resp = key_confirmation_mac(&raw_resp.k2, ID_A, ID_B);
+    assert_eq!(mac_init, mac_resp);
+}
+
+#[test]
+fn mismatched_pin_fails_at_key_confirmation_not_at_pake() {
+    let initiator = start_initiator("123456", ID_A, ID_B).expect("start");
+    let s1 = initiator.step1_packet();
+    // Responder uses a *different* PIN — PAKE itself completes (no error
+    // at step3), but k2 silently diverges.
+    let responder = respond(&s1, "654321", ID_A, ID_B).expect("respond");
+    let s2 = responder.step2_packet();
+    let raw_init = initiator.step3(&s2).expect("step3 — PAKE itself does NOT error on wrong PIN");
+
+    // Key confirmation MUST catch the divergence.
+    let session = PairingSession::with_clock(Arc::new(TestClock::new(1_700_000_000)));
+    session.issue_pin().unwrap();
+    let peer_mac = key_confirmation_mac(&responder.raw_keys.k2, ID_A, ID_B);
+    let result = finalize_with_confirmation(&raw_init, &peer_mac, &session);
+    assert_eq!(result.err(), Some(PairError::KeyConfirmationFailed));
+
+    // Failure must bump the lockout counter.
+    assert_eq!(session.failed_count().unwrap(), 1);
+}
+
+#[test]
+fn pin_expires_after_60_seconds_via_mock_clock() {
+    let t0: i64 = 1_700_000_000;
+    let clock = Arc::new(TestClock::new(t0));
+    let session = PairingSession::with_clock(clock.clone());
+    session.issue_pin().unwrap();
+    assert!(session.pin_valid().unwrap());
+
+    // Just before expiry → still valid.
+    clock.set(t0 + PIN_EXPIRY_SECS - 1);
+    assert!(session.pin_valid().unwrap());
+
+    // At 60s → expired.
+    clock.set(t0 + PIN_EXPIRY_SECS);
+    assert!(!session.pin_valid().unwrap());
+
+    // PinExpired surfaces from finalize_with_confirmation even with a
+    // matching MAC.
+    let initiator = start_initiator("123456", ID_A, ID_B).unwrap();
+    let s1 = initiator.step1_packet();
+    let responder = respond(&s1, "123456", ID_A, ID_B).unwrap();
+    let s2 = responder.step2_packet();
+    let raw = initiator.step3(&s2).unwrap();
+    let mac = key_confirmation_mac(&raw.k2, ID_A, ID_B);
+    let res = finalize_with_confirmation(&raw, &mac, &session);
+    assert_eq!(res.err(), Some(PairError::PinExpired));
+}
+
+#[test]
+fn three_failed_attempts_locks_out() {
+    let session = PairingSession::with_clock(Arc::new(TestClock::new(1_700_000_000)));
+    session.issue_pin().unwrap();
+
+    for i in 0..LOCKOUT_AFTER_ATTEMPTS {
+        let initiator = start_initiator("123456", ID_A, ID_B).unwrap();
+        let s1 = initiator.step1_packet();
+        let responder = respond(&s1, "999999", ID_A, ID_B).unwrap();
+        let s2 = responder.step2_packet();
+        let raw = initiator.step3(&s2).unwrap();
+        let bad_mac = key_confirmation_mac(&responder.raw_keys.k2, ID_A, ID_B);
+        let res = finalize_with_confirmation(&raw, &bad_mac, &session);
+        if i < LOCKOUT_AFTER_ATTEMPTS - 1 {
+            assert_eq!(res.err(), Some(PairError::KeyConfirmationFailed));
+            assert!(!session.is_locked().unwrap());
+        } else {
+            // Third strike: still reported as KCF this round, then locked.
+            assert_eq!(res.err(), Some(PairError::KeyConfirmationFailed));
+            assert!(session.is_locked().unwrap());
+        }
+    }
+
+    // Subsequent attempts return LockedOut even with a matching MAC.
+    let initiator = start_initiator("123456", ID_A, ID_B).unwrap();
+    let s1 = initiator.step1_packet();
+    let responder = respond(&s1, "123456", ID_A, ID_B).unwrap();
+    let s2 = responder.step2_packet();
+    let raw = initiator.step3(&s2).unwrap();
+    let good_mac = key_confirmation_mac(&raw.k2, ID_A, ID_B);
+    let res = finalize_with_confirmation(&raw, &good_mac, &session);
+    assert_eq!(res.err(), Some(PairError::LockedOut));
+}
+
+#[test]
+fn non_six_digit_pin_rejected_before_pake() {
+    // App-layer validation: rejected before any PAKE state is allocated.
+    assert_eq!(validate_pin("12345"), Err(PairError::InvalidPin));
+    assert_eq!(validate_pin("1234567"), Err(PairError::InvalidPin));
+    assert_eq!(validate_pin("12345a"), Err(PairError::InvalidPin));
+    assert_eq!(validate_pin(""), Err(PairError::InvalidPin));
+    assert!(validate_pin("123456").is_ok());
+
+    // start_initiator and respond also enforce the gate at the entry
+    // point so a malformed wire frame never reaches PAKE.
+    assert_eq!(
+        start_initiator("12345", ID_A, ID_B).err(),
+        Some(PairError::InvalidPin)
+    );
+    let dummy_step1 = [0u8; pake_cpace::STEP1_PACKET_BYTES];
+    assert_eq!(
+        respond(&dummy_step1, "abc", ID_A, ID_B).err(),
+        Some(PairError::InvalidPin)
+    );
+}
+
+#[test]
+fn capability_token_verifies_under_owner_key() {
+    let owner_key = fresh_signing_key();
+    let pubkey = owner_key.verifying_key();
+
+    let body = CapabilityBody::issue_v1(
+        "vault-local",
+        "peer-device",
+        "vault-peer",
+        Scope::ReadWrite,
+    );
+    let cap = Capability::sign(&body, &owner_key);
+
+    let verified = cap.verify(&pubkey).expect("verify under owner key");
+    assert_eq!(verified, body);
+    // Reserved fields land on the wire in v1 form.
+    assert_eq!(verified.format_version, 1);
+    assert_eq!(verified.requires_unlock, 0);
+    assert!(verified.wrapped_key.is_none());
+    assert!(verified.expires_at.is_none());
+
+    // Round-trips through to_bytes / from_bytes.
+    let bytes = cap.to_bytes();
+    let cap2 = Capability::from_bytes(&bytes).unwrap();
+    let verified2 = cap2.verify(&pubkey).unwrap();
+    assert_eq!(verified2, body);
+}
+
+#[test]
+fn capability_token_fails_under_other_key() {
+    let owner_key = fresh_signing_key();
+    let attacker_key = fresh_signing_key();
+
+    let body = CapabilityBody::issue_v1("v", "p", "vp", Scope::Read);
+    let cap = Capability::sign(&body, &owner_key);
+
+    let res = cap.verify(&attacker_key.verifying_key());
+    assert!(res.is_err(), "must reject signature from non-owner key");
+}

--- a/src-tauri/src/sync/tests/state_tests.rs
+++ b/src-tauri/src/sync/tests/state_tests.rs
@@ -1,0 +1,261 @@
+//! TDD coverage for #416 sync-state metadata + history blob store.
+//! Test names are spec-prescribed — do not rename.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use crate::sync::clock::TestClock;
+use crate::sync::history::HistoryConfig;
+use crate::sync::state::{SyncState, SCHEMA_VERSION};
+use crate::sync::tombstone::TOMBSTONE_TTL_SECS;
+use crate::sync::{ApplyOutcome, ContentHash, VersionVector};
+
+const PEER_SELF: &str = "selfpeer-aaaaaaaaaaaaaaaa";
+const PEER_OTHER: &str = "otherpeer-bbbbbbbbbbbbbbbb";
+const VAULT: &str = "vault-uuid-0000";
+
+fn h(byte: u8) -> ContentHash {
+    let mut out = [0u8; 32];
+    out[0] = byte;
+    out
+}
+
+fn open_state(dir: &TempDir, clock: Arc<TestClock>) -> SyncState {
+    SyncState::open_with(
+        dir.path(),
+        PEER_SELF.to_string(),
+        clock,
+        HistoryConfig::default(),
+    )
+    .expect("open sync state")
+}
+
+#[test]
+fn schema_creates_with_user_version_1() {
+    let tmp = TempDir::new().unwrap();
+    let clock = Arc::new(TestClock::new(1_700_000_000));
+    let state = open_state(&tmp, clock);
+
+    assert_eq!(state.schema_version().unwrap(), SCHEMA_VERSION);
+    assert_eq!(SCHEMA_VERSION, 1);
+
+    // Sanity: every spec'd table exists.
+    let conn = state.lock_conn().unwrap();
+    for table in [
+        "sync_files",
+        "sync_peers",
+        "sync_vault_grants",
+        "sync_history",
+        "sync_tombstones",
+    ] {
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                rusqlite::params![table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1, "table {table} must exist");
+    }
+
+    for index in ["idx_tombstones_expires", "idx_history_retained"] {
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?1",
+                rusqlite::params![index],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1, "index {index} must exist");
+    }
+
+    // Re-opening must be idempotent and preserve user_version.
+    drop(conn);
+    drop(state);
+    let clock2 = Arc::new(TestClock::new(1_700_000_100));
+    let state2 = open_state(&tmp, clock2);
+    assert_eq!(state2.schema_version().unwrap(), SCHEMA_VERSION);
+}
+
+#[test]
+fn record_local_write_increments_self_counter() {
+    let tmp = TempDir::new().unwrap();
+    let clock = Arc::new(TestClock::new(1_700_000_000));
+    let state = open_state(&tmp, clock);
+
+    let vv1 = state
+        .record_local_write(VAULT, "notes/a.md", h(0xAA), b"hello v1")
+        .unwrap();
+    assert_eq!(vv1.0.get(PEER_SELF).copied(), Some(1));
+
+    let vv2 = state
+        .record_local_write(VAULT, "notes/a.md", h(0xAB), b"hello v2")
+        .unwrap();
+    assert_eq!(vv2.0.get(PEER_SELF).copied(), Some(2));
+
+    // Persisted state matches the latest write.
+    let row = state.get_file(VAULT, "notes/a.md").unwrap().unwrap();
+    assert_eq!(row.content_hash, h(0xAB));
+    assert_eq!(row.version_vector.0.get(PEER_SELF).copied(), Some(2));
+
+    // Other peers must remain untouched.
+    assert!(!row.version_vector.0.contains_key(PEER_OTHER));
+}
+
+#[test]
+fn apply_remote_write_dominates_when_vv_strictly_greater() {
+    let tmp = TempDir::new().unwrap();
+    let clock = Arc::new(TestClock::new(1_700_000_000));
+    let state = open_state(&tmp, clock);
+
+    // Bring up local file at vv {self: 1}.
+    let local_vv = state
+        .record_local_write(VAULT, "notes/a.md", h(0x01), b"local v1")
+        .unwrap();
+    assert_eq!(local_vv.0.get(PEER_SELF).copied(), Some(1));
+
+    // Remote arrives with strictly-greater vv {self: 1, other: 2} — fast-forward.
+    let mut remote_vv = local_vv.clone();
+    remote_vv.0.insert(PEER_OTHER.to_string(), 2);
+    let outcome = state
+        .apply_remote_write(VAULT, "notes/a.md", h(0x02), remote_vv.clone(), b"remote v2")
+        .unwrap();
+    assert_eq!(outcome, ApplyOutcome::FastForward);
+
+    let row = state.get_file(VAULT, "notes/a.md").unwrap().unwrap();
+    assert_eq!(row.content_hash, h(0x02));
+    assert_eq!(row.version_vector, remote_vv);
+
+    // Stale remote that's strictly dominated by current → discard, no-op.
+    let stale = VersionVector(
+        [(PEER_SELF.to_string(), 1u64)].into_iter().collect(),
+    );
+    let outcome2 = state
+        .apply_remote_write(VAULT, "notes/a.md", h(0x99), stale, b"stale")
+        .unwrap();
+    assert_eq!(outcome2, ApplyOutcome::Discard);
+    let row2 = state.get_file(VAULT, "notes/a.md").unwrap().unwrap();
+    assert_eq!(row2.content_hash, h(0x02));
+}
+
+#[test]
+fn apply_remote_write_concurrent_returns_conflict() {
+    let tmp = TempDir::new().unwrap();
+    let clock = Arc::new(TestClock::new(1_700_000_000));
+    let state = open_state(&tmp, clock);
+
+    // Local: {self: 1}
+    state
+        .record_local_write(VAULT, "notes/a.md", h(0x01), b"local")
+        .unwrap();
+    // Remote: {other: 1} — neither dominates → concurrent.
+    let remote_vv = VersionVector(
+        [(PEER_OTHER.to_string(), 1u64)].into_iter().collect(),
+    );
+
+    let outcome = state
+        .apply_remote_write(VAULT, "notes/a.md", h(0x02), remote_vv.clone(), b"remote")
+        .unwrap();
+    assert_eq!(outcome, ApplyOutcome::Conflict);
+
+    // Conflict must NOT mutate sync_files (caller decides what to do).
+    let row = state.get_file(VAULT, "notes/a.md").unwrap().unwrap();
+    assert_eq!(row.content_hash, h(0x01));
+    assert_eq!(row.version_vector.0.get(PEER_SELF).copied(), Some(1));
+    assert!(!row.version_vector.0.contains_key(PEER_OTHER));
+
+    // But the remote version must be retained in history so the
+    // 3-way merge call site can fetch the bytes by hash.
+    let bytes = state
+        .get_history(VAULT, "notes/a.md", &h(0x02))
+        .unwrap()
+        .expect("conflict path stashes the remote blob");
+    assert_eq!(bytes, b"remote");
+}
+
+#[test]
+fn history_keeps_last_2_versions_lru() {
+    let tmp = TempDir::new().unwrap();
+    let clock = Arc::new(TestClock::new(1_700_000_000));
+    let state = open_state(&tmp, clock.clone());
+
+    // Three successive local writes — history must keep only the last 2.
+    state
+        .record_local_write(VAULT, "n.md", h(0x01), b"v1")
+        .unwrap();
+    clock.advance(Duration::from_secs(1));
+    state
+        .record_local_write(VAULT, "n.md", h(0x02), b"v2")
+        .unwrap();
+    clock.advance(Duration::from_secs(1));
+    state
+        .record_local_write(VAULT, "n.md", h(0x03), b"v3")
+        .unwrap();
+
+    // Oldest version evicted from the index.
+    assert!(
+        state.get_history(VAULT, "n.md", &h(0x01)).unwrap().is_none(),
+        "v1 must be LRU-evicted"
+    );
+    // Two most-recent versions retained.
+    assert_eq!(
+        state.get_history(VAULT, "n.md", &h(0x02)).unwrap(),
+        Some(b"v2".to_vec())
+    );
+    assert_eq!(
+        state.get_history(VAULT, "n.md", &h(0x03)).unwrap(),
+        Some(b"v3".to_vec())
+    );
+
+    // Per-file scoping: a different path keeps its own 2-version window.
+    state
+        .record_local_write(VAULT, "other.md", h(0xAA), b"o1")
+        .unwrap();
+    assert_eq!(
+        state.get_history(VAULT, "other.md", &h(0xAA)).unwrap(),
+        Some(b"o1".to_vec())
+    );
+    // ...without disturbing n.md's window.
+    assert_eq!(
+        state.get_history(VAULT, "n.md", &h(0x03)).unwrap(),
+        Some(b"v3".to_vec())
+    );
+}
+
+#[test]
+fn tombstones_expire_after_30_days() {
+    let tmp = TempDir::new().unwrap();
+    let t0: i64 = 1_700_000_000;
+    let clock = Arc::new(TestClock::new(t0));
+    let state = open_state(&tmp, clock.clone());
+
+    let vv = VersionVector(
+        [(PEER_SELF.to_string(), 1u64)].into_iter().collect(),
+    );
+    state
+        .tombstones()
+        .record_delete(VAULT, "deleted.md", &vv)
+        .unwrap();
+
+    assert!(state.tombstones().is_tombstoned(VAULT, "deleted.md").unwrap());
+    assert_eq!(state.tombstones().count().unwrap(), 1);
+
+    // Just before TTL → still live.
+    clock.set(t0 + TOMBSTONE_TTL_SECS - 1);
+    assert!(state.tombstones().is_tombstoned(VAULT, "deleted.md").unwrap());
+    let removed = state.tombstones().gc().unwrap();
+    assert_eq!(removed, 0);
+    assert_eq!(state.tombstones().count().unwrap(), 1);
+
+    // At-or-past TTL → expired and GC'able.
+    clock.set(t0 + TOMBSTONE_TTL_SECS);
+    assert!(!state.tombstones().is_tombstoned(VAULT, "deleted.md").unwrap());
+    let removed = state.tombstones().gc().unwrap();
+    assert_eq!(removed, 1);
+    assert_eq!(state.tombstones().count().unwrap(), 0);
+
+    // Sanity: TTL constant matches "30 days" per the locked decision.
+    assert_eq!(TOMBSTONE_TTL_SECS, 30 * 24 * 60 * 60);
+}

--- a/src-tauri/src/sync/tests/transport_tests.rs
+++ b/src-tauri/src/sync/tests/transport_tests.rs
@@ -1,0 +1,136 @@
+//! TDD coverage for #419 Noise transport layer.
+
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::thread;
+
+use crate::sync::protocol::{
+    decode_frame, encode_frame, ChangeEvent, ChangeKind, FrameError, SyncFrame, MAX_FRAME_BYTES,
+};
+use crate::sync::transport::{
+    drive_handshake, generate_static_keypair, ik_initiator, ik_responder, xx_initiator,
+    xx_responder, EncryptedChannel,
+};
+use crate::sync::VersionVector;
+
+fn sample_change_event() -> ChangeEvent {
+    let mut hash = [0u8; 32];
+    hash[0] = 0xAB;
+    let mut vv = VersionVector::new();
+    vv.increment("PEERA");
+    ChangeEvent {
+        vault_id: "vault-uuid".into(),
+        path: PathBuf::from("notes/a.md"),
+        kind: ChangeKind::Upserted {
+            content: b"hello world".to_vec(),
+        },
+        source_peer: "PEERA".into(),
+        version_vector: vv,
+        content_hash: hash,
+    }
+}
+
+#[test]
+fn change_event_serializes_round_trip() {
+    let evt = sample_change_event();
+    let frame = SyncFrame::Change(evt.clone());
+    let bytes = encode_frame(&frame).unwrap();
+    assert!(bytes.len() > 4);
+    let (decoded, consumed) = decode_frame(&bytes).unwrap();
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(decoded, frame);
+    if let SyncFrame::Change(e) = decoded {
+        assert_eq!(e, evt);
+    }
+
+    // Short buffer surfaces as `Short`, not a deserialize error.
+    assert_eq!(decode_frame(&bytes[..2]).unwrap_err(), FrameError::Short);
+    assert_eq!(decode_frame(&bytes[..3]).unwrap_err(), FrameError::Short);
+
+    // Frame announcing a length over the cap is rejected before alloc.
+    let mut malicious = Vec::new();
+    malicious.extend_from_slice(&(MAX_FRAME_BYTES + 1).to_be_bytes());
+    let err = decode_frame(&malicious).unwrap_err();
+    assert!(matches!(err, FrameError::TooLarge { .. }));
+}
+
+/// Spec-prescribed: XX bootstrap → IK resume on a fresh connection.
+/// Uses two threads on a real loopback TCP pair (no mocks).
+#[test]
+fn noise_xx_bootstrap_then_ik_resume_with_cached_keys() {
+    let initiator_kp = generate_static_keypair().unwrap();
+    let responder_kp = generate_static_keypair().unwrap();
+
+    // ─── Round 1: XX bootstrap. Each side learns the other's static key. ───
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let init_priv = initiator_kp.private.clone();
+    let resp_priv = responder_kp.private.clone();
+    let resp_pub_expected = responder_kp.public.clone();
+    let init_pub_expected = initiator_kp.public.clone();
+
+    let resp_thread = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let hs = xx_responder(&resp_priv).unwrap();
+        let (transport, remote_static) = drive_handshake(hs, &mut stream, false).unwrap();
+        // Responder learned initiator's static key during XX.
+        assert_eq!(remote_static.unwrap(), init_pub_expected);
+        // Receive a frame, send one back.
+        let mut chan = EncryptedChannel { stream, state: transport };
+        let frame = chan.recv().unwrap();
+        let echo = match frame {
+            SyncFrame::Change(_) => SyncFrame::Change(sample_change_event()),
+            other => other,
+        };
+        chan.send(&echo).unwrap();
+    });
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    let hs = xx_initiator(&init_priv).unwrap();
+    let (transport, remote_static) = drive_handshake(hs, &mut stream, true).unwrap();
+    assert_eq!(remote_static.unwrap(), resp_pub_expected);
+    let mut chan = EncryptedChannel { stream, state: transport };
+    chan.send(&SyncFrame::Change(sample_change_event())).unwrap();
+    let echoed = chan.recv().unwrap();
+    assert!(matches!(echoed, SyncFrame::Change(_)));
+    resp_thread.join().unwrap();
+
+    // ─── Round 2: IK resume. Initiator already knows responder's static. ───
+    let listener2 = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port2 = listener2.local_addr().unwrap().port();
+    let resp_priv2 = responder_kp.private.clone();
+    let init_priv2 = initiator_kp.private.clone();
+    let resp_pub2 = responder_kp.public.clone();
+    let init_pub_expected2 = initiator_kp.public.clone();
+
+    let resp_thread2 = thread::spawn(move || {
+        let (mut stream, _) = listener2.accept().unwrap();
+        let hs = ik_responder(&resp_priv2).unwrap();
+        let (transport, remote_static) = drive_handshake(hs, &mut stream, false).unwrap();
+        assert_eq!(remote_static.unwrap(), init_pub_expected2);
+        let mut chan = EncryptedChannel { stream, state: transport };
+        let _ = chan.recv().unwrap();
+        chan.send(&SyncFrame::BatchEnd {
+            vault_id: "v".into(),
+        })
+        .unwrap();
+    });
+    let mut stream2 = TcpStream::connect(("127.0.0.1", port2)).unwrap();
+    let hs = ik_initiator(&init_priv2, &resp_pub2).unwrap();
+    let (transport, _remote_static) = drive_handshake(hs, &mut stream2, true).unwrap();
+    let mut chan2 = EncryptedChannel { stream: stream2, state: transport };
+    chan2
+        .send(&SyncFrame::BatchBegin {
+            vault_id: "v".into(),
+        })
+        .unwrap();
+    let evt = chan2.recv().unwrap();
+    assert_eq!(
+        evt,
+        SyncFrame::BatchEnd {
+            vault_id: "v".into()
+        }
+    );
+    resp_thread2.join().unwrap();
+}

--- a/src-tauri/src/sync/tombstone.rs
+++ b/src-tauri/src/sync/tombstone.rs
@@ -1,0 +1,100 @@
+//! Deletion records with a 30-day TTL (epic #73). The TTL gives offline
+//! peers a window to receive the deletion without resurrection;
+//! `gc_tombstones` clears expired rows so the table stays bounded.
+
+use rusqlite::params;
+
+use crate::error::VaultError;
+
+use super::state::SyncState;
+use super::VersionVector;
+
+/// Tombstone retention window per epic #73's "30-day TTL" decision.
+pub const TOMBSTONE_TTL_SECS: i64 = 30 * 24 * 60 * 60;
+
+pub struct Tombstones<'a> {
+    state: &'a SyncState,
+}
+
+impl<'a> Tombstones<'a> {
+    pub(crate) fn new(state: &'a SyncState) -> Self {
+        Self { state }
+    }
+
+    /// Record a deletion. `expires_at` is `now + TOMBSTONE_TTL_SECS`.
+    /// On conflict (re-delete) the row is replaced so the TTL window
+    /// extends — the deletion event we're propagating is the most recent.
+    pub fn record_delete(
+        &self,
+        vault_id: &str,
+        path: &str,
+        deleted_at_vv: &VersionVector,
+    ) -> Result<(), VaultError> {
+        let now = self.state.clock().now_secs();
+        let expires_at = now + TOMBSTONE_TTL_SECS;
+        let vv_bytes = deleted_at_vv.to_bytes();
+        let conn = self.state.lock_conn()?;
+        conn.execute(
+            "INSERT INTO sync_tombstones (vault_id, path, deleted_at_vv, expires_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(vault_id, path) DO UPDATE SET
+                 deleted_at_vv = excluded.deleted_at_vv,
+                 expires_at = excluded.expires_at",
+            params![vault_id, path, &vv_bytes, expires_at],
+        )
+        .map_err(|e| VaultError::SyncState {
+            msg: format!("sqlite: {e}"),
+        })?;
+        Ok(())
+    }
+
+    /// Returns true if a non-expired tombstone exists for this `(vault_id, path)`.
+    pub fn is_tombstoned(&self, vault_id: &str, path: &str) -> Result<bool, VaultError> {
+        let now = self.state.clock().now_secs();
+        let conn = self.state.lock_conn()?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sync_tombstones
+                 WHERE vault_id = ?1 AND path = ?2 AND expires_at > ?3",
+                params![vault_id, path, now],
+                |row| row.get(0),
+            )
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("sqlite: {e}"),
+            })?;
+        Ok(count > 0)
+    }
+
+    /// Delete expired tombstones. Returns the count removed. Indexed
+    /// scan via `idx_tombstones_expires` keeps this O(removed).
+    pub fn gc(&self) -> Result<usize, VaultError> {
+        self.gc_at(self.state.clock().now_secs())
+    }
+
+    /// Like [`gc`] but explicit about the "now" boundary — used by tests
+    /// that want to verify the TTL math without relying on the wrapped
+    /// clock.
+    pub fn gc_at(&self, now: i64) -> Result<usize, VaultError> {
+        let conn = self.state.lock_conn()?;
+        let n = conn
+            .execute(
+                "DELETE FROM sync_tombstones WHERE expires_at <= ?1",
+                params![now],
+            )
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("sqlite: {e}"),
+            })?;
+        Ok(n)
+    }
+
+    /// Total live tombstone count (for tests + diagnostics).
+    pub fn count(&self) -> Result<usize, VaultError> {
+        let conn = self.state.lock_conn()?;
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_tombstones", [], |row| row.get(0))
+            .map_err(|e| VaultError::SyncState {
+                msg: format!("sqlite: {e}"),
+            })?;
+        Ok(n as usize)
+    }
+}

--- a/src-tauri/src/sync/transport.rs
+++ b/src-tauri/src/sync/transport.rs
@@ -1,0 +1,241 @@
+//! Noise-encrypted transport for sync (epic #73).
+//!
+//! Two patterns:
+//!   - **XX (bootstrap):** first sync after pairing. Exchanges static
+//!     keys mutually so each side learns the other's long-term Noise
+//!     static — equivalent to the long-term Ed25519 key in spirit, but
+//!     a separate Curve25519 key (Noise's primitives). After XX,
+//!     persisted peer record gains the static key.
+//!   - **IK (steady-state):** subsequent connections. Initiator already
+//!     knows responder's static key (from the XX bootstrap), so the
+//!     handshake is one-shot.
+//!
+//! Cipher suite: `Noise_*_25519_ChaChaPoly_SHA256` per epic #73.
+//!
+//! Framing: each Noise message body is itself a length-prefixed bincode
+//! `SyncFrame`. Noise messages over the wire carry a u16 length prefix
+//! (Noise's per-message limit is 65535 bytes), and we chunk frame bodies
+//! larger than that across multiple Noise messages on send / reassemble
+//! on receive. Header is `[u32 BE total_frame_len][...payload...]`,
+//! identical to `protocol::encode_frame`.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+use snow::{HandshakeState, TransportState};
+
+use super::protocol::{FrameError, SyncFrame, MAX_FRAME_BYTES};
+
+const PATTERN_XX: &str = "Noise_XX_25519_ChaChaPoly_SHA256";
+const PATTERN_IK: &str = "Noise_IK_25519_ChaChaPoly_SHA256";
+
+/// Noise's per-message hard limit. We chunk longer payloads.
+const NOISE_MAX_MSG: usize = 65535;
+/// Noise auth tag overhead per message (ChaChaPoly = 16 bytes).
+const NOISE_TAG_LEN: usize = 16;
+/// Plaintext budget per Noise message after the auth tag.
+const NOISE_PT_BUDGET: usize = NOISE_MAX_MSG - NOISE_TAG_LEN;
+
+#[derive(Debug)]
+pub enum TransportError {
+    Io(std::io::Error),
+    Noise(snow::Error),
+    Frame(FrameError),
+    /// Protocol violation: frame too large to chunk reasonably.
+    FrameTooLarge,
+    /// Peer disconnected mid-handshake or mid-frame.
+    UnexpectedClose,
+}
+
+impl From<std::io::Error> for TransportError {
+    fn from(e: std::io::Error) -> Self {
+        TransportError::Io(e)
+    }
+}
+impl From<snow::Error> for TransportError {
+    fn from(e: snow::Error) -> Self {
+        TransportError::Noise(e)
+    }
+}
+impl From<FrameError> for TransportError {
+    fn from(e: FrameError) -> Self {
+        TransportError::Frame(e)
+    }
+}
+
+/// Generate a fresh Curve25519 keypair (32-byte private + 32-byte public).
+/// Used at sync-engine startup to mint a per-install Noise static key.
+/// Held separately from the Ed25519 device key — Noise wants Curve25519
+/// natively and converting Ed25519 ↔ X25519 is a footgun we sidestep.
+pub fn generate_static_keypair() -> Result<NoiseKeypair, TransportError> {
+    let builder = snow::Builder::new(PATTERN_XX.parse()?);
+    let kp = builder.generate_keypair()?;
+    Ok(NoiseKeypair {
+        private: kp.private,
+        public: kp.public,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct NoiseKeypair {
+    pub private: Vec<u8>,
+    pub public: Vec<u8>,
+}
+
+// ─── Handshake builders ───────────────────────────────────────────────
+
+pub fn xx_initiator(local_static: &[u8]) -> Result<HandshakeState, TransportError> {
+    Ok(snow::Builder::new(PATTERN_XX.parse()?)
+        .local_private_key(local_static)
+        .build_initiator()?)
+}
+
+pub fn xx_responder(local_static: &[u8]) -> Result<HandshakeState, TransportError> {
+    Ok(snow::Builder::new(PATTERN_XX.parse()?)
+        .local_private_key(local_static)
+        .build_responder()?)
+}
+
+pub fn ik_initiator(
+    local_static: &[u8],
+    remote_static: &[u8],
+) -> Result<HandshakeState, TransportError> {
+    Ok(snow::Builder::new(PATTERN_IK.parse()?)
+        .local_private_key(local_static)
+        .remote_public_key(remote_static)
+        .build_initiator()?)
+}
+
+pub fn ik_responder(local_static: &[u8]) -> Result<HandshakeState, TransportError> {
+    Ok(snow::Builder::new(PATTERN_IK.parse()?)
+        .local_private_key(local_static)
+        .build_responder()?)
+}
+
+// ─── Synchronous TCP handshake driver ──────────────────────────────────
+
+/// Drive a Noise handshake to completion over a `TcpStream`. Each Noise
+/// message is u16-length-prefixed on the wire (length excludes the
+/// prefix itself).
+///
+/// Caller passes a fresh `HandshakeState` from one of the builders above.
+/// Returns the resulting `TransportState` (encryption-only state) plus
+/// the remote's static public key (`Some` for XX, the responder side
+/// already holds it for IK initiator).
+pub fn drive_handshake(
+    mut hs: HandshakeState,
+    stream: &mut TcpStream,
+    is_initiator: bool,
+) -> Result<(TransportState, Option<Vec<u8>>), TransportError> {
+    let mut buf = [0u8; NOISE_MAX_MSG];
+    // Pattern step counter: initiator writes first.
+    let mut my_turn = is_initiator;
+    while !hs.is_handshake_finished() {
+        if my_turn {
+            let len = hs.write_message(&[], &mut buf)?;
+            write_noise_msg(stream, &buf[..len])?;
+        } else {
+            let msg = read_noise_msg(stream)?;
+            let mut scratch = [0u8; NOISE_MAX_MSG];
+            hs.read_message(&msg, &mut scratch)?;
+        }
+        my_turn = !my_turn;
+    }
+    let remote_static = hs.get_remote_static().map(|s| s.to_vec());
+    let ts = hs.into_transport_mode()?;
+    Ok((ts, remote_static))
+}
+
+fn write_noise_msg(stream: &mut TcpStream, msg: &[u8]) -> Result<(), TransportError> {
+    if msg.len() > NOISE_MAX_MSG {
+        return Err(TransportError::FrameTooLarge);
+    }
+    stream.write_all(&(msg.len() as u16).to_be_bytes())?;
+    stream.write_all(msg)?;
+    Ok(())
+}
+
+fn read_noise_msg(stream: &mut TcpStream) -> Result<Vec<u8>, TransportError> {
+    let mut len_buf = [0u8; 2];
+    read_exact_or_close(stream, &mut len_buf)?;
+    let len = u16::from_be_bytes(len_buf) as usize;
+    let mut body = vec![0u8; len];
+    read_exact_or_close(stream, &mut body)?;
+    Ok(body)
+}
+
+fn read_exact_or_close(stream: &mut TcpStream, out: &mut [u8]) -> Result<(), TransportError> {
+    match stream.read_exact(out) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            Err(TransportError::UnexpectedClose)
+        }
+        Err(e) => Err(TransportError::Io(e)),
+    }
+}
+
+// ─── Encrypted frame channel ──────────────────────────────────────────
+
+/// Wraps a Noise `TransportState` + `TcpStream` into a `SyncFrame`-level
+/// I/O channel. Each frame is bincode-encoded + chunked across as many
+/// Noise messages as needed.
+pub struct EncryptedChannel {
+    pub stream: TcpStream,
+    pub state: TransportState,
+}
+
+impl EncryptedChannel {
+    /// Encrypt + send a `SyncFrame`. Frames over `MAX_FRAME_BYTES` are
+    /// rejected at the framing layer.
+    ///
+    /// On the wire each frame is `[u32 BE bincode_len][noise_chunks...]`,
+    /// where each chunk is `[u16 BE n][ciphertext n bytes]`. The plaintext
+    /// across the chunks reassembles to the bincode-encoded `SyncFrame`
+    /// payload — no `protocol::encode_frame` length prefix is included
+    /// (the outer u32 already gives the receiver the total length).
+    pub fn send(&mut self, frame: &SyncFrame) -> Result<(), TransportError> {
+        let body = bincode::serialize(frame).map_err(|e| {
+            super::protocol::FrameError::Serialize(e.to_string())
+        })?;
+        if body.len() as u64 > MAX_FRAME_BYTES as u64 {
+            return Err(TransportError::FrameTooLarge);
+        }
+        self.stream.write_all(&(body.len() as u32).to_be_bytes())?;
+        let mut offset = 0;
+        let mut ct = [0u8; NOISE_MAX_MSG];
+        while offset < body.len() {
+            let take = (body.len() - offset).min(NOISE_PT_BUDGET);
+            let n = self.state.write_message(&body[offset..offset + take], &mut ct)?;
+            self.stream.write_all(&(n as u16).to_be_bytes())?;
+            self.stream.write_all(&ct[..n])?;
+            offset += take;
+        }
+        Ok(())
+    }
+
+    /// Read + decrypt the next `SyncFrame`. Blocks until the full frame
+    /// is on the wire.
+    pub fn recv(&mut self) -> Result<SyncFrame, TransportError> {
+        let mut len_buf = [0u8; 4];
+        read_exact_or_close(&mut self.stream, &mut len_buf)?;
+        let total = u32::from_be_bytes(len_buf);
+        if total > MAX_FRAME_BYTES {
+            return Err(TransportError::FrameTooLarge);
+        }
+        let mut body = Vec::with_capacity(total as usize);
+        let mut pt = [0u8; NOISE_MAX_MSG];
+        while body.len() < total as usize {
+            let mut n_buf = [0u8; 2];
+            read_exact_or_close(&mut self.stream, &mut n_buf)?;
+            let n = u16::from_be_bytes(n_buf) as usize;
+            let mut ct = vec![0u8; n];
+            read_exact_or_close(&mut self.stream, &mut ct)?;
+            let plain_len = self.state.read_message(&ct, &mut pt)?;
+            body.extend_from_slice(&pt[..plain_len]);
+        }
+        let frame: SyncFrame = bincode::deserialize(&body).map_err(|e| {
+            super::protocol::FrameError::Deserialize(e.to_string())
+        })?;
+        Ok(frame)
+    }
+}

--- a/src-tauri/src/sync/vault_id.rs
+++ b/src-tauri/src/sync/vault_id.rs
@@ -1,0 +1,39 @@
+//! Per-vault UUIDv4 stored at `<vault>/.vaultcore/vault-id` (epic #73).
+//!
+//! Generated on first call, then read verbatim on every subsequent call —
+//! the vault-id outlives any single sync peering, so it must persist
+//! across launches without rotation.
+
+use std::fs;
+use std::path::Path;
+
+use uuid::Uuid;
+
+use crate::error::VaultError;
+
+const VAULT_ID_FILENAME: &str = "vault-id";
+
+/// Read `vault-id`, or generate + write a fresh UUIDv4 if missing.
+/// Returns the canonical hyphenated string.
+///
+/// `metadata_dir` is the path returned by `VaultStorage::metadata_path()`
+/// (i.e. `<vault>/.vaultcore`). The caller is expected to have already
+/// ensured it exists; this function will `create_dir_all` defensively.
+pub fn load_or_create(metadata_dir: &Path) -> Result<String, VaultError> {
+    fs::create_dir_all(metadata_dir).map_err(VaultError::Io)?;
+    let path = metadata_dir.join(VAULT_ID_FILENAME);
+    if path.exists() {
+        let raw = fs::read_to_string(&path).map_err(VaultError::Io)?;
+        let trimmed = raw.trim().to_string();
+        // Defensive: only accept well-formed UUIDs. A corrupt file should
+        // surface as an error, never as silent regeneration — that would
+        // re-pair with peers under a different identity.
+        Uuid::parse_str(&trimmed).map_err(|e| VaultError::SyncState {
+            msg: format!("vault-id at {} is not a valid UUID: {e}", path.display()),
+        })?;
+        return Ok(trimmed);
+    }
+    let id = Uuid::new_v4().to_string();
+    fs::write(&path, &id).map_err(VaultError::Io)?;
+    Ok(id)
+}

--- a/src-tauri/tauri.conf.uat-b.json
+++ b/src-tauri/tauri.conf.uat-b.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "productName": "VaultCore (B)",
+  "identifier": "com.vaultcore.app.uat-b",
+  "build": {
+    "devUrl": "http://localhost:5174",
+    "beforeDevCommand": "pnpm dev:b"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "VaultCore (B)",
+        "width": 1200,
+        "height": 800,
+        "resizable": true,
+        "fullscreen": false,
+        "dragDropEnabled": false
+      }
+    ]
+  }
+}

--- a/src-tauri/tests/sync_e2e.rs
+++ b/src-tauri/tests/sync_e2e.rs
@@ -1,0 +1,1039 @@
+//! End-to-end LAN sync acceptance test (epic #73, ticket #6).
+//!
+//! Spins up two in-process `Device` instances on `127.0.0.1` with two
+//! distinct vault directories and validates the full happy path of the
+//! v1 sync stack: discovery (mDNS, cfg-gated), PAKE pairing with key
+//! confirmation, capability grant exchange, change-event propagation,
+//! conflict-copy on concurrent edits, tombstone-driven deletion, and
+//! Merkle catch-up after one side has been offline.
+//!
+//! Synchronization across the two devices is done by polling helpers
+//! (`wait_until`) — no `std::thread::sleep` is used to wait for sync
+//! progress. The mDNS scenario is gated behind `#[cfg(not(ci_no_mdns))]`
+//! with a manual peer-address override path so the rest of the test runs
+//! on CI environments that block multicast.
+
+use std::collections::{HashMap, HashSet};
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use ed25519_dalek::SigningKey;
+use rand_core::RngCore;
+use sha2::{Digest, Sha256};
+use snow::TransportState;
+use tempfile::TempDir;
+
+use vaultcore_lib::sync::capability::{Capability, CapabilityBody, Scope};
+use vaultcore_lib::sync::clock::SystemClock;
+use vaultcore_lib::sync::conflict::{conflict_copy_path, resolve, ResolveOutcome};
+use vaultcore_lib::sync::engine::{InboundDecision, SyncEngine};
+use vaultcore_lib::sync::history::HistoryConfig;
+use vaultcore_lib::sync::merkle::{diff_paths, MerkleTree};
+use vaultcore_lib::sync::pairing::{
+    finalize_with_confirmation, key_confirmation_mac, respond, start_initiator, PairingSession,
+};
+use vaultcore_lib::sync::protocol::{ChangeEvent, ChangeKind, SyncFrame, MAX_FRAME_BYTES};
+use vaultcore_lib::sync::state::{PeerTrust, SyncState};
+use vaultcore_lib::sync::transport::{
+    drive_handshake, generate_static_keypair, xx_initiator, xx_responder, NoiseKeypair,
+};
+use vaultcore_lib::sync::ContentHash;
+use vaultcore_lib::WriteIgnoreList;
+
+#[cfg(not(ci_no_mdns))]
+use vaultcore_lib::sync::discovery::{
+    AdvertisedVault, Discovery, MdnsDiscovery, PeerAd, PROTO_VERSION,
+};
+
+/// Vault id shared by both devices — this is the *same* vault, replicated.
+const VAULT_ID: &str = "e2e-vault-uuid-0001";
+const PIN: &str = "314159";
+const PROPAGATION_TIMEOUT: Duration = Duration::from_secs(2);
+const CATCHUP_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Noise per-message hard limit (matches the in-tree transport constant
+/// — duplicated here because the production module keeps the value private).
+const NOISE_MAX_MSG: usize = 65535;
+const NOISE_TAG_LEN: usize = 16;
+const NOISE_PT_BUDGET: usize = NOISE_MAX_MSG - NOISE_TAG_LEN;
+
+// ─── Polling helper ───────────────────────────────────────────────────
+
+/// Block until `cond` returns true or `deadline` elapses. Returns the
+/// elapsed time on success, or `None` on timeout. Yields with a 5ms park
+/// between probes so a failing poll burns near-zero CPU but recovers
+/// quickly when the expected event fires. The cadence is well below the
+/// 2s / 1s budgets the scenarios assert against.
+fn wait_until<F: FnMut() -> bool>(deadline: Duration, mut cond: F) -> Option<Duration> {
+    let start = Instant::now();
+    let stop_at = start + deadline;
+    loop {
+        if cond() {
+            return Some(start.elapsed());
+        }
+        if Instant::now() >= stop_at {
+            return None;
+        }
+        thread::park_timeout(Duration::from_millis(5));
+    }
+}
+
+// ─── Hash helper ──────────────────────────────────────────────────────
+
+fn hash(content: &[u8]) -> ContentHash {
+    let d = Sha256::digest(content);
+    let mut o: ContentHash = [0; 32];
+    o.copy_from_slice(&d);
+    o
+}
+
+// ─── Split-half encrypted peer link ───────────────────────────────────
+//
+// The in-tree `EncryptedChannel` couples `TcpStream` and `TransportState`
+// into a single `&mut self` API — fine for the production engine which
+// drives both directions from one task, but a deadlock waiting to happen
+// in this test where the reader is parked on `recv` while the writer
+// wants to broadcast. We split the two halves: a `Mutex<TransportState>`
+// shared between sender + receiver (Noise needs all crypto ops serialized
+// — write/read share a transcript hash), and two cloned `TcpStream`
+// handles so the actual blocking I/O happens with no Noise lock held.
+
+/// Outbound half: cloned TcpStream owned by the sender thread.
+struct PeerOut {
+    stream: Mutex<TcpStream>,
+    state: Arc<Mutex<TransportState>>,
+}
+
+impl PeerOut {
+    /// Encrypt + send a `SyncFrame` over the wire. Frame format matches
+    /// `EncryptedChannel::send` byte-for-byte:
+    ///   [u32 BE bincode_len][noise_chunk]*
+    /// where each chunk is `[u16 BE n][ciphertext n bytes]`.
+    fn send(&self, frame: &SyncFrame) -> std::io::Result<()> {
+        let body = bincode::serialize(frame).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bincode: {e}"))
+        })?;
+        if body.len() as u64 > MAX_FRAME_BYTES as u64 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "frame too large",
+            ));
+        }
+        // Build the entire wire payload under the Noise lock, release it,
+        // then push to the socket. Holding the Noise lock across blocking
+        // socket writes would re-introduce the same deadlock the split
+        // is supposed to prevent.
+        let mut wire: Vec<u8> = Vec::with_capacity(4 + body.len() + 16);
+        wire.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        {
+            let mut state = self.state.lock().expect("noise state");
+            let mut offset = 0usize;
+            let mut ct = [0u8; NOISE_MAX_MSG];
+            while offset < body.len() {
+                let take = (body.len() - offset).min(NOISE_PT_BUDGET);
+                let n = state
+                    .write_message(&body[offset..offset + take], &mut ct)
+                    .map_err(|e| {
+                        std::io::Error::new(std::io::ErrorKind::Other, format!("noise: {e}"))
+                    })?;
+                wire.extend_from_slice(&(n as u16).to_be_bytes());
+                wire.extend_from_slice(&ct[..n]);
+                offset += take;
+            }
+        }
+        let mut stream = self.stream.lock().expect("stream");
+        stream.write_all(&wire)?;
+        Ok(())
+    }
+}
+
+/// Inbound half: cloned TcpStream owned by the reader thread. Owns its
+/// own copy of the stream handle (via `try_clone`) so reads and writes
+/// proceed in parallel.
+struct PeerIn {
+    stream: TcpStream,
+    state: Arc<Mutex<TransportState>>,
+}
+
+impl PeerIn {
+    fn recv(&mut self) -> std::io::Result<SyncFrame> {
+        let mut len_buf = [0u8; 4];
+        self.stream.read_exact(&mut len_buf)?;
+        let total = u32::from_be_bytes(len_buf);
+        if total > MAX_FRAME_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "frame too large",
+            ));
+        }
+        // Read all chunks off the wire first (no Noise lock), then
+        // decrypt in one pass under the lock. This matches the sender
+        // discipline and keeps the Noise mutex un-held during the
+        // potentially-blocking socket read.
+        let mut chunks: Vec<Vec<u8>> = Vec::new();
+        let mut consumed = 0usize;
+        while consumed < total as usize {
+            let mut n_buf = [0u8; 2];
+            self.stream.read_exact(&mut n_buf)?;
+            let n = u16::from_be_bytes(n_buf) as usize;
+            let mut ct = vec![0u8; n];
+            self.stream.read_exact(&mut ct)?;
+            // Noise tag is 16 bytes — plaintext per chunk = n - 16.
+            consumed += n.saturating_sub(NOISE_TAG_LEN);
+            chunks.push(ct);
+        }
+        let mut body: Vec<u8> = Vec::with_capacity(total as usize);
+        let mut state = self.state.lock().expect("noise state");
+        let mut pt = [0u8; NOISE_MAX_MSG];
+        for ct in chunks {
+            let plain_len = state.read_message(&ct, &mut pt).map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::Other, format!("noise: {e}"))
+            })?;
+            body.extend_from_slice(&pt[..plain_len]);
+        }
+        drop(state);
+        let frame: SyncFrame = bincode::deserialize(&body).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bincode: {e}"))
+        })?;
+        Ok(frame)
+    }
+}
+
+/// Split a finished Noise handshake's `(stream, state)` pair into the
+/// per-direction halves above.
+fn split_link(stream: TcpStream, state: TransportState) -> std::io::Result<(PeerOut, PeerIn)> {
+    let read_stream = stream.try_clone()?;
+    let state_arc = Arc::new(Mutex::new(state));
+    let out = PeerOut {
+        stream: Mutex::new(stream),
+        state: Arc::clone(&state_arc),
+    };
+    let inp = PeerIn {
+        stream: read_stream,
+        state: state_arc,
+    };
+    Ok((out, inp))
+}
+
+// ─── Device wiring ────────────────────────────────────────────────────
+
+/// One sync-stack instance. Holds the on-disk vault root, the metadata
+/// store, the engine, and a Noise static key for the transport.
+/// Spawned threads (server accept loop + per-peer read loops) push
+/// completed `ChangeEvent`s through `apply_remote_event` and mirror the
+/// working-tree side effects (write file, delete file, write conflict
+/// copy).
+struct Device {
+    name: &'static str,
+    self_peer_id: String,
+    /// Ed25519 long-term key — used to sign capability grants.
+    signing_key: SigningKey,
+    /// Curve25519 Noise static — used by the transport handshake.
+    noise_kp: NoiseKeypair,
+    vault_root: PathBuf,
+    state: Arc<SyncState>,
+    engine: Arc<SyncEngine>,
+    server: Mutex<Option<RunningServer>>,
+    /// Outbound peer connections, keyed by peer device_id. Sends are
+    /// serialized per-peer through `PeerOut`'s internal mutex.
+    peers: Mutex<HashMap<String, Arc<PeerOut>>>,
+    _tmp: TempDir,
+}
+
+struct RunningServer {
+    addr: SocketAddr,
+    stop_flag: Arc<AtomicBool>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl Device {
+    fn new(name: &'static str) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let vault_root = tmp.path().to_path_buf();
+        let metadata = vault_root.join(".vaultcore");
+        std::fs::create_dir_all(&metadata).expect("metadata dir");
+
+        let signing_key = fresh_signing_key();
+        let device_id = derive_test_device_id(&signing_key);
+        let noise_kp = generate_static_keypair().expect("noise kp");
+
+        let state = Arc::new(
+            SyncState::open_with(
+                &metadata,
+                device_id.clone(),
+                Arc::new(SystemClock),
+                HistoryConfig::default(),
+            )
+            .expect("sync state open"),
+        );
+
+        let write_ignore = Arc::new(Mutex::new(WriteIgnoreList::default()));
+        let engine = Arc::new(SyncEngine::new(state.clone(), write_ignore));
+        engine
+            .set_vault_root(vault_root.clone())
+            .expect("set vault root");
+
+        Self {
+            name,
+            self_peer_id: device_id,
+            signing_key,
+            noise_kp,
+            vault_root,
+            state,
+            engine,
+            server: Mutex::new(None),
+            peers: Mutex::new(HashMap::new()),
+            _tmp: tmp,
+        }
+    }
+
+    fn start_server(self: &Arc<Self>) -> SocketAddr {
+        let listener = TcpListener::bind((Ipv4Addr::new(127, 0, 0, 1), 0)).expect("bind");
+        listener
+            .set_nonblocking(true)
+            .expect("listener nonblocking");
+        let addr = listener.local_addr().expect("local addr");
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let stop_flag_t = Arc::clone(&stop_flag);
+        let me = Arc::clone(self);
+        let join = thread::spawn(move || {
+            accept_loop(me, listener, stop_flag_t);
+        });
+        *self.server.lock().expect("server lock") = Some(RunningServer {
+            addr,
+            stop_flag,
+            join: Some(join),
+        });
+        addr
+    }
+
+    fn stop_server(&self) {
+        let Some(mut srv) = self.server.lock().expect("server lock").take() else {
+            return;
+        };
+        srv.stop_flag.store(true, Ordering::SeqCst);
+        if let Some(j) = srv.join.take() {
+            let _ = j.join();
+        }
+        let mut peers = self.peers.lock().expect("peers lock");
+        for (_, ch) in peers.drain() {
+            if let Ok(s) = ch.stream.lock() {
+                let _ = s.shutdown(Shutdown::Both);
+            }
+        }
+    }
+
+    fn server_addr(&self) -> Option<SocketAddr> {
+        self.server
+            .lock()
+            .expect("server lock")
+            .as_ref()
+            .map(|s| s.addr)
+    }
+
+    /// Local write: persist to disk, record in sync state + Merkle tree,
+    /// then broadcast to every connected peer.
+    fn write_local(&self, rel: &str, content: &[u8]) {
+        let abs = self.vault_root.join(rel);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(&abs, content).expect("write local");
+        let h = hash(content);
+        let event = self
+            .engine
+            .on_local_write(VAULT_ID, PathBuf::from(rel), content.to_vec(), h)
+            .expect("on_local_write");
+        let tree = MerkleTree::new(&self.state, VAULT_ID);
+        tree.upsert_file(rel, h).expect("merkle upsert");
+        self.broadcast(SyncFrame::Change(event));
+    }
+
+    /// Local delete: drop the file, record a tombstone, broadcast the
+    /// matching `Deleted` event.
+    fn delete_local(&self, rel: &str) {
+        let abs = self.vault_root.join(rel);
+        let _ = std::fs::remove_file(&abs);
+        let mut vv = self
+            .state
+            .get_file(VAULT_ID, rel)
+            .expect("get_file")
+            .map(|r| r.version_vector)
+            .unwrap_or_default();
+        vv.increment(&self.self_peer_id);
+        self.state
+            .tombstones()
+            .record_delete(VAULT_ID, rel, &vv)
+            .expect("record tombstone");
+        let tree = MerkleTree::new(&self.state, VAULT_ID);
+        tree.remove_file(rel).expect("merkle remove");
+        let event = ChangeEvent {
+            vault_id: VAULT_ID.into(),
+            path: PathBuf::from(rel),
+            kind: ChangeKind::Deleted,
+            source_peer: self.self_peer_id.clone(),
+            version_vector: vv,
+            content_hash: [0u8; 32],
+        };
+        self.broadcast(SyncFrame::Change(event));
+    }
+
+    fn broadcast(&self, frame: SyncFrame) {
+        let peers: Vec<Arc<PeerOut>> = self
+            .peers
+            .lock()
+            .expect("peers lock")
+            .values()
+            .cloned()
+            .collect();
+        for ch in peers {
+            // Best-effort send; a dead connection is fine — the catch-up
+            // path picks the file up via Merkle on reconnect.
+            let _ = ch.send(&frame);
+        }
+    }
+
+    fn file_contents(&self, rel: &str) -> Option<Vec<u8>> {
+        std::fs::read(self.vault_root.join(rel)).ok()
+    }
+
+    fn file_exists(&self, rel: &str) -> bool {
+        self.vault_root.join(rel).exists()
+    }
+
+    /// Walk the working tree looking for any conflict-copy file matching
+    /// `<stem> (conflict from … YYYY-MM-DD HH:MM)<.ext>`.
+    fn find_conflict_copy(&self, parent: &str, stem_prefix: &str) -> Option<PathBuf> {
+        let dir = self.vault_root.join(parent);
+        let entries = std::fs::read_dir(&dir).ok()?;
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with(&format!("{stem_prefix} (conflict from "))
+                && name.ends_with(").md")
+            {
+                return Some(entry.path());
+            }
+        }
+        None
+    }
+
+    fn merkle_root(&self) -> Option<ContentHash> {
+        MerkleTree::new(&self.state, VAULT_ID)
+            .root()
+            .expect("merkle root")
+    }
+}
+
+// ─── Trust + capability bootstrapping ─────────────────────────────────
+
+/// Mutually pair A and B in-process via PAKE + key-confirmation, persist
+/// the trust + grants on both sides, then open a Noise-encrypted TCP
+/// channel + register reader threads.
+fn pair_and_connect(a: &Arc<Device>, b: &Arc<Device>, addr_b_listening: SocketAddr) {
+    // ─── Step 1: PAKE round-trip (matching PIN, in-process). ──────────
+    let session_a = PairingSession::new();
+    let session_b = PairingSession::new();
+    session_a.issue_pin().expect("a issue pin");
+    session_b.issue_pin().expect("b issue pin");
+
+    let initiator = start_initiator(PIN, &a.self_peer_id, &b.self_peer_id).expect("pake start");
+    let s1 = initiator.step1_packet();
+    let responder = respond(&s1, PIN, &a.self_peer_id, &b.self_peer_id).expect("pake respond");
+    let s2 = responder.step2_packet();
+    let raw_a = initiator.step3(&s2).expect("pake step3");
+    let raw_b = responder.raw_keys;
+    let mac_b = key_confirmation_mac(&raw_b.k2, &a.self_peer_id, &b.self_peer_id);
+    let mac_a = key_confirmation_mac(&raw_a.k2, &a.self_peer_id, &b.self_peer_id);
+    finalize_with_confirmation(&raw_a, &mac_b, &session_a).expect("a finalize");
+    finalize_with_confirmation(&raw_b, &mac_a, &session_b).expect("b finalize");
+
+    // ─── Step 2: persist peer trust on both sides. ────────────────────
+    a.state
+        .upsert_peer(
+            &b.self_peer_id,
+            &b.signing_key.verifying_key().to_bytes(),
+            b.name,
+            PeerTrust::Trusted,
+        )
+        .expect("a upsert peer");
+    b.state
+        .upsert_peer(
+            &a.self_peer_id,
+            &a.signing_key.verifying_key().to_bytes(),
+            a.name,
+            PeerTrust::Trusted,
+        )
+        .expect("b upsert peer");
+
+    // ─── Step 3: cross-issue ReadWrite capability grants. ────────────
+    // Engine semantics (see `engine_tests::pair_peer_with_grant`): each
+    // side stores a capability *signed by the peer*, with body.peer_device_id
+    // equal to that peer's own device id. The row PK lands at
+    // `(vault_id, peer_id)` and verifies under the peer's pubkey from
+    // `sync_peers`.
+    let cap_b_self = Capability::sign(
+        &CapabilityBody::issue_v1(VAULT_ID, &b.self_peer_id, VAULT_ID, Scope::ReadWrite),
+        &b.signing_key,
+    );
+    let cap_a_self = Capability::sign(
+        &CapabilityBody::issue_v1(VAULT_ID, &a.self_peer_id, VAULT_ID, Scope::ReadWrite),
+        &a.signing_key,
+    );
+    a.state
+        .upsert_vault_grant(&cap_b_self)
+        .expect("a store cap_b_self");
+    b.state
+        .upsert_vault_grant(&cap_a_self)
+        .expect("b store cap_a_self");
+
+    // ─── Step 4: Noise XX TCP handshake A→B + register reader. ───────
+    open_outbound(a, b, addr_b_listening);
+    // Wait for B's accept loop to register the inbound side under A's
+    // device id. This is bounded — accept_loop runs hot.
+    let _ = wait_until(Duration::from_secs(2), || {
+        b.peers
+            .lock()
+            .map(|g| g.contains_key(&a.self_peer_id))
+            .unwrap_or(false)
+    });
+}
+
+/// Open a fresh outbound link from `a` to `b`. Used by both the initial
+/// pairing connect and by `reconnect` (the persisted peer + grant rows
+/// outlive the TCP socket).
+fn open_outbound(a: &Arc<Device>, b: &Arc<Device>, addr_b_listening: SocketAddr) {
+    let mut stream = TcpStream::connect(addr_b_listening).expect("connect");
+    stream.set_nodelay(true).expect("nodelay");
+    let hs = xx_initiator(&a.noise_kp.private).expect("xx_initiator");
+    let (transport, _remote_static) =
+        drive_handshake(hs, &mut stream, true).expect("handshake initiator");
+    let (out, inp) = split_link(stream, transport).expect("split link");
+    let out_arc = Arc::new(out);
+    a.peers
+        .lock()
+        .expect("a peers lock")
+        .insert(b.self_peer_id.clone(), Arc::clone(&out_arc));
+    let a_for_reader = Arc::clone(a);
+    let peer_id_b = b.self_peer_id.clone();
+    thread::spawn(move || peer_read_loop(a_for_reader, peer_id_b, inp));
+}
+
+// ─── Server side accept + per-connection driver ───────────────────────
+
+fn accept_loop(device: Arc<Device>, listener: TcpListener, stop_flag: Arc<AtomicBool>) {
+    while !stop_flag.load(Ordering::SeqCst) {
+        match listener.accept() {
+            Ok((stream, _peer_addr)) => {
+                stream.set_nodelay(true).ok();
+                stream.set_nonblocking(false).ok();
+                let device_t = Arc::clone(&device);
+                thread::spawn(move || {
+                    serve_inbound(device_t, stream);
+                });
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::park_timeout(Duration::from_millis(10));
+            }
+            Err(_) => {
+                thread::park_timeout(Duration::from_millis(10));
+            }
+        }
+    }
+}
+
+/// Responder side of the Noise XX handshake. Once the channel is up,
+/// the connection is symmetric — register on the outbound peers map +
+/// run a reader. Caveat: the responder doesn't know the peer's device
+/// id until the first frame arrives (frames carry `source_peer`), so we
+/// peek at the first frame, use its `source_peer` as the registration
+/// key, then process it and continue reading.
+fn serve_inbound(device: Arc<Device>, mut stream: TcpStream) {
+    let hs = match xx_responder(&device.noise_kp.private) {
+        Ok(hs) => hs,
+        Err(_) => return,
+    };
+    let (transport, _remote_static) = match drive_handshake(hs, &mut stream, false) {
+        Ok(out) => out,
+        Err(_) => return,
+    };
+    let (out, mut inp) = match split_link(stream, transport) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let out_arc = Arc::new(out);
+
+    // Discover peer id from the first inbound frame, register the
+    // outbound half, then stay in the reader loop.
+    let first_frame = match inp.recv() {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    let peer_id = peer_id_of(&first_frame).map(|s| s.to_string()).unwrap_or_default();
+    if !peer_id.is_empty() {
+        device
+            .peers
+            .lock()
+            .expect("peers lock")
+            .insert(peer_id.clone(), Arc::clone(&out_arc));
+    }
+    handle_frame(&device, &peer_id, first_frame);
+    peer_read_loop(device, peer_id, inp);
+}
+
+fn peer_read_loop(device: Arc<Device>, peer_id: String, mut inp: PeerIn) {
+    loop {
+        let frame = match inp.recv() {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+        handle_frame(&device, &peer_id, frame);
+    }
+}
+
+fn peer_id_of(frame: &SyncFrame) -> Option<&str> {
+    match frame {
+        SyncFrame::Change(e) => Some(&e.source_peer),
+        _ => None,
+    }
+}
+
+/// Consume one inbound frame: validate via engine, then mirror the
+/// decision onto the working tree. This is the "watcher hook" the
+/// production code wires up in `lib.rs`; in this test it lives inline
+/// because we don't want to bring up Tauri / notify.
+fn handle_frame(device: &Arc<Device>, peer_id: &str, frame: SyncFrame) {
+    let event = match frame {
+        SyncFrame::Change(e) => e,
+        // Batch markers are no-ops at this layer.
+        _ => return,
+    };
+    let decision = match device.engine.apply_remote_event(&event, peer_id) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    match decision {
+        InboundDecision::FastForward {
+            path,
+            content,
+            content_hash,
+        }
+        | InboundDecision::Created {
+            path,
+            content,
+            content_hash,
+        } => {
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&path, &content);
+            let rel = relative_to(&device.vault_root, &path);
+            let tree = MerkleTree::new(&device.state, VAULT_ID);
+            let _ = tree.upsert_file(&rel, content_hash);
+        }
+        InboundDecision::Delete { path } => {
+            let _ = std::fs::remove_file(&path);
+            let rel = relative_to(&device.vault_root, &path);
+            let tree = MerkleTree::new(&device.state, VAULT_ID);
+            let _ = tree.remove_file(&rel);
+        }
+        InboundDecision::NeedsMerge {
+            path,
+            remote_content,
+            remote_hash: _,
+        } => {
+            let rel = relative_to(&device.vault_root, &path);
+            let local_record = match device.state.get_file(VAULT_ID, &rel) {
+                Ok(Some(r)) => r,
+                _ => return,
+            };
+            let local_content = match std::fs::read(&path) {
+                Ok(b) => b,
+                Err(_) => return,
+            };
+            let outcome = match resolve(
+                &device.state,
+                VAULT_ID,
+                Path::new(&rel),
+                &local_record,
+                &local_content,
+                &remote_content,
+                &event.version_vector,
+                peer_id,
+            ) {
+                Ok(o) => o,
+                Err(_) => return,
+            };
+            match outcome {
+                ResolveOutcome::Merged {
+                    merged_content,
+                    merged_vv: _,
+                } => {
+                    let _ = std::fs::write(&path, &merged_content);
+                }
+                ResolveOutcome::OverlapKeptLocal {
+                    copy_path,
+                    copy_content,
+                }
+                | ResolveOutcome::NoBaseInHistory {
+                    copy_path,
+                    copy_content,
+                } => {
+                    let abs_copy = device.vault_root.join(&copy_path);
+                    if let Some(parent) = abs_copy.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    let _ = std::fs::write(&abs_copy, &copy_content);
+                }
+            }
+        }
+        InboundDecision::Rename { from, to } => {
+            let _ = std::fs::rename(&from, &to);
+        }
+        InboundDecision::Discard | InboundDecision::Rejected { .. } => {}
+    }
+}
+
+fn relative_to(root: &Path, abs: &Path) -> String {
+    abs.strip_prefix(root)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| abs.to_string_lossy().to_string())
+}
+
+// ─── Catch-up reconciliation (Merkle-driven pull) ─────────────────────
+
+/// On reconnect, `local` compares its Merkle tree against `remote`'s and
+/// pulls every differing-or-missing path back from `remote`'s
+/// `sync_files` + `History`. Models the production catch-up loop in a
+/// test-friendly form: read peer's tree in-process via a closure (the
+/// production path runs the same descent over the wire).
+fn catchup_pull_from(local: &Arc<Device>, remote: &Arc<Device>) -> Duration {
+    let start = Instant::now();
+    let local_tree = MerkleTree::new(&local.state, VAULT_ID);
+    let remote_tree = MerkleTree::new(&remote.state, VAULT_ID);
+
+    let mut peer_lookup = |p: &str| remote_tree.node(p).ok().flatten();
+    let differing = diff_paths(&local_tree, &mut peer_lookup).unwrap_or_default();
+    for rel in &differing {
+        pull_one(local, remote, rel);
+    }
+
+    // Also pull remote-only paths the local tree never registered.
+    let local_paths = collect_files(&local_tree);
+    for rel in collect_files(&remote_tree) {
+        if !local_paths.contains(&rel) {
+            pull_one(local, remote, &rel);
+        }
+    }
+    start.elapsed()
+}
+
+fn pull_one(local: &Arc<Device>, remote: &Arc<Device>, rel: &str) {
+    let Ok(Some(rec)) = remote.state.get_file(VAULT_ID, rel) else {
+        return;
+    };
+    let Ok(Some(content)) = remote
+        .state
+        .get_history(VAULT_ID, rel, &rec.content_hash)
+    else {
+        return;
+    };
+    let evt = ChangeEvent {
+        vault_id: VAULT_ID.into(),
+        path: PathBuf::from(rel),
+        kind: ChangeKind::Upserted {
+            content: content.clone(),
+        },
+        source_peer: remote.self_peer_id.clone(),
+        version_vector: rec.version_vector.clone(),
+        content_hash: rec.content_hash,
+    };
+    handle_frame(local, &remote.self_peer_id, SyncFrame::Change(evt));
+}
+
+fn collect_files(tree: &MerkleTree<'_>) -> HashSet<String> {
+    fn walk(tree: &MerkleTree<'_>, folder: &str, out: &mut HashSet<String>) {
+        let Ok(children) = tree.children(folder) else {
+            return;
+        };
+        for c in children {
+            match c.kind {
+                vaultcore_lib::sync::merkle::NodeKind::File => {
+                    out.insert(c.path);
+                }
+                vaultcore_lib::sync::merkle::NodeKind::Folder => walk(tree, &c.path, out),
+            }
+        }
+    }
+    let mut out = HashSet::new();
+    walk(tree, "", &mut out);
+    out
+}
+
+// ─── Identity helpers ─────────────────────────────────────────────────
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand_core::OsRng.fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+/// `device_id = base32(SHA-256(pubkey)[..16])` — same recipe as
+/// `identity::derive_device_id` but tests can't reach in there without
+/// pulling the full `Identity` ceremony (which requires an OS keychain).
+fn derive_test_device_id(sk: &SigningKey) -> String {
+    use data_encoding::BASE32_NOPAD;
+    let pubkey = sk.verifying_key().to_bytes();
+    let digest = Sha256::digest(pubkey);
+    BASE32_NOPAD.encode(&digest[..16])
+}
+
+// ─── mDNS discovery (cfg-gated for CI) ────────────────────────────────
+
+#[cfg(not(ci_no_mdns))]
+fn discover_peer_addr_via_mdns(
+    self_id: &str,
+    self_port: u16,
+    peer_id: &str,
+) -> Option<(MdnsDiscovery, SocketAddr)> {
+    let d = MdnsDiscovery::new().ok()?;
+    let ad = PeerAd {
+        device_id: self_id.to_string(),
+        name: self_id.into(),
+        vaults: vec![AdvertisedVault {
+            id: VAULT_ID.into(),
+            name: "E2E".into(),
+        }],
+        pubkey_fp: self_id.chars().take(8).collect(),
+        proto: PROTO_VERSION.to_string(),
+        addrs: Vec::new(),
+        port: self_port,
+    };
+    d.start(ad).ok()?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(snap) = d.peers() {
+            if let Some(p) = snap.peers.iter().find(|p| p.device_id == peer_id) {
+                let ip = p
+                    .addrs
+                    .iter()
+                    .find(|a| matches!(a, IpAddr::V4(_)))
+                    .copied()
+                    .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+                return Some((d, SocketAddr::new(ip, p.port)));
+            }
+        }
+        thread::park_timeout(Duration::from_millis(150));
+    }
+    let _ = d.stop();
+    None
+}
+
+// ─── The single end-to-end test ───────────────────────────────────────
+
+#[test]
+fn lan_sync_two_devices_loopback_full_acceptance() {
+    eprintln!("[e2e] device init");
+    let a = Arc::new(Device::new("alice"));
+    let b = Arc::new(Device::new("bob"));
+
+    eprintln!("[e2e] start servers");
+    a.start_server();
+    let addr_b_listening = b.start_server();
+    eprintln!("[e2e] B listening @ {addr_b_listening}");
+
+    // ─── Discovery: try mDNS first, fall back to direct override ─────
+    // The test still pairs over the directly-known address afterwards
+    // — the mDNS step is purely "did the loopback advertiser see the
+    // listener". This matches the spec's "may not work on all CI
+    // environments" caveat: success is informational, failure is
+    // tolerated.
+    #[cfg(not(ci_no_mdns))]
+    let _mdns_handles: Option<(MdnsDiscovery, MdnsDiscovery)> = {
+        let port_a = a.server_addr().unwrap().port();
+        let port_b = b.server_addr().unwrap().port();
+        let a_disc = discover_peer_addr_via_mdns(&a.self_peer_id, port_a, &b.self_peer_id);
+        let b_disc = discover_peer_addr_via_mdns(&b.self_peer_id, port_b, &a.self_peer_id);
+        match (a_disc, b_disc) {
+            (Some((da, addr_b_via_mdns)), Some((db, _))) => {
+                assert_eq!(
+                    addr_b_via_mdns.port(),
+                    addr_b_listening.port(),
+                    "mDNS-resolved port must match listener"
+                );
+                println!("[e2e] mDNS discovery succeeded");
+                Some((da, db))
+            }
+            _ => {
+                println!("[e2e] mDNS discovery skipped/unavailable on this host");
+                None
+            }
+        }
+    };
+
+    // ─── PAKE pair + connect (always; mDNS only resolves the address). ──
+    eprintln!("[e2e] pair+connect start");
+    pair_and_connect(&a, &b, addr_b_listening);
+    eprintln!("[e2e] pair+connect done");
+
+    // ─── Scenario 4: write `note.md` on A → B sees it within 2s. ──────
+    eprintln!("[e2e] s4: write note.md on A");
+    a.write_local("note.md", b"hello from alice");
+    eprintln!("[e2e] s4: wait for propagation");
+    let prop1 = wait_until(PROPAGATION_TIMEOUT, || {
+        b.file_contents("note.md").as_deref() == Some(b"hello from alice".as_ref())
+    })
+    .expect("note.md must propagate to B within 2s");
+    println!(
+        "[e2e] propagation A→B (note.md): {} ms",
+        prop1.as_millis()
+    );
+
+    // ─── Scenario 5: concurrent edit → conflict-copy on the loser. ───
+    // Drop the live channel so each side's write happens under network
+    // partition. After reconnect, both sides have made a write off the
+    // same v1 base — VVs are concurrent → conflict copy.
+    drop_connections(&a, &b);
+
+    a.write_local("note.md", b"alice's concurrent edit");
+    b.write_local("note.md", b"bob's concurrent edit");
+
+    reconnect(&a, &b, addr_b_listening);
+    rebroadcast_latest(&a, "note.md");
+    rebroadcast_latest(&b, "note.md");
+
+    let conflict = wait_until(PROPAGATION_TIMEOUT, || {
+        a.find_conflict_copy("", "note").is_some() || b.find_conflict_copy("", "note").is_some()
+    });
+    assert!(
+        conflict.is_some(),
+        "a conflict-copy file must appear within 2s"
+    );
+    let copy_path = a
+        .find_conflict_copy("", "note")
+        .or_else(|| b.find_conflict_copy("", "note"))
+        .expect("conflict copy path");
+    let name = copy_path.file_name().unwrap().to_string_lossy().to_string();
+    assert!(
+        name.starts_with("note (conflict from "),
+        "obsidian-compatible name expected, got {name}"
+    );
+    assert!(
+        name.ends_with(").md"),
+        "obsidian-compatible name expected, got {name}"
+    );
+    // Sanity: the canonical formatter produces the same shape.
+    let canonical = conflict_copy_path(Path::new("note.md"), "peer", &a.state);
+    let canonical_name = canonical.file_name().unwrap().to_string_lossy().to_string();
+    assert!(
+        canonical_name.starts_with("note (conflict from peer "),
+        "canonical formatter shape sanity: {canonical_name}"
+    );
+    println!("[e2e] conflict-copy filename: {name}");
+
+    // ─── Scenario 6: delete on A → tombstone propagates → file gone on B. ──
+    // Clean up the diverged note.md on B first so the delete event
+    // applies cleanly. (B's note.md is the side that "won" — we want
+    // the user-visible state to converge after the delete.)
+    a.delete_local("note.md");
+    let prop_del = wait_until(PROPAGATION_TIMEOUT, || !b.file_exists("note.md"))
+        .expect("note.md deletion must propagate to B within 2s");
+    println!(
+        "[e2e] tombstone propagation A→B: {} ms",
+        prop_del.as_millis()
+    );
+    assert!(
+        b.state
+            .tombstones()
+            .is_tombstoned(VAULT_ID, "note.md")
+            .unwrap(),
+        "B must record a live tombstone after receiving the delete"
+    );
+
+    // ─── Scenario 7: B offline, A writes 3 files, B reconnects → catch-up. ──
+    drop_connections(&a, &b);
+
+    a.write_local("docs/one.md", b"one");
+    a.write_local("docs/two.md", b"two");
+    a.write_local("docs/three.md", b"three");
+
+    reconnect(&a, &b, addr_b_listening);
+    let catchup_elapsed = catchup_pull_from(&b, &a);
+    assert!(
+        catchup_elapsed <= CATCHUP_TIMEOUT,
+        "Merkle catch-up must reconcile 3 files within 1s, took {} ms",
+        catchup_elapsed.as_millis()
+    );
+    for rel in ["docs/one.md", "docs/two.md", "docs/three.md"] {
+        assert!(
+            b.file_exists(rel),
+            "B must have caught up file {rel} after Merkle reconciliation"
+        );
+    }
+    let root_a = a.merkle_root();
+    let root_b = b.merkle_root();
+    assert_eq!(
+        root_a, root_b,
+        "Merkle roots must match after catch-up; mismatch implies divergence"
+    );
+    println!(
+        "[e2e] Merkle catch-up (3 files): {} ms",
+        catchup_elapsed.as_millis()
+    );
+
+    // ─── Teardown ────────────────────────────────────────────────────
+    a.stop_server();
+    b.stop_server();
+}
+
+// ─── Connection-management helpers ────────────────────────────────────
+
+fn drop_connections(a: &Arc<Device>, b: &Arc<Device>) {
+    for d in [a, b] {
+        let mut peers = d.peers.lock().expect("peers lock");
+        for (_, ch) in peers.drain() {
+            if let Ok(s) = ch.stream.lock() {
+                let _ = s.shutdown(Shutdown::Both);
+            }
+        }
+    }
+}
+
+fn reconnect(a: &Arc<Device>, b: &Arc<Device>, addr_b_listening: SocketAddr) {
+    open_outbound(a, b, addr_b_listening);
+    let _ = wait_until(Duration::from_secs(2), || {
+        b.peers
+            .lock()
+            .map(|g| g.contains_key(&a.self_peer_id))
+            .unwrap_or(false)
+    });
+}
+
+/// Re-emit the most recent change for `rel` to all currently connected
+/// peers. Used to drive concurrent writes through the wire after a
+/// reconnect — without this, the write happens while the channel is
+/// down and the broadcast goes nowhere.
+fn rebroadcast_latest(device: &Arc<Device>, rel: &str) {
+    let Ok(Some(rec)) = device.state.get_file(VAULT_ID, rel) else {
+        return;
+    };
+    let Ok(Some(content)) = device
+        .state
+        .get_history(VAULT_ID, rel, &rec.content_hash)
+    else {
+        return;
+    };
+    let evt = ChangeEvent {
+        vault_id: VAULT_ID.into(),
+        path: PathBuf::from(rel),
+        kind: ChangeKind::Upserted { content },
+        source_peer: device.self_peer_id.clone(),
+        version_vector: rec.version_vector.clone(),
+        content_hash: rec.content_hash,
+    };
+    device.broadcast(SyncFrame::Change(evt));
+}

--- a/src-tauri/tests/sync_e2e.rs
+++ b/src-tauri/tests/sync_e2e.rs
@@ -28,7 +28,7 @@ use sha2::{Digest, Sha256};
 use snow::TransportState;
 use tempfile::TempDir;
 
-use vaultcore_lib::sync::capability::{Capability, CapabilityBody, Scope};
+use vaultcore_lib::sync::capability::{CapabilityBody, Scope};
 use vaultcore_lib::sync::clock::SystemClock;
 use vaultcore_lib::sync::conflict::{conflict_copy_path, resolve, ResolveOutcome};
 use vaultcore_lib::sync::engine::{InboundDecision, SyncEngine};
@@ -37,8 +37,12 @@ use vaultcore_lib::sync::merkle::{diff_paths, MerkleTree};
 use vaultcore_lib::sync::pairing::{
     finalize_with_confirmation, key_confirmation_mac, respond, start_initiator, PairingSession,
 };
+use vaultcore_lib::sync::pairing_engine::{
+    drive_initiator_after_pake, drive_responder_after_pake, exchange_vault_grant_initiator,
+    exchange_vault_grant_responder,
+};
 use vaultcore_lib::sync::protocol::{ChangeEvent, ChangeKind, SyncFrame, MAX_FRAME_BYTES};
-use vaultcore_lib::sync::state::{PeerTrust, SyncState};
+use vaultcore_lib::sync::state::SyncState;
 use vaultcore_lib::sync::transport::{
     drive_handshake, generate_static_keypair, xx_initiator, xx_responder, NoiseKeypair,
 };
@@ -229,6 +233,9 @@ fn split_link(stream: TcpStream, state: TransportState) -> std::io::Result<(Peer
 /// working-tree side effects (write file, delete file, write conflict
 /// copy).
 struct Device {
+    /// Display label, kept around for log messages even when the engine
+    /// derives peer names from device ids post-UI-1.5.
+    #[allow(dead_code)]
     name: &'static str,
     self_peer_id: String,
     /// Ed25519 long-term key — used to sign capability grants.
@@ -431,9 +438,18 @@ impl Device {
 
 // ─── Trust + capability bootstrapping ─────────────────────────────────
 
-/// Mutually pair A and B in-process via PAKE + key-confirmation, persist
-/// the trust + grants on both sides, then open a Noise-encrypted TCP
-/// channel + register reader threads.
+/// Mutually pair A and B in-process via PAKE + key-confirmation, then
+/// drive the engine integration layer (`pairing_engine`) end-to-end:
+/// Noise XX bootstrap, long-term key attestation under k2 →
+/// `state.upsert_peer(.., Trusted)` on both sides, vault-grant exchange
+/// → `state.upsert_vault_grant(..)` on both sides. Returns the open
+/// noise channel A→B so the test's `peers` map can pick up where the
+/// engine left off.
+///
+/// This is the regression check for UI-1.5: the manual upsert calls
+/// have been replaced by `drive_*_after_pake` + `exchange_vault_grant_*`,
+/// and any drift between the engine's persistence and what the e2e
+/// scenarios expect would surface as the test breaking.
 fn pair_and_connect(a: &Arc<Device>, b: &Arc<Device>, addr_b_listening: SocketAddr) {
     // ─── Step 1: PAKE round-trip (matching PIN, in-process). ──────────
     let session_a = PairingSession::new();
@@ -451,50 +467,87 @@ fn pair_and_connect(a: &Arc<Device>, b: &Arc<Device>, addr_b_listening: SocketAd
     let mac_a = key_confirmation_mac(&raw_a.k2, &a.self_peer_id, &b.self_peer_id);
     finalize_with_confirmation(&raw_a, &mac_b, &session_a).expect("a finalize");
     finalize_with_confirmation(&raw_b, &mac_a, &session_b).expect("b finalize");
+    let k2_a = raw_a.k2;
+    let k2_b = raw_b.k2;
 
-    // ─── Step 2: persist peer trust on both sides. ────────────────────
-    a.state
-        .upsert_peer(
-            &b.self_peer_id,
-            &b.signing_key.verifying_key().to_bytes(),
-            b.name,
-            PeerTrust::Trusted,
+    // ─── Step 2: drive the engine on B (responder thread). ────────────
+    // The accept_loop on B is purposely *not* used during pairing — it
+    // only kicks in for steady-state IK reconnects. Pairing wants a
+    // dedicated listener so the engine controls both sides of the XX
+    // handshake without racing the steady-state acceptor.
+    let pairing_listener =
+        TcpListener::bind((Ipv4Addr::new(127, 0, 0, 1), 0)).expect("pairing bind");
+    let pairing_addr = pairing_listener.local_addr().expect("pairing addr");
+    let b_for_thread = Arc::clone(b);
+    let a_id_for_thread = a.self_peer_id.clone();
+    let pair_thread = thread::spawn(move || {
+        let (mut stream, _) = pairing_listener
+            .accept()
+            .expect("pairing accept");
+        stream.set_nodelay(true).ok();
+        let mut session = drive_responder_after_pake(
+            &mut stream,
+            &b_for_thread.noise_kp,
+            &b_for_thread.signing_key,
+            &b_for_thread.self_peer_id,
+            &a_id_for_thread,
+            &k2_b,
+            &b_for_thread.state,
         )
-        .expect("a upsert peer");
-    b.state
-        .upsert_peer(
-            &a.self_peer_id,
-            &a.signing_key.verifying_key().to_bytes(),
-            a.name,
-            PeerTrust::Trusted,
+        .expect("b drive responder");
+        let body_b = CapabilityBody::issue_v1(
+            VAULT_ID,
+            &b_for_thread.self_peer_id,
+            VAULT_ID,
+            Scope::ReadWrite,
+        );
+        exchange_vault_grant_responder(
+            &mut session,
+            &b_for_thread.signing_key,
+            &body_b,
+            &a_id_for_thread,
+            &b_for_thread.state,
         )
-        .expect("b upsert peer");
+        .expect("b grant exchange");
+    });
 
-    // ─── Step 3: cross-issue ReadWrite capability grants. ────────────
-    // Engine semantics (see `engine_tests::pair_peer_with_grant`): each
-    // side stores a capability *signed by the peer*, with body.peer_device_id
-    // equal to that peer's own device id. The row PK lands at
-    // `(vault_id, peer_id)` and verifies under the peer's pubkey from
-    // `sync_peers`.
-    let cap_b_self = Capability::sign(
-        &CapabilityBody::issue_v1(VAULT_ID, &b.self_peer_id, VAULT_ID, Scope::ReadWrite),
-        &b.signing_key,
-    );
-    let cap_a_self = Capability::sign(
-        &CapabilityBody::issue_v1(VAULT_ID, &a.self_peer_id, VAULT_ID, Scope::ReadWrite),
+    // ─── Step 3: drive the engine on A (initiator). ──────────────────
+    let mut stream = TcpStream::connect(pairing_addr).expect("pairing connect");
+    stream.set_nodelay(true).ok();
+    let mut session = drive_initiator_after_pake(
+        &mut stream,
+        &a.noise_kp,
         &a.signing_key,
+        &a.self_peer_id,
+        &b.self_peer_id,
+        &k2_a,
+        &a.state,
+    )
+    .expect("a drive initiator");
+    let body_a = CapabilityBody::issue_v1(
+        VAULT_ID,
+        &a.self_peer_id,
+        VAULT_ID,
+        Scope::ReadWrite,
     );
-    a.state
-        .upsert_vault_grant(&cap_b_self)
-        .expect("a store cap_b_self");
-    b.state
-        .upsert_vault_grant(&cap_a_self)
-        .expect("b store cap_a_self");
+    exchange_vault_grant_initiator(
+        &mut session,
+        &a.signing_key,
+        &body_a,
+        &b.self_peer_id,
+        &a.state,
+    )
+    .expect("a grant exchange");
+    pair_thread.join().expect("pairing thread");
+    // The pairing socket is no longer needed for sync — we close it and
+    // open a fresh sync connection through the steady-state accept loop
+    // below. (Reusing the pairing socket would require teaching the
+    // accept loop on B to skip the XX dance for already-bootstrapped
+    // peers; out of scope for this layer.)
+    drop(session);
 
-    // ─── Step 4: Noise XX TCP handshake A→B + register reader. ───────
+    // ─── Step 4: open the steady-state Noise channel A→B + register reader. ───
     open_outbound(a, b, addr_b_listening);
-    // Wait for B's accept loop to register the inbound side under A's
-    // device id. This is bounded — accept_loop runs hot.
     let _ = wait_until(Duration::from_secs(2), || {
         b.peers
             .lock()

--- a/src/components/Layout/MobileSettingsSheet.svelte
+++ b/src/components/Layout/MobileSettingsSheet.svelte
@@ -22,7 +22,7 @@
    * Auto-lock is included — it's a pure setting on settingsStore with no
    * encrypted-folders UI dependency.
    */
-  import { X, ChevronLeft, ChevronRight, Palette, Type, Calendar, ShieldCheck, FolderOpen } from "lucide-svelte";
+  import { X, ChevronLeft, ChevronRight, Palette, Type, Calendar, ShieldCheck, FolderOpen, Network } from "lucide-svelte";
   import { themeStore, type Theme } from "../../store/themeStore";
   import {
     settingsStore,
@@ -34,6 +34,14 @@
     type MonoFont,
   } from "../../store/settingsStore";
   import { vaultStore } from "../../store/vaultStore";
+  import {
+    selfIdentity,
+    discoverable as discoverableStore,
+    pairedPeers,
+    setDiscoverable,
+    revokePeer,
+  } from "../../store/syncStore";
+  import { openPairingModal, openPairingModalWithAddr } from "../../store/pairingModalStore";
   import { onDestroy } from "svelte";
 
   let {
@@ -46,7 +54,7 @@
     onSwitchVault: () => void;
   } = $props();
 
-  type CategoryId = "appearance" | "fonts" | "daily" | "security" | "vault";
+  type CategoryId = "appearance" | "fonts" | "daily" | "security" | "vault" | "sync";
   let activeCategory = $state<CategoryId | null>(null);
   // bind:this writes a live DOM node here — $state matches the drawer /
   // burger pattern so Svelte's reactive scope sees the binding writes
@@ -100,11 +108,12 @@
     label: string;
     icon: typeof Palette;
   }> = [
+    { id: "vault",      label: "Vault",            icon: FolderOpen },
+    { id: "sync",       label: "Synchronisieren",  icon: Network },
     { id: "appearance", label: "Erscheinungsbild", icon: Palette },
     { id: "fonts",      label: "Schrift",          icon: Type },
     { id: "daily",      label: "Tagesnotizen",     icon: Calendar },
     { id: "security",   label: "Sicherheit",       icon: ShieldCheck },
-    { id: "vault",      label: "Vault",            icon: FolderOpen },
   ];
 
   function onThemeChange(e: Event) {
@@ -176,7 +185,27 @@
     daily: "Tagesnotizen",
     security: "Sicherheit",
     vault: "Vault",
+    sync: "Synchronisieren",
   };
+
+  // ── Sync category state (UI-7) ─────────────────────────────────────────
+  let manualPeerAddr = $state("");
+  function onPairManual(): void {
+    const v = manualPeerAddr.trim();
+    if (!v) return;
+    openPairingModalWithAddr(v);
+    manualPeerAddr = "";
+  }
+  function onPairNew(): void {
+    openPairingModal();
+  }
+  async function onToggleDiscoverable(e: Event): Promise<void> {
+    await setDiscoverable((e.target as HTMLInputElement).checked);
+  }
+  async function onRevokePeer(deviceId: string, name: string): Promise<void> {
+    if (!confirm(`Synchronisierung mit ${name} widerrufen?`)) return;
+    await revokePeer(deviceId);
+  }
 </script>
 
 {#if open}
@@ -322,6 +351,73 @@
           >
             Vault wechseln…
           </button>
+        </section>
+      {:else if activeCategory === "sync"}
+        <section class="vc-mobile-settings-section" data-testid="settings-sync">
+          <div class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Dieses Gerät</span>
+            <div class="vc-mobile-settings-vault-path">{$selfIdentity?.device_name ?? "—"}</div>
+            <div class="vc-mobile-settings-vault-path" style="font-size: 11px; opacity: 0.7;">
+              {$selfIdentity?.device_id ?? ""}
+            </div>
+          </div>
+
+          <label class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Auf diesem Netzwerk sichtbar</span>
+            <input
+              type="checkbox"
+              checked={$discoverableStore}
+              onchange={onToggleDiscoverable}
+            />
+          </label>
+
+          <div class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">Mit IP koppeln</span>
+            <input
+              type="text"
+              placeholder="z.B. 192.168.1.42"
+              bind:value={manualPeerAddr}
+              data-testid="settings-sync-manual-addr"
+              aria-label="Peer-Adresse manuell eingeben"
+            />
+          </div>
+          <button
+            type="button"
+            class="vc-mobile-settings-action"
+            disabled={!manualPeerAddr.trim()}
+            onclick={onPairManual}
+            data-testid="settings-sync-pair-manual"
+          >
+            Mit IP koppeln
+          </button>
+
+          <button
+            type="button"
+            class="vc-mobile-settings-action"
+            onclick={onPairNew}
+            data-testid="settings-sync-pair-new"
+          >
+            Neues Gerät koppeln…
+          </button>
+
+          {#if $pairedPeers.length > 0}
+            <div class="vc-mobile-settings-field">
+              <span class="vc-mobile-settings-field-label">Gekoppelte Geräte</span>
+            </div>
+            {#each $pairedPeers as peer (peer.device_id)}
+              <div class="vc-mobile-settings-field">
+                <div class="vc-mobile-settings-vault-path">{peer.device_name}</div>
+                <button
+                  type="button"
+                  class="vc-mobile-settings-action"
+                  onclick={() => onRevokePeer(peer.device_id, peer.device_name)}
+                  aria-label={`Synchronisierung mit ${peer.device_name} widerrufen`}
+                >
+                  Widerrufen
+                </button>
+              </div>
+            {/each}
+          {/if}
         </section>
       {/if}
     </div>

--- a/src/components/Layout/MobileSettingsSheet.svelte
+++ b/src/components/Layout/MobileSettingsSheet.svelte
@@ -37,6 +37,7 @@
   import {
     selfIdentity,
     discoverable as discoverableStore,
+    discoveredPeers,
     pairedPeers,
     setDiscoverable,
     revokePeer,
@@ -198,6 +199,9 @@
   }
   function onPairNew(): void {
     openPairingModal();
+  }
+  function onPairDiscovered(peer: import("../../ipc/commands").DiscoveredPeer): void {
+    openPairingModal(peer);
   }
   async function onToggleDiscoverable(e: Event): Promise<void> {
     await setDiscoverable((e.target as HTMLInputElement).checked);
@@ -370,6 +374,31 @@
               onchange={onToggleDiscoverable}
             />
           </label>
+
+          <div class="vc-mobile-settings-field">
+            <span class="vc-mobile-settings-field-label">In diesem Netzwerk gesehen</span>
+            {#if $discoveredPeers.length === 0}
+              <div class="vc-mobile-settings-vault-path" style="opacity: 0.7;">
+                Keine Geräte gefunden
+              </div>
+            {:else}
+              {#each $discoveredPeers as p (p.device_id)}
+                <div class="vc-mobile-settings-field">
+                  <div class="vc-mobile-settings-vault-path">{p.device_name}</div>
+                  <div class="vc-mobile-settings-vault-path" style="font-size: 11px; opacity: 0.7;">
+                    {p.addr || "(keine Adresse)"}
+                  </div>
+                  <button
+                    type="button"
+                    class="vc-mobile-settings-action"
+                    onclick={() => onPairDiscovered(p)}
+                  >
+                    Koppeln…
+                  </button>
+                </div>
+              {/each}
+            {/if}
+          </div>
 
           <div class="vc-mobile-settings-field">
             <span class="vc-mobile-settings-field-label">Mit IP koppeln</span>

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -13,9 +13,15 @@
   import MobilePropertiesSheet from "./MobilePropertiesSheet.svelte";
   import MobileSettingsSheet from "./MobileSettingsSheet.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
+  import PairingModal from "../Settings/PairingModal.svelte";
   import EncryptionStatusbar from "../Statusbar/EncryptionStatusbar.svelte";
   import SyncStatusPill from "../Statusbar/SyncStatusPill.svelte";
   import { settingsModalRequest } from "../../store/settingsModalStore";
+  import {
+    pairingModal,
+    closePairingModal,
+  } from "../../store/pairingModalStore";
+  import { selfIdentity } from "../../store/syncStore";
   import TopbarReadingToggle from "./TopbarReadingToggle.svelte";
   import { tabSupportsReading } from "../../lib/tabKind";
   import PasswordPromptModal from "../common/PasswordPromptModal.svelte";
@@ -1168,6 +1174,25 @@
 <!-- UI-4: ambient sync status pill — stacked at bottom: 84px above the
      encryption pill (48). Self-hides while idle/healthy. -->
 <SyncStatusPill />
+
+<!-- UI-3: PairingModal — subscribes to pairingModalStore. Opens when
+     a SettingsModal trigger or a "Mit IP koppeln" action sets the
+     store to non-null. Vaults list is synthesised from the currently-
+     open vault path so step 4 (vault grant) has at least one entry. -->
+{#if $pairingModal !== null}
+  {@const currentPath = $vaultStore.currentPath}
+  {@const vaultName = currentPath
+    ? currentPath.split(/[\\/]/).filter(Boolean).pop() ?? "Vault"
+    : "Vault"}
+  {@const vaultId = currentPath ?? "default"}
+  <PairingModal
+    open={true}
+    vaults={[{ id: vaultId, name: vaultName }]}
+    selfDeviceName={$selfIdentity?.device_name ?? ""}
+    manualPeerAddr={$pairingModal.manualPeerAddr}
+    onClose={closePairingModal}
+  />
+{/if}
 
 <!-- #389 — mobile bottom-tab-bar. Parent gates on `isMobile`; the component
      itself doesn't subscribe to viewportStore. -->

--- a/src/components/Layout/VaultLayout.svelte
+++ b/src/components/Layout/VaultLayout.svelte
@@ -14,6 +14,8 @@
   import MobileSettingsSheet from "./MobileSettingsSheet.svelte";
   import SettingsModal from "../Settings/SettingsModal.svelte";
   import EncryptionStatusbar from "../Statusbar/EncryptionStatusbar.svelte";
+  import SyncStatusPill from "../Statusbar/SyncStatusPill.svelte";
+  import { settingsModalRequest } from "../../store/settingsModalStore";
   import TopbarReadingToggle from "./TopbarReadingToggle.svelte";
   import { tabSupportsReading } from "../../lib/tabKind";
   import PasswordPromptModal from "../common/PasswordPromptModal.svelte";
@@ -90,6 +92,34 @@
   let commandPaletteOpen = $state(false);
   let templatePickerOpen = $state(false);
   let settingsOpen = $state(false);
+  /** UI-4 hook: cross-component opener for the Settings modal — the
+   *  SyncStatusPill error click pushes a request into
+   *  `settingsModalStore`; we forward it to the local flag here. The
+   *  pending anchor is used by SettingsModal to scroll to that section
+   *  after open. */
+  let pendingSettingsAnchor = $state<"sync" | null>(null);
+  let lastSettingsRequestSeq = 0;
+  const unsubSettingsRequest = settingsModalRequest.subscribe((req) => {
+    if (!req) return;
+    if (req.seq === lastSettingsRequestSeq) return;
+    lastSettingsRequestSeq = req.seq;
+    pendingSettingsAnchor = req.anchor;
+    settingsOpen = true;
+  });
+
+  // After Settings opens with a pending anchor, scroll the matching
+  // section into view via the agreed-on `data-testid="settings-<anchor>"`
+  // contract (see UI-2 / UI-4). queueMicrotask gives the modal a tick
+  // to mount before we look up the node.
+  $effect(() => {
+    if (!settingsOpen || !pendingSettingsAnchor) return;
+    const anchor = pendingSettingsAnchor;
+    queueMicrotask(() => {
+      const el = document.querySelector(`[data-testid="settings-${anchor}"]`);
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+      pendingSettingsAnchor = null;
+    });
+  });
   let dragStartX = 0;
   let dragStartWidth = 0;
 
@@ -392,6 +422,7 @@
 
   onDestroy(() => {
     unsubTab();
+    unsubSettingsRequest();
     // #395 Boy Scout — `unsubBacklinks` (line ~782) was previously module-level
     // and never torn down, leaking a backlinksStore subscriber on every
     // VaultLayout unmount (vault switch, HMR). Cleaned up here.
@@ -1133,6 +1164,10 @@
 
 <!-- #357: auto-encrypt-on-drop live progress pill. Self-hides while idle. -->
 <EncryptionStatusbar />
+
+<!-- UI-4: ambient sync status pill — stacked at bottom: 84px above the
+     encryption pill (48). Self-hides while idle/healthy. -->
+<SyncStatusPill />
 
 <!-- #389 — mobile bottom-tab-bar. Parent gates on `isMobile`; the component
      itself doesn't subscribe to viewportStore. -->

--- a/src/components/Settings/PairingModal.svelte
+++ b/src/components/Settings/PairingModal.svelte
@@ -1,0 +1,674 @@
+<script lang="ts">
+  // UI-3 — 4-step pairing modal (LAN sync). Stacked over SettingsModal at
+  // z-index 310/311, mirroring the shortcut-conflict modal (#65).
+  //
+  // Steps:
+  //   1. Role selection — initiator (zeigt PIN) vs responder (gibt PIN ein).
+  //   2. PIN exchange — initiator displays XXX–XXX + QR; responder fills 6 boxes.
+  //   3. Key confirmation — both sides read out fingerprints, agree.
+  //   4. Vault grant — initiator picks which vaults the new peer may sync.
+  //
+  // All actions go through `syncStore` (UI-1). The component never invokes
+  // Tauri directly. Bridge engineer note: `pairing_step` returns
+  // `awaiting_peer` until raw_keys arrive in the session, and
+  // `pairing_confirm` errors when raw_keys are absent — this is treated as
+  // "still verifying" not as a security signal.
+  //
+  // a11y notes:
+  //   - Countdown announces every 10 s (snap-to-nearest-10) on a polite
+  //     `aria-live` wrapper; the per-second readout has `aria-live="off"`
+  //     so screen readers don't drown in updates (issue from Vitruvius).
+  //   - Lockout copy is symmetric — never discloses which side typed wrong
+  //     (a leak there would let an attacker who watches one side infer
+  //     state from copy alone).
+
+  import { onMount, onDestroy, tick } from "svelte";
+  import {
+    pendingPairingSession,
+    startInitiator,
+    startResponder,
+    stepPairing,
+    confirmPairing,
+    cancelPairing,
+    grantVault,
+  } from "../../store/syncStore";
+  import type { VaultRef, PairingStep } from "../../ipc/commands";
+
+  interface Props {
+    open: boolean;
+    /** Vaults the local device owns and can offer the new peer. */
+    vaults: VaultRef[];
+    /** Element to return focus to after close (the "Neues Gerät koppeln…"
+     *  button in SettingsModal). */
+    triggerEl?: HTMLElement | null;
+    /** Local device name for the key-confirmation readout. */
+    selfDeviceName?: string;
+    onClose: () => void;
+  }
+
+  let {
+    open,
+    vaults,
+    triggerEl = null,
+    selfDeviceName = "",
+    onClose,
+  }: Props = $props();
+
+  // ── State ─────────────────────────────────────────────────────────────
+
+  type Role = "initiator" | "responder";
+
+  let step = $state<1 | 2 | 3 | 4>(1);
+  let role = $state<Role>("initiator");
+  let pinDigits = $state<string[]>(["", "", "", "", "", ""]);
+  let attemptsRemaining = $state<number | null>(null);
+  let pinError = $state<string | null>(null);
+  let lockedOut = $state(false);
+  let qrDataUrl = $state<string | null>(null);
+  let grantedVaultIds = $state<Set<string>>(new Set());
+  let submitting = $state(false);
+
+  // Field refs for the responder 6-box input.
+  let pinFieldEls: HTMLInputElement[] = $state([]);
+  let firstRadioEl = $state<HTMLInputElement | null>(null);
+
+  // Subscription to the pending session.
+  let sessionPin = $state<string | null>(null);
+  let sessionExpiresAt = $state<number | null>(null);
+  let lastStep = $state<PairingStep | null>(null);
+  const _unsub = pendingPairingSession.subscribe((s) => {
+    sessionPin = s?.pin ?? null;
+    sessionExpiresAt = s?.expires_at_unix ?? null;
+    lastStep = s?.last_step ?? null;
+    if (!s) return;
+    // Reflect the store role onto local state so the modal can rehydrate
+    // mid-flow (e.g. closed and reopened, or session arrived while still
+    // on step 1).
+    role = s.role;
+    // A session exists → we're past role-selection. Advance to step 2
+    // unless we've already moved past it.
+    if (step === 1) step = 2;
+    // When the engine signals awaiting_confirmation, advance into step 3
+    // automatically — we already have a peer_fingerprint to show.
+    if (
+      step <= 2 &&
+      s.last_step?.kind === "awaiting_confirmation" &&
+      s.last_step?.peer_fingerprint
+    ) {
+      step = 3;
+    }
+  });
+
+  // ── Countdown ─────────────────────────────────────────────────────────
+  //
+  // Plain `setInterval(1000)` so the per-second readout updates smoothly;
+  // the announced (a11y) value is derived to the nearest 10 so AT users
+  // get a calm cadence.
+  let nowMs = $state(Date.now());
+  let interval: ReturnType<typeof setInterval> | null = null;
+  const secondsLeft = $derived(
+    sessionExpiresAt == null ? 0 : Math.max(0, sessionExpiresAt - Math.floor(nowMs / 1000)),
+  );
+  const announcedTime = $derived(Math.round(secondsLeft / 10) * 10);
+
+  function startCountdown() {
+    stopCountdown();
+    interval = setInterval(() => {
+      nowMs = Date.now();
+    }, 1000);
+  }
+  function stopCountdown() {
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────
+
+  onMount(async () => {
+    if (open) {
+      await tick();
+      firstRadioEl?.focus();
+    }
+    startCountdown();
+  });
+
+  onDestroy(() => {
+    stopCountdown();
+    try {
+      _unsub();
+    } catch {
+      /* swallow */
+    }
+  });
+
+  $effect(() => {
+    if (!open) {
+      // Reset to a known starting state when the parent closes the modal.
+      step = 1;
+      role = "initiator";
+      pinDigits = ["", "", "", "", "", ""];
+      attemptsRemaining = null;
+      pinError = null;
+      lockedOut = false;
+      qrDataUrl = null;
+      grantedVaultIds = new Set();
+      submitting = false;
+      return;
+    }
+    // Open: focus first interactive on step 1.
+    void tick().then(() => {
+      if (step === 1) firstRadioEl?.focus();
+    });
+  });
+
+  // ── Step transitions ──────────────────────────────────────────────────
+
+  async function advanceFromRole() {
+    if (role === "initiator") {
+      const dto = await startInitiator();
+      step = 2;
+      // Lazy import keeps the QR lib out of the main bundle until needed.
+      try {
+        const mod = await import("qrcode");
+        const fn = (mod.default?.toDataURL ?? mod.toDataURL) as
+          | ((text: string) => Promise<string>)
+          | undefined;
+        if (fn) qrDataUrl = await fn(dto.pin);
+      } catch {
+        qrDataUrl = null;
+      }
+    } else {
+      step = 2;
+      // Focus the first PIN box after the DOM updates.
+      await tick();
+      pinFieldEls[0]?.focus();
+    }
+  }
+
+  async function submitResponderPin() {
+    const joined = pinDigits.join("");
+    if (joined.length !== 6 || lockedOut || submitting) return;
+    submitting = true;
+    try {
+      await startResponder(joined);
+      const result = await stepPairing(joined);
+      handleStepResult(result);
+    } catch (e) {
+      pinError = "Verbindung fehlgeschlagen.";
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function handleStepResult(result: PairingStep) {
+    if (result.kind === "failed") {
+      attemptsRemaining = result.attempts_remaining;
+      if ((result.attempts_remaining ?? 0) <= 0) {
+        lockedOut = true;
+        pinError = null;
+      } else {
+        pinError = `Falscher PIN — ${result.attempts_remaining} Versuche verbleibend.`;
+        // Wipe digits so the user can retype.
+        pinDigits = ["", "", "", "", "", ""];
+        void tick().then(() => pinFieldEls[0]?.focus());
+      }
+    } else if (result.kind === "awaiting_confirmation") {
+      step = 3;
+    }
+    // awaiting_peer / complete: store subscription path handles the rest.
+  }
+
+  async function onConfirmKeys() {
+    if (submitting) return;
+    submitting = true;
+    try {
+      await confirmPairing();
+      // Initiator drives step 4 (vault grants). Responder is done after
+      // confirm — the initiator will issue grants later via Settings.
+      if (role === "initiator") {
+        step = 4;
+      } else {
+        finishAndClose();
+      }
+    } catch (e) {
+      pinError = "Schlüsselbestätigung fehlgeschlagen.";
+    } finally {
+      submitting = false;
+    }
+  }
+
+  async function onRejectKeys() {
+    await doCancel();
+  }
+
+  async function onDone() {
+    if (grantedVaultIds.size === 0 || submitting) return;
+    submitting = true;
+    try {
+      // Issue grants for the checked vaults. We don't know the peer's
+      // device_id from the modal scope alone — confirm has just landed,
+      // so the freshly-paired peer is the most-recently-paired entry.
+      // To keep this self-contained we read `lastStep.peer_fingerprint`
+      // as a stable handle the syncStore can map; in the integration
+      // (UI-1.5) this resolves to a real device_id.
+      const peerHandle = lastStep?.peer_fingerprint ?? "";
+      for (const vaultId of grantedVaultIds) {
+        await grantVault(peerHandle, vaultId, "read+write");
+      }
+      finishAndClose();
+    } catch (e) {
+      pinError = "Vault-Freigabe fehlgeschlagen.";
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function finishAndClose() {
+    onClose();
+    // Return focus to the trigger button.
+    void tick().then(() => triggerEl?.focus());
+  }
+
+  async function doCancel() {
+    try {
+      await cancelPairing();
+    } finally {
+      onClose();
+      void tick().then(() => triggerEl?.focus());
+    }
+  }
+
+  // ── PIN field interactions ────────────────────────────────────────────
+
+  function onPinInput(idx: number, e: Event) {
+    if (lockedOut) return;
+    const target = e.target as HTMLInputElement;
+    // Strip non-digits and clamp to length 1.
+    const v = target.value.replace(/\D/g, "").slice(-1);
+    target.value = v;
+    pinDigits[idx] = v;
+    pinDigits = [...pinDigits];
+    if (v && idx < 5) {
+      pinFieldEls[idx + 1]?.focus();
+    }
+    if (v && idx === 5 && pinDigits.every((d) => d.length === 1)) {
+      void submitResponderPin();
+    }
+  }
+
+  function onPinKeyDown(idx: number, e: KeyboardEvent) {
+    if (lockedOut) return;
+    if (e.key === "Backspace" && pinDigits[idx] === "" && idx > 0) {
+      e.preventDefault();
+      pinFieldEls[idx - 1]?.focus();
+      return;
+    }
+    if (e.key === "ArrowLeft" && idx > 0) {
+      e.preventDefault();
+      pinFieldEls[idx - 1]?.focus();
+    } else if (e.key === "ArrowRight" && idx < 5) {
+      e.preventDefault();
+      pinFieldEls[idx + 1]?.focus();
+    }
+  }
+
+  function onPinPaste(e: ClipboardEvent) {
+    if (lockedOut) return;
+    const data = e.clipboardData?.getData("text") ?? "";
+    const digits = data.replace(/\D/g, "").slice(0, 6);
+    if (digits.length === 0) return;
+    e.preventDefault();
+    const next = pinDigits.slice();
+    for (let i = 0; i < 6; i++) next[i] = digits[i] ?? "";
+    pinDigits = next;
+    // Mirror to the DOM (some test runners read .value back).
+    for (let i = 0; i < 6; i++) {
+      const el = pinFieldEls[i];
+      if (el) el.value = next[i] ?? "";
+    }
+    const lastFilled = digits.length - 1;
+    pinFieldEls[Math.min(lastFilled + 1, 5)]?.focus();
+    if (digits.length === 6) void submitResponderPin();
+  }
+
+  // ── Global Escape ─────────────────────────────────────────────────────
+
+  function onKey(e: KeyboardEvent) {
+    if (!open) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      void doCancel();
+    }
+  }
+
+  $effect(() => {
+    if (open) {
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }
+  });
+
+  // ── Display helpers ───────────────────────────────────────────────────
+
+  const formattedPin = $derived.by(() => {
+    const pin = sessionPin ?? "";
+    if (pin.length !== 6) return pin;
+    // U+2013 EN DASH between the two triplets.
+    return `${pin.slice(0, 3)}–${pin.slice(3, 6)}`;
+  });
+
+  function shortFp(fp: string | null | undefined): string {
+    if (!fp) return "";
+    return `${fp.slice(0, 12)}…`;
+  }
+
+  function toggleVault(id: string) {
+    const next = new Set(grantedVaultIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    grantedVaultIds = next;
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="vc-pairing-backdrop vc-modal-scrim"
+    role="presentation"
+    onclick={() => doCancel()}
+    data-testid="pairing-backdrop"
+  ></div>
+  <div
+    class="vc-pairing-modal vc-modal-surface"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="pairing-title"
+    data-testid="pairing-modal"
+  >
+    <h3 id="pairing-title" class="vc-pairing-title">
+      {#if step === 1}Neues Gerät koppeln{/if}
+      {#if step === 2 && role === "initiator"}PIN auf dem anderen Gerät eingeben{/if}
+      {#if step === 2 && role === "responder"}PIN vom anderen Gerät eingeben{/if}
+      {#if step === 3}Schlüssel bestätigen{/if}
+      {#if step === 4}Vaults freigeben{/if}
+    </h3>
+
+    {#if step === 1}
+      <div class="vc-pairing-role" role="radiogroup" aria-label="Rolle wählen">
+        <label class="vc-theme-radio" class:vc-theme-radio--active={role === "initiator"}>
+          <input
+            type="radio"
+            name="vc-pairing-role"
+            value="initiator"
+            checked={role === "initiator"}
+            bind:this={firstRadioEl}
+            onchange={() => (role = "initiator")}
+          />
+          <span>Dieses Gerät zeigt den PIN</span>
+        </label>
+        <label class="vc-theme-radio" class:vc-theme-radio--active={role === "responder"}>
+          <input
+            type="radio"
+            name="vc-pairing-role"
+            value="responder"
+            checked={role === "responder"}
+            onchange={() => (role = "responder")}
+          />
+          <span>Dieses Gerät gibt den PIN ein</span>
+        </label>
+      </div>
+      <div class="vc-pairing-actions">
+        <button
+          type="button"
+          class="vc-password-modal-cancel"
+          onclick={() => doCancel()}
+        >Abbrechen</button>
+        <button
+          type="button"
+          class="vc-password-modal-ok"
+          onclick={advanceFromRole}
+          data-testid="pairing-next"
+        >Weiter</button>
+      </div>
+    {:else if step === 2 && role === "initiator"}
+      <div class="vc-pairing-pin-display" data-testid="pairing-initiator-pin">
+        {formattedPin}
+      </div>
+      <div
+        class="vc-pairing-countdown"
+        aria-live="polite"
+        data-testid="pairing-countdown-live"
+      >{announcedTime}</div>
+      <div class="vc-pairing-countdown-text" aria-live="off" data-testid="pairing-countdown-inner">
+        Läuft ab in {secondsLeft} Sekunden
+      </div>
+      {#if qrDataUrl}
+        <img src={qrDataUrl} alt="QR-Code mit PIN" class="vc-pairing-qr" width="160" height="160" />
+      {/if}
+      <div class="vc-pairing-actions">
+        <button
+          type="button"
+          class="vc-password-modal-cancel"
+          onclick={() => doCancel()}
+        >Abbrechen</button>
+      </div>
+    {:else if step === 2 && role === "responder"}
+      {#if lockedOut}
+        <div class="vc-pairing-lockout" role="alert" data-testid="pairing-lockout">
+          Gesperrt — 60 Sekunden warten
+        </div>
+      {:else}
+        <div class="vc-pairing-pin-input" onpaste={onPinPaste}>
+          {#each pinDigits as _digit, i (i)}
+            <input
+              bind:this={pinFieldEls[i]}
+              type="text"
+              maxlength="1"
+              inputmode="numeric"
+              autocomplete="one-time-code"
+              class="vc-pairing-pin-field"
+              data-testid={`pairing-pin-field-${i}`}
+              value={pinDigits[i]}
+              oninput={(e) => onPinInput(i, e)}
+              onkeydown={(e) => onPinKeyDown(i, e)}
+            />
+          {/each}
+        </div>
+        {#if pinError}
+          <div class="vc-pairing-pin-error" role="alert" data-testid="pairing-pin-error">
+            {pinError}
+          </div>
+        {/if}
+      {/if}
+      <div class="vc-pairing-actions">
+        <button
+          type="button"
+          class="vc-password-modal-cancel"
+          onclick={() => doCancel()}
+        >Abbrechen</button>
+      </div>
+    {:else if step === 3}
+      <div class="vc-pairing-keys">
+        <div class="vc-pairing-key-row">
+          <span class="vc-pairing-key-label">Dieses Gerät</span>
+          <span class="vc-pairing-key-name">{selfDeviceName || "—"}</span>
+          <span class="vc-pairing-key-fp">{shortFp(lastStep?.peer_fingerprint)}</span>
+        </div>
+        <div class="vc-pairing-key-row">
+          <span class="vc-pairing-key-label">Anderes Gerät</span>
+          <span class="vc-pairing-key-fp">{shortFp(lastStep?.peer_fingerprint)}</span>
+        </div>
+      </div>
+      <div class="vc-pairing-actions">
+        <button
+          type="button"
+          class="vc-password-modal-cancel"
+          onclick={onRejectKeys}
+          data-testid="pairing-key-reject"
+        >Ablehnen</button>
+        <button
+          type="button"
+          class="vc-password-modal-ok"
+          onclick={onConfirmKeys}
+          data-testid="pairing-key-confirm"
+        >Bestätigen</button>
+      </div>
+    {:else if step === 4}
+      <ul class="vc-pairing-vaults" role="list">
+        {#each vaults as v (v.id)}
+          <li class="vc-pairing-vault">
+            <label class="vc-snippets-toggle">
+              <input
+                type="checkbox"
+                data-vault-id={v.id}
+                checked={grantedVaultIds.has(v.id)}
+                onchange={() => toggleVault(v.id)}
+              />
+              <span class="vc-snippets-toggle-track" aria-hidden="true">
+                <span class="vc-snippets-toggle-thumb"></span>
+              </span>
+              <span class="vc-pairing-vault-name">{v.name}</span>
+            </label>
+          </li>
+        {/each}
+      </ul>
+      <div class="vc-pairing-actions">
+        <button
+          type="button"
+          class="vc-password-modal-cancel"
+          onclick={() => doCancel()}
+        >Abbrechen</button>
+        <button
+          type="button"
+          class="vc-password-modal-ok"
+          onclick={onDone}
+          disabled={grantedVaultIds.size === 0 || submitting}
+          data-testid="pairing-done"
+        >Fertig</button>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .vc-pairing-backdrop {
+    z-index: 310;
+  }
+  .vc-pairing-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 480px;
+    max-width: calc(100vw - 32px);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    z-index: 311;
+  }
+  .vc-pairing-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .vc-pairing-role {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .vc-pairing-pin-display {
+    font-family: var(--vc-font-mono);
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    text-align: center;
+    color: var(--color-text);
+  }
+  .vc-pairing-countdown {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    text-align: center;
+  }
+  .vc-pairing-countdown-text {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    text-align: center;
+  }
+  .vc-pairing-qr {
+    align-self: center;
+    image-rendering: pixelated;
+  }
+  .vc-pairing-pin-input {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+  }
+  .vc-pairing-pin-field {
+    width: 40px;
+    height: 32px;
+    text-align: center;
+    font-family: var(--vc-font-mono);
+    font-size: 18px;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    outline: none;
+  }
+  .vc-pairing-pin-field:focus {
+    border-color: var(--color-accent);
+  }
+  .vc-pairing-pin-error,
+  .vc-pairing-lockout {
+    font-size: 12px;
+    color: var(--color-error, #d14343);
+    text-align: center;
+  }
+  .vc-pairing-keys {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 12px;
+  }
+  .vc-pairing-key-row {
+    display: grid;
+    grid-template-columns: 100px 1fr auto;
+    gap: 8px;
+    align-items: center;
+  }
+  .vc-pairing-key-label {
+    color: var(--color-text-muted);
+  }
+  .vc-pairing-key-name {
+    color: var(--color-text);
+  }
+  .vc-pairing-key-fp {
+    font-family: var(--vc-font-mono);
+    color: var(--color-text);
+  }
+  .vc-pairing-vaults {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .vc-pairing-vault-name {
+    margin-left: 8px;
+    font-size: 13px;
+    color: var(--color-text);
+  }
+  .vc-pairing-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>

--- a/src/components/Settings/PairingModal.svelte
+++ b/src/components/Settings/PairingModal.svelte
@@ -43,6 +43,11 @@
     triggerEl?: HTMLElement | null;
     /** Local device name for the key-confirmation readout. */
     selfDeviceName?: string;
+    /** When set, the modal opens directly in responder mode, skips the
+     *  role-selection step, and dials this address instead of relying
+     *  on mDNS discovery. Used on Android (no NSD bridge yet) and any
+     *  LAN where multicast is blocked. Format: "host" or "host:port". */
+    manualPeerAddr?: string | null;
     onClose: () => void;
   }
 
@@ -51,6 +56,7 @@
     vaults,
     triggerEl = null,
     selfDeviceName = "",
+    manualPeerAddr = null,
     onClose,
   }: Props = $props();
 
@@ -128,8 +134,19 @@
 
   onMount(async () => {
     if (open) {
+      // Manual-peer flow skips role selection — go straight to step 2
+      // responder so the user enters the PIN that the other device is
+      // already showing.
+      if (manualPeerAddr) {
+        role = "responder";
+        step = 2;
+      }
       await tick();
-      firstRadioEl?.focus();
+      if (manualPeerAddr) {
+        pinFieldEls[0]?.focus();
+      } else {
+        firstRadioEl?.focus();
+      }
     }
     startCountdown();
   });
@@ -192,7 +209,7 @@
     if (joined.length !== 6 || lockedOut || submitting) return;
     submitting = true;
     try {
-      await startResponder(joined);
+      await startResponder(joined, undefined, manualPeerAddr ?? undefined);
       const result = await stepPairing(joined);
       handleStepResult(result);
     } catch (e) {

--- a/src/components/Settings/PairingModal.svelte
+++ b/src/components/Settings/PairingModal.svelte
@@ -30,7 +30,7 @@
     stepPairing,
     confirmPairing,
     cancelPairing,
-    grantVault,
+    pairingGrantVault,
   } from "../../store/syncStore";
   import type { VaultRef, PairingStep } from "../../ipc/commands";
 
@@ -247,15 +247,11 @@
     if (grantedVaultIds.size === 0 || submitting) return;
     submitting = true;
     try {
-      // Issue grants for the checked vaults. We don't know the peer's
-      // device_id from the modal scope alone — confirm has just landed,
-      // so the freshly-paired peer is the most-recently-paired entry.
-      // To keep this self-contained we read `lastStep.peer_fingerprint`
-      // as a stable handle the syncStore can map; in the integration
-      // (UI-1.5) this resolves to a real device_id.
-      const peerHandle = lastStep?.peer_fingerprint ?? "";
+      // Issue grants over the active pairing session's open Noise
+      // channel. Both sides must be in step 4 simultaneously — the
+      // engine call is symmetric and blocks waiting for the peer.
       for (const vaultId of grantedVaultIds) {
-        await grantVault(peerHandle, vaultId, "read+write");
+        await pairingGrantVault(vaultId, "read+write");
       }
       finishAndClose();
     } catch (e) {

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
-  import { X, RefreshCw, Keyboard, RotateCcw } from "lucide-svelte";
+  import { X, RefreshCw, Keyboard, RotateCcw, Copy } from "lucide-svelte";
   import { themeStore, type Theme } from "../../store/themeStore";
   import {
     settingsStore,
@@ -27,6 +27,18 @@
     hotkeyFromEvent,
     validateHotKey,
   } from "../../lib/commands/hotkeyOverrides";
+  import {
+    selfIdentity,
+    discoverable,
+    pairedPeers,
+    discoveredPeers,
+    setDiscoverable,
+    setDeviceName,
+    revokePeer,
+  } from "../../store/syncStore";
+  import { openPairingModal } from "../../store/pairingModalStore";
+  import { relativeTime } from "../../lib/relativeTime";
+  import type { DiscoveredPeer } from "../../ipc/commands";
 
   let { open, onClose, onSwitchVault }: {
     open: boolean;
@@ -235,7 +247,85 @@
     }
   }
 
-  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); });
+  // ── SYNCHRONISIERUNG ───────────────────────────────────────────────────
+  // Editable device name commits on blur or Enter. We track the "baseline"
+  // value so an unchanged blur (user clicked away without editing) does not
+  // dispatch a no-op IPC call.
+  let deviceNameDraft = $state<string>("");
+  let deviceNameBaseline = $state<string>("");
+  const unsubSelfIdentity = selfIdentity.subscribe((id) => {
+    if (!id) return;
+    // If the user is mid-edit (draft differs from baseline) preserve their
+    // typing across remote-driven identity refreshes.
+    if (deviceNameDraft === deviceNameBaseline) {
+      deviceNameDraft = id.device_name;
+    }
+    deviceNameBaseline = id.device_name;
+  });
+
+  async function commitDeviceName(): Promise<void> {
+    const next = deviceNameDraft.trim();
+    if (!next || next === deviceNameBaseline) return;
+    try {
+      await setDeviceName(next);
+      deviceNameBaseline = next;
+    } catch (e) {
+      // Roll the draft back to the baseline on error so the input
+      // visibly snaps to the still-effective name.
+      deviceNameDraft = deviceNameBaseline;
+      if (isVaultError(e)) toastStore.error(vaultErrorCopy(e));
+      else toastStore.error("Gerätename konnte nicht gespeichert werden");
+    }
+  }
+
+  function onDeviceNameKeydown(e: KeyboardEvent): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      (e.currentTarget as HTMLInputElement).blur();
+    }
+  }
+
+  async function onDiscoverableToggle(e: Event): Promise<void> {
+    const on = (e.target as HTMLInputElement).checked;
+    try {
+      await setDiscoverable(on);
+    } catch (err) {
+      if (isVaultError(err)) toastStore.error(vaultErrorCopy(err));
+      else toastStore.error("Sichtbarkeit konnte nicht geändert werden");
+    }
+  }
+
+  async function onCopy(text: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Clipboard blocked (permissions / non-secure context). Stay silent —
+      // the copy buttons are convenience; user can still select-and-copy.
+    }
+  }
+
+  async function onRevokePeer(deviceId: string, deviceName: string): Promise<void> {
+    const ok = window.confirm(
+      `Synchronisierung mit "${deviceName}" wirklich widerrufen? Dieses Gerät erhält keine Updates mehr.`,
+    );
+    if (!ok) return;
+    try {
+      await revokePeer(deviceId);
+    } catch (e) {
+      if (isVaultError(e)) toastStore.error(vaultErrorCopy(e));
+      else toastStore.error("Widerruf fehlgeschlagen");
+    }
+  }
+
+  function onPairDiscovered(peer: DiscoveredPeer): void {
+    openPairingModal(peer);
+  }
+
+  function onPairNew(): void {
+    openPairingModal();
+  }
+
+  onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); unsubSelfIdentity(); });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -271,6 +361,140 @@
             onclick={onSwitchVault}
             data-testid="settings-switch-vault"
           >Vault wechseln…</button>
+        </div>
+      </section>
+
+      <!-- Section — Synchronisierung (UI-2) -->
+      <section class="vc-settings-section" data-testid="settings-sync">
+        <h3 class="vc-settings-section-title">SYNCHRONISIERUNG</h3>
+
+        <!-- This-device card: editable name + device id + pubkey fingerprint -->
+        <div class="vc-settings-row">
+          <label for="sync-device-name">Gerätename</label>
+          <input
+            id="sync-device-name"
+            class="vc-settings-text"
+            type="text"
+            value={deviceNameDraft}
+            oninput={(e) => (deviceNameDraft = (e.target as HTMLInputElement).value)}
+            onblur={commitDeviceName}
+            onkeydown={onDeviceNameKeydown}
+            data-testid="settings-sync-device-name"
+            aria-label="Gerätename"
+          />
+        </div>
+        <div class="vc-settings-row">
+          <span>Geräte-ID</span>
+          <span class="vc-sync-id-wrap">
+            <code class="vc-sync-id">{$selfIdentity?.device_id ?? "—"}</code>
+            <button
+              type="button"
+              class="vc-shortcut-btn"
+              onclick={() => onCopy($selfIdentity?.device_id ?? "")}
+              disabled={!$selfIdentity}
+              aria-label="Geräte-ID kopieren"
+              title="Geräte-ID kopieren"
+            ><Copy size={14} /></button>
+          </span>
+        </div>
+        <div class="vc-settings-row">
+          <span>Schlüssel-Fingerabdruck</span>
+          <span class="vc-sync-id-wrap">
+            <code class="vc-sync-id">{$selfIdentity?.pubkey_fingerprint ?? "—"}</code>
+            <button
+              type="button"
+              class="vc-shortcut-btn"
+              onclick={() => onCopy($selfIdentity?.pubkey_fingerprint ?? "")}
+              disabled={!$selfIdentity}
+              aria-label="Schlüssel-Fingerabdruck kopieren"
+              title="Schlüssel-Fingerabdruck kopieren"
+            ><Copy size={14} /></button>
+          </span>
+        </div>
+
+        <!-- Discoverable toggle (reuse the snippets toggle skin verbatim). -->
+        <div class="vc-settings-row">
+          <span>Im Netzwerk sichtbar</span>
+          <label class="vc-snippets-toggle">
+            <input
+              type="checkbox"
+              checked={$discoverable}
+              onchange={onDiscoverableToggle}
+              aria-label="Dieses Gerät im Netzwerk sichtbar machen"
+              data-testid="settings-sync-discoverable"
+            />
+            <span class="vc-snippets-toggle-track" aria-hidden="true">
+              <span class="vc-snippets-toggle-thumb"></span>
+            </span>
+          </label>
+        </div>
+        <p class="vc-settings-hint">
+          Andere Geräte in diesem Netzwerk können dieses Gerät sehen und eine
+          Kopplung anfragen. Aus, wenn keine Kopplung läuft.
+        </p>
+
+        <!-- Paired devices -->
+        <h4 class="vc-sync-subhead">Gekoppelte Geräte</h4>
+        {#if $pairedPeers.length === 0}
+          <p class="vc-settings-hint">Noch keine gekoppelten Geräte.</p>
+        {:else}
+          <ul class="vc-security-list" role="list" data-testid="settings-sync-paired">
+            {#each $pairedPeers as peer (peer.device_id)}
+              <li class="vc-security-row">
+                <span class="vc-sync-peer-name">{peer.device_name}</span>
+                <span class="vc-sync-peer-meta">{relativeTime(peer.last_seen)}</span>
+                <span class="vc-sync-peer-meta">
+                  {#if peer.grants.length === 0}
+                    keine Freigaben
+                  {:else}
+                    {peer.grants.map((g) => g.vault_name).join(", ")}
+                  {/if}
+                </span>
+                <button
+                  type="button"
+                  class="vc-settings-btn vc-sync-revoke-btn"
+                  onclick={() => onRevokePeer(peer.device_id, peer.device_name)}
+                  aria-label={`Synchronisierung mit ${peer.device_name} widerrufen`}
+                >Widerrufen</button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+
+        <!-- Discovered (ambient — no rescan button per user decision 5) -->
+        <h4 class="vc-sync-subhead">In diesem Netzwerk gesehen</h4>
+        {#if $discoveredPeers.length === 0}
+          <p class="vc-settings-hint">
+            {#if $discoverable}
+              Suche nach Geräten…
+            {:else}
+              Aktiviere "Im Netzwerk sichtbar", um Geräte zu finden.
+            {/if}
+          </p>
+        {:else}
+          <ul class="vc-security-list" role="list" data-testid="settings-sync-discovered">
+            {#each $discoveredPeers as peer (peer.device_id)}
+              <li class="vc-security-row">
+                <span class="vc-sync-peer-name">{peer.device_name}</span>
+                <span class="vc-sync-peer-meta">{peer.addr || "—"}</span>
+                <button
+                  type="button"
+                  class="vc-settings-btn"
+                  onclick={() => onPairDiscovered(peer)}
+                  aria-label={`Mit ${peer.device_name} koppeln`}
+                >Koppeln…</button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+
+        <div class="vc-settings-row vc-sync-pair-row">
+          <button
+            type="button"
+            class="vc-vault-switch-btn"
+            onclick={onPairNew}
+            data-testid="settings-sync-pair-new"
+          >Neues Gerät koppeln…</button>
         </div>
       </section>
 
@@ -809,6 +1033,51 @@
     opacity: 0.55;
     cursor: not-allowed;
   }
+
+  /* Section — Synchronisierung (UI-2) */
+  .vc-sync-id-wrap {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .vc-sync-id {
+    font-family: var(--vc-font-mono);
+    font-size: 12px;
+    color: var(--color-text-muted);
+    user-select: text;
+    padding: 2px 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+  }
+  .vc-sync-subhead {
+    margin: 16px 0 8px 0;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .vc-sync-peer-name {
+    font-size: 13px;
+    color: var(--color-text);
+    flex: 1 1 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .vc-sync-peer-meta {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+  }
+  /* Vitruvius constraint: revoke is destructive but visually muted —
+     border colour shifts to error on hover; never a red fill. */
+  .vc-sync-revoke-btn:hover:not(:disabled) {
+    border-color: var(--color-error);
+    color: var(--color-error);
+    background: var(--color-surface);
+  }
+  .vc-sync-pair-row { justify-content: flex-end; margin-top: 12px; margin-bottom: 0; }
 
   /* Section — CSS-Snippets */
   .vc-snippets-head {

--- a/src/components/Settings/SettingsModal.svelte
+++ b/src/components/Settings/SettingsModal.svelte
@@ -36,7 +36,7 @@
     setDeviceName,
     revokePeer,
   } from "../../store/syncStore";
-  import { openPairingModal } from "../../store/pairingModalStore";
+  import { openPairingModal, openPairingModalWithAddr } from "../../store/pairingModalStore";
   import { relativeTime } from "../../lib/relativeTime";
   import type { DiscoveredPeer } from "../../ipc/commands";
 
@@ -325,6 +325,18 @@
     openPairingModal();
   }
 
+  /** Manual peer-address entry — used when mDNS isn't available
+   *  (Android pre-NSD bridge, multicast-blocked LANs). User types
+   *  the other device's IP (optionally with :port), modal opens in
+   *  responder mode and dials that address. */
+  let manualPeerAddr = $state("");
+  function onPairManual(): void {
+    const v = manualPeerAddr.trim();
+    if (!v) return;
+    openPairingModalWithAddr(v);
+    manualPeerAddr = "";
+  }
+
   onDestroy(() => { unsubTheme(); unsubSettings(); unsubVault(); unsubCommands(); unsubSnippets(); unsubSelfIdentity(); });
 </script>
 
@@ -495,6 +507,29 @@
             onclick={onPairNew}
             data-testid="settings-sync-pair-new"
           >Neues Gerät koppeln…</button>
+        </div>
+
+        <!-- Manual peer entry: used when mDNS discovery isn't available
+             (Android pre-NSD bridge, multicast-blocked LANs). Type the
+             other device's IP (optionally :port) and pair. Reuses
+             existing input + button styling. -->
+        <div class="vc-settings-row vc-sync-pair-row">
+          <input
+            type="text"
+            class="vc-settings-text"
+            placeholder="z.B. 192.168.1.42 oder 192.168.1.42:17092"
+            bind:value={manualPeerAddr}
+            onkeydown={(e) => { if (e.key === "Enter") onPairManual(); }}
+            data-testid="settings-sync-manual-addr"
+            aria-label="Peer-Adresse manuell eingeben"
+          />
+          <button
+            type="button"
+            class="vc-settings-btn"
+            disabled={!manualPeerAddr.trim()}
+            onclick={onPairManual}
+            data-testid="settings-sync-pair-manual"
+          >Mit IP koppeln</button>
         </div>
       </section>
 

--- a/src/components/Settings/__tests__/PairingModal.test.ts
+++ b/src/components/Settings/__tests__/PairingModal.test.ts
@@ -1,0 +1,500 @@
+// UI-3 — PairingModal.svelte unit tests.
+//
+// Drives the 4-step state machine through a mocked syncStore so the
+// modal can be exercised without a real Tauri peer transport. Bridge
+// engineer note (UI-1): `pairing_step` returns `awaiting_peer` until
+// the engine drives raw_keys into the session and `pairing_confirm`
+// errors when raw_keys are absent — both surface to UI as a generic
+// "still verifying" state and never as a security-relevant error.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+import { tick } from "svelte";
+import type {
+  PairingStartInitiator,
+  PairingStartResponder,
+  PairingStep,
+  VaultRef,
+} from "../../../ipc/commands";
+import type { PendingPairingSession } from "../../../store/syncStore";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+//
+// The store is mocked as a small fake whose `pendingPairingSession`
+// readable can be driven by the test. Action functions are spies so
+// each test can assert call ordering without involving Tauri.
+//
+// `vi.mock` factories are hoisted, so we build everything inside the
+// factory and re-import via `vi.importMock` after `import`s settle.
+
+vi.mock("../../../store/syncStore", () => {
+  // `writable` import inside the factory — vi hoists the factory above
+  // top-level imports, so a plain reference would be uninitialized.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { writable } = require("svelte/store") as typeof import("svelte/store");
+  const pending = writable<PendingPairingSession | null>(null);
+  return {
+    pendingPairingSession: { subscribe: pending.subscribe },
+    __pendingPairingSessionStore: pending,
+    startInitiator: vi.fn<() => Promise<PairingStartInitiator>>(),
+    startResponder: vi.fn<(pin: string) => Promise<PairingStartResponder>>(),
+    stepPairing: vi.fn<(payload?: string) => Promise<PairingStep>>(),
+    confirmPairing: vi.fn<() => Promise<void>>(),
+    cancelPairing: vi.fn<() => Promise<void>>(),
+    grantVault: vi.fn<
+      (peerDeviceId: string, vaultId: string, scope: "read" | "read+write") => Promise<void>
+    >(),
+  };
+});
+
+// `qrcode` is dynamically imported by the component (smaller bundle on
+// the role-selection step). Stub the toDataURL surface so jsdom doesn't
+// choke on canvas APIs.
+vi.mock("qrcode", () => ({
+  default: {
+    toDataURL: vi.fn(async () => "data:image/png;base64,FAKEQR"),
+  },
+  toDataURL: vi.fn(async () => "data:image/png;base64,FAKEQR"),
+}));
+
+import * as syncStoreMock from "../../../store/syncStore";
+import PairingModal from "../PairingModal.svelte";
+
+const pendingPairingSessionStore = (syncStoreMock as unknown as {
+  __pendingPairingSessionStore: import("svelte/store").Writable<PendingPairingSession | null>;
+}).__pendingPairingSessionStore;
+const startInitiator = syncStoreMock.startInitiator as unknown as ReturnType<
+  typeof vi.fn<() => Promise<PairingStartInitiator>>
+>;
+const startResponder = syncStoreMock.startResponder as unknown as ReturnType<
+  typeof vi.fn<(pin: string) => Promise<PairingStartResponder>>
+>;
+const stepPairing = syncStoreMock.stepPairing as unknown as ReturnType<
+  typeof vi.fn<(payload?: string) => Promise<PairingStep>>
+>;
+const confirmPairing = syncStoreMock.confirmPairing as unknown as ReturnType<
+  typeof vi.fn<() => Promise<void>>
+>;
+const cancelPairing = syncStoreMock.cancelPairing as unknown as ReturnType<
+  typeof vi.fn<() => Promise<void>>
+>;
+const grantVault = syncStoreMock.grantVault as unknown as ReturnType<
+  typeof vi.fn<
+    (peerDeviceId: string, vaultId: string, scope: "read" | "read+write") => Promise<void>
+  >
+>;
+
+const SAMPLE_VAULTS: VaultRef[] = [
+  { id: "v-alpha", name: "Alpha" },
+  { id: "v-beta", name: "Beta" },
+];
+
+const SAMPLE_INITIATOR: PairingStartInitiator = {
+  session_id: "sess-A",
+  pin: "123456",
+  expires_at_unix: Math.floor(Date.now() / 1000) + 90,
+};
+
+function pendingInitiator(): PendingPairingSession {
+  return {
+    session_id: SAMPLE_INITIATOR.session_id,
+    role: "initiator",
+    pin: SAMPLE_INITIATOR.pin,
+    expires_at_unix: SAMPLE_INITIATOR.expires_at_unix,
+    last_step: null,
+  };
+}
+
+function pendingResponder(): PendingPairingSession {
+  return {
+    session_id: "sess-R",
+    role: "responder",
+    pin: null,
+    expires_at_unix: null,
+    last_step: null,
+  };
+}
+
+function awaitingConfirmation(fingerprint: string): PairingStep {
+  return {
+    kind: "awaiting_confirmation",
+    peer_fingerprint: fingerprint,
+    attempts_remaining: 3,
+  };
+}
+
+function failedStep(remaining: number): PairingStep {
+  return { kind: "failed", peer_fingerprint: null, attempts_remaining: remaining };
+}
+
+beforeEach(() => {
+  pendingPairingSessionStore.set(null);
+  startInitiator.mockReset();
+  startResponder.mockReset();
+  stepPairing.mockReset();
+  confirmPairing.mockReset();
+  cancelPairing.mockReset();
+  grantVault.mockReset();
+
+  startInitiator.mockResolvedValue(SAMPLE_INITIATOR);
+  startResponder.mockResolvedValue({ session_id: "sess-R" });
+  stepPairing.mockResolvedValue({
+    kind: "awaiting_peer",
+    peer_fingerprint: null,
+    attempts_remaining: 3,
+  });
+  confirmPairing.mockResolvedValue();
+  cancelPairing.mockResolvedValue();
+  grantVault.mockResolvedValue();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function open(props: Partial<{
+  open: boolean;
+  vaults: VaultRef[];
+  triggerEl: HTMLElement | null;
+  selfDeviceName: string;
+  onClose: () => void;
+}> = {}) {
+  return render(PairingModal, {
+    props: {
+      open: true,
+      vaults: SAMPLE_VAULTS,
+      triggerEl: null,
+      selfDeviceName: "MacBook",
+      onClose: vi.fn(),
+      ...props,
+    },
+  });
+}
+
+describe("PairingModal — open + focus", () => {
+  it("opens_with_focus_on_first_interactive_element", async () => {
+    const { container } = open();
+    await tick();
+    await tick();
+    // Step 1 is role selection — first interactive is the initiator radio.
+    const firstRadio = container.querySelector<HTMLInputElement>(
+      'input[type="radio"][name="vc-pairing-role"]',
+    );
+    expect(firstRadio).toBeTruthy();
+    expect(document.activeElement).toBe(firstRadio);
+  });
+});
+
+describe("PairingModal — initiator step 2 PIN display", () => {
+  it("initiator_displays_6_digit_pin_with_dash_separator", async () => {
+    const { container } = open();
+    await tick();
+    pendingPairingSessionStore.set(pendingInitiator());
+    await tick();
+    await tick();
+    const pinDisplay = container.querySelector('[data-testid="pairing-initiator-pin"]');
+    expect(pinDisplay).toBeTruthy();
+    // Visible text must group XXX–XXX with an en-dash (U+2013) so the
+    // user reads two triplets, not one stretched run.
+    expect(pinDisplay!.textContent).toContain("123–456");
+  });
+});
+
+describe("PairingModal — responder step 2 PIN input", () => {
+  function setupResponder() {
+    const r = open();
+    // Click the responder radio and continue to step 2.
+    return r;
+  }
+
+  async function selectResponderAndAdvance(container: HTMLElement) {
+    const responderRadio = container.querySelector<HTMLInputElement>(
+      'input[type="radio"][value="responder"]',
+    )!;
+    await fireEvent.click(responderRadio);
+    await tick();
+    const next = container.querySelector<HTMLButtonElement>(
+      '[data-testid="pairing-next"]',
+    )!;
+    await fireEvent.click(next);
+    await tick();
+  }
+
+  it("responder_paste_6_digits_distributes_to_six_fields", async () => {
+    const { container } = setupResponder();
+    await tick();
+    await selectResponderAndAdvance(container);
+
+    const fields = container.querySelectorAll<HTMLInputElement>(
+      '[data-testid^="pairing-pin-field-"]',
+    );
+    expect(fields.length).toBe(6);
+    const first = fields[0]!;
+    first.focus();
+    // Simulate a real paste: clipboardData with the full PIN. The
+    // component intercepts `paste` before the native single-char
+    // distribution and writes one digit into each field. jsdom doesn't
+    // implement `DataTransfer`, so we synthesize the minimal surface
+    // (`getData`) the component reads.
+    const clipboardData = {
+      getData: (type: string) => (type === "text" ? "246813" : ""),
+    } as unknown as DataTransfer;
+    await fireEvent.paste(first, { clipboardData });
+    await tick();
+    expect(Array.from(fields).map((f) => f.value)).toEqual([
+      "2",
+      "4",
+      "6",
+      "8",
+      "1",
+      "3",
+    ]);
+  });
+
+  it("responder_auto_advances_on_digit_entry", async () => {
+    const { container } = setupResponder();
+    await tick();
+    await selectResponderAndAdvance(container);
+    const fields = container.querySelectorAll<HTMLInputElement>(
+      '[data-testid^="pairing-pin-field-"]',
+    );
+    fields[0]!.focus();
+    await fireEvent.input(fields[0]!, { target: { value: "7" } });
+    await tick();
+    expect(document.activeElement).toBe(fields[1]);
+    await fireEvent.input(fields[1]!, { target: { value: "3" } });
+    await tick();
+    expect(document.activeElement).toBe(fields[2]);
+  });
+
+  it("responder_backspace_moves_to_previous_field", async () => {
+    const { container } = setupResponder();
+    await tick();
+    await selectResponderAndAdvance(container);
+    const fields = container.querySelectorAll<HTMLInputElement>(
+      '[data-testid^="pairing-pin-field-"]',
+    );
+    // Type into first two so cursor is on field index 2 (third box).
+    fields[0]!.focus();
+    await fireEvent.input(fields[0]!, { target: { value: "9" } });
+    await tick();
+    await fireEvent.input(fields[1]!, { target: { value: "9" } });
+    await tick();
+    // Now on fields[2], empty. Backspace on empty must move back.
+    expect(document.activeElement).toBe(fields[2]);
+    await fireEvent.keyDown(fields[2]!, { key: "Backspace" });
+    await tick();
+    expect(document.activeElement).toBe(fields[1]);
+  });
+});
+
+describe("PairingModal — failure / lockout", () => {
+  it("failed_attempt_shows_remaining_count_with_role_alert", async () => {
+    stepPairing.mockResolvedValueOnce(failedStep(2));
+    // Simulate startResponder populating the store after the user
+    // submits the PIN — the test's store fake doesn't auto-do this.
+    startResponder.mockImplementation(async () => {
+      pendingPairingSessionStore.set(pendingResponder());
+      return { session_id: "sess-R" };
+    });
+    const { container } = open();
+    await tick();
+    const responderRadio = container.querySelector<HTMLInputElement>(
+      'input[type="radio"][value="responder"]',
+    )!;
+    await fireEvent.click(responderRadio);
+    await tick();
+    await fireEvent.click(
+      container.querySelector<HTMLButtonElement>('[data-testid="pairing-next"]')!,
+    );
+    await tick();
+    const fields = container.querySelectorAll<HTMLInputElement>(
+      '[data-testid^="pairing-pin-field-"]',
+    );
+    fields[0]!.focus();
+    const digits = ["1", "1", "1", "1", "1", "1"];
+    for (let i = 0; i < 6; i++) {
+      await fireEvent.input(fields[i]!, { target: { value: digits[i] } });
+      await tick();
+    }
+    // Final input completes the PIN — the component dispatches step()
+    // with the joined value. Awaiting the spy's promise lets the
+    // component apply the failed result.
+    await stepPairing.mock.results[0]?.value;
+    await tick();
+    await tick();
+    const err = container.querySelector('[data-testid="pairing-pin-error"]');
+    expect(err).toBeTruthy();
+    expect(err!.getAttribute("role")).toBe("alert");
+    expect(err!.textContent).toMatch(/2 Versuche verbleibend/);
+  });
+
+  it("error_message_does_not_disclose_which_side_typed_wrong", async () => {
+    stepPairing.mockResolvedValueOnce(failedStep(2));
+    startResponder.mockImplementation(async () => {
+      pendingPairingSessionStore.set(pendingResponder());
+      return { session_id: "sess-R" };
+    });
+    const { container } = open();
+    await tick();
+    const responderRadio = container.querySelector<HTMLInputElement>(
+      'input[type="radio"][value="responder"]',
+    )!;
+    await fireEvent.click(responderRadio);
+    await tick();
+    await fireEvent.click(
+      container.querySelector<HTMLButtonElement>('[data-testid="pairing-next"]')!,
+    );
+    await tick();
+    const fields = container.querySelectorAll<HTMLInputElement>(
+      '[data-testid^="pairing-pin-field-"]',
+    );
+    fields[0]!.focus();
+    for (let i = 0; i < 6; i++) {
+      await fireEvent.input(fields[i]!, { target: { value: "1" } });
+      await tick();
+    }
+    await stepPairing.mock.results[0]?.value;
+    await tick();
+    const err = container.querySelector('[data-testid="pairing-pin-error"]');
+    expect(err).toBeTruthy();
+    const text = err!.textContent?.toLowerCase() ?? "";
+    // Must not mention either side of the exchange.
+    expect(text).not.toMatch(/du|dein|peer|gegenstelle|sender|empfänger|other|their/);
+  });
+
+  it("lockout_replaces_input_after_3_failures", async () => {
+    stepPairing.mockResolvedValue(failedStep(0));
+    startResponder.mockImplementation(async () => {
+      pendingPairingSessionStore.set(pendingResponder());
+      return { session_id: "sess-R" };
+    });
+    const { container } = open();
+    await tick();
+    const responderRadio = container.querySelector<HTMLInputElement>(
+      'input[type="radio"][value="responder"]',
+    )!;
+    await fireEvent.click(responderRadio);
+    await tick();
+    await fireEvent.click(
+      container.querySelector<HTMLButtonElement>('[data-testid="pairing-next"]')!,
+    );
+    await tick();
+    const fields = container.querySelectorAll<HTMLInputElement>(
+      '[data-testid^="pairing-pin-field-"]',
+    );
+    fields[0]!.focus();
+    for (let i = 0; i < 6; i++) {
+      await fireEvent.input(fields[i]!, { target: { value: "1" } });
+      await tick();
+    }
+    // Wait for the step() promise the component fired.
+    await stepPairing.mock.results[stepPairing.mock.results.length - 1]?.value;
+    await tick();
+    await tick();
+    const lockout = container.querySelector('[data-testid="pairing-lockout"]');
+    expect(lockout).toBeTruthy();
+    expect(lockout!.getAttribute("role")).toBe("alert");
+    expect(lockout!.textContent).toMatch(/Gesperrt/);
+    // Input fields are gone.
+    expect(
+      container.querySelectorAll('[data-testid^="pairing-pin-field-"]').length,
+    ).toBe(0);
+  });
+});
+
+describe("PairingModal — countdown a11y", () => {
+  it("countdown_announces_at_10_second_intervals_only", async () => {
+    vi.useFakeTimers();
+    // Pin expires 90 s in the future relative to a fixed clock.
+    const now = 1_700_000_000_000;
+    vi.setSystemTime(now);
+    const { container } = open();
+    await tick();
+    pendingPairingSessionStore.set({
+      session_id: "sess-A",
+      role: "initiator",
+      pin: "123456",
+      expires_at_unix: Math.floor(now / 1000) + 90,
+      last_step: null,
+    });
+    await tick();
+    await tick();
+
+    const live = container.querySelector('[data-testid="pairing-countdown-live"]');
+    expect(live).toBeTruthy();
+    expect(live!.getAttribute("aria-live")).toBe("polite");
+
+    // First snap: 90 → "90".
+    expect(live!.textContent?.trim()).toBe("90");
+
+    // Tick 5 s — under the 10-second snap, announcement must NOT change.
+    vi.advanceTimersByTime(5_000);
+    await tick();
+    expect(live!.textContent?.trim()).toBe("90");
+
+    // Tick another 5 s (10 s total) — snap to 80.
+    vi.advanceTimersByTime(5_000);
+    await tick();
+    expect(live!.textContent?.trim()).toBe("80");
+
+    // Inner per-second readout, if rendered, must have aria-live=off so
+    // it doesn't double-announce.
+    const inner = container.querySelector('[data-testid="pairing-countdown-inner"]');
+    if (inner) {
+      expect(inner.getAttribute("aria-live")).toBe("off");
+    }
+  });
+});
+
+describe("PairingModal — escape", () => {
+  it("escape_cancels_pairing", async () => {
+    const onClose = vi.fn();
+    open({ onClose });
+    await tick();
+    pendingPairingSessionStore.set(pendingInitiator());
+    await tick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await tick();
+    await tick();
+    expect(cancelPairing).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("PairingModal — step 4 vault grant", () => {
+  it("vault_grant_step_disables_done_until_at_least_one_checked", async () => {
+    const { container } = open();
+    await tick();
+    // Drive into step 4 by placing the session in awaiting_confirmation
+    // and confirming the keys, then waiting for the synthetic step-4
+    // transition.
+    pendingPairingSessionStore.set({
+      ...pendingInitiator(),
+      last_step: awaitingConfirmation("ABCDEF1234567890"),
+    });
+    await tick();
+    await tick();
+    const confirmBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="pairing-key-confirm"]',
+    )!;
+    expect(confirmBtn).toBeTruthy();
+    await fireEvent.click(confirmBtn);
+    await tick();
+    await tick();
+
+    const done = container.querySelector<HTMLButtonElement>(
+      '[data-testid="pairing-done"]',
+    );
+    expect(done).toBeTruthy();
+    expect(done!.disabled).toBe(true);
+
+    const checkbox = container.querySelector<HTMLInputElement>(
+      'input[type="checkbox"][data-vault-id="v-alpha"]',
+    )!;
+    await fireEvent.click(checkbox);
+    await tick();
+    expect(done!.disabled).toBe(false);
+  });
+});

--- a/src/components/Settings/__tests__/SettingsModal.sync.test.ts
+++ b/src/components/Settings/__tests__/SettingsModal.sync.test.ts
@@ -1,0 +1,251 @@
+// UI-2 — component tests for the SYNCHRONISIERUNG section inside
+// SettingsModal.svelte. Verifies section ordering, control bindings,
+// revoke confirmation flow, clipboard copy, and editable device name
+// commit-on-blur. Other Settings sections are stubbed to no-ops via
+// store mocks so this suite stays focused on the new surface.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+
+// ── IPC mocks ─────────────────────────────────────────────────────────
+//
+// SettingsModal indirectly imports `../../ipc/commands` for `lockAllFolders`
+// and the snippet IPC; the SYNC section adds the sync_* family. Mock the
+// whole module — only the sync_* surface is exercised here.
+
+vi.mock("../../../ipc/commands", () => ({
+  syncGetSelfIdentity: vi.fn(),
+  syncSetDeviceName: vi.fn(),
+  syncGetDiscoverable: vi.fn(),
+  syncSetDiscoverable: vi.fn(),
+  syncListDiscoveredPeers: vi.fn(),
+  syncListPairedPeers: vi.fn(),
+  syncPairingStartInitiator: vi.fn(),
+  syncPairingStartResponder: vi.fn(),
+  syncPairingStep: vi.fn(),
+  syncPairingConfirm: vi.fn(),
+  syncPairingCancel: vi.fn(),
+  syncGrantVault: vi.fn(),
+  syncRevokePeer: vi.fn(),
+  syncRevokeVaultGrant: vi.fn(),
+  // unrelated commands SettingsModal imports
+  lockAllFolders: vi.fn(),
+  listSnippets: vi.fn(async () => []),
+  readSnippet: vi.fn(),
+}));
+
+vi.mock("../../../ipc/events", () => ({
+  listenPeersDiscovered: vi.fn(async () => () => {}),
+  listenPeerPaired: vi.fn(async () => () => {}),
+  listenSyncStatus: vi.fn(async () => () => {}),
+  listenStalePeerResurrect: vi.fn(async () => () => {}),
+}));
+
+// Stub stores SettingsModal subscribes to so we don't need to bootstrap
+// the whole app. We override only the slices the sync section depends on
+// (selfIdentity, discoverable, pairedPeers, discoveredPeers, ready).
+//
+// `vi.mock` is hoisted to the top of the file, so the mock factories
+// can't reference module-scope locals. We use `vi.hoisted(...)` to
+// declare a shared bag that both the factories and the test bodies see.
+import type {
+  SelfIdentity,
+  PairedPeer,
+  DiscoveredPeer,
+} from "../../../ipc/commands";
+
+const stores = vi.hoisted(() => {
+  // Have to require svelte/store inside the hoisted factory; top-level
+  // imports run after `vi.hoisted`.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { writable } = require("svelte/store") as typeof import("svelte/store");
+  return {
+    selfIdentity: writable<unknown>(null),
+    discoverable: writable<boolean>(false),
+    pairedPeers: writable<unknown[]>([]),
+    discoveredPeers: writable<unknown[]>([]),
+    ready: writable<boolean>(true),
+    setDiscoverable: vi.fn(),
+    setDeviceName: vi.fn(),
+    revokePeer: vi.fn(),
+    openPairingModal: vi.fn(),
+  };
+});
+
+vi.mock("../../../store/syncStore", () => ({
+  selfIdentity: stores.selfIdentity,
+  discoverable: stores.discoverable,
+  pairedPeers: stores.pairedPeers,
+  discoveredPeers: stores.discoveredPeers,
+  syncStoreReady: stores.ready,
+  setDiscoverable: (v: boolean) => stores.setDiscoverable(v),
+  setDeviceName: (n: string) => stores.setDeviceName(n),
+  revokePeer: (id: string) => stores.revokePeer(id),
+}));
+
+vi.mock("../../../store/pairingModalStore", () => ({
+  openPairingModal: (peer?: DiscoveredPeer) => stores.openPairingModal(peer),
+}));
+
+// Freeze "now" so relativeTime() is deterministic.
+vi.mock("../../../lib/relativeTime", () => ({
+  relativeTime: (t: number | null | undefined) =>
+    t == null ? "nie" : `vor ${1000 - t} Sekunden`,
+  nowSeconds: () => 1000,
+}));
+
+import SettingsModal from "../SettingsModal.svelte";
+
+function renderModal() {
+  return render(SettingsModal, {
+    props: {
+      open: true,
+      onClose: () => {},
+      onSwitchVault: () => {},
+    },
+  });
+}
+
+beforeEach(() => {
+  stores.selfIdentity.set({
+    device_id: "ABCDEFGHIJKLMNOPQRSTUVWX",
+    device_name: "Alice's Mac",
+    pubkey_fingerprint: "AB12CD34",
+  });
+  stores.discoverable.set(false);
+  stores.pairedPeers.set([]);
+  stores.discoveredPeers.set([]);
+  stores.setDiscoverable.mockReset();
+  stores.setDeviceName.mockReset();
+  stores.revokePeer.mockReset();
+  stores.openPairingModal.mockReset();
+});
+
+describe("SettingsModal — SYNCHRONISIERUNG section", () => {
+  it("renders after VAULT and before ERSCHEINUNGSBILD", () => {
+    renderModal();
+    const sections = Array.from(
+      document.querySelectorAll(".vc-settings-section-title"),
+    ).map((el) => el.textContent?.trim());
+    const vaultIdx = sections.indexOf("VAULT");
+    const syncIdx = sections.indexOf("SYNCHRONISIERUNG");
+    const appearanceIdx = sections.indexOf("ERSCHEINUNGSBILD");
+    expect(vaultIdx).toBeGreaterThanOrEqual(0);
+    expect(syncIdx).toBeGreaterThan(vaultIdx);
+    expect(appearanceIdx).toBeGreaterThan(syncIdx);
+  });
+
+  it("toggling discoverable dispatches setDiscoverable", async () => {
+    renderModal();
+    const toggle = screen.getByLabelText(
+      "Dieses Gerät im Netzwerk sichtbar machen",
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    await fireEvent.click(toggle);
+    expect(stores.setDiscoverable).toHaveBeenCalledWith(true);
+  });
+
+  it("renders each paired peer row with revoke aria-label", () => {
+    stores.pairedPeers.set([
+      {
+        device_id: "PEER01",
+        device_name: "Bob's Laptop",
+        last_seen: 800,
+        grants: [{ vault_id: "v1", vault_name: "Notes", scope: "read+write" }],
+      },
+      {
+        device_id: "PEER02",
+        device_name: "Bob's Phone",
+        last_seen: null,
+        grants: [],
+      },
+    ]);
+    renderModal();
+    expect(
+      screen.getByLabelText("Synchronisierung mit Bob's Laptop widerrufen"),
+    ).toBeTruthy();
+    expect(
+      screen.getByLabelText("Synchronisierung mit Bob's Phone widerrufen"),
+    ).toBeTruthy();
+    expect(screen.getByText("Bob's Laptop")).toBeTruthy();
+    expect(screen.getByText("Bob's Phone")).toBeTruthy();
+  });
+
+  it("renders the empty-paired hint when no peers are paired", () => {
+    stores.pairedPeers.set([]);
+    renderModal();
+    expect(screen.getByText("Noch keine gekoppelten Geräte.")).toBeTruthy();
+  });
+
+  it("revoke button confirms then dispatches revokePeer; cancel does nothing", async () => {
+    stores.pairedPeers.set([
+      {
+        device_id: "PEER01",
+        device_name: "Bob's Laptop",
+        last_seen: 900,
+        grants: [],
+      },
+    ]);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValueOnce(false);
+    renderModal();
+    const btn = screen.getByLabelText(
+      "Synchronisierung mit Bob's Laptop widerrufen",
+    );
+    await fireEvent.click(btn);
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(stores.revokePeer).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValueOnce(true);
+    await fireEvent.click(btn);
+    expect(stores.revokePeer).toHaveBeenCalledWith("PEER01");
+    confirmSpy.mockRestore();
+  });
+
+  it("copy-device-id button writes the device id to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    renderModal();
+    const copyBtn = screen.getByLabelText("Geräte-ID kopieren");
+    await fireEvent.click(copyBtn);
+    expect(writeText).toHaveBeenCalledWith("ABCDEFGHIJKLMNOPQRSTUVWX");
+  });
+
+  it("editable device name commits on blur", async () => {
+    renderModal();
+    const input = screen.getByLabelText("Gerätename") as HTMLInputElement;
+    expect(input.value).toBe("Alice's Mac");
+    input.value = "Alice's MacBook";
+    await fireEvent.input(input);
+    await fireEvent.blur(input);
+    expect(stores.setDeviceName).toHaveBeenCalledWith("Alice's MacBook");
+  });
+
+  it("editable device name does NOT dispatch when value is unchanged", async () => {
+    renderModal();
+    const input = screen.getByLabelText("Gerätename") as HTMLInputElement;
+    await fireEvent.blur(input);
+    expect(stores.setDeviceName).not.toHaveBeenCalled();
+  });
+
+  it("'Neues Gerät koppeln…' button opens the pairing modal", async () => {
+    renderModal();
+    const btn = screen.getByText("Neues Gerät koppeln…");
+    await fireEvent.click(btn);
+    expect(stores.openPairingModal).toHaveBeenCalledTimes(1);
+    expect(stores.openPairingModal.mock.calls[0]?.[0]).toBeUndefined();
+  });
+
+  it("clicking a discovered peer opens the pairing modal pre-filled", async () => {
+    const peer: DiscoveredPeer = {
+      device_id: "PEER42",
+      device_name: "Carol's iPad",
+      vaults: [],
+      addr: "192.168.1.42:7878",
+    };
+    stores.discoveredPeers.set([peer]);
+    renderModal();
+    const btn = screen.getByLabelText("Mit Carol's iPad koppeln");
+    await fireEvent.click(btn);
+    expect(stores.openPairingModal).toHaveBeenCalledWith(peer);
+  });
+});

--- a/src/components/Statusbar/SyncStatusPill.svelte
+++ b/src/components/Statusbar/SyncStatusPill.svelte
@@ -1,0 +1,113 @@
+<!--
+  UI-4 — ambient sync status indicator.
+
+  Stacked above EncryptionStatusbar (`bottom: 48px`) at `bottom: 84px`
+  per the existing 12 / 48 / 84 stacking convention. Hidden when sync
+  is idle and healthy across every vault. While syncing, surfaces an
+  aggregated peer + in-flight-file count. On error, becomes a button
+  that opens Settings on the SYNCHRONISIERUNG section.
+
+  Geometry / tokens cloned from EncryptionStatusbar; no new design tokens.
+-->
+<script lang="ts">
+  import { syncStatusByVault } from "../../store/syncStore";
+  import { requestOpenSettings } from "../../store/settingsModalStore";
+
+  type Mode = "idle" | "syncing" | "error";
+
+  // Aggregate worst-state across vaults: error > syncing > idle.
+  // Sums are computed across all reporting vaults so users with
+  // multiple vaults paired see one consolidated pill.
+  const vm = $derived.by(() => {
+    const statuses = Object.values($syncStatusByVault);
+    let mode: Mode = "idle";
+    let peers = 0;
+    let files = 0;
+    for (const s of statuses) {
+      peers += s.peer_count;
+      files += s.in_flight_files;
+      if (s.error) {
+        mode = "error";
+      } else if (mode !== "error" && (s.peer_count > 0 || s.in_flight_files > 0)) {
+        mode = "syncing";
+      }
+    }
+    return { mode, peers, files };
+  });
+
+  function onErrorClick(): void {
+    requestOpenSettings("sync");
+  }
+</script>
+
+{#if vm.mode === "error"}
+  <!-- Vitruvius constraint: error pill is a `<button>` AND carries
+       role="alert" + aria-live="assertive" so the label announces
+       immediately when sync fails. Svelte's a11y lint flags this
+       because alert is canonically non-interactive — the constraint
+       overrides because the user must be able to click straight to
+       Settings without a separate live region. -->
+  <!-- svelte-ignore a11y_no_interactive_element_to_noninteractive_role -->
+  <button
+    type="button"
+    class="vc-encrypt-bar vc-encrypt-bar-error"
+    onclick={onErrorClick}
+    role="alert"
+    aria-live="assertive"
+    aria-label="Synchronisierungsfehler — Einstellungen öffnen"
+    data-testid="sync-status-pill"
+  >
+    <div class="vc-encrypt-label">Synchronisierungsfehler · Einstellungen öffnen</div>
+  </button>
+{:else if vm.mode === "syncing"}
+  <div
+    class="vc-encrypt-bar"
+    role="status"
+    aria-live="polite"
+    data-testid="sync-status-pill"
+  >
+    <div class="vc-encrypt-label">{vm.peers} verbunden · {vm.files} Dateien</div>
+  </div>
+{/if}
+
+<style>
+  /* Geometry mirrors `.vc-encrypt-bar` in EncryptionStatusbar; the only
+     delta is `bottom` (84 vs 48) so the two pills can coexist on screen.
+     Token set is identical — no new design tokens introduced. */
+  .vc-encrypt-bar {
+    position: fixed;
+    left: 50%;
+    bottom: 84px;
+    transform: translateX(-50%);
+    min-width: 320px;
+    max-width: 640px;
+    padding: 6px 10px;
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: center;
+    background: var(--color-surface, rgba(30, 30, 30, 0.9));
+    color: var(--color-text, #eee);
+    border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+    border-radius: 6px;
+    font-size: 12px;
+    z-index: 40;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+    /* Reset native button defaults for the error variant. */
+    font-family: inherit;
+    text-align: left;
+    cursor: default;
+  }
+  button.vc-encrypt-bar { cursor: pointer; }
+  button.vc-encrypt-bar:hover { background: var(--color-accent-bg, rgba(255,255,255,0.05)); }
+
+  .vc-encrypt-bar-error {
+    border-left: 4px solid var(--color-error, #d9534f);
+    padding-left: 6px;
+  }
+
+  .vc-encrypt-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/components/Statusbar/__tests__/SyncStatusPill.test.ts
+++ b/src/components/Statusbar/__tests__/SyncStatusPill.test.ts
@@ -1,0 +1,103 @@
+// UI-4 — SyncStatusPill.
+//
+// Idle/healthy: nothing rendered.
+// Syncing:     plain pill, role=status / aria-live=polite, non-interactive.
+// Error:       pill becomes a button with role=alert, aria-live=assertive,
+//              left-border accent, and clicking opens settings on the SYNC
+//              section.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import type { SyncStatusPayload } from "../../../ipc/events";
+
+const stores = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { writable } = require("svelte/store") as typeof import("svelte/store");
+  return {
+    syncStatusByVault: writable<Record<string, SyncStatusPayload>>({}),
+    requestOpenSettings: vi.fn(),
+  };
+});
+
+vi.mock("../../../store/syncStore", () => ({
+  syncStatusByVault: stores.syncStatusByVault,
+}));
+
+vi.mock("../../../store/settingsModalStore", () => ({
+  requestOpenSettings: (anchor: "sync" | null) => stores.requestOpenSettings(anchor),
+}));
+
+import SyncStatusPill from "../SyncStatusPill.svelte";
+
+beforeEach(() => {
+  stores.syncStatusByVault.set({});
+  stores.requestOpenSettings.mockReset();
+});
+
+describe("SyncStatusPill", () => {
+  it("hidden when all vaults are idle (no peers, no in-flight files, no error)", () => {
+    stores.syncStatusByVault.set({
+      v1: { vault_id: "v1", peer_count: 0, in_flight_files: 0, error: null },
+    });
+    render(SyncStatusPill);
+    expect(screen.queryByTestId("sync-status-pill")).toBeNull();
+  });
+
+  it("hidden when state is empty (no vaults reporting)", () => {
+    render(SyncStatusPill);
+    expect(screen.queryByTestId("sync-status-pill")).toBeNull();
+  });
+
+  it("shows count when at least one vault is syncing", () => {
+    stores.syncStatusByVault.set({
+      v1: { vault_id: "v1", peer_count: 2, in_flight_files: 5, error: null },
+      v2: { vault_id: "v2", peer_count: 1, in_flight_files: 3, error: null },
+    });
+    render(SyncStatusPill);
+    const pill = screen.getByTestId("sync-status-pill");
+    expect(pill).toBeTruthy();
+    // Aggregated across vaults: 3 peers · 8 files
+    expect(pill.textContent).toContain("3 verbunden");
+    expect(pill.textContent).toContain("8 Dateien");
+    expect(pill.getAttribute("role")).toBe("status");
+    expect(pill.getAttribute("aria-live")).toBe("polite");
+    // Non-interactive in syncing state — must not be a button.
+    expect(pill.tagName).toBe("DIV");
+  });
+
+  it("error overrides syncing — pill becomes a button with error border and alert role", () => {
+    stores.syncStatusByVault.set({
+      v1: { vault_id: "v1", peer_count: 0, in_flight_files: 0, error: "permission denied" },
+      v2: { vault_id: "v2", peer_count: 1, in_flight_files: 4, error: null },
+    });
+    render(SyncStatusPill);
+    const pill = screen.getByTestId("sync-status-pill");
+    expect(pill.tagName).toBe("BUTTON");
+    expect(pill.getAttribute("role")).toBe("alert");
+    expect(pill.getAttribute("aria-live")).toBe("assertive");
+    expect(pill.getAttribute("aria-label")).toBe(
+      "Synchronisierungsfehler — Einstellungen öffnen",
+    );
+    expect(pill.classList.contains("vc-encrypt-bar-error")).toBe(true);
+  });
+
+  it("clicking the error pill requests settings open on the sync section", async () => {
+    stores.syncStatusByVault.set({
+      v1: { vault_id: "v1", peer_count: 0, in_flight_files: 0, error: "boom" },
+    });
+    render(SyncStatusPill);
+    const pill = screen.getByTestId("sync-status-pill");
+    await fireEvent.click(pill);
+    expect(stores.requestOpenSettings).toHaveBeenCalledWith("sync");
+  });
+
+  it("syncing pill click is a no-op (not a button)", async () => {
+    stores.syncStatusByVault.set({
+      v1: { vault_id: "v1", peer_count: 1, in_flight_files: 1, error: null },
+    });
+    render(SyncStatusPill);
+    const pill = screen.getByTestId("sync-status-pill");
+    await fireEvent.click(pill);
+    expect(stores.requestOpenSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Toast/Toast.svelte
+++ b/src/components/Toast/Toast.svelte
@@ -19,18 +19,31 @@
     info: "var(--color-accent)",
     warning: "var(--color-warning)",
   };
+
+  // UI-5: a resurrect toast carries role="alert" + aria-live="assertive"
+  // so screen readers announce it immediately. Default keeps the UI-04
+  // "status" / "polite" pairing.
+  const role = $derived(toast.role ?? "status");
+  const ariaLive = $derived(toast.ariaLive ?? "polite");
 </script>
 
 <div
   class="vc-toast"
   data-testid="toast"
   data-variant={toast.variant}
-  role="status"
-  aria-live="polite"
+  {role}
+  aria-live={ariaLive}
   style:border-left-color={borderColor[toast.variant]}
 >
   <span class="vc-toast-icon" aria-hidden="true">{icon[toast.variant]}</span>
   <span class="vc-toast-message">{toast.message}</span>
+  {#if toast.action}
+    <button
+      type="button"
+      class="vc-toast-action"
+      onclick={() => toast.action!.onClick()}
+    >{toast.action.label}</button>
+  {/if}
   <button
     type="button"
     class="vc-toast-dismiss"
@@ -49,7 +62,7 @@
     padding: 12px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr auto auto;
     gap: 8px;
     align-items: center;
     color: var(--color-text);
@@ -64,6 +77,23 @@
   }
   .vc-toast-message {
     word-break: break-word;
+  }
+  .vc-toast-action {
+    background: none;
+    border: none;
+    padding: 0 4px;
+    color: var(--color-accent);
+    text-decoration: underline;
+    cursor: pointer;
+    font: inherit;
+  }
+  .vc-toast-action:hover {
+    text-decoration: none;
+  }
+  .vc-toast-action:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
   .vc-toast-dismiss {
     background: none;

--- a/src/components/Toast/__tests__/Toast.test.ts
+++ b/src/components/Toast/__tests__/Toast.test.ts
@@ -1,0 +1,90 @@
+// UI-5 — Toast.svelte rendering of the new action-button slot, plus
+// the role / aria-live overrides required by the stale-peer resurrect
+// toast (warning + role="alert" + aria-live="assertive").
+//
+// UI-04 base coverage (variants, dismiss button, auto-dismiss, stacking
+// cap) lives in tests/Toast.test.ts and stays green; this file only
+// exercises the new surface introduced by UI-5.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import ToastContainer from "../ToastContainer.svelte";
+import { toastStore } from "../../../store/toastStore";
+
+beforeEach(() => {
+  toastStore._reset();
+});
+
+describe("UI-5 Toast component — action-button slot", () => {
+  it("renders_action_button_when_provided: action label appears as a button", async () => {
+    render(ToastContainer);
+    toastStore.push({
+      variant: "warning",
+      message: "stale peer",
+      persist: true,
+      action: { label: "Überprüfen", onClick: () => {} },
+    });
+    const btn = await screen.findByRole("button", { name: "Überprüfen" });
+    expect(btn).toBeTruthy();
+  });
+
+  it("does NOT render an action button for toasts without an action", async () => {
+    render(ToastContainer);
+    toastStore.push({ variant: "info", message: "plain" });
+    await screen.findByTestId("toast");
+    expect(screen.queryByRole("button", { name: "Überprüfen" })).toBeNull();
+  });
+
+  it("clicking_action_invokes_callback_and_does_not_close: callback fires, toast remains", async () => {
+    render(ToastContainer);
+    const onClick = vi.fn();
+    toastStore.push({
+      variant: "warning",
+      message: "with action",
+      persist: true,
+      action: { label: "Überprüfen", onClick },
+    });
+    const btn = await screen.findByRole("button", { name: "Überprüfen" });
+    await fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    // Toast still in DOM — the action callback is the caller's
+    // responsibility; the toast itself stays until the ✕ button is
+    // clicked or the caller calls dismiss().
+    expect(screen.queryByTestId("toast")).not.toBeNull();
+  });
+
+  it("✕ button still removes a persistent toast", async () => {
+    render(ToastContainer);
+    toastStore.push({
+      variant: "warning",
+      message: "x",
+      persist: true,
+      action: { label: "Überprüfen", onClick: () => {} },
+    });
+    const dismiss = await screen.findByLabelText("Dismiss notification");
+    await fireEvent.click(dismiss);
+    expect(screen.queryByTestId("toast")).toBeNull();
+  });
+
+  it("role + ariaLive overrides apply to the toast root", async () => {
+    render(ToastContainer);
+    toastStore.push({
+      variant: "warning",
+      message: "alert",
+      persist: true,
+      role: "alert",
+      ariaLive: "assertive",
+    });
+    const toast = await screen.findByTestId("toast");
+    expect(toast.getAttribute("role")).toBe("alert");
+    expect(toast.getAttribute("aria-live")).toBe("assertive");
+  });
+
+  it("role defaults to status / aria-live=polite when not provided (UI-04 backwards-compat)", async () => {
+    render(ToastContainer);
+    toastStore.push({ variant: "info", message: "x" });
+    const toast = await screen.findByTestId("toast");
+    expect(toast.getAttribute("role")).toBe("status");
+    expect(toast.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -844,6 +844,29 @@ export async function syncPairingCancel(sessionId: string): Promise<void> {
   }
 }
 
+/**
+ * Issue a vault grant inside an active pairing session. Unlike
+ * `syncGrantVault`, which targets an already-paired peer in the
+ * persisted DB, this one routes through the pairing engine's open
+ * Noise channel so the grant is exchanged with the peer in-flight
+ * during step 4 of the pairing flow.
+ */
+export async function syncPairingGrantVault(
+  sessionId: string,
+  vaultId: string,
+  scope: "read" | "read+write",
+): Promise<void> {
+  try {
+    await invoke<void>("sync_pairing_grant_vault", {
+      sessionId,
+      vaultId,
+      scope,
+    });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function syncGrantVault(
   peerDeviceId: string,
   vaultId: string,

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -679,3 +679,202 @@ export async function listEncryptedFolders(): Promise<EncryptedFolderView[]> {
     throw normalizeError(e);
   }
 }
+
+// ── UI-1 — sync IPC bridge ────────────────────────────────────────────────
+//
+// Thin wrappers over the `commands::sync_cmds` Rust module. Every command
+// returns a normalized `VaultError` on failure so `syncStore` can route
+// rollback logic the same way other stores do (see `encryptedFoldersStore`).
+// No polling: the store subscribes to `sync://*` events for state updates;
+// commands are user-driven actions only (toggle discoverable, start
+// pairing, grant a vault, etc).
+
+export interface SelfIdentity {
+  device_id: string;
+  device_name: string;
+  pubkey_fingerprint: string;
+}
+
+export interface VaultRef {
+  id: string;
+  name: string;
+}
+
+export interface DiscoveredPeer {
+  device_id: string;
+  device_name: string;
+  vaults: VaultRef[];
+  /** `host:port` rendered server-side; empty string when no address yet. */
+  addr: string;
+}
+
+export interface Grant {
+  vault_id: string;
+  vault_name: string;
+  /** Backend uses `read+write` literal (not `read_write`) — matches the
+   *  capability scope serialization. */
+  scope: "read" | "read+write";
+}
+
+export interface PairedPeer {
+  device_id: string;
+  device_name: string;
+  /** Unix seconds; null when never reachable post-pair. */
+  last_seen: number | null;
+  grants: Grant[];
+}
+
+export interface PairingStartInitiator {
+  session_id: string;
+  pin: string;
+  expires_at_unix: number;
+}
+
+export interface PairingStartResponder {
+  session_id: string;
+}
+
+export type PairingStepKind =
+  | "awaiting_peer"
+  | "awaiting_confirmation"
+  | "failed"
+  | "complete";
+
+export interface PairingStep {
+  kind: PairingStepKind;
+  peer_fingerprint: string | null;
+  attempts_remaining: number | null;
+}
+
+export async function syncGetSelfIdentity(): Promise<SelfIdentity> {
+  try {
+    return await invoke<SelfIdentity>("sync_get_self_identity");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncSetDeviceName(name: string): Promise<void> {
+  try {
+    await invoke<void>("sync_set_device_name", { name });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncGetDiscoverable(): Promise<boolean> {
+  try {
+    return await invoke<boolean>("sync_get_discoverable");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncSetDiscoverable(on: boolean): Promise<void> {
+  try {
+    await invoke<void>("sync_set_discoverable", { on });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncListDiscoveredPeers(): Promise<DiscoveredPeer[]> {
+  try {
+    return await invoke<DiscoveredPeer[]>("sync_list_discovered_peers");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncListPairedPeers(): Promise<PairedPeer[]> {
+  try {
+    return await invoke<PairedPeer[]>("sync_list_paired_peers");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncPairingStartInitiator(): Promise<PairingStartInitiator> {
+  try {
+    return await invoke<PairingStartInitiator>("sync_pairing_start_initiator");
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncPairingStartResponder(
+  pin: string,
+): Promise<PairingStartResponder> {
+  try {
+    return await invoke<PairingStartResponder>("sync_pairing_start_responder", {
+      pin,
+    });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncPairingStep(
+  sessionId: string,
+  payload?: string,
+): Promise<PairingStep> {
+  try {
+    return await invoke<PairingStep>("sync_pairing_step", {
+      sessionId,
+      payload: payload ?? null,
+    });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncPairingConfirm(sessionId: string): Promise<void> {
+  try {
+    await invoke<void>("sync_pairing_confirm", { sessionId });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncPairingCancel(sessionId: string): Promise<void> {
+  try {
+    await invoke<void>("sync_pairing_cancel", { sessionId });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncGrantVault(
+  peerDeviceId: string,
+  vaultId: string,
+  scope: "read" | "read+write",
+): Promise<void> {
+  try {
+    await invoke<void>("sync_grant_vault", {
+      peerDeviceId,
+      vaultId,
+      scope,
+    });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncRevokePeer(peerDeviceId: string): Promise<void> {
+  try {
+    await invoke<void>("sync_revoke_peer", { peerDeviceId });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function syncRevokeVaultGrant(
+  peerDeviceId: string,
+  vaultId: string,
+): Promise<void> {
+  try {
+    await invoke<void>("sync_revoke_vault_grant", { peerDeviceId, vaultId });
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -804,10 +804,14 @@ export async function syncPairingStartInitiator(): Promise<PairingStartInitiator
 
 export async function syncPairingStartResponder(
   pin: string,
+  peerDeviceId?: string,
+  peerAddr?: string,
 ): Promise<PairingStartResponder> {
   try {
     return await invoke<PairingStartResponder>("sync_pairing_start_responder", {
       pin,
+      peerDeviceId: peerDeviceId ?? null,
+      peerAddr: peerAddr ?? null,
     });
   } catch (e) {
     throw normalizeError(e);

--- a/src/ipc/events.ts
+++ b/src/ipc/events.ts
@@ -152,3 +152,67 @@ export function listenEncryptDropProgress(
     handler(event.payload),
   );
 }
+
+// ── UI-1 — sync events ────────────────────────────────────────────────────
+//
+// Four typed event channels emitted by `commands::sync_cmds::SyncRuntime`.
+// `peers-discovered` is debounced 250 ms server-side; everything else
+// fires once per state transition. Frontend stores must not poll any
+// `sync_*` command on a timer — the contract is event-driven.
+
+import type { DiscoveredPeer } from "./commands";
+
+export interface PeerPairedPayload {
+  device_id: string;
+  device_name: string;
+}
+
+/** Per-vault sync status. `error` is populated on the first transport
+ *  failure for a vault; cleared on the next successful sync. */
+export interface SyncStatusPayload {
+  vault_id: string;
+  peer_count: number;
+  in_flight_files: number;
+  error: string | null;
+}
+
+/** Stale-peer resurrection: a previously paired peer reappears with
+ *  pending changes. UI-5 surfaces this as a persistent toast. */
+export interface StalePeerResurrectPayload {
+  peer_device_id: string;
+  peer_name: string;
+  pending_change_count: number;
+}
+
+export const PEERS_DISCOVERED_EVENT = "sync://peers-discovered";
+export const PEER_PAIRED_EVENT = "sync://peer-paired";
+export const SYNC_STATUS_EVENT = "sync://sync-status";
+export const STALE_PEER_RESURRECT_EVENT = "sync://stale-peer-resurrect";
+
+export function listenPeersDiscovered(
+  handler: (payload: DiscoveredPeer[]) => void,
+): Promise<UnlistenFn> {
+  return listen<DiscoveredPeer[]>(PEERS_DISCOVERED_EVENT, (event) =>
+    handler(event.payload),
+  );
+}
+
+export function listenPeerPaired(
+  handler: (payload: PeerPairedPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<PeerPairedPayload>(PEER_PAIRED_EVENT, (event) => handler(event.payload));
+}
+
+export function listenSyncStatus(
+  handler: (payload: SyncStatusPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<SyncStatusPayload>(SYNC_STATUS_EVENT, (event) => handler(event.payload));
+}
+
+export function listenStalePeerResurrect(
+  handler: (payload: StalePeerResurrectPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<StalePeerResurrectPayload>(STALE_PEER_RESURRECT_EVENT, (event) =>
+    handler(event.payload),
+  );
+}

--- a/src/lib/__tests__/relativeTime.test.ts
+++ b/src/lib/__tests__/relativeTime.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { relativeTime } from "../relativeTime";
+
+describe("relativeTime", () => {
+  afterEach(() => vi.useRealTimers());
+
+  function freezeNow(unixSeconds: number): void {
+    vi.useFakeTimers();
+    vi.setSystemTime(unixSeconds * 1000);
+  }
+
+  it("renders nie for null / undefined", () => {
+    expect(relativeTime(null)).toBe("nie");
+    expect(relativeTime(undefined)).toBe("nie");
+  });
+
+  it("returns gerade eben for sub-45-second deltas", () => {
+    freezeNow(10_000);
+    expect(relativeTime(10_000)).toBe("gerade eben");
+    expect(relativeTime(9_990)).toBe("gerade eben");
+  });
+
+  it("returns gerade eben for future timestamps (clock skew)", () => {
+    freezeNow(10_000);
+    expect(relativeTime(11_000)).toBe("gerade eben");
+  });
+
+  it("renders minutes with singular / plural distinction", () => {
+    freezeNow(10_000);
+    expect(relativeTime(10_000 - 60)).toBe("vor 1 Minute");
+    expect(relativeTime(10_000 - 60 * 5)).toBe("vor 5 Minuten");
+  });
+
+  it("renders hours with singular / plural distinction", () => {
+    freezeNow(10_000);
+    expect(relativeTime(10_000 - 3600)).toBe("vor 1 Stunde");
+    expect(relativeTime(10_000 - 3600 * 2)).toBe("vor 2 Stunden");
+  });
+
+  it("renders days and weeks", () => {
+    freezeNow(10_000_000);
+    expect(relativeTime(10_000_000 - 86400)).toBe("vor 1 Tag");
+    expect(relativeTime(10_000_000 - 86400 * 3)).toBe("vor 3 Tagen");
+    expect(relativeTime(10_000_000 - 86400 * 14)).toBe("vor 2 Wochen");
+  });
+});

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,0 +1,37 @@
+// Compact German relative-time formatter for paired-peer "last seen"
+// timestamps in the Settings → SYNCHRONISIERUNG section.
+//
+// Backend supplies Unix seconds; null means the peer was paired but
+// never reachable since (e.g. paired offline, or peer hasn't been on
+// the LAN since first handshake). UI surfaces null as "nie".
+
+const MIN = 60;
+const HOUR = 60 * 60;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+/** Now, in Unix seconds. Hoisted so tests can stub it. */
+export function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export function relativeTime(unixSeconds: number | null | undefined): string {
+  if (unixSeconds == null) return "nie";
+  const delta = nowSeconds() - unixSeconds;
+  if (delta < 0) return "gerade eben";
+  if (delta < 45) return "gerade eben";
+  if (delta < HOUR) {
+    const m = Math.max(1, Math.round(delta / MIN));
+    return m === 1 ? "vor 1 Minute" : `vor ${m} Minuten`;
+  }
+  if (delta < DAY) {
+    const h = Math.round(delta / HOUR);
+    return h === 1 ? "vor 1 Stunde" : `vor ${h} Stunden`;
+  }
+  if (delta < WEEK) {
+    const d = Math.round(delta / DAY);
+    return d === 1 ? "vor 1 Tag" : `vor ${d} Tagen`;
+  }
+  const w = Math.round(delta / WEEK);
+  return w === 1 ? "vor 1 Woche" : `vor ${w} Wochen`;
+}

--- a/src/store/__tests__/syncStore.test.ts
+++ b/src/store/__tests__/syncStore.test.ts
@@ -1,0 +1,477 @@
+// UI-1 — unit tests for the syncStore.
+//
+// Coverage matrix:
+//   1. `initSyncStore` populates identity / discoverable / paired peers.
+//   2. Event handlers update the matching slice (peers-discovered,
+//      peer-paired triggers re-fetch, sync-status keyed by vault_id,
+//      stale-peer-resurrect appended to queue).
+//   3. Optimistic actions roll back on backend error
+//      (setDiscoverable, revokePeer, revokeVaultGrant).
+//   4. Pairing flow: start → step → confirm clears the pending session.
+//   5. `resetSyncStore` clears state and tears down listeners.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("../../ipc/commands", () => ({
+  syncGetSelfIdentity: vi.fn(),
+  syncSetDeviceName: vi.fn(),
+  syncGetDiscoverable: vi.fn(),
+  syncSetDiscoverable: vi.fn(),
+  syncListDiscoveredPeers: vi.fn(),
+  syncListPairedPeers: vi.fn(),
+  syncPairingStartInitiator: vi.fn(),
+  syncPairingStartResponder: vi.fn(),
+  syncPairingStep: vi.fn(),
+  syncPairingConfirm: vi.fn(),
+  syncPairingCancel: vi.fn(),
+  syncGrantVault: vi.fn(),
+  syncRevokePeer: vi.fn(),
+  syncRevokeVaultGrant: vi.fn(),
+}));
+
+vi.mock("../../ipc/events", () => ({
+  listenPeersDiscovered: vi.fn(async () => () => {}),
+  listenPeerPaired: vi.fn(async () => () => {}),
+  listenSyncStatus: vi.fn(async () => () => {}),
+  listenStalePeerResurrect: vi.fn(async () => () => {}),
+}));
+
+import {
+  syncGetSelfIdentity,
+  syncGetDiscoverable,
+  syncSetDiscoverable,
+  syncListPairedPeers,
+  syncPairingStartInitiator,
+  syncPairingStartResponder,
+  syncPairingStep,
+  syncPairingConfirm,
+  syncPairingCancel,
+  syncGrantVault,
+  syncRevokePeer,
+  syncRevokeVaultGrant,
+} from "../../ipc/commands";
+import {
+  listenPeersDiscovered,
+  listenPeerPaired,
+  listenSyncStatus,
+  listenStalePeerResurrect,
+} from "../../ipc/events";
+
+// Cast the mocks for typed access.
+const m = {
+  getIdentity: syncGetSelfIdentity as unknown as ReturnType<typeof vi.fn>,
+  getDiscoverable: syncGetDiscoverable as unknown as ReturnType<typeof vi.fn>,
+  setDiscoverable: syncSetDiscoverable as unknown as ReturnType<typeof vi.fn>,
+  listPaired: syncListPairedPeers as unknown as ReturnType<typeof vi.fn>,
+  startInitiator: syncPairingStartInitiator as unknown as ReturnType<typeof vi.fn>,
+  startResponder: syncPairingStartResponder as unknown as ReturnType<typeof vi.fn>,
+  step: syncPairingStep as unknown as ReturnType<typeof vi.fn>,
+  confirm: syncPairingConfirm as unknown as ReturnType<typeof vi.fn>,
+  cancel: syncPairingCancel as unknown as ReturnType<typeof vi.fn>,
+  grant: syncGrantVault as unknown as ReturnType<typeof vi.fn>,
+  revokePeer: syncRevokePeer as unknown as ReturnType<typeof vi.fn>,
+  revokeGrant: syncRevokeVaultGrant as unknown as ReturnType<typeof vi.fn>,
+  listenPeers: listenPeersDiscovered as unknown as ReturnType<typeof vi.fn>,
+  listenPaired: listenPeerPaired as unknown as ReturnType<typeof vi.fn>,
+  listenStatus: listenSyncStatus as unknown as ReturnType<typeof vi.fn>,
+  listenStale: listenStalePeerResurrect as unknown as ReturnType<typeof vi.fn>,
+};
+
+import {
+  initSyncStore,
+  resetSyncStore,
+  setDiscoverable,
+  startInitiator,
+  startResponder,
+  stepPairing,
+  confirmPairing,
+  cancelPairing,
+  grantVault,
+  revokePeer,
+  revokeVaultGrant,
+  dismissResurrect,
+  selfIdentity,
+  discoverable,
+  discoveredPeers,
+  pairedPeers,
+  syncStatusByVault,
+  pendingPairingSession,
+  staleResurrectQueue,
+  syncStoreReady,
+} from "../syncStore";
+
+const sampleIdentity = {
+  device_id: "ABCDEFGHIJKLMNOPQRSTUVWX",
+  device_name: "Alice's Mac",
+  pubkey_fingerprint: "ABCDEFGH",
+};
+
+describe("syncStore", () => {
+  beforeEach(() => {
+    Object.values(m).forEach((mock) => mock.mockReset());
+    // Default: every listener returns a no-op unlisten.
+    m.listenPeers.mockImplementation(async () => () => {});
+    m.listenPaired.mockImplementation(async () => () => {});
+    m.listenStatus.mockImplementation(async () => () => {});
+    m.listenStale.mockImplementation(async () => () => {});
+    resetSyncStore();
+  });
+
+  afterEach(() => {
+    resetSyncStore();
+  });
+
+  // ─── init ──────────────────────────────────────────────────────────────
+
+  it("initSyncStore populates identity / discoverable / pairedPeers and flips ready", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(true);
+    m.listPaired.mockResolvedValue([
+      {
+        device_id: "PEER1",
+        device_name: "Bob",
+        last_seen: 1700_000_000,
+        grants: [],
+      },
+    ]);
+    expect(get(syncStoreReady)).toBe(false);
+    await initSyncStore();
+    expect(get(syncStoreReady)).toBe(true);
+    expect(get(selfIdentity)).toEqual(sampleIdentity);
+    expect(get(discoverable)).toBe(true);
+    expect(get(pairedPeers)).toHaveLength(1);
+    expect(get(pairedPeers)[0]!.device_id).toBe("PEER1");
+  });
+
+  it("initSyncStore tolerates a failing identity fetch", async () => {
+    m.getIdentity.mockRejectedValue(new Error("keychain locked"));
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    await initSyncStore();
+    expect(get(selfIdentity)).toBeNull();
+    expect(get(syncStoreReady)).toBe(true);
+  });
+
+  it("initSyncStore subscribes to all four sync events", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    await initSyncStore();
+    expect(m.listenPeers).toHaveBeenCalledTimes(1);
+    expect(m.listenPaired).toHaveBeenCalledTimes(1);
+    expect(m.listenStatus).toHaveBeenCalledTimes(1);
+    expect(m.listenStale).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── event-driven updates ──────────────────────────────────────────────
+
+  it("peers-discovered event replaces discoveredPeers", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    let captured: ((p: any) => void) | null = null;
+    m.listenPeers.mockImplementation(async (h: any) => {
+      captured = h;
+      return () => {};
+    });
+    await initSyncStore();
+    expect(captured).not.toBeNull();
+    captured!([
+      { device_id: "P1", device_name: "X", vaults: [], addr: "1.2.3.4:17091" },
+    ]);
+    expect(get(discoveredPeers)).toHaveLength(1);
+    captured!([]); // empty snapshot replaces the prior list
+    expect(get(discoveredPeers)).toHaveLength(0);
+  });
+
+  it("peer-paired event triggers a paired-peers re-fetch", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        device_id: "FRESH",
+        device_name: "Fresh",
+        last_seen: null,
+        grants: [],
+      },
+    ]);
+    let captured: ((p: any) => void) | null = null;
+    m.listenPaired.mockImplementation(async (h: any) => {
+      captured = h;
+      return () => {};
+    });
+    await initSyncStore();
+    expect(get(pairedPeers)).toHaveLength(0);
+    captured!({ device_id: "FRESH", device_name: "Fresh" });
+    // Wait for the async refresh to complete.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(get(pairedPeers)).toHaveLength(1);
+    expect(get(pairedPeers)[0]!.device_id).toBe("FRESH");
+  });
+
+  it("sync-status events accumulate into syncStatusByVault keyed by vault_id", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    let captured: ((p: any) => void) | null = null;
+    m.listenStatus.mockImplementation(async (h: any) => {
+      captured = h;
+      return () => {};
+    });
+    await initSyncStore();
+    captured!({
+      vault_id: "v1",
+      peer_count: 1,
+      in_flight_files: 3,
+      error: null,
+    });
+    captured!({
+      vault_id: "v2",
+      peer_count: 0,
+      in_flight_files: 0,
+      error: "no peers reachable",
+    });
+    const status = get(syncStatusByVault);
+    expect(status.v1!.peer_count).toBe(1);
+    expect(status.v1!.in_flight_files).toBe(3);
+    expect(status.v2!.error).toBe("no peers reachable");
+    // Update v1: in_flight drops, no error.
+    captured!({ vault_id: "v1", peer_count: 1, in_flight_files: 0, error: null });
+    expect(get(syncStatusByVault).v1!.in_flight_files).toBe(0);
+    // v2 untouched.
+    expect(get(syncStatusByVault).v2!.error).toBe("no peers reachable");
+  });
+
+  it("stale-peer-resurrect events append to the queue with monotonic ids", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    let captured: ((p: any) => void) | null = null;
+    m.listenStale.mockImplementation(async (h: any) => {
+      captured = h;
+      return () => {};
+    });
+    await initSyncStore();
+    captured!({
+      peer_device_id: "PEER1",
+      peer_name: "Bob",
+      pending_change_count: 4,
+    });
+    captured!({
+      peer_device_id: "PEER1",
+      peer_name: "Bob",
+      pending_change_count: 5,
+    });
+    const queue = get(staleResurrectQueue);
+    expect(queue).toHaveLength(2);
+    expect(queue[0]!.id).toBe(1);
+    expect(queue[1]!.id).toBe(2);
+    // dismissResurrect removes every entry for that peer.
+    dismissResurrect("PEER1");
+    expect(get(staleResurrectQueue)).toHaveLength(0);
+  });
+
+  // ─── optimistic actions + rollback ─────────────────────────────────────
+
+  it("setDiscoverable flips the local flag immediately and rolls back on error", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    await initSyncStore();
+    expect(get(discoverable)).toBe(false);
+    // Success path.
+    m.setDiscoverable.mockResolvedValueOnce(undefined);
+    await setDiscoverable(true);
+    expect(get(discoverable)).toBe(true);
+    expect(m.setDiscoverable).toHaveBeenCalledWith(true);
+    // Failure path: prior value restored.
+    m.setDiscoverable.mockRejectedValueOnce(new Error("daemon dead"));
+    await expect(setDiscoverable(false)).rejects.toThrow("daemon dead");
+    expect(get(discoverable)).toBe(true);
+  });
+
+  it("revokePeer optimistically removes the peer and restores on error", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([
+      { device_id: "P1", device_name: "B", last_seen: null, grants: [] },
+      { device_id: "P2", device_name: "C", last_seen: null, grants: [] },
+    ]);
+    await initSyncStore();
+    expect(get(pairedPeers)).toHaveLength(2);
+    m.revokePeer.mockRejectedValueOnce(new Error("nope"));
+    await expect(revokePeer("P1")).rejects.toThrow("nope");
+    // Rollback: P1 is back.
+    expect(get(pairedPeers).map((p) => p.device_id)).toEqual(["P1", "P2"]);
+    m.revokePeer.mockResolvedValueOnce(undefined);
+    await revokePeer("P1");
+    expect(get(pairedPeers).map((p) => p.device_id)).toEqual(["P2"]);
+  });
+
+  it("revokeVaultGrant optimistically drops the grant and restores on error", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([
+      {
+        device_id: "P1",
+        device_name: "B",
+        last_seen: null,
+        grants: [
+          { vault_id: "v1", vault_name: "v1", scope: "read+write" },
+          { vault_id: "v2", vault_name: "v2", scope: "read" },
+        ],
+      },
+    ]);
+    await initSyncStore();
+    m.revokeGrant.mockRejectedValueOnce(new Error("nope"));
+    await expect(revokeVaultGrant("P1", "v1")).rejects.toThrow("nope");
+    expect(get(pairedPeers)[0]!.grants).toHaveLength(2);
+    m.revokeGrant.mockResolvedValueOnce(undefined);
+    await revokeVaultGrant("P1", "v1");
+    expect(get(pairedPeers)[0]!.grants.map((g) => g.vault_id)).toEqual(["v2"]);
+  });
+
+  // ─── pairing flow ──────────────────────────────────────────────────────
+
+  it("startInitiator stores a pending session with PIN and expiry", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    await initSyncStore();
+    m.startInitiator.mockResolvedValueOnce({
+      session_id: "S1",
+      pin: "654321",
+      expires_at_unix: 1700_000_000,
+    });
+    const dto = await startInitiator();
+    expect(dto.pin).toBe("654321");
+    const pending = get(pendingPairingSession);
+    expect(pending?.role).toBe("initiator");
+    expect(pending?.pin).toBe("654321");
+  });
+
+  it("startResponder stores a pending responder session", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    await initSyncStore();
+    m.startResponder.mockResolvedValueOnce({ session_id: "R1" });
+    await startResponder("123456");
+    const pending = get(pendingPairingSession);
+    expect(pending?.role).toBe("responder");
+    expect(pending?.pin).toBeNull();
+    expect(m.startResponder).toHaveBeenCalledWith("123456");
+  });
+
+  it("stepPairing dispatches the right session id and stashes the result", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    await initSyncStore();
+    m.startInitiator.mockResolvedValueOnce({
+      session_id: "SID",
+      pin: "111111",
+      expires_at_unix: 0,
+    });
+    await startInitiator();
+    m.step.mockResolvedValueOnce({
+      kind: "awaiting_confirmation",
+      peer_fingerprint: "ABCDEFGH",
+      attempts_remaining: 3,
+    });
+    const step = await stepPairing();
+    expect(step.kind).toBe("awaiting_confirmation");
+    expect(m.step).toHaveBeenCalledWith("SID", undefined);
+    expect(get(pendingPairingSession)?.last_step?.peer_fingerprint).toBe("ABCDEFGH");
+  });
+
+  it("stepPairing throws when no pending session exists", async () => {
+    await expect(stepPairing()).rejects.toThrow("no pairing session");
+  });
+
+  it("confirmPairing clears the pending session and refreshes paired peers", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      { device_id: "NEW", device_name: "n", last_seen: null, grants: [] },
+    ]);
+    await initSyncStore();
+    m.startInitiator.mockResolvedValueOnce({
+      session_id: "C1",
+      pin: "1",
+      expires_at_unix: 0,
+    });
+    await startInitiator();
+    m.confirm.mockResolvedValueOnce(undefined);
+    await confirmPairing();
+    expect(get(pendingPairingSession)).toBeNull();
+    expect(get(pairedPeers).map((p) => p.device_id)).toEqual(["NEW"]);
+  });
+
+  it("cancelPairing clears the pending session even if cancel command fails", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValue([]);
+    await initSyncStore();
+    m.startInitiator.mockResolvedValueOnce({
+      session_id: "X",
+      pin: "1",
+      expires_at_unix: 0,
+    });
+    await startInitiator();
+    m.cancel.mockRejectedValueOnce(new Error("backend gone"));
+    // The store still clears the pending session (matches encryption-modal
+    // pattern: the user clicked cancel; their intent is final regardless
+    // of whether the backend ack came through).
+    await cancelPairing();
+    expect(get(pendingPairingSession)).toBeNull();
+  });
+
+  // ─── grants ────────────────────────────────────────────────────────────
+
+  it("grantVault dispatches the command and refreshes the list", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(false);
+    m.listPaired.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        device_id: "P1",
+        device_name: "B",
+        last_seen: null,
+        grants: [{ vault_id: "v1", vault_name: "v1", scope: "read" }],
+      },
+    ]);
+    await initSyncStore();
+    m.grant.mockResolvedValueOnce(undefined);
+    await grantVault("P1", "v1", "read");
+    expect(m.grant).toHaveBeenCalledWith("P1", "v1", "read");
+    expect(get(pairedPeers)[0]!.grants).toHaveLength(1);
+  });
+
+  // ─── reset ─────────────────────────────────────────────────────────────
+
+  it("resetSyncStore clears state and tears down listeners", async () => {
+    m.getIdentity.mockResolvedValue(sampleIdentity);
+    m.getDiscoverable.mockResolvedValue(true);
+    m.listPaired.mockResolvedValue([]);
+    const unlistenA = vi.fn();
+    const unlistenB = vi.fn();
+    const unlistenC = vi.fn();
+    const unlistenD = vi.fn();
+    m.listenPeers.mockResolvedValueOnce(unlistenA);
+    m.listenPaired.mockResolvedValueOnce(unlistenB);
+    m.listenStatus.mockResolvedValueOnce(unlistenC);
+    m.listenStale.mockResolvedValueOnce(unlistenD);
+    await initSyncStore();
+    expect(get(discoverable)).toBe(true);
+    resetSyncStore();
+    expect(unlistenA).toHaveBeenCalledTimes(1);
+    expect(unlistenB).toHaveBeenCalledTimes(1);
+    expect(unlistenC).toHaveBeenCalledTimes(1);
+    expect(unlistenD).toHaveBeenCalledTimes(1);
+    expect(get(syncStoreReady)).toBe(false);
+    expect(get(discoverable)).toBe(false);
+    expect(get(selfIdentity)).toBeNull();
+  });
+});

--- a/src/store/__tests__/toastStore.test.ts
+++ b/src/store/__tests__/toastStore.test.ts
@@ -1,0 +1,237 @@
+// UI-5 — toastStore persist API + action option.
+//
+// These tests are additive to tests/Toast.test.ts (UI-04). They cover
+// only the new surface introduced by UI-5: the `persist` flag (no
+// auto-dismiss), the per-toast `action` slot, and the stale-peer
+// resurrect wiring that pushes a persistent warning toast for each
+// new entry in `syncStore.staleResurrectQueue`.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("../../ipc/commands", () => ({
+  syncGetSelfIdentity: vi.fn(async () => null),
+  syncGetDiscoverable: vi.fn(async () => false),
+  syncListPairedPeers: vi.fn(async () => []),
+  syncSetDiscoverable: vi.fn(),
+  syncSetDeviceName: vi.fn(),
+  syncPairingStartInitiator: vi.fn(),
+  syncPairingStartResponder: vi.fn(),
+  syncPairingStep: vi.fn(),
+  syncPairingConfirm: vi.fn(),
+  syncPairingCancel: vi.fn(),
+  syncGrantVault: vi.fn(),
+  syncRevokePeer: vi.fn(),
+  syncRevokeVaultGrant: vi.fn(),
+}));
+
+vi.mock("../../ipc/events", () => ({
+  listenPeersDiscovered: vi.fn(async () => () => {}),
+  listenPeerPaired: vi.fn(async () => () => {}),
+  listenSyncStatus: vi.fn(async () => () => {}),
+  listenStalePeerResurrect: vi.fn(async () => () => {}),
+}));
+
+import { toastStore } from "../toastStore";
+import {
+  initStaleResurrectToasts,
+  resetStaleResurrectToasts,
+} from "../staleResurrectToasts";
+import {
+  _setStateForTest as setSyncState,
+  resetSyncStore,
+} from "../syncStore";
+
+beforeEach(() => {
+  toastStore._reset();
+  resetSyncStore();
+  resetStaleResurrectToasts();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ─── Part A — toastStore.persist + action ────────────────────────────────
+
+describe("UI-5 toastStore.push({ persist: true })", () => {
+  it("persist_true_skips_auto_dismiss: persistent toast is NOT removed after 5000 ms", () => {
+    vi.useFakeTimers();
+    toastStore.push({
+      variant: "warning",
+      message: "stays put",
+      persist: true,
+    });
+    expect(get(toastStore)).toHaveLength(1);
+    vi.advanceTimersByTime(60_000);
+    expect(get(toastStore)).toHaveLength(1);
+  });
+
+  it("persist_false_default_still_auto_dismisses_after_5s: omitting persist preserves UI-04 behaviour", () => {
+    vi.useFakeTimers();
+    toastStore.push({ variant: "error", message: "fleeting" });
+    expect(get(toastStore)).toHaveLength(1);
+    vi.advanceTimersByTime(5001);
+    expect(get(toastStore)).toHaveLength(0);
+  });
+
+  it("explicit persist:false matches the default (auto-dismisses)", () => {
+    vi.useFakeTimers();
+    toastStore.push({ variant: "info", message: "x", persist: false });
+    vi.advanceTimersByTime(5001);
+    expect(get(toastStore)).toHaveLength(0);
+  });
+
+  it("close_button_removes_persistent_toast: dismiss(id) clears a persistent toast", () => {
+    const id = toastStore.push({
+      variant: "warning",
+      message: "x",
+      persist: true,
+    });
+    expect(get(toastStore)).toHaveLength(1);
+    toastStore.dismiss(id);
+    expect(get(toastStore)).toHaveLength(0);
+  });
+
+  it("backwards-compat: existing convenience helpers (.error, .info) still auto-dismiss", () => {
+    vi.useFakeTimers();
+    toastStore.error("boom");
+    toastStore.info("ok");
+    expect(get(toastStore)).toHaveLength(2);
+    vi.advanceTimersByTime(5001);
+    expect(get(toastStore)).toHaveLength(0);
+  });
+
+  it("action option is stored on the toast and surfaced to subscribers", () => {
+    const onClick = vi.fn();
+    toastStore.push({
+      variant: "warning",
+      message: "with action",
+      persist: true,
+      action: { label: "Überprüfen", onClick },
+    });
+    const items = get(toastStore);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.action?.label).toBe("Überprüfen");
+    expect(items[0]!.action?.onClick).toBe(onClick);
+  });
+
+  it("role + ariaLive options propagate to the stored toast", () => {
+    toastStore.push({
+      variant: "warning",
+      message: "alert",
+      persist: true,
+      role: "alert",
+      ariaLive: "assertive",
+    });
+    const items = get(toastStore);
+    expect(items[0]!.role).toBe("alert");
+    expect(items[0]!.ariaLive).toBe("assertive");
+  });
+
+  it("MAX_TOASTS cap still applies even when oldest is persistent", () => {
+    toastStore.push({ variant: "warning", message: "p1", persist: true });
+    toastStore.push({ variant: "info", message: "x" });
+    toastStore.push({ variant: "info", message: "y" });
+    toastStore.push({ variant: "info", message: "z" });
+    const items = get(toastStore);
+    expect(items).toHaveLength(3);
+    expect(items.some((t) => t.message === "p1")).toBe(false);
+  });
+});
+
+// ─── Part B — stale-peer resurrect wiring ───────────────────────────────
+
+describe("UI-5 stale-peer resurrect → toast", () => {
+  it("stale_peer_event_pushes_persistent_warning_toast", async () => {
+    initStaleResurrectToasts();
+    setSyncState({
+      staleResurrectQueue: [
+        {
+          id: 1,
+          peer_device_id: "PEER-A",
+          peer_name: "MacBook Bob",
+          pending_change_count: 4,
+        },
+      ],
+    });
+    const items = get(toastStore);
+    expect(items).toHaveLength(1);
+    const t = items[0]!;
+    expect(t.variant).toBe("warning");
+    expect(t.persist).toBe(true);
+    expect(t.role).toBe("alert");
+    expect(t.ariaLive).toBe("assertive");
+    expect(t.message).toBe(
+      "MacBook Bob war über 30 Tage offline — 4 ausstehende Änderungen prüfen?",
+    );
+    expect(t.action?.label).toBe("Überprüfen");
+  });
+
+  it("does not auto-dismiss the resurrect toast", () => {
+    vi.useFakeTimers();
+    initStaleResurrectToasts();
+    setSyncState({
+      staleResurrectQueue: [
+        {
+          id: 1,
+          peer_device_id: "PEER-A",
+          peer_name: "Bob",
+          pending_change_count: 1,
+        },
+      ],
+    });
+    expect(get(toastStore)).toHaveLength(1);
+    vi.advanceTimersByTime(60_000);
+    expect(get(toastStore)).toHaveLength(1);
+  });
+
+  it("only pushes one toast per queue entry, even when other slices change", () => {
+    initStaleResurrectToasts();
+    setSyncState({
+      staleResurrectQueue: [
+        { id: 1, peer_device_id: "P1", peer_name: "Bob", pending_change_count: 1 },
+      ],
+    });
+    expect(get(toastStore)).toHaveLength(1);
+    // Unrelated re-set with the same entry must not duplicate.
+    setSyncState({
+      staleResurrectQueue: [
+        { id: 1, peer_device_id: "P1", peer_name: "Bob", pending_change_count: 1 },
+      ],
+      discoverable: true,
+    });
+    expect(get(toastStore)).toHaveLength(1);
+  });
+
+  it("action_button_navigates_to_sync_section_for_peer: invokes onOpenSyncSettings with peer id", () => {
+    const open = vi.fn();
+    initStaleResurrectToasts({ onOpenSyncSettings: open });
+    setSyncState({
+      staleResurrectQueue: [
+        { id: 9, peer_device_id: "PEER-Z", peer_name: "Z", pending_change_count: 2 },
+      ],
+    });
+    const t = get(toastStore)[0]!;
+    t.action!.onClick();
+    expect(open).toHaveBeenCalledWith("PEER-Z");
+  });
+
+  it("clicking the action does NOT remove the peer from staleResurrectQueue (close button only closes the toast)", () => {
+    const open = vi.fn();
+    initStaleResurrectToasts({ onOpenSyncSettings: open });
+    setSyncState({
+      staleResurrectQueue: [
+        { id: 1, peer_device_id: "P1", peer_name: "Bob", pending_change_count: 1 },
+      ],
+    });
+    const t = get(toastStore)[0]!;
+    t.action!.onClick();
+    // Per locked decision: peer stays in queue until handled in Settings.
+    // We assert via syncStore state, since dismissResurrect() is the
+    // explicit dismissal API.
+    // (We can't easily import _getStateForTest here without re-exporting,
+    //  but the action callback contract is the focused behaviour.)
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/pairingModalStore.ts
+++ b/src/store/pairingModalStore.ts
@@ -1,0 +1,28 @@
+// Cross-component opener for the PairingModal (UI-3). Settings →
+// SYNCHRONISIERUNG section calls `openPairingModal()` to start a
+// fresh pairing session, or `openPairingModal({ peer })` to pre-fill
+// the modal with a peer the user just clicked in the discovered
+// list. The PairingModal subscribes to this store and renders when
+// the value is non-null.
+//
+// Mirrors `encryptionModalStore.ts` — keeps modal lifetime off the
+// component that triggered the open (Settings can be torn down via
+// Escape mid-pairing without aborting the flow).
+
+import { writable } from "svelte/store";
+import type { DiscoveredPeer } from "../ipc/commands";
+
+export type PairingModalRequest = {
+  /** When set, pre-fill the responder/initiator UI with this peer. */
+  peer?: DiscoveredPeer;
+} | null;
+
+export const pairingModal = writable<PairingModalRequest>(null);
+
+export function openPairingModal(peer?: DiscoveredPeer): void {
+  pairingModal.set(peer ? { peer } : {});
+}
+
+export function closePairingModal(): void {
+  pairingModal.set(null);
+}

--- a/src/store/pairingModalStore.ts
+++ b/src/store/pairingModalStore.ts
@@ -15,12 +15,21 @@ import type { DiscoveredPeer } from "../ipc/commands";
 export type PairingModalRequest = {
   /** When set, pre-fill the responder/initiator UI with this peer. */
   peer?: DiscoveredPeer;
+  /** When set, the modal opens directly in responder mode and dials
+   *  this address — skipping mDNS discovery. Used on Android (no NSD
+   *  bridge yet) and any LAN where multicast is blocked. */
+  manualPeerAddr?: string;
 } | null;
 
 export const pairingModal = writable<PairingModalRequest>(null);
 
 export function openPairingModal(peer?: DiscoveredPeer): void {
   pairingModal.set(peer ? { peer } : {});
+}
+
+/** Open the modal in responder mode and dial `addr` (host or host:port). */
+export function openPairingModalWithAddr(addr: string): void {
+  pairingModal.set({ manualPeerAddr: addr });
 }
 
 export function closePairingModal(): void {

--- a/src/store/settingsModalStore.ts
+++ b/src/store/settingsModalStore.ts
@@ -1,0 +1,37 @@
+// Cross-component opener for the Settings modal.
+//
+// VaultLayout still owns the `open` state of the modal (via a local
+// `$state` flag) — but components that need to *request* settings be
+// opened from outside the layout (e.g. UI-4 SyncStatusPill error
+// state, future toast actions) push into this store, and VaultLayout
+// subscribes once and forwards to its local flag.
+//
+// The store carries an optional section anchor so callers can ask
+// the modal to scroll to a specific section after open. VaultLayout
+// resolves the anchor by looking up `[data-testid=settings-<anchor>]`
+// once the modal is rendered.
+
+import { writable } from "svelte/store";
+
+export type SettingsAnchor = "sync" | null;
+
+export interface SettingsModalRequest {
+  /** Monotonic counter so the same anchor request twice in a row still
+   *  triggers a fresh `open` (subscribers compare against the previous
+   *  value reference). */
+  seq: number;
+  anchor: SettingsAnchor;
+}
+
+const internal = writable<SettingsModalRequest | null>(null);
+let seq = 0;
+
+export const settingsModalRequest = { subscribe: internal.subscribe };
+
+export function requestOpenSettings(anchor: SettingsAnchor = null): void {
+  internal.set({ seq: ++seq, anchor });
+}
+
+export function clearSettingsRequest(): void {
+  internal.set(null);
+}

--- a/src/store/staleResurrectToasts.ts
+++ b/src/store/staleResurrectToasts.ts
@@ -1,0 +1,83 @@
+// UI-5 — bridge: syncStore.staleResurrectQueue → persistent toast.
+//
+// A previously paired peer that comes back online with > 30 days of
+// drift surfaces in syncStore.staleResurrectQueue (UI-1 wires the
+// `sync://stale-peer-resurrect` event into the queue). For each NEW
+// entry we push a persistent warning toast carrying:
+//
+//   - role="alert" / aria-live="assertive"   (immediate announce)
+//   - persist: true                          (decision 3 — never auto-dismiss)
+//   - action "Überprüfen"                    (opens Settings → SYNC, scoped)
+//
+// The toast's ✕ button only closes the toast; the peer remains in
+// syncStore.staleResurrectQueue until handled in Settings (caller of
+// onOpenSyncSettings is responsible for dispatching dismissResurrect()
+// once the user accepts or declines the resync).
+
+import { staleResurrectQueue, type StaleResurrectEntry } from "./syncStore";
+import { toastStore } from "./toastStore";
+
+export interface StaleResurrectToastsOptions {
+  /** Invoked when the user clicks "Überprüfen". Receives the peer's
+   *  device id so the consumer can scope the SYNC settings panel to
+   *  that peer. UI-2 (settings-engineer) owns the actual modal-open
+   *  side; this module just bridges the click. */
+  onOpenSyncSettings?: (peerDeviceId: string) => void;
+}
+
+let unsubscribe: (() => void) | null = null;
+let seenIds = new Set<number>();
+let onOpen: ((peerDeviceId: string) => void) | null = null;
+
+function buildMessage(entry: StaleResurrectEntry): string {
+  return `${entry.peer_name} war über 30 Tage offline — ${entry.pending_change_count} ausstehende Änderungen prüfen?`;
+}
+
+function pushToastFor(entry: StaleResurrectEntry): void {
+  toastStore.push({
+    variant: "warning",
+    message: buildMessage(entry),
+    persist: true,
+    role: "alert",
+    ariaLive: "assertive",
+    action: {
+      label: "Überprüfen",
+      onClick: () => {
+        onOpen?.(entry.peer_device_id);
+      },
+    },
+  });
+}
+
+/** Start watching the syncStore queue. Idempotent — calling twice
+ *  replaces the previous subscription. Safe to call after
+ *  initSyncStore() at app bootstrap. */
+export function initStaleResurrectToasts(
+  options: StaleResurrectToastsOptions = {},
+): void {
+  resetStaleResurrectToasts();
+  onOpen = options.onOpenSyncSettings ?? null;
+  unsubscribe = staleResurrectQueue.subscribe((queue) => {
+    for (const entry of queue) {
+      if (seenIds.has(entry.id)) continue;
+      seenIds.add(entry.id);
+      pushToastFor(entry);
+    }
+  });
+}
+
+/** Tear down the subscription and forget which entries we've already
+ *  surfaced. Used by tests; production keeps the bridge live for the
+ *  whole app lifetime. */
+export function resetStaleResurrectToasts(): void {
+  if (unsubscribe) {
+    try {
+      unsubscribe();
+    } catch {
+      /* swallow */
+    }
+  }
+  unsubscribe = null;
+  seenIds = new Set<number>();
+  onOpen = null;
+}

--- a/src/store/syncStore.ts
+++ b/src/store/syncStore.ts
@@ -291,8 +291,12 @@ export async function startInitiator(): Promise<PairingStartInitiator> {
   return dto;
 }
 
-export async function startResponder(pin: string): Promise<PairingStartResponder> {
-  const dto = await syncPairingStartResponder(pin);
+export async function startResponder(
+  pin: string,
+  peerDeviceId?: string,
+  peerAddr?: string,
+): Promise<PairingStartResponder> {
+  const dto = await syncPairingStartResponder(pin, peerDeviceId, peerAddr);
   patch({
     pendingPairingSession: {
       session_id: dto.session_id,

--- a/src/store/syncStore.ts
+++ b/src/store/syncStore.ts
@@ -1,0 +1,409 @@
+// UI-1 — frontend store for the LAN sync IPC bridge.
+//
+// Mirrors `commands::sync_cmds::SyncRuntime` on the Rust side. The store
+// holds five independent slices (identity, discoverable toggle,
+// discovered-peer list, paired-peer list, per-vault sync status), plus
+// two queue-shaped slices for in-flight pairing flows and stale-peer
+// resurrect prompts.
+//
+// Update strategy:
+// - `init()` runs once at app bootstrap. It fetches the initial
+//   identity / discoverable / paired-peers state and subscribes to all
+//   four `sync://*` events. Subsequent changes arrive exclusively via
+//   events; the store NEVER polls a `sync_*` command on a timer.
+// - User actions (toggle discoverable, start pairing, grant vault,
+//   etc.) dispatch a command and apply an optimistic update. On error
+//   the optimistic update rolls back and the error is rethrown so the
+//   caller can render it (toast / inline / modal — store-level code is
+//   purpose-agnostic).
+//
+// Why optimistic on `setDiscoverable`: the toggle is the most-clicked
+// surface in Settings, and waiting ~50 ms for the round-trip on every
+// click feels laggy. Other actions (pairing, grants) are explicit
+// confirmation flows where the user expects a brief spinner — those
+// dispatch the command first and update state from the response.
+
+import { writable, derived, get, type Readable } from "svelte/store";
+
+import {
+  syncGetSelfIdentity,
+  syncGetDiscoverable,
+  syncSetDiscoverable,
+  syncListPairedPeers,
+  syncPairingStartInitiator,
+  syncPairingStartResponder,
+  syncPairingStep,
+  syncPairingConfirm,
+  syncPairingCancel,
+  syncGrantVault,
+  syncRevokePeer,
+  syncRevokeVaultGrant,
+  type SelfIdentity,
+  type DiscoveredPeer,
+  type PairedPeer,
+  type PairingStartInitiator,
+  type PairingStartResponder,
+  type PairingStep,
+} from "../ipc/commands";
+import {
+  listenPeersDiscovered,
+  listenPeerPaired,
+  listenSyncStatus,
+  listenStalePeerResurrect,
+  type SyncStatusPayload,
+  type StalePeerResurrectPayload,
+} from "../ipc/events";
+
+export type PairingSessionRole = "initiator" | "responder";
+
+export interface PendingPairingSession {
+  session_id: string;
+  role: PairingSessionRole;
+  /** Initiator only — the 6-digit PIN displayed to the user. */
+  pin: string | null;
+  /** Initiator only — Unix seconds at which the PIN expires. */
+  expires_at_unix: number | null;
+  /** Latest poll of the state machine; null until the first step()
+   *  has returned. */
+  last_step: PairingStep | null;
+}
+
+export interface StaleResurrectEntry extends StalePeerResurrectPayload {
+  /** Monotonic id assigned client-side so duplicate-peer events
+   *  produce a queue entry per occurrence rather than collapsing. */
+  id: number;
+}
+
+interface SyncStoreState {
+  selfIdentity: SelfIdentity | null;
+  discoverable: boolean;
+  discoveredPeers: DiscoveredPeer[];
+  pairedPeers: PairedPeer[];
+  /** Keyed by `vault_id`. Cleared per-vault when a `peer_count = 0` and
+   *  no `error` arrives — i.e. the steady empty state. */
+  syncStatusByVault: Record<string, SyncStatusPayload>;
+  pendingPairingSession: PendingPairingSession | null;
+  staleResurrectQueue: StaleResurrectEntry[];
+  /** True once `init()` has finished its initial fetches. UI shells
+   *  bind on this to render skeletons during cold start. */
+  ready: boolean;
+}
+
+const initialState: SyncStoreState = {
+  selfIdentity: null,
+  discoverable: false,
+  discoveredPeers: [],
+  pairedPeers: [],
+  syncStatusByVault: {},
+  pendingPairingSession: null,
+  staleResurrectQueue: [],
+  ready: false,
+};
+
+const internal = writable<SyncStoreState>({ ...initialState });
+
+let unlistenFns: Array<() => void> = [];
+let staleSeq = 0;
+
+// ─── Derived selectors ─────────────────────────────────────────────────────
+
+export const selfIdentity: Readable<SelfIdentity | null> = derived(
+  internal,
+  ($s) => $s.selfIdentity,
+);
+
+export const discoverable: Readable<boolean> = derived(internal, ($s) => $s.discoverable);
+
+export const discoveredPeers: Readable<DiscoveredPeer[]> = derived(
+  internal,
+  ($s) => $s.discoveredPeers,
+);
+
+export const pairedPeers: Readable<PairedPeer[]> = derived(
+  internal,
+  ($s) => $s.pairedPeers,
+);
+
+export const syncStatusByVault: Readable<Record<string, SyncStatusPayload>> = derived(
+  internal,
+  ($s) => $s.syncStatusByVault,
+);
+
+export const pendingPairingSession: Readable<PendingPairingSession | null> = derived(
+  internal,
+  ($s) => $s.pendingPairingSession,
+);
+
+export const staleResurrectQueue: Readable<StaleResurrectEntry[]> = derived(
+  internal,
+  ($s) => $s.staleResurrectQueue,
+);
+
+export const syncStoreReady: Readable<boolean> = derived(internal, ($s) => $s.ready);
+
+// ─── Internals ─────────────────────────────────────────────────────────────
+
+function patch(p: Partial<SyncStoreState>): void {
+  internal.update((s) => ({ ...s, ...p }));
+}
+
+async function refreshPairedPeers(): Promise<void> {
+  try {
+    const peers = await syncListPairedPeers();
+    patch({ pairedPeers: peers });
+  } catch (e) {
+    // Don't throw — list_paired_peers can transiently fail (e.g. SQLite
+    // open race during vault switch). Last-known state remains; the
+    // next event-driven fetch will recover.
+    // eslint-disable-next-line no-console
+    console.warn("syncStore: refreshPairedPeers failed", e);
+  }
+}
+
+// ─── Actions ───────────────────────────────────────────────────────────────
+
+/** Run once at app bootstrap. Fetches initial identity + discoverable +
+ *  paired-peers, then subscribes to the four `sync://*` events. */
+export async function initSyncStore(): Promise<void> {
+  // Tear down any previous subscriptions (HMR / test resets).
+  for (const f of unlistenFns) {
+    try {
+      f();
+    } catch {
+      /* swallow */
+    }
+  }
+  unlistenFns = [];
+
+  // Initial fetches in parallel — they're independent and a slow
+  // mDNS daemon should not block the identity card render.
+  const [identityRes, discoverableRes, pairedRes] = await Promise.allSettled([
+    syncGetSelfIdentity(),
+    syncGetDiscoverable(),
+    syncListPairedPeers(),
+  ]);
+
+  patch({
+    selfIdentity:
+      identityRes.status === "fulfilled" ? identityRes.value : null,
+    discoverable:
+      discoverableRes.status === "fulfilled" ? discoverableRes.value : false,
+    pairedPeers: pairedRes.status === "fulfilled" ? pairedRes.value : [],
+    ready: true,
+  });
+
+  try {
+    unlistenFns.push(
+      await listenPeersDiscovered((peers) => {
+        patch({ discoveredPeers: peers });
+      }),
+    );
+    unlistenFns.push(
+      await listenPeerPaired(() => {
+        // Re-fetch the paired list rather than splice the event payload —
+        // a confirmed peer also needs its (initially empty) grants array
+        // surfaced, which only the full query returns.
+        void refreshPairedPeers();
+      }),
+    );
+    unlistenFns.push(
+      await listenSyncStatus((status) => {
+        internal.update((s) => ({
+          ...s,
+          syncStatusByVault: {
+            ...s.syncStatusByVault,
+            [status.vault_id]: status,
+          },
+        }));
+      }),
+    );
+    unlistenFns.push(
+      await listenStalePeerResurrect((payload) => {
+        const entry: StaleResurrectEntry = { ...payload, id: ++staleSeq };
+        internal.update((s) => ({
+          ...s,
+          staleResurrectQueue: [...s.staleResurrectQueue, entry],
+        }));
+      }),
+    );
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("syncStore: subscribe failed", e);
+  }
+}
+
+/** Tear down event listeners. Used by tests; production typically
+ *  keeps the store live for the whole app lifetime. */
+export function resetSyncStore(): void {
+  for (const f of unlistenFns) {
+    try {
+      f();
+    } catch {
+      /* swallow */
+    }
+  }
+  unlistenFns = [];
+  staleSeq = 0;
+  internal.set({ ...initialState });
+}
+
+/** Toggle the "Discoverable on this network" preference. Optimistic:
+ *  the local flag flips immediately; on backend failure the prior
+ *  value is restored and the error rethrown. */
+export async function setDiscoverable(on: boolean): Promise<void> {
+  const previous = get(internal).discoverable;
+  patch({ discoverable: on });
+  try {
+    await syncSetDiscoverable(on);
+  } catch (e) {
+    patch({ discoverable: previous });
+    throw e;
+  }
+}
+
+export async function setDeviceName(name: string): Promise<void> {
+  const previous = get(internal).selfIdentity;
+  // Optimistic update on the cached identity.
+  if (previous) {
+    patch({ selfIdentity: { ...previous, device_name: name } });
+  }
+  try {
+    const { syncSetDeviceName } = await import("../ipc/commands");
+    await syncSetDeviceName(name);
+  } catch (e) {
+    patch({ selfIdentity: previous });
+    throw e;
+  }
+}
+
+export async function startInitiator(): Promise<PairingStartInitiator> {
+  const dto = await syncPairingStartInitiator();
+  patch({
+    pendingPairingSession: {
+      session_id: dto.session_id,
+      role: "initiator",
+      pin: dto.pin,
+      expires_at_unix: dto.expires_at_unix,
+      last_step: null,
+    },
+  });
+  return dto;
+}
+
+export async function startResponder(pin: string): Promise<PairingStartResponder> {
+  const dto = await syncPairingStartResponder(pin);
+  patch({
+    pendingPairingSession: {
+      session_id: dto.session_id,
+      role: "responder",
+      pin: null,
+      expires_at_unix: null,
+      last_step: null,
+    },
+  });
+  return dto;
+}
+
+export async function stepPairing(payload?: string): Promise<PairingStep> {
+  const session = get(internal).pendingPairingSession;
+  if (!session) {
+    throw new Error("no pairing session in progress");
+  }
+  const step = await syncPairingStep(session.session_id, payload);
+  patch({
+    pendingPairingSession: { ...session, last_step: step },
+  });
+  return step;
+}
+
+export async function confirmPairing(): Promise<void> {
+  const session = get(internal).pendingPairingSession;
+  if (!session) {
+    throw new Error("no pairing session in progress");
+  }
+  await syncPairingConfirm(session.session_id);
+  patch({ pendingPairingSession: null });
+  // The peer-paired event handler will refresh the list, but call it
+  // here too so the UI doesn't depend on event arrival timing.
+  await refreshPairedPeers();
+}
+
+export async function cancelPairing(): Promise<void> {
+  const session = get(internal).pendingPairingSession;
+  if (!session) return;
+  // The user clicked Cancel; their intent is final. We notify the
+  // backend but swallow errors — even if the backend ack fails the
+  // local session is gone from the user's perspective. Matches the
+  // encryption-modal cancel idiom.
+  try {
+    await syncPairingCancel(session.session_id);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("syncStore: cancel pairing backend error", e);
+  }
+  patch({ pendingPairingSession: null });
+}
+
+export async function grantVault(
+  peerDeviceId: string,
+  vaultId: string,
+  scope: "read" | "read+write",
+): Promise<void> {
+  await syncGrantVault(peerDeviceId, vaultId, scope);
+  await refreshPairedPeers();
+}
+
+export async function revokePeer(peerDeviceId: string): Promise<void> {
+  // Optimistic: remove from the visible list immediately. Restore on error.
+  const previous = get(internal).pairedPeers;
+  patch({ pairedPeers: previous.filter((p) => p.device_id !== peerDeviceId) });
+  try {
+    await syncRevokePeer(peerDeviceId);
+  } catch (e) {
+    patch({ pairedPeers: previous });
+    throw e;
+  }
+}
+
+export async function revokeVaultGrant(
+  peerDeviceId: string,
+  vaultId: string,
+): Promise<void> {
+  const previous = get(internal).pairedPeers;
+  patch({
+    pairedPeers: previous.map((p) =>
+      p.device_id === peerDeviceId
+        ? { ...p, grants: p.grants.filter((g) => g.vault_id !== vaultId) }
+        : p,
+    ),
+  });
+  try {
+    await syncRevokeVaultGrant(peerDeviceId, vaultId);
+  } catch (e) {
+    patch({ pairedPeers: previous });
+    throw e;
+  }
+}
+
+/** UI-5 hook: dismiss a stale-peer-resurrect entry once the user has
+ *  acted (accepted resync or declined). */
+export function dismissResurrect(peerDeviceId: string): void {
+  internal.update((s) => ({
+    ...s,
+    staleResurrectQueue: s.staleResurrectQueue.filter(
+      (e) => e.peer_device_id !== peerDeviceId,
+    ),
+  }));
+}
+
+// ─── Test helpers ──────────────────────────────────────────────────────────
+
+/** Test-only: snapshot the underlying internal state. */
+export function _getStateForTest(): SyncStoreState {
+  return get(internal);
+}
+
+/** Test-only: directly set state. */
+export function _setStateForTest(patch: Partial<SyncStoreState>): void {
+  internal.update((s) => ({ ...s, ...patch }));
+}

--- a/src/store/syncStore.ts
+++ b/src/store/syncStore.ts
@@ -36,6 +36,7 @@ import {
   syncPairingConfirm,
   syncPairingCancel,
   syncGrantVault,
+  syncPairingGrantVault,
   syncRevokePeer,
   syncRevokeVaultGrant,
   type SelfIdentity,
@@ -350,6 +351,24 @@ export async function grantVault(
   scope: "read" | "read+write",
 ): Promise<void> {
   await syncGrantVault(peerDeviceId, vaultId, scope);
+  await refreshPairedPeers();
+}
+
+/**
+ * Issue a vault grant inside an active pairing session. Routes through
+ * the pairing engine's open Noise channel — both sides must be in step
+ * 4 of their respective PairingModal flows simultaneously, since the
+ * underlying engine call is symmetric and blocks waiting for the peer.
+ */
+export async function pairingGrantVault(
+  vaultId: string,
+  scope: "read" | "read+write",
+): Promise<void> {
+  const session = get(internal).pendingPairingSession;
+  if (!session) {
+    throw new Error("pairingGrantVault: no active pairing session");
+  }
+  await syncPairingGrantVault(session.session_id, vaultId, scope);
   await refreshPairedPeers();
 }
 

--- a/src/store/toastStore.ts
+++ b/src/store/toastStore.ts
@@ -1,15 +1,40 @@
-// toastStore — UI-04 unified error surface.
+// toastStore — UI-04 unified error surface, extended in UI-5.
 // Classic Svelte `writable` per D-06 / RC-01. Caps at 3 stacked toasts
-// (oldest evicted) and auto-dismisses each toast after 5000ms.
+// (oldest evicted) and auto-dismisses each toast after 5000ms unless
+// the caller passes `persist: true` (UI-5: stale-peer resurrect must
+// never auto-dismiss — user decision 3).
 
 import { writable } from "svelte/store";
 
 export type ToastVariant = "error" | "conflict" | "clean-merge" | "info" | "warning";
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface Toast {
   id: number;
   variant: ToastVariant;
   message: string;
+  /** UI-5: when true the toast stays until explicitly dismissed. */
+  persist?: boolean;
+  /** UI-5: optional inline action button rendered next to the message. */
+  action?: ToastAction;
+  /** UI-5: override the default ARIA role ("status"). Use "alert" for
+   *  toasts that demand immediate attention (resurrect prompt). */
+  role?: "status" | "alert";
+  /** UI-5: override the default aria-live ("polite"). */
+  ariaLive?: "polite" | "assertive";
+}
+
+export interface PushToastArgs {
+  variant: ToastVariant;
+  message: string;
+  persist?: boolean;
+  action?: ToastAction;
+  role?: "status" | "alert";
+  ariaLive?: "polite" | "assertive";
 }
 
 const MAX_TOASTS = 3;
@@ -35,9 +60,17 @@ function scheduleDismiss(id: number): void {
   timers.set(id, t);
 }
 
-function pushToast(args: { variant: ToastVariant; message: string }): number {
+function pushToast(args: PushToastArgs): number {
   const id = nextId++;
-  const toast: Toast = { id, variant: args.variant, message: args.message };
+  const toast: Toast = {
+    id,
+    variant: args.variant,
+    message: args.message,
+    persist: args.persist ?? false,
+  };
+  if (args.action !== undefined) toast.action = args.action;
+  if (args.role !== undefined) toast.role = args.role;
+  if (args.ariaLive !== undefined) toast.ariaLive = args.ariaLive;
   _store.update((toasts) => {
     const next = [...toasts, toast];
     while (next.length > MAX_TOASTS) {
@@ -46,7 +79,7 @@ function pushToast(args: { variant: ToastVariant; message: string }): number {
     }
     return next;
   });
-  scheduleDismiss(id);
+  if (!toast.persist) scheduleDismiss(id);
   return id;
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,11 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
   plugins: [svelte()],
+  // Mirror vite.config.ts so components under test that read build-time
+  // constants (SettingsModal renders __VC_BUILD_VERSION__) don't ReferenceError.
+  define: {
+    __VC_BUILD_VERSION__: JSON.stringify('test'),
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary

Closes the milestone **Vault sync v1** (epic #73). Ships the full LAN P2P sync stack — backend, IPC, desktop + Android UI — with a real two-runtime acceptance test on loopback TCP.

Sub-issues delivered:
- #416 sync-state metadata + history blob store
- #417 identity (Ed25519 + keychain) + cross-platform mDNS discovery
- #418 PAKE pairing + capability tokens
- #419 Noise IK transport + change-event sync engine
- #420 Merkle reconciliation + conflict-copy + tombstone propagation

Plus the UI surfaces and the IPC plumbing that drives them:
- IPC bridge: 14 commands, 4 events, debounced 250 ms peer-discovered emitter
- Pairing engine: post-PAKE Noise XX → long-term-key attestation → vault-grant exchange
- Frontend: typed IPC wrappers + `syncStore` + cross-component opener stores
- `SettingsModal` SYNCHRONISIERUNG section (between VAULT and ERSCHEINUNGSBILD per user decision)
- `PairingModal` 4-step state machine (role → PIN → key confirm → vault grant) with a11y countdown + 6-field auto-advance PIN input + symmetric lockout copy
- `SyncStatusPill` ambient indicator at `bottom: 84px`
- `toastStore` `persist: true` + persistent stale-peer-resurrect toast
- Two-on-one-host UAT recipe: `VAULTCORE_KEYCHAIN_ACCOUNT` env override + `tauri.conf.uat-b.json` + `pnpm tauri:b` script
- Android: build unblocked, manual peer-addr entry (text field + 'Mit IP koppeln') as the primary pairing path until the NSD JNI bridge ships

## Test plan

Automated:
- [x] `cargo test -p vaultcore --lib sync::` — 45 sync unit tests
- [x] `cargo test -p vaultcore --lib commands::sync_cmds` — 37 IPC tests (incl. 8 manual-peer-addr cases)
- [x] `cargo test --test sync_e2e` — full two-device LAN acceptance: PAKE → pair → propagation 5 ms → conflict-copy → tombstone propagation 5 ms → Merkle catch-up 13 ms
- [x] `pnpm vitest run` — all sync UI / store / toast tests green; 2 pre-existing `longPress` failures unrelated

Manual UAT (#6, blocked on human gate):
- [ ] Two `pnpm tauri dev` instances on the same Mac, distinct keychain accounts via `tauri:b`
- [ ] Phone↔Mac pairing via 'Mit IP koppeln' (Android, no NSD bridge yet)
- [ ] 16-step walk-through (mDNS discovery, pairing, propagation, concurrent edits → conflict copies, deletes → tombstones, revoke, wrong PIN lockout, PIN expiry, reconnect)

## Out of scope (follow-ups)

- Android NSD JNI bridge — manual peer entry is the workaround
- Conflict-copy resolution UI ("compare / keep mine / keep theirs")
- Permanent Devices sidebar panel (Vitruvius rejected this)
- Per-file sync progress, sync history / audit log